### PR TITLE
Fail closed on interrupted runs before reconciliation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,14 @@ _Avoid_: Live issue, prompt
 An immutable commit representing accepted work at a stage boundary and identifying the exact subject of gates or review.
 _Avoid_: Snapshot, latest code
 
+**Recovery diagnosis**:
+A read-only comparison of one persisted non-terminal run with its registered repository, worktree, Git projection, and GitHub projections.
+_Avoid_: Reconciliation, recovery
+
+**Recovery-required result**:
+A typed fail-closed refusal that reports the agreement state and discovered discrepancies without claiming that the run was recovered; issue #21 supersedes it with complete reconciliation.
+_Avoid_: Recovered run, automatic continuation
+
 **Gate**:
 A repository-declared deterministic command whose result is tied to an exact checkpoint and does not depend on model judgment.
 _Avoid_: Agent check, review

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,6 +192,19 @@ The coordinator then fetches `origin/<target_branch>`, records that fetched comm
 
 The GitHub adapter invokes the locally authenticated `gh` CLI. The coordinator receives issue and mutation results in memory; GitHub credentials are not read into or persisted by the factory. `factory status` reports the active run's stage, status, branch, and worktree, or the latest terminal run when no run is active.
 
+Before any later coordinator command can progress a persisted non-terminal run,
+the new process performs a read-only recovery diagnosis. It compares the run
+identifier, registered repository, worktree, branch, checkpoint SHA, issue
+number and factory state label, marked status-comment identity, and persisted
+pull-request identity when present. A missing or mismatched projection is
+reported alongside every other discovered discrepancy. Even when all sources
+agree, the command returns the typed `recovery-required` result and refuses to
+resume: this version performs no Git, GitHub, worker, terminal, harness, or
+workflow-state mutation and consumes no workflow budget. `factory status`
+remains available and prints the run, agreement state, discrepancies, and safe
+operator actions. Issue #21 explicitly supersedes this boundary with complete
+reconciliation and idempotent effect recovery.
+
 After a claim, `factory agent` starts the visible Codex implementation role and
 prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -361,11 +361,30 @@ func runStatus(ctx context.Context, args []string, defaultConfigPath string, out
 		}
 	} else {
 		label := "active run"
-		if result.LatestRun.Status == store.StatusComplete || result.LatestRun.Status == store.StatusCancelled || result.LatestRun.Status == store.StatusFailed {
+		if store.IsTerminalStatus(result.LatestRun.Status) {
 			label = "last run"
 		}
 		if !writeOutput(output, errorsOutput, "%s: %s (stage=%s status=%s branch=%s worktree=%s)\n", label, result.LatestRun.ID, result.LatestRun.Stage, result.LatestRun.Status, result.LatestRun.Branch, result.LatestRun.Worktree) {
 			return 1
+		}
+	}
+	if result.Recovery != nil {
+		agreement := "disagree"
+		if result.Recovery.SourcesAgree {
+			agreement = "agree"
+		}
+		if !writeOutput(output, errorsOutput, "recovery: %s (run=%s sources=%s)\n", result.Recovery.Code, result.Recovery.RunID, agreement) {
+			return 1
+		}
+		for _, discrepancy := range result.Recovery.Discrepancies {
+			if !writeOutput(output, errorsOutput, "recovery discrepancy: %s.%s expected=%q observed=%q\n", discrepancy.Source, discrepancy.Field, discrepancy.Expected, discrepancy.Observed) {
+				return 1
+			}
+		}
+		for _, action := range result.Recovery.SafeActions {
+			if !writeOutput(output, errorsOutput, "recovery safe action: %s\n", action) {
+				return 1
+			}
 		}
 	}
 	return 0

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -301,29 +301,42 @@ func newAgentService(t *testing.T) (*factory.Service, *agentRunStore, *agentWork
 		t.Fatal(err)
 	}
 	policy := validRepositoryConfig()
-	packetData, err := json.Marshal(factory.SpecificationPacket{Version: 1, Issue: githubIssueFixture(), RepositoryConfig: policy})
-	if err != nil {
-		t.Fatal(err)
-	}
 	created := time.Date(2026, 8, 21, 8, 0, 0, 0, time.UTC)
-	run := store.Run{ID: "run-agent", RepositoryPath: repositoryPath, IssueNumber: 6, Stage: store.StageClaim, Status: store.StatusActive, StatusCommentID: "comment-1", Worktree: worktreePath, CheckpointSHA: "base", ImageDigest: policy.WorkerBuild.Digest, SpecificationPacket: string(packetData), CreatedAt: created, UpdatedAt: created}
 	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{Path: repositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"}, AuthorizedUsers: []string{"alice"}, Polling: config.PollingConfig{Interval: "30s", Backoff: "5m"}, Cmux: config.CmuxConfig{ControlWorkspace: "factory-control"}, OperationalDataPath: filepath.Join(root, "state", "factory.db"), RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml")}}}
-	runStore := &agentRunStore{runs: map[string]store.Run{run.ID: run}, current: &run, invocations: map[string]store.Invocation{}}
+	runStore := &agentRunStore{runs: map[string]store.Run{}, invocations: map[string]store.Invocation{}}
 	runtime := &agentWorker{}
 	terminalRuntime := &agentTerminal{}
 	harnessRuntime := &agentHarness{}
-	githubRuntime := &fakeGitHub{issueValue: githubIssueFixture()}
+	issue := githubIssueFixture()
+	issue.Labels = []string{github.LabelAgentReady}
+	githubRuntime := &fakeGitHub{issueValue: issue}
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: "base", Branch: "factory/run-agent", Worktree: worktreePath}},
+		state:        gitadapter.WorktreeState{Branch: "factory/run-agent", HeadSHA: "base", ChangedPaths: []string{"internal/factory/agent.go"}},
+	}
+	ids := []string{"run-agent", "generated"}
 	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
-		Config:    &fakeConfig{value: host},
-		OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
-		Worker:    runtime,
-		Terminal:  terminalRuntime,
-		Harness:   harnessRuntime,
-		GitHub:    githubRuntime,
-		Now:       func() time.Time { return created },
-		NewRunID:  func() (string, error) { return "generated", nil },
-		Worktree:  &inspectingWorktree{state: gitadapter.WorktreeState{HeadSHA: "base", ChangedPaths: []string{"internal/factory/agent.go"}}},
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		Worker:         runtime,
+		Terminal:       terminalRuntime,
+		Harness:        harnessRuntime,
+		GitHub:         githubRuntime,
+		Now:            func() time.Time { return created },
+		NewRunID: func() (string, error) {
+			if len(ids) == 0 {
+				return "", errors.New("run id fixture exhausted")
+			}
+			id := ids[0]
+			ids = ids[1:]
+			return id, nil
+		},
+		Worktree: worktree,
 	})
