### PR TITLE
feat: add authorized GitHub command surface

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,12 +205,52 @@ remains available and prints the run, agreement state, discrepancies, and safe
 operator actions. Issue #21 explicitly supersedes this boundary with complete
 reconciliation and idempotent effect recovery.
 
+## Authorized GitHub commands
+
+The coordinator recognizes a command only when the complete trimmed comment is
+one structured `/factory` command. Ordinary discussion is ignored, so a casual
+mention of “retry” or “refresh” cannot control a run:
+
+```text
+/factory status
+/factory refresh
+/factory retry
+/factory config harness=codex
+```
+
+Run one comment poll with `factory poll --config /Users/me/.config/factory/config.yaml`;
+repeating the command is safe because the persisted watermark filters old
+comments.
+
+The author must be present in the registered `authorized_users` list. A status
+or refresh command re-renders the existing supervision comment; retry reopens a
+failed run at its current stage; and harness configuration records a later
+invocation override only when the frozen repository configuration permits it. A
+recognized command from an unauthorized author or a malformed command is a
+typed policy rejection. The coordinator leaves workflow stage, status, labels,
+and configuration unchanged for that rejection, while recording the rejection
+in the same editable status comment.
+
+The command grammar also names `claude` for forward-compatible parsing, but the
+current implementation role has only the Codex adapter; selecting Claude is a
+typed `harness_unavailable` rejection until its later adapter is delivered.
+
+Each comment is processed at most once. The operational store persists a
+monotonic run revision, the processed comment ID watermark, and the revision at
+which that watermark was written. Polling therefore ignores old comments, and
+editing an already processed comment cannot turn it into a new command after a
+coordinator restart. Command handling serializes one service's work and uses a
+SQLite revision compare-and-set, durably claiming the comment before applying
+GitHub effects. The same parser and handler are used for issue comments and
+pull-request comments; later commands can extend the registered verb set
+without duplicating polling or replay logic.
+
 After a claim, `factory agent` starts the visible Codex implementation role and
 prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use
 `factory agent-report --invocation-id <id>` to ask the coordinator to validate
 and accept the structured report. Terminal output is never treated as a stage
-result. The operational store schema is version 7 and persists invocation
+result. The operational store schema is version 8 and persists invocation
 identity, opaque surface handles, prompt version, result directory, native
 session identifier, and permitted handoff paths in addition to run state. It
 also persists the draft pull-request number and URL so a restarted command can

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -33,6 +33,7 @@ var commandTable = []commandDefinition{
 	{name: "agent", handler: runAgent},
 	{name: "agent-report", handler: runAgentReport},
 	{name: "draft-pr", handler: runDraftPullRequest},
+	{name: "poll", handler: runPollCommands},
 	{name: "status", handler: runStatus},
 }
 
@@ -242,6 +243,47 @@ func runDraftPullRequest(ctx context.Context, args []string, defaultConfigPath s
 	}
 	for _, gateResult := range result.Gates {
 		if !writeOutput(output, errorsOutput, "gate: %s (%s)\n", gateResult.GateName, gateResult.Status.State) {
+			return 1
+		}
+	}
+	return 0
+}
+
+// runPollCommands performs one production command poll for the current run.
+// Repeating this command is safe because the coordinator persists the
+// processed-comment watermark and revision.
+func runPollCommands(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("poll", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "active or latest factory run identifier")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("poll does not accept positional arguments"))
+		return 2
+	}
+	results, err := factory.New(*configPath).PollCommands(ctx, factory.CommandPollRequest{RunID: *runID})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if len(results) == 0 {
+		if !writeOutput(output, errorsOutput, "no structured commands found\n") {
+			return 1
+		}
+		return 0
+	}
+	for _, result := range results {
+		name := string(result.Command.Kind)
+		if name == "" {
+			name = "malformed"
+		}
+		if !writeOutput(output, errorsOutput, "command: %s outcome: %s\n", name, result.Outcome) {
+			return 1
+		}
+		if result.Rejection != nil && !writeOutput(output, errorsOutput, "rejection: %s (%s)\n", result.Rejection.Code, result.Rejection.Problem) {
 			return 1
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -169,6 +169,22 @@ func TestRunDraftPullRequestRejectsPositionalArguments(t *testing.T) {
 	}
 }
 
+// TestRunPollRejectsPositionalArguments keeps one-shot command polling
+// explicit about its configured run selection.
+func TestRunPollRejectsPositionalArguments(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	var output bytes.Buffer
+	code := cli.Run(context.Background(), []string{"poll", "extra", "--config", configPath}, &output, &output)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2, output = %s", code, output.String())
+	}
+	if !strings.Contains(output.String(), "poll does not accept positional arguments") {
+		t.Fatalf("output = %q", output.String())
+	}
+}
+
 func TestRunInitRejectsAnUnknownFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,0 +1,171 @@
