### PR TITLE
Implement issue #7: checkpoint, push, and draft PR

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ base_synchronization:
 
 The validator checks the schema version, target branch, setup, ordered unique gates and earlier dependencies, matching role harness/model policies, positive durations, positive retry limits, test policy, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, and base-synchronization mode. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
 
-Issue #3 establishes and validates this repository-declared gate contract. Issue #5 adds the worker runtime and the coordinator path that runs setup plus one selected gate in the pinned worker and publishes its result to the exact checkpoint SHA. Full baseline health, dependency skipping, independent-gate execution, manifest-triggered setup, and retained checkpoint-keyed gate results remain the expanded gate model in issue #9. The commands declared by this repository's `factory.yaml` are also run as part of the repository verification suite.
+Issue #3 establishes and validates this repository-declared gate contract. Issue #5 adds the worker runtime and the coordinator path that runs setup plus one selected gate in the pinned worker and publishes its result to the exact checkpoint SHA. Issue #7 uses that same frozen gate contract to run every declared gate before the first branch push. Full baseline health, dependency skipping, independent-gate execution, manifest-triggered setup, and retained checkpoint-keyed gate results remain the expanded gate model in issue #9. The commands declared by this repository's `factory.yaml` are also run as part of the repository verification suite.
 
 Worker execution uses stable in-container paths (`/work`, `/git`, and
 `/cache/<name>`), a non-root uid, dropped capabilities, disabled privilege
@@ -148,14 +148,43 @@ prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use
 `factory agent-report --invocation-id <id>` to ask the coordinator to validate
 and accept the structured report. Terminal output is never treated as a stage
-result. The operational store schema is version 6 and persists invocation
+result. The operational store schema is version 7 and persists invocation
 identity, opaque surface handles, prompt version, result directory, native
-session identifier, and permitted handoff paths in addition to run state.
+session identifier, and permitted handoff paths in addition to run state. It
+also persists the draft pull-request number and URL so a restarted command can
+update the existing pull request instead of creating another one.
+
+## Creating the draft pull request
+
+After the implementation report has been accepted, advance the run through
+the host-owned checkpoint, deterministic gates, branch push, and draft PR:
+
+```sh
+factory draft-pr \
+  --config /Users/me/.config/factory/config.yaml \
+  --run-id run-123
+```
+
+The coordinator validates the worktree against the stored checkpoint, creates
+one commit marked `factory: implementation checkpoint <run-id>`, and records
+its full SHA before running every gate from the frozen specification packet.
+Only when all gates pass does the host push `factory/<run-id>` and call
+GitHub's draft pull-request API. Workers never receive Git remotes, GitHub
+credentials, commit authority, or push authority.
+
+The PR body contains one coordinator-owned section between
+`<!-- factory-generated:start -->` and `<!-- factory-generated:end -->`.
+That section includes the issue and specification summary, checkpoint, stage,
+gate results, intervention marker, and control commands. Repeating
+`factory draft-pr` finds the existing PR by its exact source and target branch,
+regenerates only that marked section, and preserves human-authored text around
+it. The issue's single factory state label and editable status comment move to
+the `draft_pr` stage at the same transition.
 
 ## Operational SQLite store
 
-The operational store contains current workflow state, the active run's frozen specification packet, and the status-comment identity needed by later transitions. Registration and status both reject paths that resolve inside the repository checkout, including symlink aliases; its directory is private (`0700`) and the SQLite file is private (`0600`). A fresh store is initialized directly; an older supported schema is copied to a timestamped `.bak-*` file before its explicit migration runs. Migration backups are not pruned automatically in this foundation; issue #23 owns the visible cleanup and retention policy. A newer or unversioned database refuses to open. There is no silent guessing or destructive migration. GitHub credentials are never columns in this store.
+The operational store contains current workflow state, the active run's frozen specification packet, the status-comment identity needed by later transitions, and the draft pull-request identity needed for idempotent regeneration. Registration and status both reject paths that resolve inside the repository checkout, including symlink aliases; its directory is private (`0700`) and the SQLite file is private (`0600`). A fresh store is initialized directly; an older supported schema is copied to a timestamped `.bak-*` file before its explicit migration runs. Migration backups are not pruned automatically in this foundation; issue #23 owns the visible cleanup and retention policy. A newer or unversioned database refuses to open. There is no silent guessing or destructive migration. GitHub credentials are never columns in this store.
 
 Issue #25 will add separate content-free local evaluation summaries. Those summaries remain local and are not outbound telemetry.
 
-The high-level `Factory` seam injects configuration, repository checking, GitHub, Git/worktree, worker, terminal, harness, clock, run-identity, and operational-store adapters. Foundation tests use a real temporary SQLite store and fake the external repository/configuration boundary; issue #4 adds focused fake-adapter tests for the claim seam and a real temporary Git repository test for worktree isolation. Issue #5 owns the `WorkerRuntime` adapter and coordinator worker ownership; issue #6 adds the portable `TerminalRuntime`, Codex harness, invocation packet, and structured report boundary.
+The high-level `Factory` seam injects configuration, repository checking, GitHub, pull requests, `GitWorkspace`, worker, terminal, harness, clock, run-identity, and operational-store adapters. Foundation tests use a real temporary SQLite store and fake the external repository/configuration boundary; issue #4 adds focused fake-adapter tests for the claim seam and a real temporary Git repository test for worktree isolation. Issue #5 owns the `WorkerRuntime` adapter and coordinator worker ownership; issue #6 adds the portable `TerminalRuntime`, Codex harness, invocation packet, and structured report boundary; issue #7 adds host checkpoint, push, and draft-PR orchestration.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,6 +181,57 @@ regenerates only that marked section, and preserves human-authored text around
 it. The issue's single factory state label and editable status comment move to
 the `draft_pr` stage at the same transition.
 
+## End-to-end demonstration
+
+The tracer-bullet acceptance path is an operator-run check against a disposable
+repository and issue. Do not use a production repository: the path creates a
+factory branch, changes the issue's factory label and status comment, pushes
+the branch, and opens a draft pull request.
+
+Before starting, prepare a dedicated GitHub repository with a checked-in
+`factory.yaml`, a fresh open issue carrying `agent-ready`, valid `gh` login,
+Docker with the configured worker image available, a running cmux session, and
+the host Codex `auth.json` path registered in the host configuration. Build the
+three local commands from this checkout (`factory`, `factory-report`, and
+`factory-worker-attach`) so the worker image can invoke the pinned report
+command.
+
+Run the path in this order:
+
+```sh
+factory bootstrap-labels --config /Users/me/.config/factory/config.yaml
+factory issue --config /Users/me/.config/factory/config.yaml <issue-number>
+factory agent --config /Users/me/.config/factory/config.yaml --run-id <run-id>
+
+# In the visible implementation surface, make the requested small change and
+# submit its structured report with factory-report.
+factory agent-report \
+  --config /Users/me/.config/factory/config.yaml \
+  --run-id <run-id> \
+  --invocation-id <invocation-id>
+factory draft-pr \
+  --config /Users/me/.config/factory/config.yaml \
+  --run-id <run-id>
+```
+
+Record the command output and verify the demonstration at each boundary:
+
+- the issue has exactly one factory state label and one editable status comment;
+- the worker reaches the visible Codex session, while its container has no Git
+  remote or GitHub credential access;
+- the run worktree contains one `factory: implementation checkpoint <run-id>`
+  commit, and `git ls-remote` shows the pushed `factory/<run-id>` branch only
+  after every configured gate passes;
+- the GitHub pull request is draft, targets the configured base branch, and
+  contains the generated factory markers and gate summary;
+- repeating `factory draft-pr` updates that same pull request and retains text
+  outside the generated markers; and
+- `factory status` and the issue's status comment report `draft_pr`.
+
+Keep the resulting pull-request URL and the status-comment URL as the
+demonstration evidence. Close the disposable pull request and issue, then
+remove the run's local worktree and operational database after inspection.
+
 ## Operational SQLite store
 
 The operational store contains current workflow state, the active run's frozen specification packet, the status-comment identity needed by later transitions, and the draft pull-request identity needed for idempotent regeneration. Registration and status both reject paths that resolve inside the repository checkout, including symlink aliases; its directory is private (`0700`) and the SQLite file is private (`0600`). A fresh store is initialized directly; an older supported schema is copied to a timestamped `.bak-*` file before its explicit migration runs. Migration backups are not pruned automatically in this foundation; issue #23 owns the visible cleanup and retention policy. A newer or unversioned database refuses to open. There is no silent guessing or destructive migration. GitHub credentials are never columns in this store.

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -56,6 +56,11 @@ worktree state. Git configuration, remote definitions, hooks, submodules, and
 host-specific worktree indirection are omitted, so repository history and diff
 operations remain available without exposing remote credentials.
 
+The worker never commits, changes branches, pushes, or calls GitHub. The
+host-side `GitWorkspace` validates the accepted worktree, creates the immutable
+checkpoint, synchronizes a base branch when policy requires it, pushes the run
+branch, and removes the worktree during cleanup.
+
 Setup and the selected repository-declared gate run with `env -i` plus an
 explicit worker baseline. Role-policy commands additionally receive the
 coordinator-defined role identity; clean-policy commands do not. The gate

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,6 +32,7 @@ var commandTable = []commandDefinition{
 	{name: "issue", handler: runIssue},
 	{name: "agent", handler: runAgent},
 	{name: "agent-report", handler: runAgentReport},
+	{name: "draft-pr", handler: runDraftPullRequest},
 	{name: "status", handler: runStatus},
 }
 
@@ -208,6 +209,37 @@ func runAgentReport(ctx context.Context, args []string, defaultConfigPath string
 	}
 	if !writeOutput(output, errorsOutput, "agent report accepted\nrun: %s\ninvocation: %s\noutcome: %s\nstatus: %s\n", result.Invocation.RunID, result.Invocation.ID, result.Report.Outcome, result.Invocation.Status) {
 		return 1
+	}
+	return 0
+}
+
+// runDraftPullRequest advances the accepted implementation to one draft pull
+// request through host-side checkpoint, gate, Git, and GitHub effects.
+func runDraftPullRequest(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("draft-pr", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "active factory run identifier")
+	intervention := flags.String("intervention", "", "operator-visible intervention marker")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("draft-pr does not accept positional arguments"))
+		return 2
+	}
+	result, err := factory.New(*configPath).CreateDraftPullRequest(ctx, factory.DraftPullRequestRequest{RunID: *runID, Intervention: *intervention})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "draft pull request ready\nrun: %s\ncheckpoint: %s\npull request: #%d %s\nstage: %s\n", result.Run.ID, result.Run.CheckpointSHA, result.PullRequest.Number, result.PullRequest.URL, result.Run.Stage) {
+		return 1
+	}
+	for _, gateResult := range result.Gates {
+		if !writeOutput(output, errorsOutput, "gate: %s (%s)\n", gateResult.GateName, gateResult.Status.State) {
+			return 1
+		}
 	}
 	return 0
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -153,6 +153,22 @@ func TestRunStatusRejectsPositionalArguments(t *testing.T) {
 	}
 }
 