+	if _, err := service.ClaimIssue(context.Background(), 6); err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
 	return service, runStore, runtime, terminalRuntime, harnessRuntime
 }
 

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -383,7 +383,30 @@ func (s *Service) openActiveRunStore(ctx context.Context) (config.RepositoryRegi
 		_ = runStore.Close()
 		return config.RepositoryRegistration{}, nil, nil, err
 	}
+	if err := s.ensureProgressionStartup(ctx, registration, run); err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
 	return registration, runStore, run, nil
+}
+
+// ensureProgressionStartup performs the one read-only startup guard for a
+// service instance. A service that found no interrupted run may continue a run
+// it claims during that same process; a fresh service refuses every persisted
+// non-terminal run until issue #21 supplies reconciliation.
+func (s *Service) ensureProgressionStartup(ctx context.Context, registration config.RepositoryRegistration, run *store.Run) error {
+	s.startupMu.Lock()
+	defer s.startupMu.Unlock()
+	if s.startupChecked {
+		return s.startupErr
+	}
+	s.startupChecked = true
+	if run == nil || store.IsTerminalStatus(run.Status) {
+		return nil
+	}
+	diagnosis := s.diagnoseInterruptedRun(ctx, registration, *run)
+	s.startupErr = recoveryRequiredError(diagnosis)
+	return s.startupErr
 }
 
 // failClaim records a terminal failure and best-effort moves the issue label

--- a/internal/factory/claim_test.go
+++ b/internal/factory/claim_test.go
@@ -259,20 +259,14 @@ func TestClaimPreservesTheOriginalErrorWhenWorkspaceCleanupFails(t *testing.T) {
 func TestTransitionEditsThePersistedStatusCommentAndKeepsStageAndStatusSeparate(t *testing.T) {
 	t.Parallel()
 
-	runStore := &fakeRunStore{saved: []store.Run{{
-		ID:              "run-fixed",
-		RepositoryPath:  "/repo",
-		IssueNumber:     42,
-		Stage:           store.StageClaim,
-		Status:          store.StatusActive,
-		Branch:          "factory/run-fixed",
-		Worktree:        "/worktree/run-fixed",
-		Coordinator:     "coordinator-test",
-		StatusCommentID: "comment-1",
-		CreatedAt:       time.Date(2026, 8, 20, 10, 11, 12, 0, time.UTC),
-	}}}
-	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 42, State: "open", Labels: []string{"enhancement", github.LabelAgentRunning}}}
-	service := newClaimService(githubAdapter, &fakeWorktree{}, runStore, validRepositoryConfig())
+	runStore := &fakeRunStore{}
+	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 42, State: "open", Labels: []string{"enhancement", github.LabelAgentReady}}}
+	worktree := &fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed"}}
+	service := newClaimService(githubAdapter, worktree, runStore, validRepositoryConfig())
+	if _, err := service.ClaimIssue(context.Background(), 42); err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	githubAdapter.createdComments = nil
 
 	got, err := service.Transition(context.Background(), factory.TransitionRequest{
 		RunID:  "run-fixed",
@@ -304,22 +298,17 @@ func TestTransitionEditsThePersistedStatusCommentAndKeepsStageAndStatusSeparate(
 func TestTransitionRecoversACommentIdentityAfterAnInterruptedPersistence(t *testing.T) {
 	t.Parallel()
 
-	runStore := &fakeRunStore{saved: []store.Run{{
-		ID:             "run-fixed",
-		RepositoryPath: "/repo",
-		IssueNumber:    42,
-		Stage:          store.StageClaim,
-		Status:         store.StatusActive,
-		Branch:         "factory/run-fixed",
-		Worktree:       "/worktree/run-fixed",
-		Coordinator:    "coordinator-test",
-		CreatedAt:      time.Date(2026, 8, 20, 10, 11, 12, 0, time.UTC),
-	}}}
+	runStore := &fakeRunStore{}
 	githubAdapter := &fakeGitHub{
-		issueValue:    github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}},
+		issueValue:    github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentReady}},
 		statusComment: github.Comment{ID: "comment-recovered", Body: "old status"},
 	}
-	service := newClaimService(githubAdapter, &fakeWorktree{}, runStore, validRepositoryConfig())
+	worktree := &fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed"}}
+	service := newClaimService(githubAdapter, worktree, runStore, validRepositoryConfig())
+	if _, err := service.ClaimIssue(context.Background(), 42); err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	runStore.saved[len(runStore.saved)-1].StatusCommentID = ""
 
 	got, err := service.Transition(context.Background(), factory.TransitionRequest{Stage: store.StageImplementation, Status: store.StatusActive})
 	if err != nil {

--- a/internal/factory/draft_pr_test.go
+++ b/internal/factory/draft_pr_test.go
@@ -2,7 +2,6 @@ package factory_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -43,21 +42,12 @@ func TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft(t *
 		{Name: "format", Command: "format", Timeout: "5m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean},
 		{Name: "test", Command: "test", Timeout: "5m", Blocking: true, DependsOn: []string{"format"}, EnvironmentPolicy: config.EnvironmentPolicyClean},
 	}
-	packetData, err := json.Marshal(factory.SpecificationPacket{
-		Version:          1,
-		Issue:            github.Issue{Number: 42, Title: "Add the factory handoff", Body: "Implement the supervised draft PR boundary."},
-		RepositoryConfig: policy,
-	})
-	if err != nil {
-		t.Fatal(err)
+	runStore := &fakeRunStore{}
+	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 42, Title: "Add the factory handoff", Body: "Implement the supervised draft PR boundary.", State: "open", Labels: []string{github.LabelAgentReady}}}
+	workspace := &draftGitWorkspace{
+		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-draft", Worktree: worktreePath},
+		state:     gitadapter.WorktreeState{Branch: "factory/run-draft", HeadSHA: factoryGateCheckpoint, ChangedPaths: []string{"internal/factory.go"}},
 	}
-	runStore := &fakeRunStore{saved: []store.Run{{
-		ID: "run-draft", RepositoryPath: "/repo", IssueNumber: 42, Stage: store.StageImplementation, Status: store.StatusActive,
-		Branch: "factory/run-draft", Worktree: worktreePath, CheckpointSHA: factoryGateCheckpoint, ImageDigest: policy.WorkerBuild.Digest,
-		StatusCommentID: "comment-1", SpecificationPacket: string(packetData), CreatedAt: time.Date(2026, 8, 21, 10, 0, 0, 0, time.UTC),
-	}}}
-	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 42, Title: "Add the factory handoff", State: "open", Labels: []string{github.LabelAgentRunning}}}
-	workspace := &draftGitWorkspace{state: gitadapter.WorktreeState{HeadSHA: factoryGateCheckpoint, ChangedPaths: []string{"internal/factory.go"}}}
 	workerRuntime := &gateWorker{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}}}
 	statuses := &gateStatuses{}
 	pullRequests := &fakePullRequests{created: github.PullRequest{Number: 17, URL: "https://github.com/example/project/pull/17", State: "open", Draft: true, HeadBranch: "factory/run-draft", BaseBranch: "main"}}