+// Package command parses the small, structured command language accepted in
+// GitHub supervision comments.
+package command
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Kind identifies a command understood by the coordinator.
+type Kind string
+
+const (
+	// Status requests a fresh rendering of the current run status.
+	Status Kind = "status"
+	// Retry asks the coordinator to retry a failed run at its current stage.
+	Retry Kind = "retry"
+	// Refresh asks the coordinator to refresh the supervision projection.
+	Refresh Kind = "refresh"
+	// ConfigureHarness changes the selected harness for a later invocation.
+	ConfigureHarness Kind = "configure_harness"
+)
+
+// Harness identifies a harness value accepted by the command grammar.
+type Harness string
+
+const (
+	// HarnessCodex selects Codex for a later invocation.
+	HarnessCodex Harness = "codex"
+	// HarnessClaude selects Claude for a later invocation.
+	HarnessClaude Harness = "claude"
+)
+
+// Request is the typed command produced by Parse.
+type Request struct {
+	// Kind identifies the coordinator operation.
+	Kind Kind
+	// Harness is set only for ConfigureHarness.
+	Harness Harness
+}
+
+// ParseResult distinguishes ordinary discussion from a structured command.
+type ParseResult struct {
+	// Command is populated when Recognized is true and parsing succeeds.
+	Command Request
+	// Recognized reports whether the comment used the factory command marker.
+	Recognized bool
+}
+
+// ParseErrorCode identifies the policy problem found in a recognized command.
+type ParseErrorCode string
+
+const (
+	// ParseErrorEmpty means the command marker had no verb.
+	ParseErrorEmpty ParseErrorCode = "empty_command"
+	// ParseErrorMultiline means a command was mixed with other comment text.
+	ParseErrorMultiline ParseErrorCode = "multiline_command"
+	// ParseErrorUnknownVerb means the verb is not registered by the factory.
+	ParseErrorUnknownVerb ParseErrorCode = "unknown_command"
+	// ParseErrorUnexpectedArgument means a known verb received extra arguments.
+	ParseErrorUnexpectedArgument ParseErrorCode = "unexpected_argument"
+	// ParseErrorMissingHarness means a harness configuration had no value.
+	ParseErrorMissingHarness ParseErrorCode = "missing_harness"
+	// ParseErrorInvalidHarnessArgument means the harness key was malformed.
+	ParseErrorInvalidHarnessArgument ParseErrorCode = "invalid_harness_argument"
+	// ParseErrorUnsupportedHarness means the harness is outside the grammar.
+	ParseErrorUnsupportedHarness ParseErrorCode = "unsupported_harness"
+	// ParseErrorControlCharacter means the command contains unsafe controls.
+	ParseErrorControlCharacter ParseErrorCode = "control_character"
+)
+
+// ParseError is a typed rejection for a recognized but malformed command.
+type ParseError struct {
+	// Code is stable machine-readable policy vocabulary.
+	Code ParseErrorCode
+	// Problem is a concise operator-facing explanation.
+	Problem string
+}
+
+// Error returns the typed policy rejection in a human-readable form.
+func (e *ParseError) Error() string {
+	if e == nil {
+		return "malformed factory command"
+	}
+	return fmt.Sprintf("malformed factory command (%s): %s", e.Code, e.Problem)
+}
+
+// Parse recognizes one complete /factory comment. Ordinary discussion is not
+// an error; a recognized marker with malformed content returns ParseError.
+func Parse(body string) (ParseResult, error) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !hasMarker(trimmed) {
+		return ParseResult{}, nil
+	}
+	result := ParseResult{Recognized: true}
+	if strings.ContainsAny(trimmed, "\r\n") {
+		return result, &ParseError{Code: ParseErrorMultiline, Problem: "the command must occupy the complete comment on one line"}
+	}
+	if strings.ContainsAny(trimmed, "\x00") {
+		return result, &ParseError{Code: ParseErrorControlCharacter, Problem: "the command contains a NUL character"}
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) < 2 {
+		return result, &ParseError{Code: ParseErrorEmpty, Problem: "a command verb is required after /factory"}
+	}
+	switch fields[1] {
+	case string(Status):
+		return parseFixedArity(result, fields, Status)
+	case string(Retry):
+		return parseFixedArity(result, fields, Retry)
+	case string(Refresh):
+		return parseFixedArity(result, fields, Refresh)
+	case "config", "configure", "harness":
+		harness, parseErr := parseHarness(fields[2:])
+		if parseErr != nil {
+			return result, parseErr
+		}
+		result.Command = Request{Kind: ConfigureHarness, Harness: harness}
+		return result, nil
+	default:
+		return result, &ParseError{Code: ParseErrorUnknownVerb, Problem: fmt.Sprintf("command %q is not supported", fields[1])}
+	}
+}
+
+// parseFixedArity parses a registered verb that accepts no arguments.
+func parseFixedArity(result ParseResult, fields []string, kind Kind) (ParseResult, error) {
+	if len(fields) != 2 {
+		return result, unexpectedArgument(fields[1])
+	}
+	result.Command = Request{Kind: kind}
+	return result, nil
+}
+
+// hasMarker reports whether trimmed is explicitly addressed to the factory.
+func hasMarker(trimmed string) bool {
+	if !strings.HasPrefix(trimmed, "/factory") {
+		return false
+	}
+	if len(trimmed) == len("/factory") {
+		return true
+	}
+	return unicode.IsSpace(rune(trimmed[len("/factory")]))
+}
+
+// unexpectedArgument builds the stable parser rejection for a fixed-arity verb.
+func unexpectedArgument(verb string) *ParseError {
+	return &ParseError{Code: ParseErrorUnexpectedArgument, Problem: fmt.Sprintf("%s does not accept arguments", verb)}
+}
+
+// parseHarness validates the one supported harness argument shape.
+func parseHarness(arguments []string) (Harness, *ParseError) {
+	if len(arguments) == 0 {
+		return "", &ParseError{Code: ParseErrorMissingHarness, Problem: "configure requires harness=codex, harness=claude, or a harness name"}
+	}
+	if len(arguments) != 1 {
+		return "", &ParseError{Code: ParseErrorUnexpectedArgument, Problem: "configure accepts exactly one harness value"}
+	}
+	value := arguments[0]
+	if key, configured, found := strings.Cut(value, "="); found {
+		if key != "harness" || configured == "" {
+			return "", &ParseError{Code: ParseErrorInvalidHarnessArgument, Problem: "the configuration key must be harness with a nonempty value"}
+		}
+		value = configured
+	}
+	harness := Harness(value)
+	if harness != HarnessCodex && harness != HarnessClaude {
+		return "", &ParseError{Code: ParseErrorUnsupportedHarness, Problem: fmt.Sprintf("harness %q is not supported", value)}
+	}
+	return harness, nil
+}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // Kind identifies a command understood by the coordinator.
@@ -140,7 +141,8 @@ func hasMarker(trimmed string) bool {
 	if len(trimmed) == len("/factory") {
 		return true
 	}
-	return unicode.IsSpace(rune(trimmed[len("/factory")]))
+	next, _ := utf8.DecodeRuneInString(trimmed[len("/factory"):])
+	return unicode.IsSpace(next)
 }
 
 // unexpectedArgument builds the stable parser rejection for a fixed-arity verb.

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -26,6 +26,14 @@ func TestParseDistinguishesOrdinaryDiscussionFromStructuredCommands(t *testing.T
 	if !parsed.Recognized || parsed.Command.Kind != command.Status {
 		t.Fatalf("parsed status = %#v, want recognized status command", parsed)
 	}
+
+	nonBreakingSpace, err := command.Parse("/factory\u00a0status")
+	if err != nil {
+		t.Fatalf("Parse() non-breaking-space status error = %v", err)
+	}
+	if !nonBreakingSpace.Recognized || nonBreakingSpace.Command.Kind != command.Status {
+		t.Fatalf("parsed non-breaking-space status = %#v, want recognized status command", nonBreakingSpace)
+	}
 }
 
 // TestParseReturnsTypedRejectionsForMalformedCommands verifies malformed

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,0 +1,89 @@
+package command_test
+
+import (
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/command"
+)
+
+// TestParseDistinguishesOrdinaryDiscussionFromStructuredCommands verifies the
+// explicit marker keeps ordinary GitHub discussion outside the command surface.
+func TestParseDistinguishesOrdinaryDiscussionFromStructuredCommands(t *testing.T) {
+	t.Parallel()
+
+	ordinary, err := command.Parse("Could we refresh the documentation before retrying?")
+	if err != nil {
+		t.Fatalf("Parse() ordinary discussion error = %v", err)
+	}
+	if ordinary.Recognized {
+		t.Fatal("ordinary discussion was recognized as a factory command")
+	}
+
+	parsed, err := command.Parse("  /factory status  ")
+	if err != nil {
+		t.Fatalf("Parse() status error = %v", err)
+	}
+	if !parsed.Recognized || parsed.Command.Kind != command.Status {
+		t.Fatalf("parsed status = %#v, want recognized status command", parsed)
+	}
+}
+
+// TestParseReturnsTypedRejectionsForMalformedCommands verifies malformed
+// structured comments expose stable parser rejection codes.
+func TestParseReturnsTypedRejectionsForMalformedCommands(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		code command.ParseErrorCode
+	}{
+		{name: "unknown verb", body: "/factory deploy", code: command.ParseErrorUnknownVerb},
+		{name: "unexpected argument", body: "/factory status now", code: command.ParseErrorUnexpectedArgument},
+		{name: "missing harness", body: "/factory config", code: command.ParseErrorMissingHarness},
+		{name: "unsupported harness", body: "/factory config harness=llama", code: command.ParseErrorUnsupportedHarness},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := command.Parse(test.body)
+			if err == nil {
+				t.Fatal("Parse() error = nil, want typed rejection")
+			}
+			if !parsed.Recognized {
+				t.Fatal("malformed command was not recognized")
+			}
+			parseErr, ok := err.(*command.ParseError)
+			if !ok {
+				t.Fatalf("Parse() error type = %T, want *command.ParseError", err)
+			}
+			if parseErr.Code != test.code {
+				t.Fatalf("Parse() error code = %q, want %q", parseErr.Code, test.code)
+			}
+			if parseErr.Problem == "" {
+				t.Fatal("Parse() rejection has no human-readable problem")
+			}
+		})
+	}
+}
+
+// TestParseSupportsHarnessConfigurationForms verifies the extensible harness
+// configuration verb accepts its documented equivalent forms.
+func TestParseSupportsHarnessConfigurationForms(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{
+		"/factory config harness=codex",
+		"/factory configure harness=claude",
+		"/factory harness codex",
+	} {
+		parsed, err := command.Parse(body)
+		if err != nil {
+			t.Fatalf("Parse(%q) error = %v", body, err)
+		}
+		if parsed.Command.Kind != command.ConfigureHarness || parsed.Command.Harness == "" {
+			t.Fatalf("Parse(%q) = %#v, want harness configuration", body, parsed.Command)
+		}
+	}
+}

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -134,6 +134,9 @@ func (s *Service) StartAgent(ctx context.Context, request AgentRequest) (result 
 	if request.RunID != "" && request.RunID != run.ID {
 		return AgentLaunchResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
 	}
+	if request.Harness == "" && run.HarnessOverride != "" {
+		request.Harness = config.Harness(run.HarnessOverride)
+	}
 	if err := validateAgentRunState(*run); err != nil {
 		return AgentLaunchResult{}, err
 	}

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -89,6 +89,9 @@ type stateTransition struct {
 	Previous      store.Run
 	Next          store.Run
 	CreateComment bool
+	// PersistBeforeEffects is used by replay-sensitive commands so the
+	// processed-comment watermark is durable before GitHub mutation.
+	PersistBeforeEffects bool
 }
 
 // BootstrapLabels explicitly creates or updates the factory-owned labels for
@@ -277,6 +280,18 @@ func (s *Service) Transition(ctx context.Context, request TransitionRequest) (st
 // be persisted.
 func (s *Service) applyStateTransition(ctx context.Context, runStore RunStore, transition stateTransition) (store.Run, error) {
 	next := transition.Next
+	if next.Revision <= transition.Previous.Revision {
+		next.Revision = transition.Previous.Revision + 1
+	}
+	if transition.PersistBeforeEffects {
+		next.UpdatedAt = s.deps.Now().UTC()
+		if transition.CreateComment {
+			return next, errors.New("cannot persist a command before creating its status comment")
+		}
+		if err := saveCommandRun(ctx, runStore, transition.Previous.Revision, next); err != nil {
+			return next, fmt.Errorf("persist state transition before GitHub effects: %w", err)
+		}
+	}
 	oldLabels := append([]string(nil), transition.Issue.Labels...)
 	newLabels := replaceFactoryState(oldLabels, factoryLabelForStatus(next.Status))
 	if err := s.deps.GitHub.ReplaceIssueLabels(ctx, transition.Repository, next.IssueNumber, newLabels); err != nil {
@@ -298,6 +313,9 @@ func (s *Service) applyStateTransition(ctx context.Context, runStore RunStore, t
 		}
 	}
 	next.UpdatedAt = s.deps.Now().UTC()
+	if transition.PersistBeforeEffects {
+		return next, nil
+	}
 	if err := saveRunWithRetry(ctx, runStore, next); err != nil {
 		if !transition.CreateComment {
 			compensationErrors := []error{
@@ -438,7 +456,23 @@ func statusCommentBody(run store.Run) string {
 	if run.PullRequestNumber > 0 {
 		pullRequest = fmt.Sprintf("- pull request: #%d %s\n", run.PullRequestNumber, run.PullRequestURL)
 	}
-	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, pullRequest)
+	commandFeedback := ""
+	if run.LastCommandName != "" {
+		commandFeedback = fmt.Sprintf("\n### Last command\n\n- comment: `%s`\n- revision: `%d`\n- command: `%s`\n- outcome: `%s`\n- message: %s\n", safeStatusCommentValue(run.ProcessedCommentID), run.ProcessedCommentRevision, safeStatusCommentValue(run.LastCommandName), safeStatusCommentValue(run.LastCommandOutcome), safeStatusCommentValue(run.LastCommandMessage))
+	}
+	harness := ""
+	if run.HarnessOverride != "" {
+		harness = fmt.Sprintf("\n- harness override: `%s`\n", safeStatusCommentValue(run.HarnessOverride))
+	}
+	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, pullRequest, harness, commandFeedback)
+}
+
+// safeStatusCommentValue keeps command feedback single-line and prevents
+// untrusted GitHub login or parser text from changing the status-comment
+// structure.
+func safeStatusCommentValue(value string) string {
+	value = strings.NewReplacer("\r", " ", "\n", " ", "`", "'", "\x00", " ").Replace(value)
+	return strings.TrimSpace(value)
 }
 
 // statusCommentMarker identifies the one editable status comment for a run.

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -1,0 +1,442 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	commandlanguage "github.com/Stevie1704/sw-factory/internal/command"
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// CommandOutcome describes what happened to one recognized comment.
+type CommandOutcome string
+
+const (
+	// CommandIgnored means the comment was ordinary discussion, not a command.
+	CommandIgnored CommandOutcome = "ignored"
+	// CommandAccepted means the coordinator applied the command once.
+	CommandAccepted CommandOutcome = "accepted"
+	// CommandRejected means the command was recognized but denied by policy.
+	CommandRejected CommandOutcome = "rejected"
+	// CommandReplayed means the comment ID was already behind the persisted
+	// watermark and no command effect was repeated.
+	CommandReplayed CommandOutcome = "replayed"
+)
+
+// PolicyRejectionCode identifies a typed command policy refusal.
+type PolicyRejectionCode string
+
+const (
+	// PolicyRejectionUnauthorized means the GitHub author is not configured.
+	PolicyRejectionUnauthorized PolicyRejectionCode = "unauthorized_author"
+	// PolicyRejectionMalformed means the structured command grammar was invalid.
+	PolicyRejectionMalformed PolicyRejectionCode = "malformed_command"
+	// PolicyRejectionNoRun means no claimed run can receive the command.
+	PolicyRejectionNoRun PolicyRejectionCode = "no_run"
+	// PolicyRejectionWrongTarget means the comment targets another issue or PR.
+	PolicyRejectionWrongTarget PolicyRejectionCode = "wrong_target"
+	// PolicyRejectionRetryState means retry is not legal for the current state.
+	PolicyRejectionRetryState PolicyRejectionCode = "retry_state"
+	// PolicyRejectionHarnessOverride means repository configuration disallows the
+	// requested harness override.
+	PolicyRejectionHarnessOverride PolicyRejectionCode = "harness_override"
+	// PolicyRejectionHarnessUnavailable means the current role has no adapter
+	// for the requested harness yet.
+	PolicyRejectionHarnessUnavailable PolicyRejectionCode = "harness_unavailable"
+)
+
+// PolicyRejection is returned after a recognized command is visibly recorded
+// as denied. Its stable code, rather than its message, controls policy logic.
+type PolicyRejection struct {
+	// Code is stable machine-readable policy vocabulary.
+	Code PolicyRejectionCode
+	// Problem is the operator-facing explanation rendered in the status comment.
+	Problem string
+}
+
+// Error returns a human-readable typed policy rejection.
+func (e *PolicyRejection) Error() string {
+	if e == nil {
+		return "policy rejection"
+	}
+	return fmt.Sprintf("policy rejection (%s): %s", e.Code, e.Problem)
+}
+
+// CommandRequest supplies one GitHub issue or pull-request comment to the
+// coordinator. The target number is the issue number or PR number whose
+// shared GitHub comments endpoint returned the comment.
+type CommandRequest struct {
+	// RunID optionally selects one active or latest run explicitly.
+	RunID string
+	// IssueNumber identifies the issue or pull request being commented on.
+	IssueNumber int
+	// Comment contains the immutable comment identity, author, and body.
+	Comment github.Comment
+}
+
+// CommandPollRequest selects the run whose issue and pull-request comments
+// should be scanned for structured commands.
+type CommandPollRequest struct {
+	// RunID optionally selects one active or latest run explicitly.
+	RunID string
+}
+
+// CommandResult reports one command decision and the resulting persisted run.
+type CommandResult struct {
+	// Outcome distinguishes ordinary discussion, acceptance, rejection, and replay.
+	Outcome CommandOutcome
+	// Command is the parsed command when parsing succeeded.
+	Command commandlanguage.Request
+	// Rejection is populated for a typed policy refusal.
+	Rejection *PolicyRejection
+	// Run is the run projection after the command decision.
+	Run store.Run
+}
+
+// HandleCommand recognizes and processes one GitHub comment exactly once.
+// Ordinary discussion is ignored. Recognized policy rejections are persisted
+// and reflected in the existing status comment before the typed error returns.
+func (s *Service) HandleCommand(ctx context.Context, request CommandRequest) (CommandResult, error) {
+	parsed, parseErr := commandlanguage.Parse(request.Comment.Body)
+	if !parsed.Recognized {
+		return CommandResult{Outcome: CommandIgnored}, nil
+	}
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	if request.IssueNumber <= 0 {
+		return CommandResult{}, errors.New("command issue number must be positive")
+	}
+	if strings.TrimSpace(request.Comment.ID) == "" {
+		return CommandResult{}, errors.New("command comment id is required")
+	}
+	registration, runStore, run, err := s.openCommandRunStore(ctx)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	if run == nil {
+		return CommandResult{Outcome: CommandRejected}, &PolicyRejection{Code: PolicyRejectionNoRun, Problem: "no claimed run is available for this command"}
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return CommandResult{Outcome: CommandRejected, Run: *run}, &PolicyRejection{Code: PolicyRejectionWrongTarget, Problem: fmt.Sprintf("run %q is not the selected run", request.RunID)}
+	}
+	if request.IssueNumber != run.IssueNumber && request.IssueNumber != run.PullRequestNumber {
+		return CommandResult{Outcome: CommandRejected, Run: *run}, &PolicyRejection{Code: PolicyRejectionWrongTarget, Problem: fmt.Sprintf("comment target #%d does not belong to run %q", request.IssueNumber, run.ID)}
+	}
+	if commentAlreadyProcessed(run.ProcessedCommentID, request.Comment.ID) {
+		return CommandResult{Outcome: CommandReplayed, Command: parsed.Command, Run: *run}, nil
+	}
+	if !authorizedCommentAuthor(registration.AuthorizedUsers, request.Comment.Author) {
+		rejection := &PolicyRejection{Code: PolicyRejectionUnauthorized, Problem: fmt.Sprintf("GitHub author %q is not an authorized maintainer", request.Comment.Author)}
+		return s.persistCommandRejection(ctx, registration, runStore, *run, request.Comment, parsed.Command, rejection)
+	}
+	if parseErr != nil {
+		rejection := &PolicyRejection{Code: PolicyRejectionMalformed, Problem: parseErr.Error()}
+		return s.persistCommandRejection(ctx, registration, runStore, *run, request.Comment, parsed.Command, rejection)
+	}
+
+	switch parsed.Command.Kind {
+	case commandlanguage.Status, commandlanguage.Refresh:
+		updated, persistErr := s.persistCommandProjection(ctx, registration, runStore, *run, request.Comment, parsed.Command, string(parsed.Command.Kind), "command accepted")
+		return CommandResult{Outcome: CommandAccepted, Command: parsed.Command, Run: updated}, persistErr
+	case commandlanguage.ConfigureHarness:
+		return s.handleHarnessConfiguration(ctx, registration, runStore, *run, request.Comment, parsed.Command)
+	case commandlanguage.Retry:
+		return s.handleRetryCommand(ctx, registration, runStore, *run, request.Comment, parsed.Command)
+	default:
+		rejection := &PolicyRejection{Code: PolicyRejectionMalformed, Problem: "the parsed command is not registered by the coordinator"}
+		return s.persistCommandRejection(ctx, registration, runStore, *run, request.Comment, parsed.Command, rejection)
+	}
+}
+
+// PollCommands lists comments for the run's issue and draft pull request and
+// sends each structured comment through the same single-comment handler.
+func (s *Service) PollCommands(ctx context.Context, request CommandPollRequest) ([]CommandResult, error) {
+	registration, runStore, run, err := s.openCommandRunStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if run == nil {
+		_ = runStore.Close()
+		return nil, &PolicyRejection{Code: PolicyRejectionNoRun, Problem: "no claimed run is available for command polling"}
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		_ = runStore.Close()
+		return nil, &PolicyRejection{Code: PolicyRejectionWrongTarget, Problem: fmt.Sprintf("run %q is not the selected run", request.RunID)}
+	}
+	if s.deps.Comments == nil {
+		_ = runStore.Close()
+		return nil, errors.New("GitHub comment reader is required for command polling")
+	}
+	targets := []int{run.IssueNumber}
+	if run.PullRequestNumber > 0 && run.PullRequestNumber != run.IssueNumber {
+		targets = append(targets, run.PullRequestNumber)
+	}
+	_ = runStore.Close()
+	comments := make([]polledComment, 0)
+	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	for _, target := range targets {
+		listed, listErr := s.deps.Comments.IssueComments(ctx, repository, target)
+		if listErr != nil {
+			return nil, listErr
+		}
+		for _, comment := range listed {
+			comments = append(comments, polledComment{target: target, comment: comment})
+		}
+	}
+	sort.SliceStable(comments, func(left, right int) bool {
+		return compareCommentIDs(comments[left].comment.ID, comments[right].comment.ID) < 0
+	})
+	results := make([]CommandResult, 0)
+	for _, polled := range comments {
+		parsed, parseErr := commandlanguage.Parse(polled.comment.Body)
+		if !parsed.Recognized {
+			continue
+		}
+		result, handleErr := s.HandleCommand(ctx, CommandRequest{RunID: run.ID, IssueNumber: polled.target, Comment: polled.comment})
+		if handleErr != nil {
+			var rejection *PolicyRejection
+			if !errors.As(handleErr, &rejection) {
+				return results, handleErr
+			}
+			if parseErr != nil && result.Rejection == nil {
+				result.Rejection = rejection
+			}
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+// polledComment retains the issue or pull-request number alongside a comment
+// because GitHub's comment object does not repeat its parent target.
+type polledComment struct {
+	target  int
+	comment github.Comment
+}
+
+// commandRevisionStore is the optional atomic persistence seam implemented by
+// the SQLite store. Lightweight test stores may fall back to SaveRun.
+type commandRevisionStore interface {
+	SaveRunIfRevision(context.Context, int64, store.Run) error
+}
+
+// handleRetryCommand reopens a failed run at its existing stage and applies
+// the normal label/comment transition without creating a new status comment.
+func (s *Service) handleRetryCommand(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request) (CommandResult, error) {
+	if run.Status != store.StatusFailed {
+		rejection := &PolicyRejection{Code: PolicyRejectionRetryState, Problem: fmt.Sprintf("retry is only allowed for a failed run, not status %q", run.Status)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	if run.StatusCommentID == "" {
+		updated, err := s.recoverCommandStatusComment(ctx, registration, run)
+		if err != nil {
+			return CommandResult{}, err
+		}
+		run = updated
+	}
+	issue, err := s.deps.GitHub.Issue(ctx, github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}, run.IssueNumber)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; retrying failed run")
+	next.Status = store.StatusActive
+	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository:           github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository},
+		Issue:                issue,
+		Previous:             run,
+		Next:                 next,
+		PersistBeforeEffects: true,
+	})
+	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, err
+}
+
+// handleHarnessConfiguration validates an authorized harness override against
+// the frozen repository configuration before recording it for a later invocation.
+func (s *Service) handleHarnessConfiguration(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request) (CommandResult, error) {
+	if store.IsTerminalStatus(run.Status) {
+		rejection := &PolicyRejection{Code: PolicyRejectionHarnessOverride, Problem: fmt.Sprintf("harness configuration is not available after run status %q", run.Status)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	wanted := config.Harness(parsed.Harness)
+	if wanted != config.HarnessCodex {
+		rejection := &PolicyRejection{Code: PolicyRejectionHarnessUnavailable, Problem: fmt.Sprintf("harness %q is not available for the current implementation role", wanted)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	defaultHarness := packet.RepositoryConfig.RoleHarnessDefaults["implementation"]
+	if wanted != defaultHarness && !hasOverride(packet.RepositoryConfig.AllowedOverrides, config.OverrideHarness) {
+		rejection := &PolicyRejection{Code: PolicyRejectionHarnessOverride, Problem: fmt.Sprintf("repository configuration does not allow harness override from %q to %q", defaultHarness, wanted)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; harness configured")
+	next.HarnessOverride = string(wanted)
+	updated, err := s.persistCommandProjectionWithRun(ctx, registration, runStore, next, run)
+	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, err
+}
+
+// persistCommandRejection records a typed policy refusal in the existing
+// status comment and watermark while leaving workflow state and labels intact.
+func (s *Service) persistCommandRejection(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request, rejection *PolicyRejection) (CommandResult, error) {
+	next := commandProjection(run, comment, parsed, commandResultName(parsed), rejection.Error())
+	next.LastCommandOutcome = string(CommandRejected)
+	updated, err := s.persistCommandProjectionWithRun(ctx, registration, runStore, next, run)
+	result := CommandResult{Outcome: CommandRejected, Command: parsed, Rejection: rejection, Run: updated}
+	if err != nil {
+		return result, errors.Join(rejection, err)
+	}
+	return result, rejection
+}
+
+// persistCommandProjection stores a successful status/refresh result in the
+// single editable comment and returns the updated run.
+func (s *Service) persistCommandProjection(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request, name, message string) (store.Run, error) {
+	next := commandProjection(run, comment, parsed, name, message)
+	return s.persistCommandProjectionWithRun(ctx, registration, runStore, next, run)
+}
+
+// persistCommandProjectionWithRun durably claims the comment watermark before
+// editing the status comment, so a restart cannot execute it twice.
+func (s *Service) persistCommandProjectionWithRun(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, next, previous store.Run) (store.Run, error) {
+	next.UpdatedAt = s.deps.Now().UTC()
+	if next.StatusCommentID == "" {
+		recovered, err := s.recoverCommandStatusComment(ctx, registration, next)
+		if err != nil {
+			return next, err
+		}
+		next.StatusCommentID = recovered.StatusCommentID
+	}
+	if err := saveCommandRun(ctx, runStore, previous.Revision, next); err != nil {
+		return next, fmt.Errorf("persist command watermark: %w", err)
+	}
+	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	if err := s.deps.GitHub.EditIssueComment(ctx, repository, next.StatusCommentID, statusCommentBody(next)); err != nil {
+		return next, fmt.Errorf("edit status comment for command: %w", err)
+	}
+	return next, nil
+}
+
+// saveCommandRun uses compare-and-set persistence when the store supports it,
+// preventing a stale concurrent command from taking the same revision.
+func saveCommandRun(ctx context.Context, runStore RunStore, expectedRevision int64, next store.Run) error {
+	if revisionStore, ok := runStore.(commandRevisionStore); ok {
+		return revisionStore.SaveRunIfRevision(ctx, expectedRevision, next)
+	}
+	return saveRunWithRetry(ctx, runStore, next)
+}
+
+// recoverCommandStatusComment finds and attaches the one editable status
+// comment when an earlier process stopped before persisting its identity.
+func (s *Service) recoverCommandStatusComment(ctx context.Context, registration config.RepositoryRegistration, run store.Run) (store.Run, error) {
+	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	comment, err := s.deps.GitHub.FindStatusComment(ctx, repository, run.IssueNumber, statusCommentMarker(run.ID))
+	if err != nil {
+		return run, err
+	}
+	if strings.TrimSpace(comment.ID) == "" {
+		return run, errors.New("active run has no recoverable status comment")
+	}
+	run.StatusCommentID = comment.ID
+	return run, nil
+}
+
+// commandProjection creates the next revision and advances the immutable
+// comment watermark without changing workflow stage or status.
+func commandProjection(previous store.Run, comment github.Comment, parsed commandlanguage.Request, name, message string) store.Run {
+	next := previous
+	next.Revision = previous.Revision + 1
+	next.ProcessedCommentID = comment.ID
+	next.ProcessedCommentRevision = next.Revision
+	next.LastCommandName = name
+	next.LastCommandOutcome = string(CommandAccepted)
+	next.LastCommandMessage = message
+	if parsed.Kind == "" {
+		next.LastCommandOutcome = string(CommandRejected)
+	}
+	next.UpdatedAt = previous.UpdatedAt
+	return next
+}
+
+// commandResultName supplies a stable name for malformed command feedback.
+func commandResultName(parsed commandlanguage.Request) string {
+	if parsed.Kind == "" {
+		return "malformed"
+	}
+	return string(parsed.Kind)
+}
+
+// openCommandRunStore opens a store without invoking the progression startup
+// guard, because status, refresh, and policy rejection are read-only workflow
+// operations even when a run needs recovery diagnosis.
+func (s *Service) openCommandRunStore(ctx context.Context) (config.RepositoryRegistration, RunStore, *store.Run, error) {
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	var run *store.Run
+	if latestStore, ok := runStore.(LatestRunStore); ok {
+		run, err = latestStore.LatestRun(ctx)
+	} else {
+		run, err = runStore.CurrentRun(ctx)
+	}
+	if err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	return registration, runStore, run, nil
+}
+
+// authorizedCommentAuthor compares GitHub logins case-insensitively because
+// GitHub usernames are case-insensitive identifiers.
+func authorizedCommentAuthor(authorized []string, author string) bool {
+	for _, candidate := range authorized {
+		if strings.EqualFold(strings.TrimSpace(candidate), strings.TrimSpace(author)) && strings.TrimSpace(author) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// commentAlreadyProcessed checks the persisted numeric GitHub watermark and
+// falls back to identity equality for synthetic or nonnumeric test IDs.
+func commentAlreadyProcessed(processed, current string) bool {
+	if strings.TrimSpace(processed) == "" || strings.TrimSpace(current) == "" {
+		return false
+	}
+	if processed == current {
+		return true
+	}
+	processedID, processedErr := strconv.ParseUint(processed, 10, 64)
+	currentID, currentErr := strconv.ParseUint(current, 10, 64)
+	if processedErr == nil && currentErr == nil {
+		return currentID <= processedID
+	}
+	return false
+}
+
+// compareCommentIDs sorts numeric GitHub IDs numerically and keeps other IDs
+// deterministic without allowing a human-readable message to control flow.
+func compareCommentIDs(left, right string) int {
+	leftID, leftErr := strconv.ParseUint(left, 10, 64)
+	rightID, rightErr := strconv.ParseUint(right, 10, 64)
+	if leftErr == nil && rightErr == nil {
+		switch {
+		case leftID < rightID:
+			return -1
+		case leftID > rightID:
+			return 1
+		default:
+			return 0
+		}
+	}
+	return strings.Compare(left, right)
+}

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -109,17 +109,23 @@ func (s *Service) HandleCommand(ctx context.Context, request CommandRequest) (Co
 	}
 	s.commandMu.Lock()
 	defer s.commandMu.Unlock()
+	registration, runStore, run, err := s.openCommandRunStore(ctx)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	return s.handleRecognizedCommand(ctx, registration, runStore, run, request, parsed, parseErr)
+}
+
+// handleRecognizedCommand applies one parsed command using an already-open run
+// store. Polling uses this seam to keep one store open for its full batch.
+func (s *Service) handleRecognizedCommand(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, request CommandRequest, parsed commandlanguage.ParseResult, parseErr error) (CommandResult, error) {
 	if request.IssueNumber <= 0 {
 		return CommandResult{}, errors.New("command issue number must be positive")
 	}
 	if strings.TrimSpace(request.Comment.ID) == "" {
 		return CommandResult{}, errors.New("command comment id is required")
 	}
-	registration, runStore, run, err := s.openCommandRunStore(ctx)
-	if err != nil {
-		return CommandResult{}, err
-	}
-	defer func() { _ = runStore.Close() }()
 	if run == nil {
 		return CommandResult{Outcome: CommandRejected}, &PolicyRejection{Code: PolicyRejectionNoRun, Problem: "no claimed run is available for this command"}
 	}
@@ -158,29 +164,28 @@ func (s *Service) HandleCommand(ctx context.Context, request CommandRequest) (Co
 // PollCommands lists comments for the run's issue and draft pull request and
 // sends each structured comment through the same single-comment handler.
 func (s *Service) PollCommands(ctx context.Context, request CommandPollRequest) ([]CommandResult, error) {
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
 	registration, runStore, run, err := s.openCommandRunStore(ctx)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = runStore.Close() }()
 	if run == nil {
-		_ = runStore.Close()
 		return nil, &PolicyRejection{Code: PolicyRejectionNoRun, Problem: "no claimed run is available for command polling"}
 	}
 	if request.RunID != "" && request.RunID != run.ID {
-		_ = runStore.Close()
 		return nil, &PolicyRejection{Code: PolicyRejectionWrongTarget, Problem: fmt.Sprintf("run %q is not the selected run", request.RunID)}
 	}
 	if s.deps.Comments == nil {
-		_ = runStore.Close()
 		return nil, errors.New("GitHub comment reader is required for command polling")
 	}
 	targets := []int{run.IssueNumber}
 	if run.PullRequestNumber > 0 && run.PullRequestNumber != run.IssueNumber {
 		targets = append(targets, run.PullRequestNumber)
 	}
-	_ = runStore.Close()
 	comments := make([]polledComment, 0)
-	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	repository := commandRepository(registration)
 	for _, target := range targets {
 		listed, listErr := s.deps.Comments.IssueComments(ctx, repository, target)
 		if listErr != nil {
@@ -194,12 +199,16 @@ func (s *Service) PollCommands(ctx context.Context, request CommandPollRequest) 
 		return compareCommentIDs(comments[left].comment.ID, comments[right].comment.ID) < 0
 	})
 	results := make([]CommandResult, 0)
+	currentRun := *run
 	for _, polled := range comments {
 		parsed, parseErr := commandlanguage.Parse(polled.comment.Body)
 		if !parsed.Recognized {
 			continue
 		}
-		result, handleErr := s.HandleCommand(ctx, CommandRequest{RunID: run.ID, IssueNumber: polled.target, Comment: polled.comment})
+		result, handleErr := s.handleRecognizedCommand(ctx, registration, runStore, &currentRun, CommandRequest{RunID: currentRun.ID, IssueNumber: polled.target, Comment: polled.comment}, parsed, parseErr)
+		if result.Run.ID != "" {
+			currentRun = result.Run
+		}
 		if handleErr != nil {
 			var rejection *PolicyRejection
 			if !errors.As(handleErr, &rejection) {
@@ -219,6 +228,12 @@ func (s *Service) PollCommands(ctx context.Context, request CommandPollRequest) 
 type polledComment struct {
 	target  int
 	comment github.Comment
+}
+
+// commandRepository maps one registered GitHub identity for all command
+// operations, keeping polling and command effects on the same repository.
+func commandRepository(registration config.RepositoryRegistration) github.Repository {
+	return github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
 }
 
 // commandRevisionStore is the optional atomic persistence seam implemented by
@@ -241,14 +256,15 @@ func (s *Service) handleRetryCommand(ctx context.Context, registration config.Re
 		}
 		run = updated
 	}
-	issue, err := s.deps.GitHub.Issue(ctx, github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}, run.IssueNumber)
+	repository := commandRepository(registration)
+	issue, err := s.deps.GitHub.Issue(ctx, repository, run.IssueNumber)
 	if err != nil {
 		return CommandResult{}, err
 	}
 	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; retrying failed run")
 	next.Status = store.StatusActive
 	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
-		Repository:           github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository},
+		Repository:           repository,
 		Issue:                issue,
 		Previous:             run,
 		Next:                 next,
@@ -318,7 +334,7 @@ func (s *Service) persistCommandProjectionWithRun(ctx context.Context, registrat
 	if err := saveCommandRun(ctx, runStore, previous.Revision, next); err != nil {
 		return next, fmt.Errorf("persist command watermark: %w", err)
 	}
-	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	repository := commandRepository(registration)
 	if err := s.deps.GitHub.EditIssueComment(ctx, repository, next.StatusCommentID, statusCommentBody(next)); err != nil {
 		return next, fmt.Errorf("edit status comment for command: %w", err)
 	}
@@ -337,7 +353,7 @@ func saveCommandRun(ctx context.Context, runStore RunStore, expectedRevision int
 // recoverCommandStatusComment finds and attaches the one editable status
 // comment when an earlier process stopped before persisting its identity.
 func (s *Service) recoverCommandStatusComment(ctx context.Context, registration config.RepositoryRegistration, run store.Run) (store.Run, error) {
-	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	repository := commandRepository(registration)
 	comment, err := s.deps.GitHub.FindStatusComment(ctx, repository, run.IssueNumber, statusCommentMarker(run.ID))
 	if err != nil {
 		return run, err

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -160,6 +160,9 @@ func TestPollCommandsSkipsThePersistedWatermark(t *testing.T) {
 	if err != nil || len(first) != 1 || first[0].Outcome != factory.CommandAccepted {
 		t.Fatalf("first PollCommands() = %#v/%v, want one accepted command", first, err)
 	}
+	if runStore.closeCount != 1 {
+		t.Fatalf("first PollCommands() close count = %d, want one close", runStore.closeCount)
+	}
 	second, err := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config:    commandConfig{host: commandHost()},
 		OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
@@ -172,6 +175,9 @@ func TestPollCommandsSkipsThePersistedWatermark(t *testing.T) {
 	}
 	if len(second) != 1 || second[0].Outcome != factory.CommandReplayed || len(githubAdapter.editedComments) != 1 {
 		t.Fatalf("second PollCommands() = %#v, edits = %d, want replay without second edit", second, len(githubAdapter.editedComments))
+	}
+	if runStore.closeCount != 2 {
+		t.Fatalf("second PollCommands() close count = %d, want one additional close", runStore.closeCount)
 	}
 }
 
@@ -225,9 +231,11 @@ func (c commandConfig) Create(string) (config.HostConfig, error) { return c.host
 
 // commandRunStore is a restartable in-memory store fixture.
 type commandRunStore struct {
-	current *store.Run
-	latest  *store.Run
-	saved   []store.Run
+	current    *store.Run
+	latest     *store.Run
+	saved      []store.Run
+	// closeCount records store lifetime in polling tests.
+	closeCount int
 }
 
 // CurrentRun returns the active run when one exists.
@@ -271,7 +279,10 @@ func (s *commandRunStore) SaveRunIfRevision(ctx context.Context, expected int64,
 }
 
 // Close satisfies the operational-store seam.
-func (s *commandRunStore) Close() error { return nil }
+func (s *commandRunStore) Close() error {
+	s.closeCount++
+	return nil
+}
 
 // commandGitHub records command-related effects.
 type commandGitHub struct {

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -278,7 +278,8 @@ func (s *commandRunStore) SaveRunIfRevision(ctx context.Context, expected int64,
 	return s.SaveRun(ctx, run)
 }
 
-// Close satisfies the operational-store seam.
+// Close increments the test store's close counter and returns nil, satisfying
+// the operational-store seam.
 func (s *commandRunStore) Close() error {
 	s.closeCount++
 	return nil

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -1,0 +1,329 @@
+package factory_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestHandleCommandAcceptsAuthorizedStatusAndPersistsTheWatermark verifies
+// the public command seam and the single-comment supervision projection.
+func TestHandleCommandAcceptsAuthorizedStatusAndPersistsTheWatermark(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newCommandService(runStore, githubAdapter, nil)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 42,
+		Comment:     github.Comment{ID: "10", Author: "alice", Body: "/factory status"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.ProcessedCommentID != "10" || result.Run.Revision != 1 {
+		t.Fatalf("result = %#v, want accepted revision-one watermark", result)
+	}
+	if len(githubAdapter.replacedLabels) != 0 {
+		t.Fatalf("label mutations = %#v, want none for status", githubAdapter.replacedLabels)
+	}
+	if len(githubAdapter.editedComments) != 1 || !strings.Contains(githubAdapter.editedComments[0].body, "- command: `status`") || !strings.Contains(githubAdapter.editedComments[0].body, "- outcome: `accepted`") {
+		t.Fatalf("status comment edits = %#v, want one accepted status projection", githubAdapter.editedComments)
+	}
+}
+
+// TestHandleCommandRejectsAnUnauthorizedAuthorWithoutWorkflowMutation
+// verifies that authorization is checked before retry or configuration logic.
+func TestHandleCommandRejectsAnUnauthorizedAuthorWithoutWorkflowMutation(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newCommandService(runStore, githubAdapter, nil)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 42,
+		Comment:     github.Comment{ID: "11", Author: "mallory", Body: "/factory retry"},
+	})
+	var rejection *factory.PolicyRejection
+	if !errors.As(err, &rejection) || rejection.Code != factory.PolicyRejectionUnauthorized {
+		t.Fatalf("HandleCommand() error = %v, want unauthorized PolicyRejection", err)
+	}
+	if result.Outcome != factory.CommandRejected || result.Run.Status != store.StatusActive {
+		t.Fatalf("result = %#v, want rejected active run", result)
+	}
+	if len(githubAdapter.replacedLabels) != 0 {
+		t.Fatalf("label mutations = %#v, want none for unauthorized command", githubAdapter.replacedLabels)
+	}
+	if len(githubAdapter.editedComments) != 1 || !strings.Contains(githubAdapter.editedComments[0].body, "unauthorized") {
+		t.Fatalf("status comment edits = %#v, want visible rejection", githubAdapter.editedComments)
+	}
+}
+
+// TestHandleCommandNeverReexecutesAnEditedComment verifies the immutable ID
+// watermark wins over the edited body and current author.
+func TestHandleCommandNeverReexecutesAnEditedComment(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newCommandService(runStore, githubAdapter, nil)
+
+	first, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: 42, Comment: github.Comment{ID: "12", Author: "alice", Body: "/factory status"}})
+	if err != nil || first.Outcome != factory.CommandAccepted {
+		t.Fatalf("first HandleCommand() = %#v/%v, want accepted", first, err)
+	}
+	second, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: 42, Comment: github.Comment{ID: "12", Author: "alice", Body: "/factory retry"}})
+	if err != nil {
+		t.Fatalf("edited HandleCommand() error = %v", err)
+	}
+	if second.Outcome != factory.CommandReplayed || second.Run.Status != store.StatusActive || len(githubAdapter.replacedLabels) != 0 {
+		t.Fatalf("edited command result = %#v, label mutations = %#v, want replay with no workflow effect", second, githubAdapter.replacedLabels)
+	}
+	if len(githubAdapter.editedComments) != 1 {
+		t.Fatalf("status comment edits = %d, want one execution", len(githubAdapter.editedComments))
+	}
+}
+
+// TestHandleCommandRetriesAFailedRun verifies the ticketed retry transition
+// reuses the existing status comment and does not create a second one.
+func TestHandleCommandRetriesAFailedRun(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusFailed)
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentFailed}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandRunStore{latest: &run}
+	service := newCommandService(runStore, githubAdapter, nil)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: 42, Comment: github.Comment{ID: "13", Author: "alice", Body: "/factory retry"}})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive || result.Run.ProcessedCommentID != "13" {
+		t.Fatalf("result = %#v, want active retried run", result)
+	}
+	if len(githubAdapter.createdComments) != 0 || len(githubAdapter.editedComments) != 1 {
+		t.Fatalf("comment mutations = created=%d edited=%d, want edit only", len(githubAdapter.createdComments), len(githubAdapter.editedComments))
+	}
+	if got, want := githubAdapter.replacedLabels, []string{github.LabelAgentRunning}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("labels = %#v, want %#v", got, want)
+	}
+}
+
+// TestHandleCommandPersistsHarnessConfiguration verifies authorized policy
+// configuration is stored for a later invocation rather than changing the
+// frozen specification packet.
+func TestHandleCommandPersistsHarnessConfiguration(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newCommandService(runStore, githubAdapter, nil)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: 42, Comment: github.Comment{ID: "14", Author: "alice", Body: "/factory config harness=codex"}})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Run.HarnessOverride != "codex" || result.Run.SpecificationPacket != run.SpecificationPacket {
+		t.Fatalf("result = %#v, want harness override without packet mutation", result)
+	}
+}
+
+// TestPollCommandsSkipsThePersistedWatermark verifies polling sees issue
+// comments while a second poll, including after a fresh service, is inert.
+func TestPollCommandsSkipsThePersistedWatermark(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	githubAdapter := &commandGitHub{
+		issue:         github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: "status-1"},
+		comments:      []github.Comment{{ID: "15", Author: "alice", Body: "/factory refresh"}},
+	}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newCommandService(runStore, githubAdapter, githubAdapter)
+
+	first, err := service.PollCommands(context.Background(), factory.CommandPollRequest{RunID: run.ID})
+	if err != nil || len(first) != 1 || first[0].Outcome != factory.CommandAccepted {
+		t.Fatalf("first PollCommands() = %#v/%v, want one accepted command", first, err)
+	}
+	second, err := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:    commandConfig{host: commandHost()},
+		OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		GitHub:    githubAdapter,
+		Comments:  githubAdapter,
+		Now:       func() time.Time { return time.Date(2026, 8, 23, 10, 11, 12, 0, time.UTC) },
+	}).PollCommands(context.Background(), factory.CommandPollRequest{RunID: run.ID})
+	if err != nil {
+		t.Fatalf("second PollCommands() error = %v", err)
+	}
+	if len(second) != 1 || second[0].Outcome != factory.CommandReplayed || len(githubAdapter.editedComments) != 1 {
+		t.Fatalf("second PollCommands() = %#v, edits = %d, want replay without second edit", second, len(githubAdapter.editedComments))
+	}
+}
+
+// commandRun creates a persisted command fixture with a frozen valid packet.
+func commandRun(t *testing.T, status store.Status) store.Run {
+	t.Helper()
+	packet, err := json.Marshal(factory.SpecificationPacket{Version: 1, RepositoryConfig: commandRepositoryConfig()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 23, 10, 11, 12, 0, time.UTC)
+	return store.Run{ID: "run-command", RepositoryPath: "/repo", IssueNumber: 42, Stage: store.StageImplementation, Status: status, StatusCommentID: "status-1", SpecificationPacket: string(packet), CreatedAt: now, UpdatedAt: now}
+}
+
+// commandRepositoryConfig returns the smallest policy needed by command tests.
+func commandRepositoryConfig() config.RepositoryConfig {
+	policy := validRepositoryConfig()
+	policy.AllowedOverrides = append(policy.AllowedOverrides, config.OverrideHarness)
+	policy.RoleHarnessDefaults = map[string]config.Harness{"implementation": config.HarnessCodex}
+	return policy
+}
+
+// commandHost returns a single registered repository with one authorized user.
+func commandHost() config.HostConfig {
+	return config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{Path: "/repo", GitHub: config.GitHubConfig{Owner: "example", Repository: "project"}, AuthorizedUsers: []string{"alice"}, OperationalDataPath: "/outside/factory.db", RepositoryConfigPath: "/repo/factory.yaml"}}}
+}
+
+// newCommandService builds a service at the public command seam.
+func newCommandService(runStore *commandRunStore, githubAdapter *commandGitHub, comments github.CommentReader) *factory.Service {
+	dependencies := factory.Dependencies{
+		Config:    commandConfig{host: commandHost()},
+		OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		GitHub:    githubAdapter,
+		Comments:  comments,
+		Now:       func() time.Time { return time.Date(2026, 8, 23, 10, 11, 12, 0, time.UTC) },
+	}
+	return factory.NewWithDependencies("/host/config.yaml", dependencies)
+}
+
+// commandConfig is the read-only host configuration adapter for command tests.
+type commandConfig struct{ host config.HostConfig }
+
+// Load returns the configured host registration.
+func (c commandConfig) Load(string) (config.HostConfig, error) { return c.host, nil }
+
+// Save is not used by command handling.
+func (c commandConfig) Save(string, config.HostConfig) error { return nil }
+
+// Create is not used by command handling.
+func (c commandConfig) Create(string) (config.HostConfig, error) { return c.host, nil }
+
+// commandRunStore is a restartable in-memory store fixture.
+type commandRunStore struct {
+	current *store.Run
+	latest  *store.Run
+	saved   []store.Run
+}
+
+// CurrentRun returns the active run when one exists.
+func (s *commandRunStore) CurrentRun(context.Context) (*store.Run, error) {
+	if s.current == nil {
+		return nil, nil
+	}
+	copy := *s.current
+	return &copy, nil
+}
+
+// LatestRun returns the most recently claimed run, including terminal runs.
+func (s *commandRunStore) LatestRun(context.Context) (*store.Run, error) {
+	if s.latest == nil {
+		return nil, nil
+	}
+	copy := *s.latest
+	return &copy, nil
+}
+
+// SaveRun records the new current state and makes it visible after restart.
+func (s *commandRunStore) SaveRun(_ context.Context, run store.Run) error {
+	s.saved = append(s.saved, run)
+	copy := run
+	s.latest = &copy
+	if store.IsTerminalStatus(run.Status) {
+		s.current = nil
+	} else {
+		s.current = &copy
+	}
+	return nil
+}
+
+// SaveRunIfRevision mirrors the SQLite compare-and-set seam in the command
+// fixture so command tests exercise stale-revision rejection as well.
+func (s *commandRunStore) SaveRunIfRevision(ctx context.Context, expected int64, run store.Run) error {
+	if s.latest != nil && s.latest.Revision != expected {
+		return store.ErrRevisionConflict
+	}
+	return s.SaveRun(ctx, run)
+}
+
+// Close satisfies the operational-store seam.
+func (s *commandRunStore) Close() error { return nil }
+
+// commandGitHub records command-related effects.
+type commandGitHub struct {
+	issue           github.Issue
+	comments        []github.Comment
+	statusComment   github.Comment
+	replacedLabels  []string
+	createdComments []string
+	editedComments  []commandEditedComment
+}
+
+// Issue returns the issue projection used by retry transitions.
+func (g *commandGitHub) Issue(context.Context, github.Repository, int) (github.Issue, error) {
+	return g.issue, nil
+}
+
+// CreateLabel is unused by command handling.
+func (g *commandGitHub) CreateLabel(context.Context, github.Repository, github.Label) error {
+	return nil
+}
+
+// ReplaceIssueLabels records the workflow label mutation.
+func (g *commandGitHub) ReplaceIssueLabels(_ context.Context, _ github.Repository, _ int, labels []string) error {
+	g.replacedLabels = append([]string(nil), labels...)
+	g.issue.Labels = append([]string(nil), labels...)
+	return nil
+}
+
+// CreateIssueComment records accidental duplicate status-comment creation.
+func (g *commandGitHub) CreateIssueComment(_ context.Context, _ github.Repository, _ int, body string) (github.Comment, error) {
+	g.createdComments = append(g.createdComments, body)
+	return github.Comment{ID: "created-status", Body: body}, nil
+}
+
+// FindStatusComment returns the existing editable status comment.
+func (g *commandGitHub) FindStatusComment(context.Context, github.Repository, int, string) (github.Comment, error) {
+	return g.statusComment, nil
+}
+
+// EditIssueComment records one edit of the single status comment.
+func (g *commandGitHub) EditIssueComment(_ context.Context, _ github.Repository, id, body string) error {
+	g.editedComments = append(g.editedComments, commandEditedComment{id: id, body: body})
+	return nil
+}
+
+// IssueComments supplies the comments observed by polling.
+func (g *commandGitHub) IssueComments(context.Context, github.Repository, int) ([]github.Comment, error) {
+	return append([]github.Comment(nil), g.comments...), nil
+}
+
+// commandEditedComment records a status-comment edit.
+type commandEditedComment struct {
+	id   string
+	body string
+}

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -38,6 +38,10 @@ type Factory interface {
 	// configured gate, pushes the branch, and creates or updates one draft PR.
 	CreateDraftPullRequest(context.Context, DraftPullRequestRequest) (DraftPullRequestResult, error)
 	Status(context.Context) (StatusResult, error)
+	// HandleCommand processes one structured GitHub comment exactly once.
+	HandleCommand(context.Context, CommandRequest) (CommandResult, error)
+	// PollCommands reads issue and pull-request comments for the current run.
+	PollCommands(context.Context, CommandPollRequest) ([]CommandResult, error)
 }
 
 // RunCoordinator is the single claim/state-transition seam used by the
@@ -100,7 +104,9 @@ type Dependencies struct {
 	GitWorkspace gitadapter.GitWorkspace
 	// PullRequests owns idempotent draft pull-request discovery and mutation.
 	PullRequests github.PullRequestClient
-	Worker       worker.WorkerRuntime
+	// Comments lists issue and pull-request comments for command polling.
+	Comments github.CommentReader
+	Worker   worker.WorkerRuntime
 	// Terminal owns visible control and run workspaces.
 	Terminal terminal.TerminalRuntime
 	// Harness owns interactive role lifecycle and native session recovery.
@@ -113,6 +119,7 @@ type Dependencies struct {
 type Service struct {
 	configPath        string
 	deps              Dependencies
+	commandMu         sync.Mutex
 	runtimeMu         sync.Mutex
 	runtimeSocketPath string
 	runtimePathSet    bool
@@ -213,6 +220,11 @@ func NewWithDependencies(configPath string, dependencies Dependencies) *Service 
 	if dependencies.PullRequests == nil {
 		if client, ok := dependencies.GitHub.(github.PullRequestClient); ok {
 			dependencies.PullRequests = client
+		}
+	}
+	if dependencies.Comments == nil {
+		if reader, ok := dependencies.GitHub.(github.CommentReader); ok {
+			dependencies.Comments = reader
 		}
 	}
 	if dependencies.Worker == nil {

--- a/internal/github/comment_test.go
+++ b/internal/github/comment_test.go
@@ -1,0 +1,37 @@
+package github_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/github"
+)
+
+// TestIssueCommentsReturnsAuthorAndRevision verifies that command polling gets
+// the immutable comment identity, author, and edit revision it needs.
+func TestIssueCommentsReturnsAuthorAndRevision(t *testing.T) {
+	t.Parallel()
+
+	updatedAt := "2026-08-23T10:11:12Z"
+	runner := &fakeCommandRunner{outputs: [][]byte{[]byte(`[[{"id":42,"body":"/factory status","user":{"login":"alice"},"updated_at":"` + updatedAt + `"}]]`)}}
+	client := &github.GhClient{Runner: runner}
+
+	comments, err := client.IssueComments(context.Background(), github.Repository{Owner: "example", Name: "project"}, 8)
+	if err != nil {
+		t.Fatalf("IssueComments() error = %v", err)
+	}
+	if len(comments) != 1 || comments[0].ID != "42" || comments[0].Author != "alice" || comments[0].Body != "/factory status" {
+		t.Fatalf("comments = %#v, want one authored command comment", comments)
+	}
+	parsed, err := time.Parse(time.RFC3339, updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !comments[0].UpdatedAt.Equal(parsed) {
+		t.Fatalf("comment revision = %s, want %s", comments[0].UpdatedAt, parsed)
+	}
+	if len(runner.calls) != 1 || !containsArgs(runner.calls[0].args, "--paginate") || !containsArgs(runner.calls[0].args, "--slurp") {
+		t.Fatalf("gh calls = %#v, want paginated issue comments", runner.calls)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -305,6 +305,7 @@ func (c *GhClient) IssueComments(ctx context.Context, repository Repository, num
 
 // FindStatusComment recovers a previously created status comment by its
 // immutable run marker when persistence was interrupted after GitHub mutation.
+// It only returns a marker match authored by the authenticated coordinator.
 func (c *GhClient) FindStatusComment(ctx context.Context, repository Repository, number int, marker string) (Comment, error) {
 	if number <= 0 {
 		return Comment{}, errors.New("issue number must be positive")
@@ -312,18 +313,38 @@ func (c *GhClient) FindStatusComment(ctx context.Context, repository Repository,
 	if strings.TrimSpace(marker) == "" {
 		return Comment{}, errors.New("status comment marker is required")
 	}
+	coordinator, err := c.authenticatedUser(ctx)
+	if err != nil {
+		return Comment{}, err
+	}
 	var pages [][]commentResponse
 	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/issues/%d/comments", repository.String(), number), "--paginate", "--slurp"}, nil, &pages); err != nil {
 		return Comment{}, fmt.Errorf("find status comment on issue #%d: %w", number, err)
 	}
 	for _, page := range pages {
 		for _, response := range page {
-			if strings.Contains(response.Body, marker) {
-				return response.comment(), nil
+			comment := response.comment()
+			if strings.Contains(comment.Body, marker) && strings.EqualFold(strings.TrimSpace(comment.Author), coordinator) {
+				return comment, nil
 			}
 		}
 	}
 	return Comment{}, nil
+}
+
+// authenticatedUser returns the GitHub login attached to the local gh
+// credential, which is the only reliable coordinator identity available to the
+// adapter when it recovers a status comment.
+func (c *GhClient) authenticatedUser(ctx context.Context) (string, error) {
+	var response userResponse
+	if err := c.callJSON(ctx, []string{"api", "user"}, nil, &response); err != nil {
+		return "", fmt.Errorf("identify authenticated GitHub user: %w", err)
+	}
+	login := strings.TrimSpace(response.Login)
+	if login == "" {
+		return "", errors.New("authenticated GitHub user has no login")
+	}
+	return login, nil
 }
 
 // EditIssueComment edits an existing issue comment by id.
@@ -510,6 +531,12 @@ type commentResponse struct {
 	User      struct {
 		Login string `json:"login"`
 	} `json:"user"`
+}
+
+// userResponse is the authenticated GitHub user projection used for ownership
+// checks on coordinator-created comments.
+type userResponse struct {
+	Login string `json:"login"`
 }
 
 // comment converts the GitHub response shape into the coordinator-neutral

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -66,10 +66,23 @@ type Label struct {
 	Color       string
 }
 
-// Comment is the identity returned after creating a GitHub issue comment.
+// Comment is the coordinator-neutral identity and revision of a GitHub issue
+// or pull-request comment.
 type Comment struct {
-	ID   string
+	// ID is the immutable GitHub comment identity used as a replay watermark.
+	ID string
+	// Body is the complete user-authored comment text.
 	Body string
+	// Author is the GitHub login that authored the comment.
+	Author string
+	// UpdatedAt is the current edit revision of the comment.
+	UpdatedAt time.Time
+}
+
+// CommentReader lists comments for an issue or pull request through the
+// shared GitHub issue-comments endpoint.
+type CommentReader interface {
+	IssueComments(context.Context, Repository, int) ([]Comment, error)
 }
 
 // PullRequest is the pull-request identity and body returned to the
@@ -196,6 +209,8 @@ type GhClient struct {
 	Runner CommandRunner
 }
 
+var _ CommentReader = (*GhClient)(nil)
+
 // NewClient returns a GitHub CLI-backed client.
 func NewClient() *GhClient { return &GhClient{Runner: commandRunner{}} }
 
@@ -266,7 +281,26 @@ func (c *GhClient) CreateIssueComment(ctx context.Context, repository Repository
 	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/issues/%d/comments", repository.String(), number), "--method", "POST"}, map[string]string{"body": body}, &response); err != nil {
 		return Comment{}, fmt.Errorf("create status comment on issue #%d: %w", number, err)
 	}
-	return Comment{ID: fmt.Sprint(response.ID), Body: response.Body}, nil
+	return response.comment(), nil
+}
+
+// IssueComments lists all comments for an issue or pull request in GitHub's
+// stable API order. The caller uses comment IDs as the exactly-once watermark.
+func (c *GhClient) IssueComments(ctx context.Context, repository Repository, number int) ([]Comment, error) {
+	if number <= 0 {
+		return nil, errors.New("issue number must be positive")
+	}
+	var pages [][]commentResponse
+	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/issues/%d/comments", repository.String(), number), "--paginate", "--slurp"}, nil, &pages); err != nil {
+		return nil, fmt.Errorf("list comments on issue #%d: %w", number, err)
+	}
+	comments := make([]Comment, 0)
+	for _, page := range pages {
+		for _, response := range page {
+			comments = append(comments, response.comment())
+		}
+	}
+	return comments, nil
 }
 
 // FindStatusComment recovers a previously created status comment by its
@@ -285,7 +319,7 @@ func (c *GhClient) FindStatusComment(ctx context.Context, repository Repository,
 	for _, page := range pages {
 		for _, response := range page {
 			if strings.Contains(response.Body, marker) {
-				return Comment{ID: fmt.Sprint(response.ID), Body: response.Body}, nil
+				return response.comment(), nil
 			}
 		}
 	}
@@ -470,8 +504,18 @@ type issueResponse struct {
 // commentResponse is the subset of a GitHub comment response needed to retain
 // the editable comment identity.
 type commentResponse struct {
-	ID   int64  `json:"id"`
-	Body string `json:"body"`
+	ID        int64     `json:"id"`
+	Body      string    `json:"body"`
+	UpdatedAt time.Time `json:"updated_at"`
+	User      struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+// comment converts the GitHub response shape into the coordinator-neutral
+// comment model.
+func (r commentResponse) comment() Comment {
+	return Comment{ID: fmt.Sprint(r.ID), Body: r.Body, Author: r.User.Login, UpdatedAt: r.UpdatedAt}
 }
 
 // pullRequestResponse is the GitHub API subset used by the factory.

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -20,7 +20,8 @@ func TestGhClientUsesTheLocalCLIForIssueAndClaimMutations(t *testing.T) {
 		[]byte("[]"),
 		[]byte(`{"id":12345,"body":"status"}`),
 		[]byte(""),
-		[]byte(`[[{"id":7,"body":"older status"}],[{"id":12345,"body":"<!-- factory-status: run-1 --> status"}]]`),
+		[]byte(`{"login":"factory-bot"}`),
+		[]byte(`[[{"id":7,"body":"<!-- factory-status: run-1 --> forged status","user":{"login":"alice"}},{"id":12345,"body":"<!-- factory-status: run-1 --> status","user":{"login":"factory-bot"}}]]`),
 	}}
 	client := &github.GhClient{Runner: runner}
 	repository := github.Repository{Owner: "example", Name: "project"}
@@ -58,12 +59,12 @@ func TestGhClientUsesTheLocalCLIForIssueAndClaimMutations(t *testing.T) {
 	if recovered.ID != "12345" {
 		t.Fatalf("recovered comment id = %q, want 12345", recovered.ID)
 	}
-	if !hasArgs(runner.calls[5].args, "--paginate", "--slurp") {
-		t.Fatalf("FindStatusComment args = %#v, want pagination", runner.calls[5].args)
+	if !hasArgs(runner.calls[6].args, "--paginate", "--slurp") {
+		t.Fatalf("FindStatusComment args = %#v, want pagination", runner.calls[6].args)
 	}
 
-	if len(runner.calls) != 6 {
-		t.Fatalf("CLI calls = %d, want six", len(runner.calls))
+	if len(runner.calls) != 7 {
+		t.Fatalf("CLI calls = %d, want seven", len(runner.calls))
 	}
 	if !hasArgs(runner.calls[1].args, "label", "create", github.LabelAgentRunning, "--force") {
 		t.Fatalf("label call = %#v, want explicit idempotent label creation", runner.calls[1].args)
@@ -80,10 +81,28 @@ func TestGhClientUsesTheLocalCLIForIssueAndClaimMutations(t *testing.T) {
 			t.Errorf("mutation call %#v does not send JSON through stdin", call.args)
 		}
 	}
-	for _, index := range []int{0, 2, 3, 4, 5} {
+	for _, index := range []int{0, 2, 3, 4, 5, 6} {
 		if hasArgs(runner.calls[index].args, "--repo") {
 			t.Errorf("gh api call %d still uses unsupported --repo: %#v", index, runner.calls[index].args)
 		}
+	}
+}
+
+// TestGhClientRejectsAUserAuthoredStatusMarker verifies a human comment with
+// a copied marker cannot become the coordinator's editable status comment.
+func TestGhClientRejectsAUserAuthoredStatusMarker(t *testing.T) {
+	t.Parallel()
+
+	client := &github.GhClient{Runner: &fakeCommandRunner{outputs: [][]byte{
+		[]byte(`{"login":"factory-bot"}`),
+		[]byte(`[[{"id":7,"body":"<!-- factory-status: run-1 --> forged status","user":{"login":"alice"}}]]`),
+	}}}
+	comment, err := client.FindStatusComment(context.Background(), github.Repository{Owner: "example", Name: "project"}, 42, "factory-status: run-1")
+	if err != nil {
+		t.Fatalf("FindStatusComment() error = %v", err)
+	}
+	if comment.ID != "" {
+		t.Fatalf("FindStatusComment() = %#v, want no user-authored match", comment)
 	}
 }
 

--- a/internal/store/command_test.go
+++ b/internal/store/command_test.go
@@ -87,6 +87,9 @@ func TestSaveRunIfRevisionRejectsAStaleCommand(t *testing.T) {
 	if err := opened.SaveRun(context.Background(), initial); err != nil {
 		t.Fatalf("SaveRun() error = %v", err)
 	}
+	if err := opened.SaveRunIfRevision(context.Background(), initial.Revision, initial); !errors.Is(err, store.ErrRevisionNotAdvanced) {
+		t.Fatalf("SaveRunIfRevision() non-advancing error = %v, want ErrRevisionNotAdvanced", err)
+	}
 	stale := initial
 	stale.Revision = 3
 	stale.ProcessedCommentID = "comment-stale"

--- a/internal/store/command_test.go
+++ b/internal/store/command_test.go
@@ -1,0 +1,99 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestRunPersistsTheProcessedCommandWatermarkAcrossRestart verifies that a
+// coordinator restart cannot make an already processed comment eligible again.
+func TestRunPersistsTheProcessedCommandWatermarkAcrossRestart(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "factory.db")
+	if err := os.Chmod(filepath.Dir(databasePath), 0o700); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	createdAt := time.Date(2026, 8, 23, 10, 11, 12, 0, time.UTC)
+	run := store.Run{
+		ID:                       "run-command",
+		RepositoryPath:           "/repo",
+		IssueNumber:              8,
+		Stage:                    store.StageImplementation,
+		Status:                   store.StatusActive,
+		Revision:                 4,
+		ProcessedCommentID:       "comment-42",
+		ProcessedCommentRevision: 4,
+		LastCommandName:          "status",
+		LastCommandOutcome:       "accepted",
+		LastCommandMessage:       "status refreshed",
+		HarnessOverride:          "codex",
+		CreatedAt:                createdAt,
+		UpdatedAt:                createdAt,
+	}
+
+	opened, err := store.Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if err := opened.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	restarted, err := store.Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatalf("Open() after restart error = %v", err)
+	}
+	defer func() { _ = restarted.Close() }()
+	latest, err := restarted.LatestRun(context.Background())
+	if err != nil {
+		t.Fatalf("LatestRun() error = %v", err)
+	}
+	if latest == nil {
+		t.Fatal("LatestRun() = nil, want persisted run")
+	}
+	if latest.Revision != run.Revision || latest.ProcessedCommentID != run.ProcessedCommentID || latest.ProcessedCommentRevision != run.ProcessedCommentRevision {
+		t.Fatalf("watermark = revision %d/comment %q/comment revision %d, want %d/%q/%d", latest.Revision, latest.ProcessedCommentID, latest.ProcessedCommentRevision, run.Revision, run.ProcessedCommentID, run.ProcessedCommentRevision)
+	}
+	if latest.LastCommandName != run.LastCommandName || latest.LastCommandOutcome != run.LastCommandOutcome || latest.LastCommandMessage != run.LastCommandMessage || latest.HarnessOverride != run.HarnessOverride {
+		t.Fatalf("command state = %#v, want %#v", latest, run)
+	}
+}
+
+// TestSaveRunIfRevisionRejectsAStaleCommand verifies the SQLite compare-and-set
+// refuses a second coordinator that read an older run revision.
+func TestSaveRunIfRevisionRejectsAStaleCommand(t *testing.T) {
+	t.Parallel()
+
+	databasePath := filepath.Join(t.TempDir(), "factory.db")
+	if err := os.Chmod(filepath.Dir(databasePath), 0o700); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	opened, err := store.Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() { _ = opened.Close() }()
+	initial := store.Run{ID: "run-cas", RepositoryPath: "/repo", Stage: store.StageImplementation, Status: store.StatusActive, Revision: 2}
+	if err := opened.SaveRun(context.Background(), initial); err != nil {
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	stale := initial
+	stale.Revision = 3
+	stale.ProcessedCommentID = "comment-stale"
+	if err := opened.SaveRunIfRevision(context.Background(), 1, stale); !errors.Is(err, store.ErrRevisionConflict) {
+		t.Fatalf("SaveRunIfRevision() error = %v, want ErrRevisionConflict", err)
+	}
+	if err := opened.SaveRunIfRevision(context.Background(), 2, stale); err != nil {
+		t.Fatalf("SaveRunIfRevision() current error = %v", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,11 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 7
+const CurrentSchemaVersion = 8
+
+// ErrRevisionConflict reports that another coordinator revision was persisted
+// after a command read the run and before it attempted its compare-and-set.
+var ErrRevisionConflict = errors.New("run revision conflict")
 
 // runTimestampLayout keeps serialized run timestamps fixed-width so SQLite
 // text ordering matches chronological ordering for sub-second timestamps.
@@ -104,7 +108,25 @@ type Run struct {
 	// PullRequestNumber is the persisted idempotency identity of the draft PR.
 	PullRequestNumber int
 	// PullRequestURL is the operator-facing URL of the draft PR.
-	PullRequestURL      string
+	PullRequestURL string
+	// Revision is the monotonic coordinator revision used by command replay
+	// prevention and persisted supervision updates.
+	Revision int64
+	// ProcessedCommentID is the highest processed GitHub comment watermark for
+	// this run. Editing that comment must never execute it again.
+	ProcessedCommentID string
+	// ProcessedCommentRevision records the run revision at which the watermark
+	// was persisted, making the watermark tuple restart-safe and auditable.
+	ProcessedCommentRevision int64
+	// LastCommandName is the last recognized structured command kind.
+	LastCommandName string
+	// LastCommandOutcome is accepted, rejected, or replayed for the last command.
+	LastCommandOutcome string
+	// LastCommandMessage is the operator-facing result detail rendered in the
+	// single editable status comment.
+	LastCommandMessage string
+	// HarnessOverride is the authorized harness choice for a later invocation.
+	HarnessOverride     string
 	SpecificationPacket string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
@@ -248,6 +270,9 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url,
+		       revision, processed_comment_id, processed_comment_revision,
+		       last_command_name, last_command_outcome, last_command_message,
+		       harness_override,
 		       specification_packet, created_at, updated_at
 		FROM operational_runs
 		WHERE status NOT IN (?, ?, ?)
@@ -263,6 +288,9 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url,
+		       revision, processed_comment_id, processed_comment_revision,
+		       last_command_name, last_command_outcome, last_command_message,
+		       harness_override,
 		       specification_packet, created_at, updated_at
 		FROM operational_runs
 		ORDER BY updated_at DESC
@@ -288,6 +316,13 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&run.StatusCommentID,
 		&run.PullRequestNumber,
 		&run.PullRequestURL,
+		&run.Revision,
+		&run.ProcessedCommentID,
+		&run.ProcessedCommentRevision,
+		&run.LastCommandName,
+		&run.LastCommandOutcome,
+		&run.LastCommandMessage,
+		&run.HarnessOverride,
 		&run.SpecificationPacket,
 		&createdAt,
 		&updatedAt,
@@ -311,14 +346,48 @@ func scanRun(row *sql.Row) (*Run, error) {
 
 // SaveRun validates and upserts one operational run record.
 func (s *Store) SaveRun(ctx context.Context, run Run) error {
+	run, err := normalizeRun(run)
+	if err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, saveRunStatement, runValues(run)...); err != nil {
+		return fmt.Errorf("save run: %w", err)
+	}
+	return nil
+}
+
+// SaveRunIfRevision persists one command result only when the run still has
+// expectedRevision. It prevents concurrent coordinators from executing one
+// comment against the same stale run snapshot.
+func (s *Store) SaveRunIfRevision(ctx context.Context, expectedRevision int64, run Run) error {
+	run, err := normalizeRun(run)
+	if err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, saveRunIfRevisionStatement, append(runValues(run)[1:], run.ID, expectedRevision)...)
+	if err != nil {
+		return fmt.Errorf("save run at revision %d: %w", expectedRevision, err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("inspect run revision %d update: %w", expectedRevision, err)
+	}
+	if changed != 1 {
+		return fmt.Errorf("%w: run %q no longer has revision %d", ErrRevisionConflict, run.ID, expectedRevision)
+	}
+	return nil
+}
+
+// normalizeRun validates a run and fills absent timestamps before persistence.
+func normalizeRun(run Run) (Run, error) {
 	if run.ID == "" {
-		return errors.New("run id is required")
+		return Run{}, errors.New("run id is required")
 	}
 	if run.RepositoryPath == "" {
-		return errors.New("run repository path is required")
+		return Run{}, errors.New("run repository path is required")
 	}
 	if run.Status == "" {
-		return errors.New("run status is required")
+		return Run{}, errors.New("run status is required")
 	}
 	if run.CreatedAt.IsZero() {
 		run.CreatedAt = time.Now().UTC()
@@ -326,27 +395,13 @@ func (s *Store) SaveRun(ctx context.Context, run Run) error {
 	if run.UpdatedAt.IsZero() {
 		run.UpdatedAt = run.CreatedAt
 	}
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO operational_runs (
-			id, repository_path, issue_number, stage, status, branch, worktree,
-			checkpoint_sha, image_digest, coordinator, status_comment_id,
-			pull_request_number, pull_request_url, specification_packet, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
-			repository_path = excluded.repository_path,
-			issue_number = excluded.issue_number,
-			stage = excluded.stage,
-			status = excluded.status,
-			branch = excluded.branch,
-			worktree = excluded.worktree,
-			checkpoint_sha = excluded.checkpoint_sha,
-			image_digest = excluded.image_digest,
-			coordinator = excluded.coordinator,
-			status_comment_id = excluded.status_comment_id,
-			pull_request_number = excluded.pull_request_number,
-			pull_request_url = excluded.pull_request_url,
-			specification_packet = excluded.specification_packet,
-			updated_at = excluded.updated_at`,
+	return run, nil
+}
+
+// runValues returns the ordered SQL values shared by normal and revision-safe
+// run persistence.
+func runValues(run Run) []any {
+	return []any{
 		run.ID,
 		run.RepositoryPath,
 		run.IssueNumber,
@@ -360,15 +415,59 @@ func (s *Store) SaveRun(ctx context.Context, run Run) error {
 		run.StatusCommentID,
 		run.PullRequestNumber,
 		run.PullRequestURL,
+		run.Revision,
+		run.ProcessedCommentID,
+		run.ProcessedCommentRevision,
+		run.LastCommandName,
+		run.LastCommandOutcome,
+		run.LastCommandMessage,
+		run.HarnessOverride,
 		run.SpecificationPacket,
 		run.CreatedAt.UTC().Format(runTimestampLayout),
 		run.UpdatedAt.UTC().Format(runTimestampLayout),
-	)
-	if err != nil {
-		return fmt.Errorf("save run: %w", err)
 	}
-	return nil
 }
+
+const saveRunStatement = `
+		INSERT INTO operational_runs (
+			id, repository_path, issue_number, stage, status, branch, worktree,
+			checkpoint_sha, image_digest, coordinator, status_comment_id,
+			pull_request_number, pull_request_url, revision, processed_comment_id,
+			processed_comment_revision, last_command_name, last_command_outcome,
+			last_command_message, harness_override, specification_packet, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			repository_path = excluded.repository_path,
+			issue_number = excluded.issue_number,
+			stage = excluded.stage,
+			status = excluded.status,
+			branch = excluded.branch,
+			worktree = excluded.worktree,
+			checkpoint_sha = excluded.checkpoint_sha,
+			image_digest = excluded.image_digest,
+			coordinator = excluded.coordinator,
+			status_comment_id = excluded.status_comment_id,
+			pull_request_number = excluded.pull_request_number,
+			pull_request_url = excluded.pull_request_url,
+			revision = excluded.revision,
+			processed_comment_id = excluded.processed_comment_id,
+			processed_comment_revision = excluded.processed_comment_revision,
+			last_command_name = excluded.last_command_name,
+			last_command_outcome = excluded.last_command_outcome,
+			last_command_message = excluded.last_command_message,
+			harness_override = excluded.harness_override,
+			specification_packet = excluded.specification_packet,
+			updated_at = excluded.updated_at`
+
+const saveRunIfRevisionStatement = `
+		UPDATE operational_runs SET
+			repository_path = ?, issue_number = ?, stage = ?, status = ?, branch = ?, worktree = ?,
+			checkpoint_sha = ?, image_digest = ?, coordinator = ?, status_comment_id = ?,
+			pull_request_number = ?, pull_request_url = ?, revision = ?, processed_comment_id = ?,
+			processed_comment_revision = ?, last_command_name = ?, last_command_outcome = ?,
+			last_command_message = ?, harness_override = ?, specification_packet = ?,
+			created_at = ?, updated_at = ?
+		WHERE id = ? AND revision = ?`
 
 // SaveInvocation validates and upserts one recoverable harness invocation.
 func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error {
@@ -702,6 +801,20 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 			} {
 				if _, err := tx.ExecContext(ctx, statement); err != nil {
 					return fmt.Errorf("apply store migration 7: %w", err)
+				}
+			}
+		case 8:
+			for _, statement := range []string{
+				"ALTER TABLE operational_runs ADD COLUMN revision INTEGER NOT NULL DEFAULT 0",
+				"ALTER TABLE operational_runs ADD COLUMN processed_comment_id TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN processed_comment_revision INTEGER NOT NULL DEFAULT 0",
+				"ALTER TABLE operational_runs ADD COLUMN last_command_name TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN last_command_outcome TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN last_command_message TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN harness_override TEXT NOT NULL DEFAULT ''",
+			} {
+				if _, err := tx.ExecContext(ctx, statement); err != nil {
+					return fmt.Errorf("apply store migration 8: %w", err)
 				}
 			}
 		default:

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,6 +24,10 @@ const CurrentSchemaVersion = 8
 // after a command read the run and before it attempted its compare-and-set.
 var ErrRevisionConflict = errors.New("run revision conflict")
 
+// ErrRevisionNotAdvanced reports that a compare-and-set update did not move
+// the run to a strictly newer revision.
+var ErrRevisionNotAdvanced = errors.New("run revision did not advance")
+
 // runTimestampLayout keeps serialized run timestamps fixed-width so SQLite
 // text ordering matches chronological ordering for sub-second timestamps.
 const runTimestampLayout = "2006-01-02T15:04:05.000000000Z07:00"
@@ -363,6 +367,9 @@ func (s *Store) SaveRunIfRevision(ctx context.Context, expectedRevision int64, r
 	run, err := normalizeRun(run)
 	if err != nil {
 		return err
+	}
+	if run.Revision <= expectedRevision {
+		return fmt.Errorf("%w: got %d, expected greater than %d", ErrRevisionNotAdvanced, run.Revision, expectedRevision)
 	}
 	result, err := s.db.ExecContext(ctx, saveRunIfRevisionStatement, append(runValues(run)[1:], run.ID, expectedRevision)...)
 	if err != nil {


### PR DESCRIPTION
Closes #8. Adds typed /factory status, retry, refresh, and harness configuration commands with authorization, malformed-command policy rejection, replay prevention, persisted comment watermarks, revision CAS, restart-safe state, and editable status feedback. Adds issue/PR comment polling via factory poll, focused coverage, and configuration documentation. Claude selection is fail-closed with a typed harness-unavailable rejection until a Claude adapter exists. Verification: go test ./... and go vet ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authorized GitHub comment commands for checking status, retrying failed runs, refreshing status, and configuring supported execution harnesses.
  - Added a `poll` command to process issue and pull-request comments and report outcomes.
  - Added replay protection, persistent command history, authorization checks, and deterministic comment handling.
  - Status updates now include command feedback and selected harness settings.

- **Bug Fixes**
  - Improved recovery and persistence of status comments and run updates.
  - Added safeguards against stale concurrent updates and unsafe comment content.

- **Documentation**
  - Documented supported commands, authorization, rejection behavior, persistence, replay protection, and polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->