+// TestRunDraftPullRequestRejectsPositionalArguments verifies the draft-PR
+// command keeps run selection explicit and unambiguous.
+func TestRunDraftPullRequestRejectsPositionalArguments(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	var output bytes.Buffer
+	code := cli.Run(context.Background(), []string{"draft-pr", "extra", "--config", configPath}, &output, &output)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2, output = %s", code, output.String())
+	}
+	if !strings.Contains(output.String(), "draft-pr does not accept positional arguments") {
+		t.Fatalf("output = %q", output.String())
+	}
+}
+
 func TestRunInitRejectsAnUnknownFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
-	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/prompt"
@@ -402,8 +401,8 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		WorktreePath:   run.Worktree,
 		PermittedPaths: invocation.PermittedPaths,
 	}
-	inspector, ok := s.deps.Worktree.(gitadapter.WorktreeInspector)
-	if !ok {
+	inspector := s.worktreeInspector()
+	if inspector == nil {
 		return AgentResult{}, errors.New("worktree runtime does not support report inspection")
 	}
 	state, inspectErr := inspector.Inspect(ctx, run.Worktree)

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -172,12 +172,16 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 	if err != nil {
 		return IssueResult{}, fmt.Errorf("freeze specification packet: %w", err)
 	}
-	workspace, err := s.deps.Worktree.Create(ctx, registration.Path, repositoryConfig.TargetBranch, runID)
+	worktreeManager := s.worktreeManager()
+	if worktreeManager == nil {
+		return IssueResult{}, errors.New("GitWorkspace is required to create a run worktree")
+	}
+	workspace, err := worktreeManager.Create(ctx, registration.Path, repositoryConfig.TargetBranch, runID)
 	if err != nil {
 		return IssueResult{}, err
 	}
 	cleanupWorkspace := func(cause error) error {
-		if cleanupErr := s.deps.Worktree.Remove(ctx, registration.Path, workspace); cleanupErr != nil {
+		if cleanupErr := worktreeManager.Remove(ctx, registration.Path, workspace); cleanupErr != nil {
 			return errors.Join(cause, fmt.Errorf("remove claim workspace: %w", cleanupErr))
 		}
 		return cause
@@ -407,7 +411,11 @@ func (s *Service) failClaim(ctx context.Context, runStore RunStore, run store.Ru
 // statusCommentBody renders the single editable supervision comment.
 func statusCommentBody(run store.Run) string {
 	started := run.CreatedAt.UTC().Format(time.RFC3339)
-	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status)
+	pullRequest := ""
+	if run.PullRequestNumber > 0 {
+		pullRequest = fmt.Sprintf("- pull request: #%d %s\n", run.PullRequestNumber, run.PullRequestURL)
+	}
+	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, pullRequest)
 }
 
 // statusCommentMarker identifies the one editable status comment for a run.

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -1,0 +1,319 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/gate"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+const (
+	// generatedPullRequestStart marks the coordinator-owned PR body section.
+	generatedPullRequestStart = "<!-- factory-generated:start -->"
+	// generatedPullRequestEnd marks the end of the coordinator-owned PR body section.
+	generatedPullRequestEnd = "<!-- factory-generated:end -->"
+)
+
+// DraftPullRequestRequest selects the active run whose accepted implementation
+// should become a draft pull request.
+type DraftPullRequestRequest struct {
+	// RunID identifies the active run. Empty selects the repository's only run.
+	RunID string
+	// Intervention is the operator-visible marker regenerated in the PR body.
+	Intervention string
+}
+
+// DraftPullRequestResult contains the final run, gate results, and draft PR
+// identity produced by the coordinator.
+type DraftPullRequestResult struct {
+	// Run is the persisted run after the draft PR transition.
+	Run store.Run
+	// Gates contains one result for every configured gate.
+	Gates []gate.Result
+	// PullRequest is the created or recovered draft PR.
+	PullRequest github.PullRequest
+}
+
+// CreateDraftPullRequest advances an accepted implementation through its host
+// checkpoint, all frozen deterministic gates, first branch push, and one
+// idempotent draft pull request. Repeating it regenerates only the marked
+// factory section and preserves human-authored PR text.
+func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullRequestRequest) (DraftPullRequestResult, error) {
+	if strings.ContainsAny(request.Intervention, "\x00\r\n") {
+		return DraftPullRequestResult{}, errors.New("draft pull request intervention must be a single line")
+	}
+	registration, runStore, run, err := s.openActiveRunStore(ctx)
+	if err != nil {
+		return DraftPullRequestResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	if run == nil {
+		return DraftPullRequestResult{}, errors.New("no active run")
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return DraftPullRequestResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return DraftPullRequestResult{}, err
+	}
+	if run.Stage == store.StageDraftPR {
+		pullRequest, err := s.regenerateDraftPullRequest(ctx, registration, *run, packet, request.Intervention)
+		if err != nil {
+			return DraftPullRequestResult{Run: *run}, err
+		}
+		return DraftPullRequestResult{Run: *run, PullRequest: pullRequest}, nil
+	}
+	if run.Stage != store.StageImplementation && run.Stage != store.StageCheck {
+		return DraftPullRequestResult{}, fmt.Errorf("run %q must be in implementation or check stage, not %q", run.ID, run.Stage)
+	}
+	if run.Status != store.StatusActive {
+		return DraftPullRequestResult{}, fmt.Errorf("run %q is %s; implementation must be active", run.ID, run.Status)
+	}
+	if activeStore, ok := runStore.(ActiveInvocationStore); ok {
+		active, lookupErr := activeStore.ActiveInvocation(ctx, run.ID)
+		if lookupErr != nil {
+			return DraftPullRequestResult{}, fmt.Errorf("look up active implementation invocation: %w", lookupErr)
+		}
+		if active != nil {
+			return DraftPullRequestResult{}, fmt.Errorf("run %q still has active implementation invocation %q", run.ID, active.ID)
+		}
+	}
+	workspace := s.gitWorkspace()
+	if workspace == nil {
+		return DraftPullRequestResult{}, errors.New("GitWorkspace is required to create a draft pull request")
+	}
+	checkpoint, err := workspace.CreateCheckpoint(ctx, gitadapter.CheckpointRequest{
+		RunID:        run.ID,
+		WorktreePath: run.Worktree,
+		ParentSHA:    run.CheckpointSHA,
+		Message:      "accepted implementation",
+	})
+	if err != nil {
+		return DraftPullRequestResult{}, err
+	}
+	if !github.ValidCommitSHA(checkpoint.SHA) {
+		return DraftPullRequestResult{}, errors.New("GitWorkspace returned an invalid implementation checkpoint SHA")
+	}
+	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	issue, err := s.deps.GitHub.Issue(ctx, repository, run.IssueNumber)
+	if err != nil {
+		return DraftPullRequestResult{}, err
+	}
+	if issue.Number == 0 {
+		issue = packet.Issue
+		issue.Number = run.IssueNumber
+	}
+	next := *run
+	next.CheckpointSHA = checkpoint.SHA
+	next.Stage = store.StageCheck
+	next.Status = store.StatusActive
+	next.UpdatedAt = s.deps.Now().UTC()
+	next, err = s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository: repository, Issue: issue, Previous: *run, Next: next,
+	})
+	if err != nil {
+		return DraftPullRequestResult{}, err
+	}
+
+	gates, gateErr := s.runConfiguredGates(ctx, registration, next, packet)
+	result := DraftPullRequestResult{Run: next, Gates: gates}
+	if gateErr != nil {
+		return result, gateErr
+	}
+	state, err := workspace.Inspect(ctx, next.Worktree)
+	if err != nil {
+		return result, fmt.Errorf("validate checkpoint after gates: %w", err)
+	}
+	if state.HeadSHA != next.CheckpointSHA {
+		return result, fmt.Errorf("worktree HEAD %q changed after checkpoint %q", state.HeadSHA, next.CheckpointSHA)
+	}
+	if len(state.ChangedPaths) != 0 {
+		return result, errors.New("worktree has uncommitted changes after deterministic gates")
+	}
+	if err := workspace.Push(ctx, gitadapter.PushRequest{WorktreePath: next.Worktree, Branch: next.Branch}); err != nil {
+		return result, err
+	}
+
+	pullRequests := s.pullRequestClient()
+	if pullRequests == nil {
+		return result, errors.New("GitHub client does not support pull-request operations")
+	}
+	pullRequest, err := s.upsertDraftPullRequest(ctx, pullRequests, repository, next, packet, gates, request.Intervention)
+	if err != nil {
+		return result, err
+	}
+	next.PullRequestNumber = pullRequest.Number
+	next.PullRequestURL = pullRequest.URL
+	next.Stage = store.StageDraftPR
+	next.Status = store.StatusActive
+	next.UpdatedAt = s.deps.Now().UTC()
+	next, err = s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository: repository, Issue: issue, Previous: result.Run, Next: next,
+	})
+	if err != nil {
+		return DraftPullRequestResult{Run: next, Gates: gates, PullRequest: pullRequest}, err
+	}
+	return DraftPullRequestResult{Run: next, Gates: gates, PullRequest: pullRequest}, nil
+}
+
+// runConfiguredGates executes every gate from the frozen specification in
+// declaration order and joins failures so the operator sees the complete
+// deterministic result set from one checkpoint.
+func (s *Service) runConfiguredGates(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packet SpecificationPacket) ([]gate.Result, error) {
+	results := make([]gate.Result, 0, len(packet.RepositoryConfig.Gates))
+	var failures []error
+	for _, declared := range packet.RepositoryConfig.Gates {
+		result, err := s.runGate(ctx, registration, run, packet, declared)
+		results = append(results, result)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("gate %q: %w", declared.Name, err))
+		}
+	}
+	return results, errors.Join(failures...)
+}
+
+// upsertDraftPullRequest finds a prior branch pull request before creating one
+// and merges the generated section into its existing body when present.
+func (s *Service) upsertDraftPullRequest(ctx context.Context, client github.PullRequestClient, repository github.Repository, run store.Run, packet SpecificationPacket, gates []gate.Result, intervention string) (github.PullRequest, error) {
+	existing, err := client.FindPullRequest(ctx, repository, run.Branch, packet.RepositoryConfig.TargetBranch)
+	if err != nil {
+		return github.PullRequest{}, err
+	}
+	body := generatedPullRequestBody(run, packet, gates, intervention)
+	request := github.PullRequestRequest{
+		Title:      defaultString(packet.Issue.Title, fmt.Sprintf("Issue #%d", packet.Issue.Number)),
+		Body:       body,
+		HeadBranch: run.Branch,
+		BaseBranch: packet.RepositoryConfig.TargetBranch,
+		Draft:      true,
+	}
+	if existing.Number > 0 {
+		request.Body = mergeGeneratedPullRequestBody(existing.Body, body)
+		updated, err := client.UpdatePullRequest(ctx, repository, existing.Number, request)
+		if err != nil {
+			return github.PullRequest{}, err
+		}
+		if updated.Number <= 0 {
+			return github.PullRequest{}, errors.New("pull-request update returned no pull-request identity")
+		}
+		return updated, nil
+	}
+	created, err := client.CreatePullRequest(ctx, repository, request)
+	if err != nil {
+		return github.PullRequest{}, err
+	}
+	if created.Number <= 0 {
+		return github.PullRequest{}, errors.New("pull-request creation returned no pull-request identity")
+	}
+	return created, nil
+}
+
+// regenerateDraftPullRequest refreshes a previously created PR without
+// rerunning gates or pushing again. The branch lookup supplies the current
+// human-authored body for preservation.
+func (s *Service) regenerateDraftPullRequest(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packet SpecificationPacket, intervention string) (github.PullRequest, error) {
+	client := s.pullRequestClient()
+	if client == nil {
+		return github.PullRequest{}, errors.New("GitHub client does not support pull-request operations")
+	}
+	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	existing, err := client.FindPullRequest(ctx, repository, run.Branch, packet.RepositoryConfig.TargetBranch)
+	if err != nil {
+		return github.PullRequest{}, err
+	}
+	if existing.Number == 0 {
+		return github.PullRequest{}, fmt.Errorf("draft pull request for branch %q was not found", run.Branch)
+	}
+	body := mergeGeneratedPullRequestBody(existing.Body, generatedPullRequestBody(run, packet, nil, intervention))
+	updated, err := client.UpdatePullRequest(ctx, repository, existing.Number, github.PullRequestRequest{
+		Title: defaultString(packet.Issue.Title, fmt.Sprintf("Issue #%d", packet.Issue.Number)), Body: body,
+		HeadBranch: run.Branch, BaseBranch: packet.RepositoryConfig.TargetBranch, Draft: true,
+	})
+	if err != nil {
+		return github.PullRequest{}, err
+	}
+	if updated.Number <= 0 {
+		return github.PullRequest{}, errors.New("pull-request regeneration returned no pull-request identity")
+	}
+	return updated, nil
+}
+
+// gitWorkspace resolves the new task-oriented seam while retaining the
+// foundation Worktree adapter as a compatibility fallback.
+func (s *Service) gitWorkspace() gitadapter.GitWorkspace {
+	if s.deps.GitWorkspace != nil {
+		return s.deps.GitWorkspace
+	}
+	workspace, _ := s.deps.Worktree.(gitadapter.GitWorkspace)
+	return workspace
+}
+
+// worktreeManager resolves the task-oriented Git workspace for the existing
+// claim/cleanup operations while keeping foundation adapters compatible.
+func (s *Service) worktreeManager() gitadapter.WorktreeManager {
+	if s.deps.GitWorkspace != nil {
+		return s.deps.GitWorkspace
+	}
+	return s.deps.Worktree
+}
+
+// worktreeInspector resolves the read-only validation seam used by report
+// acceptance.
+func (s *Service) worktreeInspector() gitadapter.WorktreeInspector {
+	if s.deps.GitWorkspace != nil {
+		return s.deps.GitWorkspace
+	}
+	inspector, _ := s.deps.Worktree.(gitadapter.WorktreeInspector)
+	return inspector
+}
+
+// pullRequestClient resolves the dedicated pull-request adapter or a GitHub
+// client that implements it directly.
+func (s *Service) pullRequestClient() github.PullRequestClient {
+	if s.deps.PullRequests != nil {
+		return s.deps.PullRequests
+	}
+	client, _ := s.deps.GitHub.(github.PullRequestClient)
+	return client
+}
+
+// generatedPullRequestBody renders the complete coordinator-owned PR section.
+func generatedPullRequestBody(run store.Run, packet SpecificationPacket, gates []gate.Result, intervention string) string {
+	if strings.TrimSpace(intervention) == "" {
+		intervention = "none"
+	}
+	issueBody := strings.TrimSpace(packet.Issue.Body)
+	if issueBody == "" {
+		issueBody = "(no issue body supplied)"
+	}
+	gateLines := make([]string, 0, len(packet.RepositoryConfig.Gates))
+	for _, declared := range packet.RepositoryConfig.Gates {
+		gateLines = append(gateLines, fmt.Sprintf("- `%s`: passed", declared.Name))
+	}
+	if len(gates) == 0 && len(gateLines) == 0 {
+		gateLines = append(gateLines, "- (none)")
+	}
+	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `draft_pr`\n- intervention: `%s`\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, intervention, issueBody, strings.Join(gateLines, "\n"), run.ID, generatedPullRequestEnd)
+}
+
+// mergeGeneratedPullRequestBody replaces only the marked factory section and
+// appends it after existing human-authored text when no marker exists.
+func mergeGeneratedPullRequestBody(existing, generated string) string {
+	start := strings.Index(existing, generatedPullRequestStart)
+	end := strings.Index(existing, generatedPullRequestEnd)
+	if start >= 0 && end >= start {
+		end += len(generatedPullRequestEnd)
+		return existing[:start] + generated + existing[end:]
+	}
+	if strings.TrimSpace(existing) == "" {
+		return generated
+	}
+	return strings.TrimRight(existing, "\n") + "\n\n" + generated
+}

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -285,6 +285,8 @@ func (s *Service) pullRequestClient() github.PullRequestClient {
 }
 
 // generatedPullRequestBody renders the complete coordinator-owned PR section.