@@ -69,6 +59,7 @@ func TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft(t *
 	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config:         &fakeConfig{value: host},
 		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
 		GitHub:         &fakeGitHubWithPullRequests{fakeGitHub: githubAdapter},
 		PullRequests:   pullRequests,
 		Worktree:       workspace,
@@ -76,9 +67,19 @@ func TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft(t *
 		Worker:         workerRuntime,
 		CommitStatuses: statuses,
 		Now:            func() time.Time { return time.Date(2026, 8, 21, 10, 1, 0, 0, time.UTC) },
+		NewRunID:       func() (string, error) { return "run-draft", nil },
 	})
+	claimed, err := service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	claimed.Run.Stage = store.StageImplementation
+	claimed.Run.Status = store.StatusActive
+	if err := runStore.SaveRun(context.Background(), claimed.Run); err != nil {
+		t.Fatalf("SaveRun() fixture setup error = %v", err)
+	}
 
-	result, err := service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: "run-draft"})
+	result, err := service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: claimed.Run.ID})
 	if err != nil {
 		t.Fatalf("CreateDraftPullRequest() error = %v", err)
 	}
@@ -133,17 +134,26 @@ func TestCreateDraftPullRequestRejectsAnActiveImplementationInvocation(t *testin
 	t.Parallel()
 
 	policy := validRepositoryConfig()
-	packetData, err := json.Marshal(factory.SpecificationPacket{Version: 1, Issue: github.Issue{Number: 42, Title: "Active agent"}, RepositoryConfig: policy})
-	if err != nil {
-		t.Fatal(err)
-	}
-	runStore := &activeInvocationRunStore{fakeRunStore: &fakeRunStore{saved: []store.Run{{ID: "run-active", RepositoryPath: "/repo", IssueNumber: 42, Stage: store.StageImplementation, Status: store.StatusActive, CheckpointSHA: factoryGateCheckpoint, ImageDigest: policy.WorkerBuild.Digest, SpecificationPacket: string(packetData)}}}, active: &store.Invocation{ID: "inv-active", RunID: "run-active", Status: store.InvocationStatusActive}}
+	runStore := &activeInvocationRunStore{fakeRunStore: &fakeRunStore{}, active: &store.Invocation{ID: "inv-active", RunID: "run-active", Status: store.InvocationStatusActive}}
 	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{Path: "/repo", OperationalDataPath: "/outside/factory.db", RepositoryConfigPath: "/repo/factory.yaml"}}}
+	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentReady}}}
+	workspace := &draftGitWorkspace{workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-active", Worktree: "/worktree/run-active"}}
 	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config: &fakeConfig{value: host}, OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
-		GitHub: &fakeGitHub{}, GitWorkspace: &draftGitWorkspace{}, Worktree: &fakeWorktree{},
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		GitHub:         githubAdapter, GitWorkspace: workspace, Worktree: workspace,
+		NewRunID: func() (string, error) { return "run-active", nil },
 	})
-	_, err = service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: "run-active"})
+	claimed, err := service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	claimed.Run.Stage = store.StageImplementation
+	claimed.Run.Status = store.StatusActive
+	if err := runStore.SaveRun(context.Background(), claimed.Run); err != nil {
+		t.Fatalf("SaveRun() fixture setup error = %v", err)
+	}
+	_, err = service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: claimed.Run.ID})
 	if err == nil || !strings.Contains(err.Error(), "still has active implementation invocation") {
 		t.Fatalf("CreateDraftPullRequest() error = %v, want validation before Git effects", err)
 	}
@@ -151,6 +161,7 @@ func TestCreateDraftPullRequestRejectsAnActiveImplementationInvocation(t *testin
 
 // draftGitWorkspace records the host Git effects for coordinator seam tests.
 type draftGitWorkspace struct {
+	workspace   gitadapter.Workspace
 	state       gitadapter.WorktreeState
 	checkpoints []gitadapter.CheckpointRequest
 	pushes      []gitadapter.PushRequest
@@ -169,8 +180,11 @@ func (s *activeInvocationRunStore) ActiveInvocation(context.Context, string) (*s
 }
 
 // Create implements GitWorkspace for the coordinator test.
-func (*draftGitWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
-	return gitadapter.Workspace{}, errors.New("unexpected Create()")
+func (w *draftGitWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	if w.workspace.Branch == "" {
+		return gitadapter.Workspace{}, errors.New("unexpected Create()")
+	}
+	return w.workspace, nil
 }
 
 // Remove implements GitWorkspace for the coordinator test.

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -116,6 +116,9 @@ type Service struct {
 	runtimeMu         sync.Mutex
 	runtimeSocketPath string
 	runtimePathSet    bool
+	startupMu         sync.Mutex
+	startupChecked    bool
+	startupErr        error
 }
 
 type InitResult struct {
@@ -149,6 +152,8 @@ type StatusResult struct {
 	ConfigPath     string
 	RepositoryPath string
 	LatestRun      *store.Run
+	// Recovery contains the read-only diagnosis for an interrupted run.
+	Recovery *RecoveryDiagnosis
 	// Deprecated: use LatestRun.
 	ActiveRun *store.Run
 }
@@ -359,6 +364,10 @@ func (s *Service) Status(ctx context.Context) (StatusResult, error) {
 	result.ActiveRun = result.LatestRun
 	if err != nil {
 		return StatusResult{}, err
+	}
+	if result.LatestRun != nil && !store.IsTerminalStatus(result.LatestRun.Status) {
+		diagnosis := s.diagnoseInterruptedRun(ctx, registration, *result.LatestRun)
+		result.Recovery = &diagnosis
 	}
 	return result, nil
 }

--- a/internal/factory/gate_test.go
+++ b/internal/factory/gate_test.go
@@ -2,15 +2,14 @@ package factory_test
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
-	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
@@ -41,13 +40,6 @@ func TestRunGateStartsThePinnedWorkerAndUsesTheFrozenGate(t *testing.T) {
 	policy := validRepositoryConfig()
 	policy.Setup = "setup-from-frozen-packet"
 	policy.Gates[0].Command = "gate-from-frozen-packet"
-	packetData, err := json.Marshal(factory.SpecificationPacket{
-		Version:          1,
-		RepositoryConfig: policy,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
 	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
 		Path:                 repositoryPath,
 		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
@@ -56,28 +48,32 @@ func TestRunGateStartsThePinnedWorkerAndUsesTheFrozenGate(t *testing.T) {
 		OperationalDataPath:  filepath.Join(root, "state", "factory.db"),
 		RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
 	}}}
-	run := store.Run{
-		ID:                  "run-gate-coordinator",
-		RepositoryPath:      repositoryPath,
-		IssueNumber:         5,
-		Stage:               store.StageClaim,
-		Status:              store.StatusActive,
-		Worktree:            worktreePath,
-		CheckpointSHA:       factoryGateCheckpoint,
-		ImageDigest:         policy.WorkerBuild.Digest,
-		SpecificationPacket: string(packetData),
-	}
+	runStore := &fakeRunStore{}
 	runtime := &gateWorker{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}}}
 	statuses := &gateStatuses{}
+	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 5, State: "open", Labels: []string{github.LabelAgentReady}}}
+	workspace := &draftGitWorkspace{
+		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-gate-coordinator", Worktree: worktreePath},
+		state:     gitadapter.WorktreeState{Branch: "factory/run-gate-coordinator", HeadSHA: factoryGateCheckpoint},
+	}
 	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config: &fakeConfig{value: host},
 		OpenStore: func(context.Context, string) (factory.OperationalStore, error) {
-			return &fakeRunStore{saved: []store.Run{run}}, nil
+			return runStore, nil
 		},
-		GitHub:         &fakeGitHub{},
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		GitHub:         githubAdapter,
+		GitWorkspace:   workspace,
+		Worktree:       workspace,
 		Worker:         runtime,
 		CommitStatuses: statuses,
+		NewRunID:       func() (string, error) { return "run-gate-coordinator", nil },
 	})
+	claimed, err := service.ClaimIssue(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	run := claimed.Run
 
 	result, err := service.RunGate(context.Background(), factory.RunGateRequest{
 		RunID:    run.ID,

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -1,0 +1,317 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// RecoveryRequiredCode is the stable code for the pre-reconciliation safety
+// boundary. Issue #21 supersedes this refusal with complete reconciliation.
+const RecoveryRequiredCode = "recovery-required"
+
+// RecoveryDiscrepancy describes one observed disagreement between persisted
+// run identity and an external projection.
+type RecoveryDiscrepancy struct {
+	// Source identifies the projection that disagrees with persisted state.
+	Source string
+	// Field identifies the identity field that differs.
+	Field string
+	// Expected is the persisted or coordinator-derived value.
+	Expected string
+	// Observed is the value read from the external projection.
+	Observed string
+}
+
+// RecoveryDiagnosis is the read-only result of checking an interrupted run.
+// SourcesAgree may be true while recovery is still required: before issue #21,
+// agreement is diagnosed but never treated as permission to resume.
+type RecoveryDiagnosis struct {
+	// Code is always RecoveryRequiredCode for a non-terminal run.
+	Code string
+	// RunID identifies the interrupted run being diagnosed.
+	RunID string
+	// SourcesAgree reports whether any discovered projection disagreed.
+	SourcesAgree bool
+	// Discrepancies contains every disagreement found during the read-only check.
+	Discrepancies []RecoveryDiscrepancy
+	// SafeActions identifies operator actions that do not claim recovery.
+	SafeActions []string
+}
+
+// RecoveryRequiredError refuses progression for a persisted non-terminal run.
+// It carries the same diagnosis exposed by Status and performs no recovery.
+type RecoveryRequiredError struct {
+	// Diagnosis is the complete read-only startup diagnosis.
+	Diagnosis RecoveryDiagnosis
+}
+
+// Error returns a stable recovery-required message without implying that the
+// coordinator repaired, resumed, or otherwise recovered the run.
+func (e *RecoveryRequiredError) Error() string {
+	if e == nil {
+		return RecoveryRequiredCode
+	}
+	agreement := "sources disagree"
+	if e.Diagnosis.SourcesAgree {
+		agreement = "sources agree"
+	}
+	discrepancyCount := len(e.Diagnosis.Discrepancies)
+	message := fmt.Sprintf("%s: run %q is interrupted; %s; %d discrepancies; no recovery occurred", RecoveryRequiredCode, e.Diagnosis.RunID, agreement, discrepancyCount)
+	if discrepancyCount != 0 {
+		details := make([]string, 0, discrepancyCount)
+		for _, discrepancy := range e.Diagnosis.Discrepancies {
+			details = append(details, fmt.Sprintf("%s.%s expected=%q observed=%q", discrepancy.Source, discrepancy.Field, discrepancy.Expected, discrepancy.Observed))
+		}
+		message += "; discrepancies: " + strings.Join(details, ", ")
+	}
+	if len(e.Diagnosis.SafeActions) != 0 {
+		message += "; safe actions: " + strings.Join(e.Diagnosis.SafeActions, "; ")
+	}
+	return message
+}
+
+// Code returns the machine-readable refusal code.
+func (e *RecoveryRequiredError) Code() string { return RecoveryRequiredCode }
+
+// diagnoseInterruptedRun compares all available persisted and external
+// identity projections without mutating Git, GitHub, the worker, the terminal,
+// the harness, or operational workflow state.
+func (s *Service) diagnoseInterruptedRun(ctx context.Context, registration config.RepositoryRegistration, run store.Run) RecoveryDiagnosis {
+	diagnosis := newRecoveryDiagnosis(run.ID)
+	comparePersistedRunIdentity(&diagnosis, registration.Path, run)
+
+	inspector := s.worktreeInspector()
+	inspectWorktreeProjection(ctx, &diagnosis, inspector, registration.Path, run)
+
+	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	inspectGitHubProjection(ctx, &diagnosis, s.deps.GitHub, s.pullRequestClient(), repository, run)
+	diagnosis.SourcesAgree = len(diagnosis.Discrepancies) == 0
+	return diagnosis
+}
+
+// newRecoveryDiagnosis creates the stable result envelope and operator actions.
+func newRecoveryDiagnosis(runID string) RecoveryDiagnosis {
+	return RecoveryDiagnosis{
+		Code:  RecoveryRequiredCode,
+		RunID: runID,
+		SafeActions: []string{
+			"inspect the diagnosis with `factory status`",
+			"verify the repository, worktree, branch, checkpoint, issue label, status comment, and pull request",
+			"wait for issue #21 before attempting automatic recovery",
+		},
+	}
+}
+
+// comparePersistedRunIdentity validates the values that can be checked before
+// consulting external projections.
+func comparePersistedRunIdentity(diagnosis *RecoveryDiagnosis, repositoryPath string, run store.Run) {
+	if strings.TrimSpace(run.ID) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "identifier", Expected: "non-empty run identifier", Observed: "empty"})
+	}
+	if strings.TrimSpace(run.RepositoryPath) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "repository", Expected: repositoryPath, Observed: "empty"})
+	} else if strings.TrimSpace(repositoryPath) == "" || resolvePath(run.RepositoryPath) != resolvePath(repositoryPath) {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "repository", Expected: repositoryPath, Observed: run.RepositoryPath})
+	}
+	if strings.TrimSpace(run.Worktree) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "worktree", Expected: "non-empty worktree path", Observed: "empty"})
+	} else if !filepath.IsAbs(run.Worktree) {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "worktree", Expected: "absolute worktree path", Observed: run.Worktree})
+	}
+	if strings.TrimSpace(run.Branch) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "branch", Expected: "non-empty branch", Observed: "empty"})
+	} else if strings.TrimSpace(run.ID) != "" {
+		expectedBranch := "factory/" + run.ID
+		if run.Branch != expectedBranch {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "branch identity", Expected: expectedBranch, Observed: run.Branch})
+		}
+	}
+	if strings.TrimSpace(run.CheckpointSHA) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "checkpoint", Expected: "non-empty checkpoint SHA", Observed: "empty"})
+	}
+	if run.IssueNumber <= 0 {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "issue", Expected: "positive issue number", Observed: fmt.Sprintf("%d", run.IssueNumber)})
+	}
+	if run.PullRequestNumber < 0 {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "pull request", Expected: "zero or positive pull-request number", Observed: fmt.Sprintf("%d", run.PullRequestNumber)})
+	}
+	if run.PullRequestNumber == 0 && strings.TrimSpace(run.PullRequestURL) != "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "pull request", Expected: "number for persisted pull-request URL", Observed: run.PullRequestURL})
+	}
+}
+
+// inspectWorktreeProjection compares the persisted checkout identity with a
+// read-only Git inspection and records observation failures as discrepancies.
+func inspectWorktreeProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, inspector gitadapter.WorktreeInspector, repositoryPath string, run store.Run) {
+	if strings.TrimSpace(run.Worktree) == "" || !filepath.IsAbs(run.Worktree) {
+		return
+	}
+	info, err := os.Stat(run.Worktree)
+	if err != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "worktree", Field: "path", Expected: "existing directory", Observed: err.Error()})
+		return
+	}
+	if !info.IsDir() {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "worktree", Field: "path", Expected: "directory", Observed: "not a directory"})
+		return
+	}
+	if inspector == nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "worktree", Field: "inspection", Expected: "read-only Git inspection", Observed: "inspector unavailable"})
+		return
+	}
+	state, err := inspector.Inspect(ctx, run.Worktree)
+	if err != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "worktree", Field: "inspection", Expected: "read-only Git inspection", Observed: err.Error()})
+		return
+	}
+	if strings.TrimSpace(state.RepositoryPath) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "worktree", Field: "repository", Expected: repositoryPath, Observed: "empty"})
+	} else if resolvePath(state.RepositoryPath) != resolvePath(repositoryPath) {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "worktree", Field: "repository", Expected: repositoryPath, Observed: state.RepositoryPath})
+	}
+	if state.Branch != run.Branch {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "worktree", Field: "branch", Expected: run.Branch, Observed: state.Branch})
+	}
+	if state.HeadSHA != run.CheckpointSHA {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "worktree", Field: "checkpoint", Expected: run.CheckpointSHA, Observed: state.HeadSHA})
+	}
+}
+
+// inspectGitHubProjection compares the issue, state label, status comment, and
+// optional pull request through read-only GitHub adapter methods.
+func inspectGitHubProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, client github.Client, pullRequests github.PullRequestClient, repository github.Repository, run store.Run) {
+	if client == nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "client", Expected: "read-only GitHub client", Observed: "client unavailable"})
+		return
+	}
+	issue, err := client.Issue(ctx, repository, run.IssueNumber)
+	if err != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "issue", Expected: fmt.Sprintf("issue #%d", run.IssueNumber), Observed: err.Error()})
+	} else {
+		if issue.Number != run.IssueNumber {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "issue", Expected: fmt.Sprintf("#%d", run.IssueNumber), Observed: fmt.Sprintf("#%d", issue.Number)})
+		}
+		if issue.IsPullRequest {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "issue", Expected: "issue, not pull request", Observed: "pull request"})
+		}
+		expectedLabel := factoryLabelForStatus(run.Status)
+		actualLabels := factoryStateLabels(issue.Labels)
+		if len(actualLabels) != 1 || actualLabels[0] != expectedLabel {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "state label", Expected: expectedLabel, Observed: strings.Join(actualLabels, ", ")})
+		}
+	}
+
+	marker := statusCommentMarker(run.ID)
+	comment, commentErr := client.FindStatusComment(ctx, repository, run.IssueNumber, marker)
+	if commentErr != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: run.StatusCommentID, Observed: commentErr.Error()})
+	} else if strings.TrimSpace(comment.ID) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: run.StatusCommentID, Observed: "missing"})
+	} else if !strings.Contains(comment.Body, marker) {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment marker", Expected: marker, Observed: "marker missing"})
+	} else if strings.TrimSpace(run.StatusCommentID) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: "persisted comment " + comment.ID, Observed: "persisted identity missing"})
+	} else if comment.ID != run.StatusCommentID {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: run.StatusCommentID, Observed: comment.ID})
+	}
+
+	inspectPullRequestProjection(ctx, diagnosis, pullRequests, repository, run)
+}
+
+// inspectPullRequestProjection checks an existing or unexpectedly discovered
+// pull request without creating, updating, or otherwise mutating it.
+func inspectPullRequestProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, pullRequests github.PullRequestClient, repository github.Repository, run store.Run) {
+	hasPersistedIdentity := run.PullRequestNumber > 0 || strings.TrimSpace(run.PullRequestURL) != ""
+	if pullRequests == nil {
+		if hasPersistedIdentity {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "pull request", Expected: "read-only pull-request client", Observed: "client unavailable"})
+		}
+		return
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "specification packet", Expected: "decodable packet for pull-request target", Observed: err.Error()})
+		return
+	}
+	baseBranch := packet.RepositoryConfig.TargetBranch
+	if strings.TrimSpace(baseBranch) == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "target branch", Expected: "non-empty target branch", Observed: "empty"})
+		return
+	}
+	pullRequest, err := pullRequests.FindPullRequest(ctx, repository, run.Branch, baseBranch)
+	if err != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "pull request", Expected: pullRequestIdentity(run), Observed: err.Error()})
+		return
+	}
+	if pullRequest.Number == 0 {
+		if hasPersistedIdentity {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "pull request", Expected: pullRequestIdentity(run), Observed: "missing"})
+		}
+		return
+	}
+	if !hasPersistedIdentity {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "pull request", Expected: "no persisted pull-request identity", Observed: fmt.Sprintf("#%d", pullRequest.Number)})
+		return
+	}
+	if pullRequest.Number != run.PullRequestNumber {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "pull request number", Expected: fmt.Sprintf("#%d", run.PullRequestNumber), Observed: fmt.Sprintf("#%d", pullRequest.Number)})
+	}
+	if strings.TrimSpace(run.PullRequestURL) != "" && pullRequest.URL != run.PullRequestURL {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "pull request URL", Expected: run.PullRequestURL, Observed: pullRequest.URL})
+	}
+	if pullRequest.HeadBranch != "" && pullRequest.HeadBranch != run.Branch {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "pull request head", Expected: run.Branch, Observed: pullRequest.HeadBranch})
+	}
+	if pullRequest.BaseBranch != "" && pullRequest.BaseBranch != baseBranch {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "pull request base", Expected: baseBranch, Observed: pullRequest.BaseBranch})
+	}
+}
+
+// pullRequestIdentity formats the persisted PR identity for diagnostics.
+func pullRequestIdentity(run store.Run) string {
+	if run.PullRequestNumber > 0 && strings.TrimSpace(run.PullRequestURL) != "" {
+		return fmt.Sprintf("#%d %s", run.PullRequestNumber, run.PullRequestURL)
+	}
+	if run.PullRequestNumber > 0 {
+		return fmt.Sprintf("#%d", run.PullRequestNumber)
+	}
+	return run.PullRequestURL
+}
+
+// factoryStateLabels extracts and sorts only labels owned by the factory so a
+// stale or duplicated lifecycle label is visible in a deterministic message.
+func factoryStateLabels(labels []string) []string {
+	result := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if hasLabel(github.FactoryStateLabels, label) {
+			result = append(result, label)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+// addRecoveryDiscrepancy appends one non-empty discrepancy to a diagnosis.
+func addRecoveryDiscrepancy(diagnosis *RecoveryDiagnosis, discrepancy RecoveryDiscrepancy) {
+	if diagnosis == nil {
+		return
+	}
+	if strings.TrimSpace(discrepancy.Source) == "" {
+		discrepancy.Source = "unknown"
+	}
+	diagnosis.Discrepancies = append(diagnosis.Discrepancies, discrepancy)
+}
+
+// recoveryRequiredError wraps a diagnosis in the typed progression refusal.
+func recoveryRequiredError(diagnosis RecoveryDiagnosis) error {
+	return &RecoveryRequiredError{Diagnosis: diagnosis}
+}

--- a/internal/factory/recovery_test.go
+++ b/internal/factory/recovery_test.go
@@ -1,0 +1,253 @@
+package factory_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestProgressionRefusesAnAgreeingInterruptedRun verifies the fail-closed
+// boundary even when every observed projection agrees with the store.
+func TestProgressionRefusesAnAgreeingInterruptedRun(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	worktreePath := filepath.Join(root, "worktree")
+	if err := mkdir(worktreePath); err != nil {
+		t.Fatal(err)
+	}
+	run := recoveryRun(worktreePath)
+	githubAdapter := &fakeGitHub{
+		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: run-recovery -->"},
+	}
+	worktree := &recoveryWorktree{state: gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA}}
+	storeAdapter := &recoveryRunStore{run: run}
+	service := newRecoveryService(t, storeAdapter, githubAdapter, worktree, nil)
+
+	_, err := service.Transition(context.Background(), factory.TransitionRequest{RunID: run.ID, Stage: store.StageImplementation, Status: store.StatusActive})
+	var recoveryErr *factory.RecoveryRequiredError
+	if !errors.As(err, &recoveryErr) {
+		t.Fatalf("Transition() error = %v, want RecoveryRequiredError", err)
+	}
+	if !recoveryErr.Diagnosis.SourcesAgree {
+		t.Fatalf("diagnosis = %#v, want agreeing sources", recoveryErr.Diagnosis)
+	}
+	if len(recoveryErr.Diagnosis.Discrepancies) != 0 {
+		t.Fatalf("discrepancies = %#v, want none", recoveryErr.Diagnosis.Discrepancies)
+	}
+	if recoveryErr.Diagnosis.Code != factory.RecoveryRequiredCode || !strings.Contains(recoveryErr.Error(), "no recovery occurred") {
+		t.Fatalf("recovery error = %q, want typed refusal without recovery", recoveryErr.Error())
+	}
+	if len(storeAdapter.saved) != 0 || len(githubAdapter.replacedHistory) != 0 || len(githubAdapter.editedComments) != 0 {
+		t.Fatalf("progression effects = saved=%d labels=%d comments=%d, want none", len(storeAdapter.saved), len(githubAdapter.replacedHistory), len(githubAdapter.editedComments))
+	}
+}
+
+// TestStatusReportsEveryRecoveryDiscrepancy verifies status remains a
+// read-only diagnosis for the source failures called out by issue 24.
+func TestStatusReportsEveryRecoveryDiscrepancy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configure  func(*store.Run, *recoveryWorktree, *fakeGitHub, *fakePullRequests)
+		wantFields []string
+	}{
+		{
+			name: "missing worktree",
+			configure: func(run *store.Run, _ *recoveryWorktree, _ *fakeGitHub, _ *fakePullRequests) {
+				run.Worktree = filepath.Join(t.TempDir(), "missing")
+			},
+			wantFields: []string{"worktree.path"},
+		},
+		{
+			name: "wrong branch and head",
+			configure: func(run *store.Run, worktree *recoveryWorktree, _ *fakeGitHub, _ *fakePullRequests) {
+				worktree.state.Branch = "factory/other-run"
+				worktree.state.HeadSHA = "different-checkpoint"
+				_ = run
+			},
+			wantFields: []string{"worktree.branch", "worktree.checkpoint"},
+		},
+		{
+			name: "worktree belongs to another repository",
+			configure: func(_ *store.Run, worktree *recoveryWorktree, _ *fakeGitHub, _ *fakePullRequests) {
+				worktree.state.RepositoryPath = "/another-repository"
+			},
+			wantFields: []string{"worktree.repository"},
+		},
+		{
+			name: "stale GitHub label",
+			configure: func(run *store.Run, _ *recoveryWorktree, githubAdapter *fakeGitHub, _ *fakePullRequests) {
+				run.Status = store.StatusWaitingForHuman
+				githubAdapter.issueValue.Labels = []string{github.LabelAgentRunning}
+			},
+			wantFields: []string{"github.state label"},
+		},
+		{
+			name: "missing status comment",
+			configure: func(_ *store.Run, _ *recoveryWorktree, githubAdapter *fakeGitHub, _ *fakePullRequests) {
+				githubAdapter.statusComment = github.Comment{}
+			},
+			wantFields: []string{"github.status comment"},
+		},
+		{
+			name: "mismatched status comment",
+			configure: func(_ *store.Run, _ *recoveryWorktree, githubAdapter *fakeGitHub, _ *fakePullRequests) {
+				githubAdapter.statusComment = github.Comment{ID: "comment-other", Body: "<!-- factory-status: run-recovery -->"}
+			},
+			wantFields: []string{"github.status comment"},
+		},
+		{
+			name: "missing pull request",
+			configure: func(run *store.Run, _ *recoveryWorktree, _ *fakeGitHub, _ *fakePullRequests) {
+				run.PullRequestNumber = 17
+				run.PullRequestURL = "https://github.com/example/project/pull/17"
+			},
+			wantFields: []string{"github.pull request"},
+		},
+		{
+			name: "mismatched pull request",
+			configure: func(run *store.Run, _ *recoveryWorktree, _ *fakeGitHub, pullRequests *fakePullRequests) {
+				run.PullRequestNumber = 17
+				run.PullRequestURL = "https://github.com/example/project/pull/17"
+				pullRequests.existing = github.PullRequest{Number: 18, URL: "https://github.com/example/project/pull/18", HeadBranch: run.Branch, BaseBranch: "main"}
+			},
+			wantFields: []string{"github.pull request number", "github.pull request URL"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			worktreePath := filepath.Join(root, "worktree")
+			if err := mkdir(worktreePath); err != nil {
+				t.Fatal(err)
+			}
+			run := recoveryRun(worktreePath)
+			githubAdapter := &fakeGitHub{
+				issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+				statusComment: github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: run-recovery -->"},
+			}
+			worktree := &recoveryWorktree{state: gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA}}
+			pullRequests := &fakePullRequests{}
+			test.configure(&run, worktree, githubAdapter, pullRequests)
+			storeAdapter := &recoveryRunStore{run: run}
+			service := newRecoveryService(t, storeAdapter, githubAdapter, worktree, pullRequests)
+
+			status, err := service.Status(context.Background())
+			if err != nil {
+				t.Fatalf("Status() error = %v", err)
+			}
+			if status.LatestRun == nil || status.Recovery == nil {
+				t.Fatalf("status = %#v, want run and recovery diagnosis", status)
+			}
+			if status.Recovery.SourcesAgree || len(status.Recovery.Discrepancies) == 0 {
+				t.Fatalf("recovery = %#v, want disagreement", status.Recovery)
+			}
+			fields := make(map[string]bool)
+			for _, discrepancy := range status.Recovery.Discrepancies {
+				fields[discrepancy.Source+"."+discrepancy.Field] = true
+			}
+			for _, field := range test.wantFields {
+				if !fields[field] {
+					t.Errorf("recovery fields = %#v, want %q", fields, field)
+				}
+			}
+			if len(storeAdapter.saved) != 0 || len(githubAdapter.replacedHistory) != 0 || len(githubAdapter.editedComments) != 0 {
+				t.Fatalf("status effects = saved=%d labels=%d comments=%d, want none", len(storeAdapter.saved), len(githubAdapter.replacedHistory), len(githubAdapter.editedComments))
+			}
+		})
+	}
+}
+
+// recoveryRun returns a complete persisted run fixture for startup diagnosis.
+func recoveryRun(worktreePath string) store.Run {
+	packet, err := json.Marshal(factory.SpecificationPacket{Version: 1, Issue: github.Issue{Number: 42, Title: "Recovery", Body: "diagnose"}, RepositoryConfig: validRepositoryConfig()})
+	if err != nil {
+		panic(err)
+	}
+	return store.Run{
+		ID: "run-recovery", RepositoryPath: "REPOSITORY", IssueNumber: 42,
+		Stage: store.StageImplementation, Status: store.StatusActive,
+		Branch: "factory/run-recovery", Worktree: worktreePath, CheckpointSHA: "checkpoint",
+		StatusCommentID: "comment-1", SpecificationPacket: string(packet),
+		CreatedAt: time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC), UpdatedAt: time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC),
+	}
+}
+
+// newRecoveryService creates a high-level service with only read-only
+// recovery projections and mutation-recording test doubles.
+func newRecoveryService(t *testing.T, runStore *recoveryRunStore, githubAdapter *fakeGitHub, worktree *recoveryWorktree, pullRequests *fakePullRequests) *factory.Service {
+	t.Helper()
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: runStore.run.RepositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		OperationalDataPath: filepath.Join(t.TempDir(), "factory.db"), RepositoryConfigPath: filepath.Join(runStore.run.RepositoryPath, "factory.yaml"),
+	}}}
+	dependencies := factory.Dependencies{
+		Config:    &fakeConfig{value: host},
+		OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		GitHub:    githubAdapter, Worktree: worktree,
+	}
+	if pullRequests != nil {
+		dependencies.PullRequests = pullRequests
+	}
+	return factory.NewWithDependencies("/host/config.yaml", dependencies)
+}
+
+// recoveryWorktree supplies a read-only Git projection for recovery tests.
+type recoveryWorktree struct {
+	fakeWorktree
+	state gitadapter.WorktreeState
+	err   error
+}
+
+// Inspect returns the configured branch and checkpoint projection.
+func (w *recoveryWorktree) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	return w.state, w.err
+}
+
+// recoveryRunStore supplies one persisted run to status and progression seams.
+type recoveryRunStore struct {
+	run   store.Run
+	saved []store.Run
+}
+
+// CurrentRun returns the persisted non-terminal run.
+func (s *recoveryRunStore) CurrentRun(context.Context) (*store.Run, error) {
+	run := s.run
+	return &run, nil
+}
+
+// LatestRun returns the same run for the read-only status projection.
+func (s *recoveryRunStore) LatestRun(context.Context) (*store.Run, error) {
+	run := s.run
+	return &run, nil
+}
+
+// SaveRun records unexpected progression persistence.
+func (s *recoveryRunStore) SaveRun(_ context.Context, run store.Run) error {
+	s.saved = append(s.saved, run)
+	return nil
+}
+
+// Close satisfies the operational-store seam.
+func (*recoveryRunStore) Close() error { return nil }
+
+// mkdir creates a recovery fixture directory without hiding setup errors.
+func mkdir(path string) error {
+	return os.MkdirAll(path, 0o755)
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -61,6 +61,11 @@ type BaseSyncRequest struct {
 // WorktreeState is the coordinator-observed state used to validate a harness
 // handoff against the actual checkout.
 type WorktreeState struct {
+	// RepositoryPath is the main checkout root owning the worktree's Git
+	// metadata, resolved from git-common-dir.
+	RepositoryPath string
+	// Branch is the current local branch name, or empty when HEAD is detached.
+	Branch string
 	// HeadSHA is the current full commit identity.
 	HeadSHA string
 	// ChangedPaths contains repository-relative paths reported by Git.
@@ -140,6 +145,14 @@ func (m *LocalWorktreeManager) Inspect(ctx context.Context, worktreePath string)
 	if strings.TrimSpace(worktreePath) == "" {
 		return WorktreeState{}, errors.New("worktree path is required")
 	}
+	commonDirOutput, err := m.runner().Run(ctx, worktreePath, []string{"rev-parse", "--git-common-dir"})
+	if err != nil {
+		return WorktreeState{}, fmt.Errorf("inspect worktree repository: %w", err)
+	}
+	branchOutput, err := m.runner().Run(ctx, worktreePath, []string{"branch", "--show-current"})
+	if err != nil {
+		return WorktreeState{}, fmt.Errorf("inspect worktree branch: %w", err)
+	}
 	headOutput, err := m.runner().Run(ctx, worktreePath, []string{"rev-parse", "HEAD"})
 	if err != nil {
 		return WorktreeState{}, fmt.Errorf("inspect worktree HEAD: %w", err)
@@ -148,7 +161,25 @@ func (m *LocalWorktreeManager) Inspect(ctx context.Context, worktreePath string)
 	if err != nil {
 		return WorktreeState{}, fmt.Errorf("inspect worktree changes: %w", err)
 	}
-	return WorktreeState{HeadSHA: strings.TrimSpace(string(headOutput)), ChangedPaths: porcelainPaths(string(statusOutput))}, nil
+	return WorktreeState{
+		RepositoryPath: repositoryPathFromCommonDir(worktreePath, strings.TrimSpace(string(commonDirOutput))),
+		Branch:         strings.TrimSpace(string(branchOutput)),
+		HeadSHA:        strings.TrimSpace(string(headOutput)),
+		ChangedPaths:   porcelainPaths(string(statusOutput)),
+	}, nil
+}
+
+// repositoryPathFromCommonDir converts Git's common metadata path into the
+// owning checkout root while preserving an empty observation for malformed
+// command output.
+func repositoryPathFromCommonDir(worktreePath, commonDir string) string {
+	if strings.TrimSpace(commonDir) == "" {
+		return ""
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(worktreePath, commonDir)
+	}
+	return filepath.Dir(filepath.Clean(commonDir))
 }
 
 // runner returns the injected command runner or the production Git runner.

--- a/internal/git/worktree_internal_test.go
+++ b/internal/git/worktree_internal_test.go
@@ -20,7 +20,13 @@ func TestInspectParsesNulDelimitedStatus(t *testing.T) {
 	if !reflect.DeepEqual(state.ChangedPaths, want) {
 		t.Fatalf("ChangedPaths = %#v, want %#v", state.ChangedPaths, want)
 	}
-	if len(runner.calls) != 2 || runner.calls[1][0] != "status" || !containsArgument(runner.calls[1], "-z") {
+	if state.Branch != "factory/run-fixed" {
+		t.Fatalf("Branch = %q, want factory/run-fixed", state.Branch)
+	}
+	if state.RepositoryPath != "/repo" {
+		t.Fatalf("RepositoryPath = %q, want /repo", state.RepositoryPath)
+	}
+	if len(runner.calls) != 4 || runner.calls[3][0] != "status" || !containsArgument(runner.calls[3], "-z") {
 		t.Fatalf("Git calls = %#v, want porcelain status with -z", runner.calls)
 	}
 }
@@ -34,6 +40,12 @@ type inspectRunner struct {
 // Run records one Git command and returns its fixture output.
 func (r *inspectRunner) Run(_ context.Context, _ string, args []string) ([]byte, error) {
 	r.calls = append(r.calls, append([]string(nil), args...))
+	if args[0] == "rev-parse" && containsArgument(args, "--git-common-dir") {
+		return []byte("/repo/.git\n"), nil
+	}
+	if args[0] == "branch" {
+		return []byte("factory/run-fixed\n"), nil
+	}
 	if args[0] == "rev-parse" {
 		return []byte("0123456789abcdef\n"), nil
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -48,6 +48,12 @@ const (
 	StatusComplete          Status = "complete"
 )
 
+// IsTerminalStatus reports whether a run has no further coordinator
+// progression state to reconcile.
+func IsTerminalStatus(status Status) bool {
+	return status == StatusComplete || status == StatusCancelled || status == StatusFailed
+}
+
 // InvocationStatus describes the lifecycle of one visible harness invocation.
 type InvocationStatus string
 


### PR DESCRIPTION
Closes #24\n\n## Summary\n\n- add a typed, read-only recovery diagnosis for persisted non-terminal runs\n- refuse progression even when repository, worktree, Git, and GitHub projections agree\n- expose discrepancies and safe operator actions through factory status and progression errors\n- validate worktree ownership, branch/HEAD, issue state label, status comment, and pull-request identity\n- document that issue #21 supersedes this guard with complete reconciliation\n\n## Verification\n\n- go test ./...\n- go vet ./...\n- gofmt -l .\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery diagnosis for interrupted runs, including detected discrepancies and safe operator actions.
  * Added read-only consistency checks across run, workspace, Git, issue, comments, labels, and pull-request state.
  * Added recovery details to `factory status` output.

* **Bug Fixes**
  * Prevented interrupted runs from resuming or modifying state until recovery is completed.
  * Improved terminal-run detection and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->