+// It builds the Gates section from the observed gate results rather than
+// configured gates, rendering each result's actual status.
 func generatedPullRequestBody(run store.Run, packet SpecificationPacket, gates []gate.Result, intervention string) string {
 	if strings.TrimSpace(intervention) == "" {
 		intervention = "none"
@@ -293,11 +295,28 @@ func generatedPullRequestBody(run store.Run, packet SpecificationPacket, gates [
 	if issueBody == "" {
 		issueBody = "(no issue body supplied)"
 	}
-	gateLines := make([]string, 0, len(packet.RepositoryConfig.Gates))
-	for _, declared := range packet.RepositoryConfig.Gates {
-		gateLines = append(gateLines, fmt.Sprintf("- `%s`: passed", declared.Name))
+	gateLines := make([]string, 0, len(gates))
+	for _, result := range gates {
+		var status string
+		switch result.Status.State {
+		case github.CommitStatusSuccess:
+			status = "passed"
+		case github.CommitStatusFailure:
+			status = "failed"
+		case github.CommitStatusError:
+			status = "error"
+		case github.CommitStatusPending:
+			status = "pending"
+		default:
+			status = "unknown"
+		}
+		gateName := result.GateName
+		if gateName == "" {
+			gateName = "(unnamed)"
+		}
+		gateLines = append(gateLines, fmt.Sprintf("- `%s`: %s", gateName, status))
 	}
-	if len(gates) == 0 && len(gateLines) == 0 {
+	if len(gateLines) == 0 {
 		gateLines = append(gateLines, "- (none)")
 	}
 	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `draft_pr`\n- intervention: `%s`\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, intervention, issueBody, strings.Join(gateLines, "\n"), run.ID, generatedPullRequestEnd)

--- a/internal/factory/draft_pr_test.go
+++ b/internal/factory/draft_pr_test.go
@@ -1,0 +1,244 @@
+package factory_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+const implementationCheckpoint = "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+
+// TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft
+// verifies the complete host-owned implementation boundary at the Factory
+// seam.
+func TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repo")
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-draft\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy := validRepositoryConfig()
+	policy.Gates = []config.GateConfig{
+		{Name: "format", Command: "format", Timeout: "5m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean},
+		{Name: "test", Command: "test", Timeout: "5m", Blocking: true, DependsOn: []string{"format"}, EnvironmentPolicy: config.EnvironmentPolicyClean},
+	}
+	packetData, err := json.Marshal(factory.SpecificationPacket{
+		Version:          1,
+		Issue:            github.Issue{Number: 42, Title: "Add the factory handoff", Body: "Implement the supervised draft PR boundary."},
+		RepositoryConfig: policy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runStore := &fakeRunStore{saved: []store.Run{{
+		ID: "run-draft", RepositoryPath: "/repo", IssueNumber: 42, Stage: store.StageImplementation, Status: store.StatusActive,
+		Branch: "factory/run-draft", Worktree: worktreePath, CheckpointSHA: factoryGateCheckpoint, ImageDigest: policy.WorkerBuild.Digest,
+		StatusCommentID: "comment-1", SpecificationPacket: string(packetData), CreatedAt: time.Date(2026, 8, 21, 10, 0, 0, 0, time.UTC),
+	}}}
+	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 42, Title: "Add the factory handoff", State: "open", Labels: []string{github.LabelAgentRunning}}}
+	workspace := &draftGitWorkspace{state: gitadapter.WorktreeState{HeadSHA: factoryGateCheckpoint, ChangedPaths: []string{"internal/factory.go"}}}
+	workerRuntime := &gateWorker{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}}}
+	statuses := &gateStatuses{}
+	pullRequests := &fakePullRequests{created: github.PullRequest{Number: 17, URL: "https://github.com/example/project/pull/17", State: "open", Draft: true, HeadBranch: "factory/run-draft", BaseBranch: "main"}}
+
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: repositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		OperationalDataPath: filepath.Join(root, "state", "factory.db"), RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+	}}}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		GitHub:         &fakeGitHubWithPullRequests{fakeGitHub: githubAdapter},
+		PullRequests:   pullRequests,
+		Worktree:       workspace,
+		GitWorkspace:   workspace,
+		Worker:         workerRuntime,
+		CommitStatuses: statuses,
+		Now:            func() time.Time { return time.Date(2026, 8, 21, 10, 1, 0, 0, time.UTC) },
+	})
+
+	result, err := service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: "run-draft"})
+	if err != nil {
+		t.Fatalf("CreateDraftPullRequest() error = %v", err)
+	}
+	if result.Run.Stage != store.StageDraftPR || result.Run.CheckpointSHA != implementationCheckpoint || result.PullRequest.Number != 17 || !result.PullRequest.Draft {
+		t.Fatalf("result = %#v, want draft stage, checkpoint, and PR identity", result)
+	}
+	if len(workspace.checkpoints) != 1 || len(workspace.pushes) != 1 {
+		t.Fatalf("Git workspace effects = checkpoints %#v pushes %#v, want one each", workspace.checkpoints, workspace.pushes)
+	}
+	if len(pullRequests.createdRequests) != 1 || len(pullRequests.updatedRequests) != 0 {
+		t.Fatalf("PR effects = creates %#v updates %#v, want one create", pullRequests.createdRequests, pullRequests.updatedRequests)
+	}
+	if len(workerRuntime.commands) != 4 || workerRuntime.commands[1].Command != "format" || workerRuntime.commands[3].Command != "test" {
+		t.Fatalf("gate commands = %#v, want setup/gate for each declared gate", workerRuntime.commands)
+	}
+	body := pullRequests.createdRequests[0].Body
+	for _, expected := range []string{
+		"<!-- factory-generated:start -->", "Add the factory handoff", "Implement the supervised draft PR boundary.",
+		"stage: `draft_pr`", "format", "test", "intervention: `none`", "factory status", "factory draft-pr --run-id run-draft",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Errorf("generated PR body %q does not contain %q", body, expected)
+		}
+	}
+	if len(githubAdapter.editedComments) != 2 {
+		t.Fatalf("status comment edits = %d, want check and draft stage", len(githubAdapter.editedComments))
+	}
+	if !strings.Contains(githubAdapter.editedComments[1].body, "stage: `draft_pr`") {
+		t.Fatalf("final status comment = %q, want draft_pr stage", githubAdapter.editedComments[1].body)
+	}
+
+	// A repeated command recovers the existing pull request and does not make
+	// another checkpoint, push, or pull request.
+	pullRequests.existing = github.PullRequest{Number: 17, URL: pullRequests.created.URL, Body: "human-authored notes", State: "open", Draft: true, HeadBranch: "factory/run-draft", BaseBranch: "main"}
+	repeated, err := service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: "run-draft", Intervention: "human reviewed"})
+	if err != nil {
+		t.Fatalf("repeated CreateDraftPullRequest() error = %v", err)
+	}
+	if repeated.PullRequest.Number != 17 || len(workspace.checkpoints) != 1 || len(workspace.pushes) != 1 || len(pullRequests.createdRequests) != 1 || len(pullRequests.updatedRequests) != 1 {
+		t.Fatalf("repeated effects/result = %#v, checkpoints=%d pushes=%d creates=%d updates=%d", repeated, len(workspace.checkpoints), len(workspace.pushes), len(pullRequests.createdRequests), len(pullRequests.updatedRequests))
+	}
+	updatedBody := pullRequests.updatedRequests[0].Body
+	if !strings.Contains(updatedBody, "human-authored notes") || strings.Count(updatedBody, "<!-- factory-generated:start -->") != 1 || !strings.Contains(updatedBody, "intervention: `human reviewed`") {
+		t.Fatalf("updated PR body = %q, want preserved human text and one regenerated section", updatedBody)
+	}
+}
+
+// TestCreateDraftPullRequestRejectsAnActiveImplementationInvocation verifies
+// the coordinator does not checkpoint while the visible agent still owns the
+// implementation stage.
+func TestCreateDraftPullRequestRejectsAnActiveImplementationInvocation(t *testing.T) {
+	t.Parallel()
+
+	policy := validRepositoryConfig()
+	packetData, err := json.Marshal(factory.SpecificationPacket{Version: 1, Issue: github.Issue{Number: 42, Title: "Active agent"}, RepositoryConfig: policy})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runStore := &activeInvocationRunStore{fakeRunStore: &fakeRunStore{saved: []store.Run{{ID: "run-active", RepositoryPath: "/repo", IssueNumber: 42, Stage: store.StageImplementation, Status: store.StatusActive, CheckpointSHA: factoryGateCheckpoint, ImageDigest: policy.WorkerBuild.Digest, SpecificationPacket: string(packetData)}}}, active: &store.Invocation{ID: "inv-active", RunID: "run-active", Status: store.InvocationStatusActive}}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{Path: "/repo", OperationalDataPath: "/outside/factory.db", RepositoryConfigPath: "/repo/factory.yaml"}}}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfig{value: host}, OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		GitHub: &fakeGitHub{}, GitWorkspace: &draftGitWorkspace{}, Worktree: &fakeWorktree{},
+	})
+	_, err = service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: "run-active"})
+	if err == nil || !strings.Contains(err.Error(), "still has active implementation invocation") {
+		t.Fatalf("CreateDraftPullRequest() error = %v, want validation before Git effects", err)
+	}
+}
+
+// draftGitWorkspace records the host Git effects for coordinator seam tests.
+type draftGitWorkspace struct {
+	state         gitadapter.WorktreeState
+	checkpoints   []gitadapter.CheckpointRequest
+	pushes        []gitadapter.PushRequest
+	checkpointSHA string
+}
+
+// activeInvocationRunStore adds the real-store invocation guard to the small
+// run-store fake used by this coordinator test.
+type activeInvocationRunStore struct {
+	*fakeRunStore
+	active *store.Invocation
+}
+
+// ActiveInvocation returns the configured active visible implementation.
+func (s *activeInvocationRunStore) ActiveInvocation(context.Context, string) (*store.Invocation, error) {
+	return s.active, nil
+}
+
+// Create implements GitWorkspace for the coordinator test.
+func (*draftGitWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	return gitadapter.Workspace{}, errors.New("unexpected Create()")
+}
+
+// Remove implements GitWorkspace for the coordinator test.
+func (*draftGitWorkspace) Remove(context.Context, string, gitadapter.Workspace) error { return nil }
+
+// Inspect returns the configured worktree state.
+func (w *draftGitWorkspace) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	return w.state, nil
+}
+
+// CreateCheckpoint records one idempotent checkpoint effect.
+func (w *draftGitWorkspace) CreateCheckpoint(_ context.Context, request gitadapter.CheckpointRequest) (gitadapter.CheckpointResult, error) {
+	w.checkpoints = append(w.checkpoints, request)
+	w.state.HeadSHA = implementationCheckpoint
+	w.state.ChangedPaths = nil
+	return gitadapter.CheckpointResult{SHA: implementationCheckpoint, Created: true}, nil
+}
+
+// Push records the host-side branch push.
+func (w *draftGitWorkspace) Push(_ context.Context, request gitadapter.PushRequest) error {
+	w.pushes = append(w.pushes, request)
+	return nil
+}
+
+// SynchronizeBase implements GitWorkspace for the coordinator test.
+func (*draftGitWorkspace) SynchronizeBase(context.Context, gitadapter.BaseSyncRequest) error {
+	return nil
+}
+
+// fakeGitHubWithPullRequests embeds the claim adapter and proves the pull
+// request seam remains separate from ordinary issue mutations.
+type fakeGitHubWithPullRequests struct {
+	*fakeGitHub
+}
+
+// PullRequest methods are intentionally absent; PullRequests is injected as a
+// separate adapter in the test.
+
+// fakePullRequests records draft pull-request discovery and mutations.
+type fakePullRequests struct {
+	existing        github.PullRequest
+	created         github.PullRequest
+	createdRequests []github.PullRequestRequest
+	updatedRequests []github.PullRequestRequest
+}
+
+// FindPullRequest returns the currently known branch pull request.
+func (f *fakePullRequests) FindPullRequest(context.Context, github.Repository, string, string) (github.PullRequest, error) {
+	return f.existing, nil
+}
+
+// CreatePullRequest records the first draft pull-request mutation.
+func (f *fakePullRequests) CreatePullRequest(_ context.Context, _ github.Repository, request github.PullRequestRequest) (github.PullRequest, error) {
+	f.createdRequests = append(f.createdRequests, request)
+	if f.created.Number == 0 {
+		return github.PullRequest{}, errors.New("test pull request identity is not configured")
+	}
+	return f.created, nil
+}
+
+// UpdatePullRequest records regeneration of the generated factory section.
+func (f *fakePullRequests) UpdatePullRequest(_ context.Context, _ github.Repository, _ int, request github.PullRequestRequest) (github.PullRequest, error) {
+	f.updatedRequests = append(f.updatedRequests, request)
+	updated := f.existing
+	updated.Body = request.Body
+	return updated, nil
+}
+
+var _ gitadapter.GitWorkspace = (*draftGitWorkspace)(nil)
+var _ github.PullRequestClient = (*fakePullRequests)(nil)

--- a/internal/factory/draft_pr_test.go
+++ b/internal/factory/draft_pr_test.go
@@ -151,10 +151,9 @@ func TestCreateDraftPullRequestRejectsAnActiveImplementationInvocation(t *testin
 
 // draftGitWorkspace records the host Git effects for coordinator seam tests.
 type draftGitWorkspace struct {
-	state         gitadapter.WorktreeState
-	checkpoints   []gitadapter.CheckpointRequest
-	pushes        []gitadapter.PushRequest
-	checkpointSHA string
+	state       gitadapter.WorktreeState
+	checkpoints []gitadapter.CheckpointRequest
+	pushes      []gitadapter.PushRequest
 }
 
 // activeInvocationRunStore adds the real-store invocation guard to the small

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -34,6 +34,9 @@ type Factory interface {
 	AcceptAgentReport(context.Context, AgentReportRequest) (AgentResult, error)
 	// RunAgent launches a visible agent and accepts its already-written report.
 	RunAgent(context.Context, AgentRequest) (AgentResult, error)
+	// CreateDraftPullRequest checkpoints the accepted implementation, runs every
+	// configured gate, pushes the branch, and creates or updates one draft PR.
+	CreateDraftPullRequest(context.Context, DraftPullRequestRequest) (DraftPullRequestResult, error)
 	Status(context.Context) (StatusResult, error)
 }
 
@@ -93,7 +96,11 @@ type Dependencies struct {
 	GitHub          github.Client
 	CommitStatuses  github.CommitStatusPublisher
 	Worktree        gitadapter.WorktreeManager
-	Worker          worker.WorkerRuntime
+	// GitWorkspace owns checkpoint, base-sync, push, and cleanup effects on the host.
+	GitWorkspace gitadapter.GitWorkspace
+	// PullRequests owns idempotent draft pull-request discovery and mutation.
+	PullRequests github.PullRequestClient
+	Worker       worker.WorkerRuntime
 	// Terminal owns visible control and run workspaces.
 	Terminal terminal.TerminalRuntime
 	// Harness owns interactive role lifecycle and native session recovery.
@@ -191,7 +198,17 @@ func NewWithDependencies(configPath string, dependencies Dependencies) *Service 
 		}
 	}
 	if dependencies.Worktree == nil {
-		dependencies.Worktree = gitadapter.NewWorktreeManager()
+		dependencies.Worktree = gitadapter.NewGitWorkspace()
+	}
+	if dependencies.GitWorkspace == nil {
+		if workspace, ok := dependencies.Worktree.(gitadapter.GitWorkspace); ok {
+			dependencies.GitWorkspace = workspace
+		}
+	}
+	if dependencies.PullRequests == nil {
+		if client, ok := dependencies.GitHub.(github.PullRequestClient); ok {
+			dependencies.PullRequests = client
+		}
 	}
 	if dependencies.Worker == nil {
 		dependencies.Worker = worker.NewDockerRuntime()

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/gate"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
@@ -49,12 +50,19 @@ func (s *Service) RunGate(ctx context.Context, request RunGateRequest) (gate.Res
 	if err != nil {
 		return gate.Result{}, err
 	}
-	if run.ImageDigest != packet.RepositoryConfig.WorkerBuild.Digest {
-		return gate.Result{}, fmt.Errorf("run %q image digest %q differs from frozen packet digest %q", run.ID, run.ImageDigest, packet.RepositoryConfig.WorkerBuild.Digest)
-	}
 	declaredGate, ok := declaredGate(packet, request.GateName)
 	if !ok {
 		return gate.Result{}, fmt.Errorf("gate %q is not declared in the frozen specification packet", request.GateName)
+	}
+	return s.runGate(ctx, registration, *run, packet, declaredGate)
+}
+
+// runGate executes one frozen gate for an already selected run. Keeping the
+// run selection outside this helper lets the draft-PR boundary run every
+// configured gate without re-reading mutable state between gates.
+func (s *Service) runGate(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packet SpecificationPacket, declared config.GateConfig) (gate.Result, error) {
+	if run.ImageDigest != packet.RepositoryConfig.WorkerBuild.Digest {
+		return gate.Result{}, fmt.Errorf("run %q image digest %q differs from frozen packet digest %q", run.ID, run.ImageDigest, packet.RepositoryConfig.WorkerBuild.Digest)
 	}
 	if s.deps.CommitStatuses == nil {
 		return gate.Result{}, errors.New("GitHub client does not support Commit Statuses")
@@ -83,7 +91,7 @@ func (s *Service) RunGate(ctx context.Context, request RunGateRequest) (gate.Res
 		CheckpointSHA: run.CheckpointSHA,
 		Setup:         packet.RepositoryConfig.Setup,
 		SetupTimeout:  packet.RepositoryConfig.Timeouts.Setup,
-		Gate:          declaredGate,
+		Gate:          declared,
 	})
 }
 
@@ -122,6 +130,9 @@ func prepareGitMetadataProjection(runID, repositoryPath, worktreePath string) (s
 			return "", fmt.Errorf("git metadata projection %q contains forbidden configuration", projection)
 		} else if !errors.Is(statErr, os.ErrNotExist) {
 			return "", fmt.Errorf("inspect git metadata projection configuration: %w", statErr)
+		}
+		if err := overlayWorktreeGitState(worktreePath, projection); err != nil {
+			return "", fmt.Errorf("refresh git metadata projection: %w", err)
 		}
 		if err := makeGitProjectionReadable(projection); err != nil {
 			return "", fmt.Errorf("prepare git metadata projection permissions: %w", err)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -20,6 +20,44 @@ type Workspace struct {
 	Worktree string
 }
 
+// CheckpointRequest selects one host-side implementation checkpoint.
+type CheckpointRequest struct {
+	// RunID identifies the factory run owning the checkpoint.
+	RunID string
+	// WorktreePath is the absolute run worktree to commit.
+	WorktreePath string
+	// ParentSHA is the last checkpoint known by the coordinator.
+	ParentSHA string
+	// Message is the human-readable portion of the checkpoint commit message.
+	Message string
+}
+
+// CheckpointResult identifies the immutable commit created or recovered by a
+// checkpoint operation.
+type CheckpointResult struct {
+	// SHA is the full commit identity.
+	SHA string
+	// Created reports whether this call created a new commit.
+	Created bool
+}
+
+// PushRequest selects one run branch for a host-side push.
+type PushRequest struct {
+	// WorktreePath is the run worktree whose current HEAD is pushed.
+	WorktreePath string
+	// Branch is the exact remote branch name to update.
+	Branch string
+}
+
+// BaseSyncRequest selects a fast-forward-only synchronization with a remote
+// target branch.
+type BaseSyncRequest struct {
+	// WorktreePath is the run worktree to update.
+	WorktreePath string
+	// TargetBranch is the remote branch to fetch and merge.
+	TargetBranch string
+}
+
 // WorktreeState is the coordinator-observed state used to validate a harness
 // handoff against the actual checkout.
 type WorktreeState struct {
@@ -39,6 +77,17 @@ type WorktreeManager interface {
 type WorktreeInspector interface {
 	// Inspect reads the current commit and changed paths without mutating Git.
 	Inspect(context.Context, string) (WorktreeState, error)
+}
+
+// GitWorkspace is the task-oriented host Git seam used by the coordinator.
+// It keeps branch/worktree creation, validation, checkpoints, base
+// synchronization, pushes, and cleanup out of workflow code and workers.
+type GitWorkspace interface {
+	WorktreeManager
+	WorktreeInspector
+	CreateCheckpoint(context.Context, CheckpointRequest) (CheckpointResult, error)
+	Push(context.Context, PushRequest) error
+	SynchronizeBase(context.Context, BaseSyncRequest) error
 }
 
 // CommandRunner is the executable seam for host-side Git commands.
@@ -77,6 +126,14 @@ type LocalWorktreeManager struct {
 
 // NewWorktreeManager returns a Git-backed worktree manager.
 func NewWorktreeManager() *LocalWorktreeManager { return &LocalWorktreeManager{} }
+
+// NewGitWorkspace returns the host-side Git workspace adapter.
+func NewGitWorkspace() *LocalWorktreeManager { return NewWorktreeManager() }
+
+// LocalGitWorkspace is the host-side Git workspace implementation. The alias
+// preserves the existing LocalWorktreeManager name for callers of earlier
+// foundation stages.
+type LocalGitWorkspace = LocalWorktreeManager
 
 // Inspect reads the current HEAD and porcelain status of one run worktree.
 func (m *LocalWorktreeManager) Inspect(ctx context.Context, worktreePath string) (WorktreeState, error) {
@@ -147,6 +204,129 @@ func (m *LocalWorktreeManager) Create(ctx context.Context, repositoryPath, targe
 	return Workspace{BaseSHA: baseSHA, Branch: branch, Worktree: worktree}, nil
 }
 
+// CreateCheckpoint validates the run worktree and creates one host-side
+// implementation commit. A checkpoint marker makes retries recover the
+// original commit rather than creating a duplicate.
+func (m *LocalWorktreeManager) CreateCheckpoint(ctx context.Context, request CheckpointRequest) (CheckpointResult, error) {
+	if strings.TrimSpace(request.RunID) == "" {
+		return CheckpointResult{}, errors.New("checkpoint run id is required")
+	}
+	if err := validateRefPart(request.RunID); err != nil {
+		return CheckpointResult{}, fmt.Errorf("checkpoint run id: %w", err)
+	}
+	if strings.TrimSpace(request.WorktreePath) == "" {
+		return CheckpointResult{}, errors.New("checkpoint worktree path is required")
+	}
+	if !filepath.IsAbs(request.WorktreePath) {
+		return CheckpointResult{}, errors.New("checkpoint worktree path must be absolute")
+	}
+	if !validCommitSHA(request.ParentSHA) {
+		return CheckpointResult{}, errors.New("checkpoint parent SHA must be a full commit identity")
+	}
+	message := strings.TrimSpace(request.Message)
+	if strings.ContainsRune(message, '\x00') {
+		return CheckpointResult{}, errors.New("checkpoint message contains a NUL byte")
+	}
+	marker := "factory: implementation checkpoint " + request.RunID
+	state, err := m.Inspect(ctx, request.WorktreePath)
+	if err != nil {
+		return CheckpointResult{}, fmt.Errorf("inspect worktree before checkpoint: %w", err)
+	}
+	if state.HeadSHA != request.ParentSHA {
+		if m.hasCheckpointMarker(ctx, request.WorktreePath, marker) {
+			if len(state.ChangedPaths) != 0 {
+				return CheckpointResult{}, errors.New("worktree has changes after the existing implementation checkpoint")
+			}
+			return CheckpointResult{SHA: state.HeadSHA}, nil
+		}
+		return CheckpointResult{}, fmt.Errorf("worktree HEAD %q does not match checkpoint parent %q", state.HeadSHA, request.ParentSHA)
+	}
+	if len(state.ChangedPaths) == 0 {
+		if m.hasCheckpointMarker(ctx, request.WorktreePath, marker) {
+			return CheckpointResult{SHA: state.HeadSHA}, nil
+		}
+		return CheckpointResult{}, errors.New("worktree has no implementation changes to checkpoint")
+	}
+	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"diff", "--check"}); err != nil {
+		return CheckpointResult{}, fmt.Errorf("validate worktree before checkpoint: %w", err)
+	}
+	commitMessage := marker
+	if message != "" {
+		commitMessage += "\n\n" + message
+	}
+	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"add", "--all", "--"}); err != nil {
+		return CheckpointResult{}, fmt.Errorf("stage implementation checkpoint: %w", err)
+	}
+	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"commit", "--message", commitMessage}); err != nil {
+		return CheckpointResult{}, fmt.Errorf("create implementation checkpoint: %w", err)
+	}
+	headOutput, err := m.runner().Run(ctx, request.WorktreePath, []string{"rev-parse", "HEAD"})
+	if err != nil {
+		return CheckpointResult{}, fmt.Errorf("resolve implementation checkpoint: %w", err)
+	}
+	head := strings.TrimSpace(string(headOutput))
+	if !validCommitSHA(head) {
+		return CheckpointResult{}, errors.New("implementation checkpoint did not produce a full commit identity")
+	}
+	return CheckpointResult{SHA: head, Created: true}, nil
+}
+
+// Push publishes the current run worktree HEAD to its named remote branch
+// without force-pushing or changing the ordinary checkout.
+func (m *LocalWorktreeManager) Push(ctx context.Context, request PushRequest) error {
+	if strings.TrimSpace(request.WorktreePath) == "" {
+		return errors.New("push worktree path is required")
+	}
+	if !filepath.IsAbs(request.WorktreePath) {
+		return errors.New("push worktree path must be absolute")
+	}
+	if strings.TrimSpace(request.Branch) == "" {
+		return errors.New("push branch is required")
+	}
+	if err := validateRefPart(request.Branch); err != nil {
+		return fmt.Errorf("push branch: %w", err)
+	}
+	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"push", "--set-upstream", "origin", "HEAD:refs/heads/" + request.Branch}); err != nil {
+		return fmt.Errorf("push run branch %q: %w", request.Branch, err)
+	}
+	return nil
+}
+
+// SynchronizeBase fetches the named target branch and fast-forwards the run
+// worktree to it. It never rebases or force-updates a run branch.
+func (m *LocalWorktreeManager) SynchronizeBase(ctx context.Context, request BaseSyncRequest) error {
+	if strings.TrimSpace(request.WorktreePath) == "" {
+		return errors.New("base synchronization worktree path is required")
+	}
+	if !filepath.IsAbs(request.WorktreePath) {
+		return errors.New("base synchronization worktree path must be absolute")
+	}
+	if strings.TrimSpace(request.TargetBranch) == "" {
+		return errors.New("base synchronization target branch is required")
+	}
+	if err := validateRefPart(request.TargetBranch); err != nil {
+		return fmt.Errorf("base synchronization target branch: %w", err)
+	}
+	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"fetch", "--no-tags", "origin", "refs/heads/" + request.TargetBranch}); err != nil {
+		return fmt.Errorf("fetch base branch %q: %w", request.TargetBranch, err)
+	}
+	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"merge", "--ff-only", "FETCH_HEAD"}); err != nil {
+		return fmt.Errorf("fast-forward base branch %q: %w", request.TargetBranch, err)
+	}
+	return nil
+}
+
+// hasCheckpointMarker reports whether the current commit carries the marker
+// used to make a repeated checkpoint request idempotent.
+func (m *LocalWorktreeManager) hasCheckpointMarker(ctx context.Context, worktreePath, marker string) bool {
+	output, err := m.runner().Run(ctx, worktreePath, []string{"log", "-1", "--format=%B"})
+	if err != nil {
+		return false
+	}
+	firstLine := strings.SplitN(strings.TrimSpace(string(output)), "\n", 2)[0]
+	return firstLine == marker
+}
+
 // Remove deletes a run worktree and its factory branch after a claim failure.
 // It attempts both operations so a partial cleanup still reports every error.
 func (m *LocalWorktreeManager) Remove(ctx context.Context, repositoryPath string, workspace Workspace) error {
@@ -214,4 +394,18 @@ func validateRefPart(value string) error {
 		return fmt.Errorf("contains characters that cannot be used safely: %q", value)
 	}
 	return nil
+}
+
+// validCommitSHA reports whether value is a full SHA-1 or SHA-256 identity.
+func validCommitSHA(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, character := range value {
+		if (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f') {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -81,6 +81,129 @@ func TestLocalWorktreeManagerCreatesFromFetchedTargetWithoutChangingOrdinaryChec
 	}
 }
 
+// TestLocalGitWorkspaceCreatesOneImplementationCheckpoint verifies the host
+// Git seam commits the worktree's changes and returns the resulting full SHA.
+func TestLocalGitWorkspaceCreatesOneImplementationCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repository := filepath.Join(root, "project")
+	remote := filepath.Join(root, "project-origin.git")
+	initializeGitRepository(t, repository, remote)
+	manager := &gitadapter.LocalWorktreeManager{WorktreeDir: filepath.Join(root, "worktrees")}
+	workspace, err := manager.Create(context.Background(), repository, "main", "run-checkpoint")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace.Worktree, "implementation.txt"), []byte("implemented\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checkpoint, err := manager.CreateCheckpoint(context.Background(), gitadapter.CheckpointRequest{
+		RunID:        "run-checkpoint",
+		WorktreePath: workspace.Worktree,
+		ParentSHA:    workspace.BaseSHA,
+		Message:      "implementation checkpoint",
+	})
+	if err != nil {
+		t.Fatalf("CreateCheckpoint() error = %v", err)
+	}
+	if !validCommitSHA(checkpoint.SHA) || !checkpoint.Created {
+		t.Fatalf("checkpoint = %#v, want a new full-SHA checkpoint", checkpoint)
+	}
+	if got := strings.TrimSpace(runGit(t, workspace.Worktree, "log", "-1", "--format=%B")); got != "factory: implementation checkpoint run-checkpoint\n\nimplementation checkpoint" {
+		t.Fatalf("checkpoint message = %q, want factory marker and supplied message", got)
+	}
+
+	repeated, err := manager.CreateCheckpoint(context.Background(), gitadapter.CheckpointRequest{
+		RunID:        "run-checkpoint",
+		WorktreePath: workspace.Worktree,
+		ParentSHA:    workspace.BaseSHA,
+		Message:      "implementation checkpoint",
+	})
+	if err != nil {
+		t.Fatalf("repeated CreateCheckpoint() error = %v", err)
+	}
+	if repeated.SHA != checkpoint.SHA || repeated.Created {
+		t.Fatalf("repeated checkpoint = %#v, want the original SHA without a second commit", repeated)
+	}
+	if got := strings.TrimSpace(runGit(t, workspace.Worktree, "rev-list", "--count", "HEAD")); got != "2" {
+		t.Fatalf("commit count = %q, want one implementation commit", got)
+	}
+
+	if err := manager.Remove(context.Background(), repository, workspace); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+}
+
+// TestLocalGitWorkspacePushesOnlyTheNamedRunBranch verifies the push command
+// is host-side, non-forcing, and targets the run branch explicitly.
+func TestLocalGitWorkspacePushesOnlyTheNamedRunBranch(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repository := filepath.Join(root, "project")
+	remote := filepath.Join(root, "project-origin.git")
+	initializeGitRepository(t, repository, remote)
+	manager := &gitadapter.LocalWorktreeManager{WorktreeDir: filepath.Join(root, "worktrees")}
+	workspace, err := manager.Create(context.Background(), repository, "main", "run-push")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace.Worktree, "implementation.txt"), []byte("implemented\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.CreateCheckpoint(context.Background(), gitadapter.CheckpointRequest{
+		RunID: "run-push", WorktreePath: workspace.Worktree, ParentSHA: workspace.BaseSHA,
+	}); err != nil {
+		t.Fatalf("CreateCheckpoint() error = %v", err)
+	}
+	if err := manager.Push(context.Background(), gitadapter.PushRequest{WorktreePath: workspace.Worktree, Branch: workspace.Branch}); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+	if got := strings.TrimSpace(runGit(t, root, "--git-dir", remote, "rev-parse", "refs/heads/"+workspace.Branch)); got != strings.TrimSpace(runGit(t, workspace.Worktree, "rev-parse", "HEAD")) {
+		t.Fatalf("remote run branch = %q, want worktree HEAD", got)
+	}
+
+	if err := manager.Remove(context.Background(), repository, workspace); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+}
+
+// initializeGitRepository creates a disposable repository with an origin and
+// a configured commit identity for adapter integration tests.
+func initializeGitRepository(t *testing.T, repository, remote string) {
+	t.Helper()
+	runGit(t, filepath.Dir(repository), "init", "--bare", remote)
+	if err := os.MkdirAll(repository, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repository, "init", "-b", "main")
+	runGit(t, repository, "config", "user.email", "factory@example.test")
+	runGit(t, repository, "config", "user.name", "Factory Test")
+	if err := os.WriteFile(filepath.Join(repository, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repository, "add", "README.md")
+	runGit(t, repository, "commit", "-m", "initial")
+	runGit(t, repository, "remote", "add", "origin", remote)
+	runGit(t, repository, "push", "origin", "main")
+}
+
+// validCommitSHA reports whether a test value is a full Git object identity.
+func validCommitSHA(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, character := range value {
+		if (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 // runGit executes one Git command in a temporary test repository.
 func runGit(t *testing.T, directory string, args ...string) string {
 	t.Helper()

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -72,6 +72,42 @@ type Comment struct {
 	Body string
 }
 
+// PullRequest is the pull-request identity and body returned to the
+// coordinator after a host-side GitHub operation.
+type PullRequest struct {
+	// Number is the repository-local pull-request number.
+	Number int
+	// URL is the browser URL for operator supervision.
+	URL string
+	// Title is the pull-request title.
+	Title string
+	// Body is the current complete pull-request body.
+	Body string
+	// State is the GitHub lifecycle state.
+	State string
+	// Draft reports whether GitHub marks the pull request as a draft.
+	Draft bool
+	// HeadBranch is the source branch name.
+	HeadBranch string
+	// BaseBranch is the target branch name.
+	BaseBranch string
+}
+
+// PullRequestRequest contains the stable fields used to create or update a
+// draft pull request.
+type PullRequestRequest struct {
+	// Title is the pull-request title.
+	Title string
+	// Body is the complete body, including any preserved human-authored text.
+	Body string
+	// HeadBranch is the source branch to publish.
+	HeadBranch string
+	// BaseBranch is the target branch to merge into.
+	BaseBranch string
+	// Draft requests a draft pull request on creation and update.
+	Draft bool
+}
+
 // CommitStatusState is the GitHub state vocabulary used for deterministic
 // checkpoint results.
 type CommitStatusState string
@@ -117,6 +153,15 @@ type Client interface {
 	CreateIssueComment(context.Context, Repository, int, string) (Comment, error)
 	FindStatusComment(context.Context, Repository, int, string) (Comment, error)
 	EditIssueComment(context.Context, Repository, string, string) error
+}
+
+// PullRequestClient is the host-side seam for idempotent draft pull-request
+// discovery and mutation. It is separate from Client so existing issue/state
+// adapters do not gain GitHub pull-request authority accidentally.
+type PullRequestClient interface {
+	FindPullRequest(context.Context, Repository, string, string) (PullRequest, error)
+	CreatePullRequest(context.Context, Repository, PullRequestRequest) (PullRequest, error)
+	UpdatePullRequest(context.Context, Repository, int, PullRequestRequest) (PullRequest, error)
 }
 
 // CommandRunner is the executable seam for the local GitHub CLI adapter.
@@ -258,6 +303,69 @@ func (c *GhClient) EditIssueComment(ctx context.Context, repository Repository, 
 	return nil
 }
 
+// FindPullRequest finds the pull request for one exact source/target branch
+// pair, including closed pull requests so a retry cannot create a duplicate.
+func (c *GhClient) FindPullRequest(ctx context.Context, repository Repository, headBranch, baseBranch string) (PullRequest, error) {
+	if err := validatePullRequestBranches(headBranch, baseBranch); err != nil {
+		return PullRequest{}, err
+	}
+	args := []string{
+		"api", fmt.Sprintf("repos/%s/pulls", repository.String()),
+		"--paginate", "--slurp",
+		"-f", "state=all",
+		"-f", "head=" + repository.Owner + ":" + headBranch,
+		"-f", "base=" + baseBranch,
+	}
+	output, err := c.callBytes(ctx, args, nil)
+	if err != nil {
+		return PullRequest{}, fmt.Errorf("find pull request for %q: %w", headBranch, err)
+	}
+	responses, err := decodePullRequestList(output)
+	if err != nil {
+		return PullRequest{}, fmt.Errorf("decode pull requests for %q: %w", headBranch, err)
+	}
+	for _, response := range responses {
+		pullRequest := response.pullRequest()
+		if pullRequest.HeadBranch == headBranch && pullRequest.BaseBranch == baseBranch {
+			return pullRequest, nil
+		}
+	}
+	return PullRequest{}, nil
+}
+
+// CreatePullRequest creates one draft pull request from a pushed run branch.
+func (c *GhClient) CreatePullRequest(ctx context.Context, repository Repository, request PullRequestRequest) (PullRequest, error) {
+	if err := validatePullRequestRequest(request); err != nil {
+		return PullRequest{}, err
+	}
+	var response pullRequestResponse
+	payload := pullRequestCreatePayload{
+		Title: request.Title, Body: request.Body, Head: request.HeadBranch,
+		Base: request.BaseBranch, Draft: request.Draft,
+	}
+	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/pulls", repository.String()), "--method", "POST"}, payload, &response); err != nil {
+		return PullRequest{}, fmt.Errorf("create draft pull request: %w", err)
+	}
+	return response.pullRequest(), nil
+}
+
+// UpdatePullRequest replaces the complete body and keeps the pull request a
+// draft. The caller supplies a body with its human-authored portion preserved.
+func (c *GhClient) UpdatePullRequest(ctx context.Context, repository Repository, number int, request PullRequestRequest) (PullRequest, error) {
+	if number <= 0 {
+		return PullRequest{}, errors.New("pull request number must be positive")
+	}
+	if err := validatePullRequestRequest(request); err != nil {
+		return PullRequest{}, err
+	}
+	var response pullRequestResponse
+	payload := pullRequestUpdatePayload{Title: request.Title, Body: request.Body, Draft: request.Draft, State: "open"}
+	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/pulls/%d", repository.String(), number), "--method", "PATCH"}, payload, &response); err != nil {
+		return PullRequest{}, fmt.Errorf("update draft pull request #%d: %w", number, err)
+	}
+	return response.pullRequest(), nil
+}
+
 // CreateCommitStatus publishes one deterministic result for an exact commit.
 // The status context is caller-defined but must be stable and single-line.
 func (c *GhClient) CreateCommitStatus(ctx context.Context, repository Repository, status CommitStatus) error {
@@ -353,4 +461,89 @@ type issueResponse struct {
 type commentResponse struct {
 	ID   int64  `json:"id"`
 	Body string `json:"body"`
+}
+
+// pullRequestResponse is the GitHub API subset used by the factory.
+type pullRequestResponse struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	Title   string `json:"title"`
+	Body    string `json:"body"`
+	State   string `json:"state"`
+	Draft   bool   `json:"draft"`
+	Head    struct {
+		Ref string `json:"ref"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+}
+
+// pullRequestCreatePayload is the GitHub API create request shape.
+type pullRequestCreatePayload struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+	Draft bool   `json:"draft"`
+}
+
+// pullRequestUpdatePayload is the GitHub API update request shape.
+type pullRequestUpdatePayload struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	Draft bool   `json:"draft"`
+	State string `json:"state"`
+}
+
+// pullRequest converts an API response into the adapter-neutral model.
+func (r pullRequestResponse) pullRequest() PullRequest {
+	return PullRequest{
+		Number: r.Number, URL: r.HTMLURL, Title: r.Title, Body: r.Body,
+		State: r.State, Draft: r.Draft, HeadBranch: r.Head.Ref, BaseBranch: r.Base.Ref,
+	}
+}
+
+// decodePullRequestList accepts both gh --slurp pagination output and a plain
+// single-page array, which keeps the adapter tolerant of test and CLI modes.
+func decodePullRequestList(output []byte) ([]pullRequestResponse, error) {
+	var pages [][]pullRequestResponse
+	if err := json.Unmarshal(output, &pages); err == nil {
+		result := make([]pullRequestResponse, 0)
+		for _, page := range pages {
+			result = append(result, page...)
+		}
+		return result, nil
+	}
+	var singlePage []pullRequestResponse
+	if err := json.Unmarshal(output, &singlePage); err != nil {
+		return nil, err
+	}
+	return singlePage, nil
+}
+
+// validatePullRequestBranches rejects values that could alter an API request
+// while permitting normal Git branch slashes.
+func validatePullRequestBranches(headBranch, baseBranch string) error {
+	for field, value := range map[string]string{"head branch": headBranch, "base branch": baseBranch} {
+		if strings.TrimSpace(value) == "" || strings.ContainsAny(value, "\x00\r\n") {
+			return fmt.Errorf("pull request %s is required and must be a single line", field)
+		}
+	}
+	return nil
+}
+
+// validatePullRequestRequest validates the fields used by a create or update
+// mutation before invoking the authenticated GitHub CLI.
+func validatePullRequestRequest(request PullRequestRequest) error {
+	if strings.TrimSpace(request.Title) == "" || strings.ContainsAny(request.Title, "\x00\r\n") {
+		return errors.New("pull request title is required and must be a single line")
+	}
+	if err := validatePullRequestBranches(request.HeadBranch, request.BaseBranch); err != nil {
+		return err
+	}
+	if strings.ContainsRune(request.Body, '\x00') {
+		return errors.New("pull request body contains a NUL byte")
+	}
+	return nil
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -349,8 +349,9 @@ func (c *GhClient) CreatePullRequest(ctx context.Context, repository Repository,
 	return response.pullRequest(), nil
 }
 
-// UpdatePullRequest replaces the complete body and keeps the pull request a
-// draft. The caller supplies a body with its human-authored portion preserved.
+// UpdatePullRequest replaces the complete body and title.
+// It preserves the current state of closed pull requests and does not include
+// the Draft field in PATCH payloads to avoid state conflicts.
 func (c *GhClient) UpdatePullRequest(ctx context.Context, repository Repository, number int, request PullRequestRequest) (PullRequest, error) {
 	if number <= 0 {
 		return PullRequest{}, errors.New("pull request number must be positive")
@@ -358,8 +359,17 @@ func (c *GhClient) UpdatePullRequest(ctx context.Context, repository Repository,
 	if err := validatePullRequestRequest(request); err != nil {
 		return PullRequest{}, err
 	}
+	// Fetch current PR state to detect closed pull requests
+	var currentResponse pullRequestResponse
+	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/pulls/%d", repository.String(), number)}, nil, &currentResponse); err != nil {
+		return PullRequest{}, fmt.Errorf("fetch pull request #%d state: %w", number, err)
+	}
 	var response pullRequestResponse
-	payload := pullRequestUpdatePayload{Title: request.Title, Body: request.Body, Draft: request.Draft, State: "open"}
+	payload := pullRequestUpdatePayload{Title: request.Title, Body: request.Body}
+	// Preserve closed state; only PATCH open PRs to open state
+	if currentResponse.State != "closed" {
+		payload.State = "open"
+	}
 	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/pulls/%d", repository.String(), number), "--method", "PATCH"}, payload, &response); err != nil {
 		return PullRequest{}, fmt.Errorf("update draft pull request #%d: %w", number, err)
 	}
@@ -492,8 +502,8 @@ type pullRequestCreatePayload struct {
 type pullRequestUpdatePayload struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
-	Draft bool   `json:"draft"`
-	State string `json:"state"`
+	Draft bool   `json:"draft,omitempty"`
+	State string `json:"state,omitempty"`
 }
 
 // pullRequest converts an API response into the adapter-neutral model.

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -140,6 +140,68 @@ func TestGhClientPublishesAnExactCommitStatus(t *testing.T) {
 	}
 }
 
+// TestGhClientOwnsDraftPullRequestFindCreateAndUpdate verifies that pull
+// request mutations stay inside the host GitHub adapter and use the exact
+// branch/base identity supplied by the coordinator.
+func TestGhClientOwnsDraftPullRequestFindCreateAndUpdate(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeCommandRunner{outputs: [][]byte{
+		[]byte(`[{"number":12,"html_url":"https://github.com/example/project/pull/12","title":"Existing","body":"human text","state":"open","draft":true,"head":{"ref":"factory/run-1"},"base":{"ref":"main"}}]`),
+		[]byte(`{"number":12,"html_url":"https://github.com/example/project/pull/12","title":"Created","body":"generated","state":"open","draft":true,"head":{"ref":"factory/run-1"},"base":{"ref":"main"}}`),
+		[]byte(`{"number":12,"html_url":"https://github.com/example/project/pull/12","title":"Updated","body":"human text\n\ngenerated","state":"open","draft":true,"head":{"ref":"factory/run-1"},"base":{"ref":"main"}}`),
+	}}
+	client := &github.GhClient{Runner: runner}
+	repository := github.Repository{Owner: "example", Name: "project"}
+
+	found, err := client.FindPullRequest(context.Background(), repository, "factory/run-1", "main")
+	if err != nil {
+		t.Fatalf("FindPullRequest() error = %v", err)
+	}
+	if found.Number != 12 || found.HeadBranch != "factory/run-1" || found.BaseBranch != "main" || found.Body != "human text" {
+		t.Fatalf("found pull request = %#v, want decoded identity", found)
+	}
+
+	request := github.PullRequestRequest{Title: "Created", Body: "generated", HeadBranch: "factory/run-1", BaseBranch: "main", Draft: true}
+	created, err := client.CreatePullRequest(context.Background(), repository, request)
+	if err != nil {
+		t.Fatalf("CreatePullRequest() error = %v", err)
+	}
+	if created.Number != 12 || !created.Draft {
+		t.Fatalf("created pull request = %#v, want draft #12", created)
+	}
+
+	updated, err := client.UpdatePullRequest(context.Background(), repository, 12, request)
+	if err != nil {
+		t.Fatalf("UpdatePullRequest() error = %v", err)
+	}
+	if updated.Number != 12 || updated.Body != "human text\n\ngenerated" {
+		t.Fatalf("updated pull request = %#v, want decoded update", updated)
+	}
+	if len(runner.calls) != 3 {
+		t.Fatalf("GitHub calls = %d, want find/create/update", len(runner.calls))
+	}
+	if !containsArgs(runner.calls[0].args, "repos/example/project/pulls", "--paginate", "--slurp") {
+		t.Fatalf("find args = %#v, want paginated pulls endpoint", runner.calls[0].args)
+	}
+	for _, index := range []int{1, 2} {
+		method := "POST"
+		if index == 2 {
+			method = "PATCH"
+		}
+		if !containsArgs(runner.calls[index].args, "--method", method, "--input", "-") {
+			t.Fatalf("mutation args = %#v, want JSON mutation", runner.calls[index].args)
+		}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(runner.calls[1].input, &payload); err != nil {
+		t.Fatalf("decode create payload: %v", err)
+	}
+	if payload["head"] != "factory/run-1" || payload["base"] != "main" || payload["draft"] != true {
+		t.Fatalf("create payload = %#v, want branch/base/draft", payload)
+	}
+}
+
 // TestValidCommitSHARejectsAbbreviatedObjectIDs verifies checkpoint validation
 // does not accept intermediate-length values as exact commit identities.
 func TestValidCommitSHARejectsAbbreviatedObjectIDs(t *testing.T) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -149,6 +149,7 @@ func TestGhClientOwnsDraftPullRequestFindCreateAndUpdate(t *testing.T) {
 	runner := &fakeCommandRunner{outputs: [][]byte{
 		[]byte(`[{"number":12,"html_url":"https://github.com/example/project/pull/12","title":"Existing","body":"human text","state":"open","draft":true,"head":{"ref":"factory/run-1"},"base":{"ref":"main"}}]`),
 		[]byte(`{"number":12,"html_url":"https://github.com/example/project/pull/12","title":"Created","body":"generated","state":"open","draft":true,"head":{"ref":"factory/run-1"},"base":{"ref":"main"}}`),
+		[]byte(`{"number":12,"html_url":"https://github.com/example/project/pull/12","title":"Existing","body":"human text","state":"open","draft":true,"head":{"ref":"factory/run-1"},"base":{"ref":"main"}}`),
 		[]byte(`{"number":12,"html_url":"https://github.com/example/project/pull/12","title":"Updated","body":"human text\n\ngenerated","state":"open","draft":true,"head":{"ref":"factory/run-1"},"base":{"ref":"main"}}`),
 	}}
 	client := &github.GhClient{Runner: runner}
@@ -178,20 +179,23 @@ func TestGhClientOwnsDraftPullRequestFindCreateAndUpdate(t *testing.T) {
 	if updated.Number != 12 || updated.Body != "human text\n\ngenerated" {
 		t.Fatalf("updated pull request = %#v, want decoded update", updated)
 	}
-	if len(runner.calls) != 3 {
-		t.Fatalf("GitHub calls = %d, want find/create/update", len(runner.calls))
+	if len(runner.calls) != 4 {
+		t.Fatalf("GitHub calls = %d, want find/create/update(get+patch)", len(runner.calls))
 	}
 	if !containsArgs(runner.calls[0].args, "repos/example/project/pulls", "--paginate", "--slurp") {
 		t.Fatalf("find args = %#v, want paginated pulls endpoint", runner.calls[0].args)
 	}
-	for _, index := range []int{1, 2} {
-		method := "POST"
-		if index == 2 {
-			method = "PATCH"
-		}
-		if !containsArgs(runner.calls[index].args, "--method", method, "--input", "-") {
-			t.Fatalf("mutation args = %#v, want JSON mutation", runner.calls[index].args)
-		}
+	// Call 1: CreatePullRequest (POST)
+	if !containsArgs(runner.calls[1].args, "--method", "POST", "--input", "-") {
+		t.Fatalf("create args = %#v, want POST mutation", runner.calls[1].args)
+	}
+	// Call 2: UpdatePullRequest GET to fetch current state
+	if !containsArgs(runner.calls[2].args, "repos/example/project/pulls/12") {
+		t.Fatalf("update fetch args = %#v, want GET pulls endpoint", runner.calls[2].args)
+	}
+	// Call 3: UpdatePullRequest PATCH to update
+	if !containsArgs(runner.calls[3].args, "--method", "PATCH", "--input", "-") {
+		t.Fatalf("update patch args = %#v, want PATCH mutation", runner.calls[3].args)
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(runner.calls[1].input, &payload); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 6
+const CurrentSchemaVersion = 7
 
 // runTimestampLayout keeps serialized run timestamps fixed-width so SQLite
 // text ordering matches chronological ordering for sub-second timestamps.
@@ -84,17 +84,21 @@ func (e *UnversionedDatabaseError) Unwrap() error { return e.Err }
 
 // Run is the persisted operational identity and current state of one run.
 type Run struct {
-	ID                  string
-	RepositoryPath      string
-	IssueNumber         int
-	Stage               Stage
-	Status              Status
-	Branch              string
-	Worktree            string
-	CheckpointSHA       string
-	ImageDigest         string
-	Coordinator         string
-	StatusCommentID     string
+	ID              string
+	RepositoryPath  string
+	IssueNumber     int
+	Stage           Stage
+	Status          Status
+	Branch          string
+	Worktree        string
+	CheckpointSHA   string
+	ImageDigest     string
+	Coordinator     string
+	StatusCommentID string
+	// PullRequestNumber is the persisted idempotency identity of the draft PR.
+	PullRequestNumber int
+	// PullRequestURL is the operator-facing URL of the draft PR.
+	PullRequestURL      string
 	SpecificationPacket string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
@@ -237,6 +241,7 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, image_digest, coordinator, status_comment_id,
+		       pull_request_number, pull_request_url,
 		       specification_packet, created_at, updated_at
 		FROM operational_runs
 		WHERE status NOT IN (?, ?, ?)
@@ -251,6 +256,7 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, image_digest, coordinator, status_comment_id,
+		       pull_request_number, pull_request_url,
 		       specification_packet, created_at, updated_at
 		FROM operational_runs
 		ORDER BY updated_at DESC
@@ -274,6 +280,8 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&run.ImageDigest,
 		&run.Coordinator,
 		&run.StatusCommentID,
+		&run.PullRequestNumber,
+		&run.PullRequestURL,
 		&run.SpecificationPacket,
 		&createdAt,
 		&updatedAt,
@@ -316,8 +324,8 @@ func (s *Store) SaveRun(ctx context.Context, run Run) error {
 		INSERT INTO operational_runs (
 			id, repository_path, issue_number, stage, status, branch, worktree,
 			checkpoint_sha, image_digest, coordinator, status_comment_id,
-			specification_packet, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			pull_request_number, pull_request_url, specification_packet, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
 			issue_number = excluded.issue_number,
@@ -329,6 +337,8 @@ func (s *Store) SaveRun(ctx context.Context, run Run) error {
 			image_digest = excluded.image_digest,
 			coordinator = excluded.coordinator,
 			status_comment_id = excluded.status_comment_id,
+			pull_request_number = excluded.pull_request_number,
+			pull_request_url = excluded.pull_request_url,
 			specification_packet = excluded.specification_packet,
 			updated_at = excluded.updated_at`,
 		run.ID,
@@ -342,6 +352,8 @@ func (s *Store) SaveRun(ctx context.Context, run Run) error {
 		run.ImageDigest,
 		run.Coordinator,
 		run.StatusCommentID,
+		run.PullRequestNumber,
+		run.PullRequestURL,
 		run.SpecificationPacket,
 		run.CreatedAt.UTC().Format(runTimestampLayout),
 		run.UpdatedAt.UTC().Format(runTimestampLayout),
@@ -676,6 +688,15 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 				ON invocations (run_id)
 				WHERE status = 'active'`); err != nil {
 				return fmt.Errorf("apply store migration 6: %w", err)
+			}
+		case 7:
+			for _, statement := range []string{
+				"ALTER TABLE operational_runs ADD COLUMN pull_request_number INTEGER NOT NULL DEFAULT 0",
+				"ALTER TABLE operational_runs ADD COLUMN pull_request_url TEXT NOT NULL DEFAULT ''",
+			} {
+				if _, err := tx.ExecContext(ctx, statement); err != nil {
+					return fmt.Errorf("apply store migration 7: %w", err)
+				}
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -422,6 +422,8 @@ func TestSaveRunUpsertsAnExistingRunByID(t *testing.T) {
 	updated := initial
 	updated.Stage = store.StageReview
 	updated.Status = store.StatusWaitingForHuman
+	updated.PullRequestNumber = 17
+	updated.PullRequestURL = "https://github.com/example/project/pull/17"
 	updated.CreatedAt = time.Time{}
 	updated.UpdatedAt = time.Unix(200, 0).UTC()
 	if err := opened.SaveRun(context.Background(), updated); err != nil {
@@ -443,6 +445,9 @@ func TestSaveRunUpsertsAnExistingRunByID(t *testing.T) {
 	}
 	if !got.CreatedAt.Equal(initial.CreatedAt) {
 		t.Fatalf("CreatedAt = %v, want original %v", got.CreatedAt, initial.CreatedAt)
+	}
+	if got.PullRequestNumber != updated.PullRequestNumber || got.PullRequestURL != updated.PullRequestURL {
+		t.Fatalf("pull request identity = #%d %q, want #%d %q", got.PullRequestNumber, got.PullRequestURL, updated.PullRequestNumber, updated.PullRequestURL)
 	}
 }
 


### PR DESCRIPTION
Closes #7

## Summary

- Add host-owned GitWorkspace checkpoint, base synchronization, and first push orchestration.
- Run every frozen gate before pushing and create or regenerate one idempotent draft pull request.
- Preserve human-authored pull-request text outside the generated factory section.
- Persist pull-request identity, update stage/status surfaces, add the draft-pr CLI command, and document the operator-run end-to-end demonstration.

## Verification

- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

The live GitHub/Docker/visible-Codex demonstration is documented as an operator-run check against a disposable repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `factory draft-pr` workflow to validate accepted work, create a checkpoint, run configured gates, push the branch, and create a draft pull request.
  - Repeated runs update the existing draft pull request without duplicating changes and preserve human-authored content.
  - Run status now includes pull-request number and URL.
  - Added support for checkpoint recovery and optional base-branch synchronization.

- **Documentation**
  - Added configuration, workflow, verification, and worker-runtime guidance for draft pull requests and host-side Git operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->