### PR TITLE
fix: finalize and cancel factory runs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,11 @@ The software factory turns an explicitly authorized GitHub issue into a supervis
 One supervised execution that owns a frozen issue, specification packet, branch, worktree, and pull request.
 _Avoid_: Job, task, workflow instance
 
+**GitHub lifecycle observation**:
+One coordinator read of the tracked issue and pull request that can identify
+successful merge completion or an unmerged closure requiring cancellation.
+_Avoid_: Screen scrape, automatic resume
+
 **Specification packet**:
 The versioned, frozen statement of product intent for a run, consisting of the claimed issue snapshot and accepted clarifications or revisions.
 _Avoid_: Live issue, prompt

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,6 +215,7 @@ mention of “retry” or “refresh” cannot control a run:
 /factory status
 /factory refresh
 /factory retry
+/factory cancel
 /factory config harness=codex
 ```
 
@@ -224,9 +225,11 @@ comments.
 
 The author must be present in the registered `authorized_users` list. A status
 or refresh command re-renders the existing supervision comment; retry reopens a
-failed run at its current stage; and harness configuration records a later
-invocation override only when the frozen repository configuration permits it. A
-recognized command from an unauthorized author or a malformed command is a
+failed or explicitly cancelled run at its current stage; cancel stops active
+worker activity while retaining the run artifacts; and harness configuration
+records a later invocation override only when the frozen repository
+configuration permits it. A recognized command from an unauthorized author or
+a malformed command is a
 typed policy rejection. The coordinator leaves workflow stage, status, labels,
 and configuration unchanged for that rejection, while recording the rejection
 in the same editable status comment.
@@ -245,16 +248,25 @@ GitHub effects. The same parser and handler are used for issue comments and
 pull-request comments; later commands can extend the registered verb set
 without duplicating polling or replay logic.
 
+The poll command also observes the tracked pull request and issue lifecycle.
+A merged pull request completes the run and records its merge commit; closing
+the issue or an unmerged pull request cancels it. Merge detection takes
+precedence over the pull request's closed state. Terminal transitions replace
+the factory state label, edit the existing status comment, notify cmux, stop
+the worker without deleting retained state, and leave the branch and worktree
+available for cleanup or an explicit retry.
+
 After a claim, `factory agent` starts the visible Codex implementation role and
 prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use
 `factory agent-report --invocation-id <id>` to ask the coordinator to validate
 and accept the structured report. Terminal output is never treated as a stage
-result. The operational store schema is version 8 and persists invocation
+result. The operational store schema is version 9 and persists invocation
 identity, opaque surface handles, prompt version, result directory, native
 session identifier, and permitted handoff paths in addition to run state. It
 also persists the draft pull-request number and URL so a restarted command can
-update the existing pull request instead of creating another one.
+update the existing pull request instead of creating another one. Terminal runs
+retain merge commit and lifecycle reason metadata for status rendering.
 
 ## Creating the draft pull request
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -261,12 +261,13 @@ prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use
 `factory agent-report --invocation-id <id>` to ask the coordinator to validate
 and accept the structured report. Terminal output is never treated as a stage
-result. The operational store schema is version 9 and persists invocation
+result. The operational store schema is version 10 and persists invocation
 identity, opaque surface handles, prompt version, result directory, native
 session identifier, and permitted handoff paths in addition to run state. It
 also persists the draft pull-request number and URL so a restarted command can
 update the existing pull request instead of creating another one. Terminal runs
-retain merge commit and lifecycle reason metadata for status rendering.
+retain merge commit, lifecycle reason, and terminal notification-delivery
+metadata for status rendering and restart-safe cmux notification retries.
 
 ## Creating the draft pull request
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -264,7 +264,19 @@ func runPollCommands(ctx context.Context, args []string, defaultConfigPath strin
 		writeError(errorsOutput, errors.New("poll does not accept positional arguments"))
 		return 2
 	}
-	results, err := factory.New(*configPath).PollCommands(ctx, factory.CommandPollRequest{RunID: *runID})
+	service := factory.New(*configPath)
+	lifecycle, err := service.PollLifecycle(ctx, factory.LifecycleRequest{RunID: *runID})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if lifecycle.Outcome != factory.LifecycleUnchanged {
+		if !writeOutput(output, errorsOutput, "lifecycle: %s run=%s status=%s\n", lifecycle.Outcome, lifecycle.Run.ID, lifecycle.Run.Status) {
+			return 1
+		}
+		return 0
+	}
+	results, err := service.PollCommands(ctx, factory.CommandPollRequest{RunID: *runID})
 	if err != nil {
 		writeError(errorsOutput, err)
 		return 1

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -17,6 +17,8 @@ const (
 	Status Kind = "status"
 	// Retry asks the coordinator to retry a failed run at its current stage.
 	Retry Kind = "retry"
+	// Cancel asks the coordinator to stop an active run while retaining its work.
+	Cancel Kind = "cancel"
 	// Refresh asks the coordinator to refresh the supervision projection.
 	Refresh Kind = "refresh"
 	// ConfigureHarness changes the selected harness for a later invocation.
@@ -110,6 +112,8 @@ func Parse(body string) (ParseResult, error) {
 		return parseFixedArity(result, fields, Status)
 	case string(Retry):
 		return parseFixedArity(result, fields, Retry)
+	case string(Cancel):
+		return parseFixedArity(result, fields, Cancel)
 	case string(Refresh):
 		return parseFixedArity(result, fields, Refresh)
 	case "config", "configure", "harness":

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -95,3 +95,17 @@ func TestParseSupportsHarnessConfigurationForms(t *testing.T) {
 		}
 	}
 }
+
+// TestParseRecognizesTheAuthorizedCancelCommand verifies cancellation uses the
+// same explicit, single-comment command grammar as the existing controls.
+func TestParseRecognizesTheAuthorizedCancelCommand(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := command.Parse("/factory cancel")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if !parsed.Recognized || parsed.Command.Kind != command.Cancel {
+		t.Fatalf("parsed cancel = %#v, want recognized cancel command", parsed)
+	}
+}

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -359,9 +359,10 @@ func githubIssueFixture() github.Issue {
 
 // agentRunStore is an in-memory invocation-capable operational-store fake.
 type agentRunStore struct {
-	runs        map[string]store.Run
-	current     *store.Run
-	invocations map[string]store.Invocation
+	runs            map[string]store.Run
+	current         *store.Run
+	invocations     map[string]store.Invocation
+	lifecycleClaims map[string]map[store.Status]bool
 }
 
 // CurrentRun returns the configured active run.
@@ -371,6 +372,29 @@ func (s *agentRunStore) CurrentRun(context.Context) (*store.Run, error) { return
 func (s *agentRunStore) SaveRun(_ context.Context, run store.Run) error {
 	s.runs[run.ID] = run
 	s.current = &run
+	return nil
+}
+
+// ClaimLifecycleNotification atomically claims notification delivery.
+func (s *agentRunStore) ClaimLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) (bool, error) {
+	if s.lifecycleClaims == nil {
+		s.lifecycleClaims = make(map[string]map[store.Status]bool)
+	}
+	if s.lifecycleClaims[runID] == nil {
+		s.lifecycleClaims[runID] = make(map[store.Status]bool)
+	}
+	if s.lifecycleClaims[runID][terminalStatus] {
+		return false, nil
+	}
+	s.lifecycleClaims[runID][terminalStatus] = true
+	return true, nil
+}
+
+// ReleaseLifecycleNotification removes a notification claim.
+func (s *agentRunStore) ReleaseLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) error {
+	if s.lifecycleClaims != nil && s.lifecycleClaims[runID] != nil {
+		delete(s.lifecycleClaims[runID], terminalStatus)
+	}
 	return nil
 }
 

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -456,6 +456,13 @@ func statusCommentBody(run store.Run) string {
 	if run.PullRequestNumber > 0 {
 		pullRequest = fmt.Sprintf("- pull request: #%d %s\n", run.PullRequestNumber, run.PullRequestURL)
 	}
+	lifecycle := ""
+	if run.MergeCommitSHA != "" {
+		lifecycle += fmt.Sprintf("- merge commit: `%s`\n", safeStatusCommentValue(run.MergeCommitSHA))
+	}
+	if run.LifecycleReason != "" {
+		lifecycle += fmt.Sprintf("- lifecycle reason: %s\n", safeStatusCommentValue(run.LifecycleReason))
+	}
 	commandFeedback := ""
 	if run.LastCommandName != "" {
 		commandFeedback = fmt.Sprintf("\n### Last command\n\n- comment: `%s`\n- revision: `%d`\n- command: `%s`\n- outcome: `%s`\n- message: %s\n", safeStatusCommentValue(run.ProcessedCommentID), run.ProcessedCommentRevision, safeStatusCommentValue(run.LastCommandName), safeStatusCommentValue(run.LastCommandOutcome), safeStatusCommentValue(run.LastCommandMessage))
@@ -464,7 +471,7 @@ func statusCommentBody(run store.Run) string {
 	if run.HarnessOverride != "" {
 		harness = fmt.Sprintf("\n- harness override: `%s`\n", safeStatusCommentValue(run.HarnessOverride))
 	}
-	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, pullRequest, harness, commandFeedback)
+	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, pullRequest, lifecycle, harness, commandFeedback)
 }
 
 // safeStatusCommentValue keeps command feedback single-line and prevents

--- a/internal/factory/claim_test.go
+++ b/internal/factory/claim_test.go
@@ -483,8 +483,9 @@ func (f *fakeWorktree) Remove(context.Context, string, gitadapter.Workspace) err
 
 // fakeRunStore keeps run records in insertion order for coordinator tests.
 type fakeRunStore struct {
-	saved      []store.Run
-	saveErrors []error
+	saved           []store.Run
+	saveErrors      []error
+	lifecycleClaims map[string]map[store.Status]bool
 }
 
 // CurrentRun returns the newest non-terminal record.
@@ -509,6 +510,29 @@ func (f *fakeRunStore) SaveRun(_ context.Context, run store.Run) error {
 		}
 	}
 	f.saved = append(f.saved, run)
+	return nil
+}
+
+// ClaimLifecycleNotification atomically claims notification delivery.
+func (f *fakeRunStore) ClaimLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) (bool, error) {
+	if f.lifecycleClaims == nil {
+		f.lifecycleClaims = make(map[string]map[store.Status]bool)
+	}
+	if f.lifecycleClaims[runID] == nil {
+		f.lifecycleClaims[runID] = make(map[store.Status]bool)
+	}
+	if f.lifecycleClaims[runID][terminalStatus] {
+		return false, nil
+	}
+	f.lifecycleClaims[runID][terminalStatus] = true
+	return true, nil
+}
+
+// ReleaseLifecycleNotification removes a notification claim.
+func (f *fakeRunStore) ReleaseLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) error {
+	if f.lifecycleClaims != nil && f.lifecycleClaims[runID] != nil {
+		delete(f.lifecycleClaims[runID], terminalStatus)
+	}
 	return nil
 }
 

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -137,6 +137,13 @@ func (s *Service) handleRecognizedCommand(ctx context.Context, registration conf
 	if request.IssueNumber != run.IssueNumber && request.IssueNumber != run.PullRequestNumber {
 		return CommandResult{Outcome: CommandRejected, Run: *run}, &PolicyRejection{Code: PolicyRejectionWrongTarget, Problem: fmt.Sprintf("comment target #%d does not belong to run %q", request.IssueNumber, run.ID)}
 	}
+	if (run.Status == store.StatusComplete || run.Status == store.StatusCancelled) && !run.LifecycleNotificationSent {
+		updated, notificationErr := s.ensureTerminalNotification(ctx, registration, runStore, *run)
+		if notificationErr != nil {
+			return CommandResult{Outcome: CommandReplayed, Command: parsed.Command, Run: updated}, notificationErr
+		}
+		*run = updated
+	}
 	if commentAlreadyProcessed(run.ProcessedCommentID, request.Comment.ID) {
 		return CommandResult{Outcome: CommandReplayed, Command: parsed.Command, Run: *run}, nil
 	}
@@ -186,6 +193,7 @@ func (s *Service) handleCancelCommand(ctx context.Context, registration config.R
 	next.Status = store.StatusCancelled
 	next.LifecycleReason = "authorized cancel command"
 	next.MergeCommitSHA = ""
+	next.LifecycleNotificationSent = false
 	next.UpdatedAt = s.deps.Now().UTC()
 	updated, err := s.transitionTerminal(ctx, registration, runStore, run, next, issue)
 	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, err
@@ -312,6 +320,7 @@ func (s *Service) handleRetryCommand(ctx context.Context, registration config.Re
 	next.Status = store.StatusActive
 	next.MergeCommitSHA = ""
 	next.LifecycleReason = ""
+	next.LifecycleNotificationSent = false
 	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
 		Repository:           repository,
 		Issue:                issue,

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -49,6 +49,8 @@ const (
 	// PolicyRejectionHarnessUnavailable means the current role has no adapter
 	// for the requested harness yet.
 	PolicyRejectionHarnessUnavailable PolicyRejectionCode = "harness_unavailable"
+	// PolicyRejectionCancelState means cancellation is not legal for the run.
+	PolicyRejectionCancelState PolicyRejectionCode = "cancel_state"
 )
 
 // PolicyRejection is returned after a recognized command is visibly recorded
@@ -151,6 +153,8 @@ func (s *Service) handleRecognizedCommand(ctx context.Context, registration conf
 	case commandlanguage.Status, commandlanguage.Refresh:
 		updated, persistErr := s.persistCommandProjection(ctx, registration, runStore, *run, request.Comment, parsed.Command, string(parsed.Command.Kind), "command accepted")
 		return CommandResult{Outcome: CommandAccepted, Command: parsed.Command, Run: updated}, persistErr
+	case commandlanguage.Cancel:
+		return s.handleCancelCommand(ctx, registration, runStore, *run, request.Comment, parsed.Command)
 	case commandlanguage.ConfigureHarness:
 		return s.handleHarnessConfiguration(ctx, registration, runStore, *run, request.Comment, parsed.Command)
 	case commandlanguage.Retry:
@@ -159,6 +163,32 @@ func (s *Service) handleRecognizedCommand(ctx context.Context, registration conf
 		rejection := &PolicyRejection{Code: PolicyRejectionMalformed, Problem: "the parsed command is not registered by the coordinator"}
 		return s.persistCommandRejection(ctx, registration, runStore, *run, request.Comment, parsed.Command, rejection)
 	}
+}
+
+// handleCancelCommand applies an authorized, idempotent cancellation request
+// while retaining every run artifact needed for later inspection or retry.
+func (s *Service) handleCancelCommand(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request) (CommandResult, error) {
+	if run.Status == store.StatusCancelled {
+		next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; run was already cancelled")
+		updated, err := s.persistCommandProjectionWithRun(ctx, registration, runStore, next, run)
+		return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, err
+	}
+	if store.IsTerminalStatus(run.Status) {
+		rejection := &PolicyRejection{Code: PolicyRejectionCancelState, Problem: fmt.Sprintf("run status %q cannot be cancelled", run.Status)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	repository := commandRepository(registration)
+	issue, err := s.deps.GitHub.Issue(ctx, repository, run.IssueNumber)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("read issue for cancellation: %w", err)
+	}
+	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; run cancelled")
+	next.Status = store.StatusCancelled
+	next.LifecycleReason = "authorized cancel command"
+	next.MergeCommitSHA = ""
+	next.UpdatedAt = s.deps.Now().UTC()
+	updated, err := s.transitionTerminal(ctx, registration, runStore, run, next, issue)
+	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, err
 }
 
 // PollCommands lists comments for the run's issue and draft pull request and
@@ -176,6 +206,13 @@ func (s *Service) PollCommands(ctx context.Context, request CommandPollRequest) 
 	}
 	if request.RunID != "" && request.RunID != run.ID {
 		return nil, &PolicyRejection{Code: PolicyRejectionWrongTarget, Problem: fmt.Sprintf("run %q is not the selected run", request.RunID)}
+	}
+	lifecycle, lifecycleErr := s.observeLifecycle(ctx, registration, runStore, run)
+	if lifecycleErr != nil {
+		return nil, lifecycleErr
+	}
+	if lifecycle.Outcome != LifecycleUnchanged {
+		return nil, nil
 	}
 	if s.deps.Comments == nil {
 		return nil, errors.New("GitHub comment reader is required for command polling")
@@ -245,8 +282,8 @@ type commandRevisionStore interface {
 // handleRetryCommand reopens a failed run at its existing stage and applies
 // the normal label/comment transition without creating a new status comment.
 func (s *Service) handleRetryCommand(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request) (CommandResult, error) {
-	if run.Status != store.StatusFailed {
-		rejection := &PolicyRejection{Code: PolicyRejectionRetryState, Problem: fmt.Sprintf("retry is only allowed for a failed run, not status %q", run.Status)}
+	if run.Status != store.StatusFailed && run.Status != store.StatusCancelled {
+		rejection := &PolicyRejection{Code: PolicyRejectionRetryState, Problem: fmt.Sprintf("retry is only allowed for a failed or cancelled run, not status %q", run.Status)}
 		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
 	}
 	if run.StatusCommentID == "" {
@@ -261,8 +298,20 @@ func (s *Service) handleRetryCommand(ctx context.Context, registration config.Re
 	if err != nil {
 		return CommandResult{}, err
 	}
-	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; retrying failed run")
+	if run.Status == store.StatusCancelled {
+		open, openErr := s.retryTargetIsOpen(ctx, registration, run, issue)
+		if openErr != nil {
+			return CommandResult{}, openErr
+		}
+		if !open {
+			rejection := &PolicyRejection{Code: PolicyRejectionRetryState, Problem: "a cancelled run can be retried only after its issue or pull request is reopened"}
+			return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+		}
+	}
+	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; retrying run")
 	next.Status = store.StatusActive
+	next.MergeCommitSHA = ""
+	next.LifecycleReason = ""
 	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
 		Repository:           repository,
 		Issue:                issue,

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -236,6 +236,10 @@ type commandRunStore struct {
 	saved      []store.Run
 	// closeCount records store lifetime in polling tests.
 	closeCount int
+	// saveErrors allows tests to inject save failures.
+	saveErrors []error
+	// lifecycleClaims tracks claimed notification deliveries.
+	lifecycleClaims map[string]map[store.Status]bool
 }
 
 // CurrentRun returns the active run when one exists.
@@ -258,6 +262,13 @@ func (s *commandRunStore) LatestRun(context.Context) (*store.Run, error) {
 
 // SaveRun records the new current state and makes it visible after restart.
 func (s *commandRunStore) SaveRun(_ context.Context, run store.Run) error {
+	if len(s.saveErrors) > 0 {
+		err := s.saveErrors[0]
+		s.saveErrors = s.saveErrors[1:]
+		if err != nil {
+			return err
+		}
+	}
 	s.saved = append(s.saved, run)
 	copy := run
 	s.latest = &copy
@@ -276,6 +287,29 @@ func (s *commandRunStore) SaveRunIfRevision(ctx context.Context, expected int64,
 		return store.ErrRevisionConflict
 	}
 	return s.SaveRun(ctx, run)
+}
+
+// ClaimLifecycleNotification atomically claims notification delivery.
+func (s *commandRunStore) ClaimLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) (bool, error) {
+	if s.lifecycleClaims == nil {
+		s.lifecycleClaims = make(map[string]map[store.Status]bool)
+	}
+	if s.lifecycleClaims[runID] == nil {
+		s.lifecycleClaims[runID] = make(map[store.Status]bool)
+	}
+	if s.lifecycleClaims[runID][terminalStatus] {
+		return false, nil
+	}
+	s.lifecycleClaims[runID][terminalStatus] = true
+	return true, nil
+}
+
+// ReleaseLifecycleNotification removes a notification claim.
+func (s *commandRunStore) ReleaseLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) error {
+	if s.lifecycleClaims != nil && s.lifecycleClaims[runID] != nil {
+		delete(s.lifecycleClaims[runID], terminalStatus)
+	}
+	return nil
 }
 
 // Close increments the test store's close counter and returns nil, satisfying

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -42,6 +42,8 @@ type Factory interface {
 	HandleCommand(context.Context, CommandRequest) (CommandResult, error)
 	// PollCommands reads issue and pull-request comments for the current run.
 	PollCommands(context.Context, CommandPollRequest) ([]CommandResult, error)
+	// PollLifecycle observes merge and closure decisions for the current run.
+	PollLifecycle(context.Context, LifecycleRequest) (LifecycleResult, error)
 }
 
 // RunCoordinator is the single claim/state-transition seam used by the

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -69,6 +69,8 @@ type OperationalStore interface {
 type RunStore interface {
 	OperationalStore
 	SaveRun(context.Context, store.Run) error
+	ClaimLifecycleNotification(context.Context, string, store.Status) (bool, error)
+	ReleaseLifecycleNotification(context.Context, string, store.Status) error
 }
 
 // LatestRunStore extends the operational-store seam with the most recently

--- a/internal/factory/lifecycle.go
+++ b/internal/factory/lifecycle.go
@@ -64,12 +64,6 @@ func (s *Service) PollLifecycle(ctx context.Context, request LifecycleRequest) (
 	return s.observeLifecycle(ctx, registration, runStore, run)
 }
 
-// ObserveLifecycle is an explicit spelling of PollLifecycle for callers that
-// perform one-shot lifecycle checks outside the regular command poller.
-func (s *Service) ObserveLifecycle(ctx context.Context, request LifecycleRequest) (LifecycleResult, error) {
-	return s.PollLifecycle(ctx, request)
-}
-
 // observeLifecycle applies one lifecycle decision against an already-open
 // command store. Terminal runs are returned without repeating external effects.
 func (s *Service) observeLifecycle(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run) (LifecycleResult, error) {
@@ -77,7 +71,14 @@ func (s *Service) observeLifecycle(ctx context.Context, registration config.Repo
 		return LifecycleResult{Outcome: LifecycleUnchanged}, nil
 	}
 	if store.IsTerminalStatus(run.Status) {
-		return LifecycleResult{Outcome: LifecycleUnchanged, Run: *run, Reason: run.LifecycleReason}, nil
+		if run.Status == store.StatusFailed {
+			return LifecycleResult{Outcome: LifecycleUnchanged, Run: *run, Reason: run.LifecycleReason}, nil
+		}
+		updated, notificationErr := s.ensureTerminalNotification(ctx, registration, runStore, *run)
+		if notificationErr != nil {
+			return LifecycleResult{Outcome: LifecycleUnchanged, Run: updated, Reason: updated.LifecycleReason}, notificationErr
+		}
+		return LifecycleResult{Outcome: LifecycleUnchanged, Run: updated, Reason: updated.LifecycleReason}, nil
 	}
 
 	repository := commandRepository(registration)
@@ -93,12 +94,16 @@ func (s *Service) observeLifecycle(ctx context.Context, registration config.Repo
 	// GitHub reports a merged pull request as closed, so merge detection must
 	// happen before either ordinary closed-state cancellation branch.
 	if hasPullRequest && pullRequest.Merged {
+		if strings.TrimSpace(pullRequest.MergeCommitSHA) == "" {
+			return LifecycleResult{}, fmt.Errorf("merged pull request #%d has no merge commit", pullRequest.Number)
+		}
 		reason := fmt.Sprintf("pull request #%d merged", pullRequest.Number)
 		next := *run
 		next.Stage = store.StageReady
 		next.Status = store.StatusComplete
 		next.MergeCommitSHA = pullRequest.MergeCommitSHA
 		next.LifecycleReason = reason
+		next.LifecycleNotificationSent = false
 		next.UpdatedAt = s.deps.Now().UTC()
 		updated, transitionErr := s.transitionTerminal(ctx, registration, runStore, *run, next, issue)
 		return LifecycleResult{Outcome: LifecycleCompleted, Run: updated, Reason: reason}, transitionErr
@@ -117,6 +122,7 @@ func (s *Service) observeLifecycle(ctx context.Context, registration config.Repo
 	next.Status = store.StatusCancelled
 	next.LifecycleReason = reason
 	next.MergeCommitSHA = ""
+	next.LifecycleNotificationSent = false
 	next.UpdatedAt = s.deps.Now().UTC()
 	updated, transitionErr := s.transitionTerminal(ctx, registration, runStore, *run, next, issue)
 	return LifecycleResult{Outcome: LifecycleCancelled, Run: updated, Reason: reason}, transitionErr
@@ -155,14 +161,19 @@ func (s *Service) trackedPullRequest(ctx context.Context, registration config.Re
 // retryTargetIsOpen confirms that a cancelled run has an explicitly reopened
 // GitHub target before the retry command reactivates its persisted state.
 func (s *Service) retryTargetIsOpen(ctx context.Context, registration config.RepositoryRegistration, run store.Run, issue github.Issue) (bool, error) {
-	if strings.EqualFold(strings.TrimSpace(issue.State), "open") {
-		return true, nil
+	issueOpen := strings.EqualFold(strings.TrimSpace(issue.State), "open")
+	if run.PullRequestNumber == 0 {
+		return issueOpen, nil
 	}
 	pullRequest, found, err := s.trackedPullRequest(ctx, registration, run)
 	if err != nil {
 		return false, err
 	}
-	return found && !pullRequest.Merged && strings.EqualFold(strings.TrimSpace(pullRequest.State), "open"), nil
+	pullRequestOpen := found && !pullRequest.Merged && strings.EqualFold(strings.TrimSpace(pullRequest.State), "open")
+	if strings.HasPrefix(strings.TrimSpace(run.LifecycleReason), "pull request #") {
+		return pullRequestOpen, nil
+	}
+	return issueOpen, nil
 }
 
 // transitionTerminal stops the worker, projects the terminal state to GitHub,
@@ -196,10 +207,24 @@ func (s *Service) transitionTerminal(ctx context.Context, registration config.Re
 	if err != nil {
 		return updated, err
 	}
-	if err := s.notifyTerminal(ctx, registration, updated); err != nil {
-		return updated, err
+	return s.ensureTerminalNotification(ctx, registration, runStore, updated)
+}
+
+// ensureTerminalNotification delivers and records the one terminal cmux
+// notification, including after a prior delivery failure or restart.
+func (s *Service) ensureTerminalNotification(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, error) {
+	if run.LifecycleNotificationSent {
+		return run, nil
 	}
-	return updated, nil
+	if err := s.notifyTerminal(ctx, registration, run); err != nil {
+		return run, err
+	}
+	run.LifecycleNotificationSent = true
+	run.UpdatedAt = s.deps.Now().UTC()
+	if err := saveRunWithRetry(ctx, runStore, run); err != nil {
+		return run, fmt.Errorf("persist lifecycle notification: %w", err)
+	}
+	return run, nil
 }
 
 // stopRunWorker stops an existing worker without removing its persistent

--- a/internal/factory/lifecycle.go
+++ b/internal/factory/lifecycle.go
@@ -1,0 +1,246 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+)
+
+// LifecycleRequest selects the run whose GitHub lifecycle should be observed.
+// An empty RunID selects the most recently persisted run.
+type LifecycleRequest struct {
+	// RunID identifies the run to observe.
+	RunID string
+}
+
+// LifecycleOutcome identifies the terminal transition, or the absence of one,
+// produced by one lifecycle observation.
+type LifecycleOutcome string
+
+const (
+	// LifecycleUnchanged means GitHub did not request a terminal transition.
+	LifecycleUnchanged LifecycleOutcome = "unchanged"
+	// LifecycleCompleted means the tracked pull request was merged.
+	LifecycleCompleted LifecycleOutcome = "completed"
+	// LifecycleCancelled means the issue or an unmerged pull request was closed.
+	LifecycleCancelled LifecycleOutcome = "cancelled"
+)
+
+// LifecycleResult reports one idempotent lifecycle observation and the latest
+// persisted run projection.
+type LifecycleResult struct {
+	// Outcome identifies the observed lifecycle decision.
+	Outcome LifecycleOutcome
+	// Run is the run after any terminal transition.
+	Run store.Run
+	// Reason is the coordinator-owned explanation for a cancellation or merge.
+	Reason string
+}
+
+// PollLifecycle observes GitHub lifecycle state once and applies the required
+// terminal transition. It never removes a branch, worktree, worker, or run
+// artifacts, so cleanup and retention remain explicit later operations.
+func (s *Service) PollLifecycle(ctx context.Context, request LifecycleRequest) (LifecycleResult, error) {
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+
+	registration, runStore, run, err := s.openCommandRunStore(ctx)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	if run == nil {
+		return LifecycleResult{Outcome: LifecycleUnchanged}, nil
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return LifecycleResult{}, fmt.Errorf("latest run is %s, not %s", run.ID, request.RunID)
+	}
+	return s.observeLifecycle(ctx, registration, runStore, run)
+}
+
+// ObserveLifecycle is an explicit spelling of PollLifecycle for callers that
+// perform one-shot lifecycle checks outside the regular command poller.
+func (s *Service) ObserveLifecycle(ctx context.Context, request LifecycleRequest) (LifecycleResult, error) {
+	return s.PollLifecycle(ctx, request)
+}
+
+// observeLifecycle applies one lifecycle decision against an already-open
+// command store. Terminal runs are returned without repeating external effects.
+func (s *Service) observeLifecycle(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run) (LifecycleResult, error) {
+	if run == nil {
+		return LifecycleResult{Outcome: LifecycleUnchanged}, nil
+	}
+	if store.IsTerminalStatus(run.Status) {
+		return LifecycleResult{Outcome: LifecycleUnchanged, Run: *run, Reason: run.LifecycleReason}, nil
+	}
+
+	repository := commandRepository(registration)
+	issue, err := s.deps.GitHub.Issue(ctx, repository, run.IssueNumber)
+	if err != nil {
+		return LifecycleResult{}, fmt.Errorf("read issue lifecycle for run %q: %w", run.ID, err)
+	}
+	pullRequest, hasPullRequest, err := s.trackedPullRequest(ctx, registration, *run)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+
+	// GitHub reports a merged pull request as closed, so merge detection must
+	// happen before either ordinary closed-state cancellation branch.
+	if hasPullRequest && pullRequest.Merged {
+		reason := fmt.Sprintf("pull request #%d merged", pullRequest.Number)
+		next := *run
+		next.Stage = store.StageReady
+		next.Status = store.StatusComplete
+		next.MergeCommitSHA = pullRequest.MergeCommitSHA
+		next.LifecycleReason = reason
+		next.UpdatedAt = s.deps.Now().UTC()
+		updated, transitionErr := s.transitionTerminal(ctx, registration, runStore, *run, next, issue)
+		return LifecycleResult{Outcome: LifecycleCompleted, Run: updated, Reason: reason}, transitionErr
+	}
+
+	reason := ""
+	switch {
+	case hasPullRequest && strings.EqualFold(strings.TrimSpace(pullRequest.State), "closed"):
+		reason = fmt.Sprintf("pull request #%d closed without merging", pullRequest.Number)
+	case strings.EqualFold(strings.TrimSpace(issue.State), "closed"):
+		reason = fmt.Sprintf("issue #%d closed", run.IssueNumber)
+	default:
+		return LifecycleResult{Outcome: LifecycleUnchanged, Run: *run}, nil
+	}
+	next := *run
+	next.Status = store.StatusCancelled
+	next.LifecycleReason = reason
+	next.MergeCommitSHA = ""
+	next.UpdatedAt = s.deps.Now().UTC()
+	updated, transitionErr := s.transitionTerminal(ctx, registration, runStore, *run, next, issue)
+	return LifecycleResult{Outcome: LifecycleCancelled, Run: updated, Reason: reason}, transitionErr
+}
+
+// trackedPullRequest loads the PR found by the run's exact branch and frozen
+// target branch. A missing PR is valid before draft-PR creation.
+func (s *Service) trackedPullRequest(ctx context.Context, registration config.RepositoryRegistration, run store.Run) (github.PullRequest, bool, error) {
+	if run.PullRequestNumber == 0 {
+		return github.PullRequest{}, false, nil
+	}
+	client := s.pullRequestClient()
+	if client == nil {
+		return github.PullRequest{}, false, errors.New("GitHub pull-request client is required to observe a tracked pull request")
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return github.PullRequest{}, false, fmt.Errorf("decode specification packet for lifecycle observation: %w", err)
+	}
+	if strings.TrimSpace(packet.RepositoryConfig.TargetBranch) == "" {
+		return github.PullRequest{}, false, errors.New("tracked run has no frozen pull-request target branch")
+	}
+	pullRequest, err := client.FindPullRequest(ctx, commandRepository(registration), run.Branch, packet.RepositoryConfig.TargetBranch)
+	if err != nil {
+		return github.PullRequest{}, false, fmt.Errorf("observe pull request #%d: %w", run.PullRequestNumber, err)
+	}
+	if pullRequest.Number == 0 {
+		return github.PullRequest{}, false, nil
+	}
+	if pullRequest.Number != run.PullRequestNumber {
+		return github.PullRequest{}, false, fmt.Errorf("tracked pull request changed from #%d to #%d", run.PullRequestNumber, pullRequest.Number)
+	}
+	return pullRequest, true, nil
+}
+
+// retryTargetIsOpen confirms that a cancelled run has an explicitly reopened
+// GitHub target before the retry command reactivates its persisted state.
+func (s *Service) retryTargetIsOpen(ctx context.Context, registration config.RepositoryRegistration, run store.Run, issue github.Issue) (bool, error) {
+	if strings.EqualFold(strings.TrimSpace(issue.State), "open") {
+		return true, nil
+	}
+	pullRequest, found, err := s.trackedPullRequest(ctx, registration, run)
+	if err != nil {
+		return false, err
+	}
+	return found && !pullRequest.Merged && strings.EqualFold(strings.TrimSpace(pullRequest.State), "open"), nil
+}
+
+// transitionTerminal stops the worker, projects the terminal state to GitHub,
+// persists it, and raises one operator notification. It deliberately leaves
+// terminal surfaces, sessions, branches, worktrees, and logs in place.
+func (s *Service) transitionTerminal(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, previous, next store.Run, issue github.Issue) (store.Run, error) {
+	if store.IsTerminalStatus(previous.Status) {
+		return previous, nil
+	}
+	if err := s.stopRunWorker(ctx, previous.ID); err != nil {
+		return next, err
+	}
+	repository := commandRepository(registration)
+	if next.StatusCommentID == "" {
+		comment, err := s.deps.GitHub.FindStatusComment(ctx, repository, next.IssueNumber, statusCommentMarker(next.ID))
+		if err != nil {
+			return next, fmt.Errorf("recover status comment for lifecycle transition: %w", err)
+		}
+		if strings.TrimSpace(comment.ID) == "" {
+			return next, errors.New("run has no recoverable status comment for lifecycle transition")
+		}
+		previous.StatusCommentID = comment.ID
+		next.StatusCommentID = comment.ID
+	}
+	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository: repository,
+		Issue:      issue,
+		Previous:   previous,
+		Next:       next,
+	})
+	if err != nil {
+		return updated, err
+	}
+	if err := s.notifyTerminal(ctx, registration, updated); err != nil {
+		return updated, err
+	}
+	return updated, nil
+}
+
+// stopRunWorker stops an existing worker without removing its persistent
+// container, role volume, worktree, or logs.
+func (s *Service) stopRunWorker(ctx context.Context, runID string) error {
+	if s.deps.Worker == nil {
+		return nil
+	}
+	if err := s.deps.Worker.Stop(ctx, runID); err != nil {
+		return fmt.Errorf("stop worker for run %q: %w", runID, err)
+	}
+	return nil
+}
+
+// notifyTerminal sends one concise cmux notification while retaining all run
+// surfaces for later inspection or explicit resume.
+func (s *Service) notifyTerminal(ctx context.Context, registration config.RepositoryRegistration, run store.Run) error {
+	terminalRuntime := s.deps.Terminal
+	if terminalRuntime == nil {
+		var err error
+		terminalRuntime, _, err = s.ensureAgentRuntime(registration.Cmux.SocketPath)
+		if err != nil {
+			return fmt.Errorf("ensure terminal runtime for lifecycle notification: %w", err)
+		}
+	}
+	control, err := terminalRuntime.EnsureControlWorkspace(ctx, terminal.WorkspaceRequest{
+		Name:             defaultString(registration.Cmux.ControlWorkspace, "factory-control"),
+		Description:      "software factory coordinator",
+		WorkingDirectory: registration.Path,
+	})
+	if err != nil {
+		return fmt.Errorf("ensure control workspace for lifecycle notification: %w", err)
+	}
+	title := "factory run cancelled"
+	body := fmt.Sprintf("%s cancelled: %s", run.ID, safeStatusCommentValue(run.LifecycleReason))
+	if run.Status == store.StatusComplete {
+		title = "factory run completed"
+		body = fmt.Sprintf("%s completed after pull request #%d merged", run.ID, run.PullRequestNumber)
+	}
+	if err := terminalRuntime.Notify(ctx, terminal.Notification{WorkspaceID: control.ID, Title: title, Body: body}); err != nil {
+		return fmt.Errorf("notify lifecycle transition: %w", err)
+	}
+	return nil
+}

--- a/internal/factory/lifecycle.go
+++ b/internal/factory/lifecycle.go
@@ -212,17 +212,45 @@ func (s *Service) transitionTerminal(ctx context.Context, registration config.Re
 
 // ensureTerminalNotification delivers and records the one terminal cmux
 // notification, including after a prior delivery failure or restart.
+// It uses a durable claim table to prevent duplicate notifications when
+// notification succeeds but the subsequent run save fails.
 func (s *Service) ensureTerminalNotification(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, error) {
 	if run.LifecycleNotificationSent {
 		return run, nil
 	}
+	// Atomically claim the right to send this notification. If the claim already
+	// exists, the notification was already delivered (even if the run flag wasn't
+	// persisted due to a prior save failure), so skip delivery.
+	claimed, err := runStore.ClaimLifecycleNotification(ctx, run.ID, run.Status)
+	if err != nil {
+		return run, fmt.Errorf("claim lifecycle notification: %w", err)
+	}
+	if !claimed {
+		// Notification already delivered by a prior attempt. Update the in-memory
+		// flag and persist it without re-sending the notification.
+		run.LifecycleNotificationSent = true
+		run.UpdatedAt = s.deps.Now().UTC()
+		if err := saveRunWithRetry(ctx, runStore, run); err != nil {
+			return run, fmt.Errorf("persist lifecycle notification flag after skipped delivery: %w", err)
+		}
+		return run, nil
+	}
+	// Claim succeeded. Attempt notification delivery.
 	if err := s.notifyTerminal(ctx, registration, run); err != nil {
+		// Delivery failed. Release the claim so a future retry can attempt delivery again.
+		if releaseErr := runStore.ReleaseLifecycleNotification(ctx, run.ID, run.Status); releaseErr != nil {
+			return run, fmt.Errorf("notify lifecycle transition: %w (also failed to release claim: %v)", err, releaseErr)
+		}
 		return run, err
 	}
+	// Notification delivered successfully. Keep the claim (it now durably records
+	// that delivery happened) and persist the flag in the run record.
 	run.LifecycleNotificationSent = true
 	run.UpdatedAt = s.deps.Now().UTC()
 	if err := saveRunWithRetry(ctx, runStore, run); err != nil {
-		return run, fmt.Errorf("persist lifecycle notification: %w", err)
+		// The claim table already records successful delivery, so a retry won't
+		// re-send the notification even though the run flag wasn't persisted.
+		return run, fmt.Errorf("persist lifecycle notification flag: %w", err)
 	}
 	return run, nil
 }

--- a/internal/factory/lifecycle_test.go
+++ b/internal/factory/lifecycle_test.go
@@ -120,6 +120,54 @@ func TestPollLifecycleRetriesAFailedTerminalNotification(t *testing.T) {
 	}
 }
 
+// TestPollLifecycleDoesNotResendAfterNotifySucceedsPersistFails verifies that
+// when notification delivery succeeds but the subsequent run save fails, a retry
+// does not send the notification again (the durable claim prevents duplicate delivery).
+func TestPollLifecycleDoesNotResendAfterNotifySucceedsPersistFails(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Branch = "factory/run-command"
+	run.PullRequestNumber = 19
+	run.PullRequestURL = "https://github.com/example/project/pull/19"
+	githubAdapter := &lifecycleGitHub{
+		commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: run.StatusCommentID}},
+		pullRequest:   github.PullRequest{Number: 19, State: "closed", Merged: true, MergeCommitSHA: strings.Repeat("f", 40), HeadBranch: run.Branch, BaseBranch: "main"},
+	}
+	// Inject a save error that will occur after notification succeeds.
+	runStore := &commandRunStore{current: &run, latest: &run, saveErrors: []error{errors.New("transient database error")}}
+	terminalRuntime := &lifecycleTerminal{}
+	service := newLifecycleService(runStore, githubAdapter, &lifecycleWorker{}, terminalRuntime)
+
+	// First poll: notification succeeds, but save fails.
+	first, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err == nil {
+		t.Fatal("first PollLifecycle() error = nil, want save failure after notification")
+	}
+	if !strings.Contains(err.Error(), "persist lifecycle notification flag") {
+		t.Fatalf("first PollLifecycle() error = %v, want persist failure", err)
+	}
+	if first.Run.Status != store.StatusComplete {
+		t.Fatalf("first lifecycle result status = %q, want complete", first.Run.Status)
+	}
+	if len(terminalRuntime.notifications) != 1 {
+		t.Fatalf("first poll notifications = %d, want exactly one", len(terminalRuntime.notifications))
+	}
+
+	// Second poll: the durable claim exists, so notification is skipped and only save is attempted.
+	second, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err != nil {
+		t.Fatalf("second PollLifecycle() error = %v", err)
+	}
+	if second.Run.Status != store.StatusComplete || !second.Run.LifecycleNotificationSent {
+		t.Fatalf("second lifecycle result = %#v, want completed run with delivered notification", second)
+	}
+	// Critical assertion: notification was NOT sent again.
+	if len(terminalRuntime.notifications) != 1 {
+		t.Fatalf("total notifications = %d, want exactly one (no duplicate after retry)", len(terminalRuntime.notifications))
+	}
+}
+
 // TestAuthorizedCancelStopsAndRetainsAnActiveRun verifies cancellation is a
 // policy-controlled terminal transition rather than workspace cleanup.
 func TestAuthorizedCancelStopsAndRetainsAnActiveRun(t *testing.T) {

--- a/internal/factory/lifecycle_test.go
+++ b/internal/factory/lifecycle_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -79,6 +80,43 @@ func TestPollLifecycleCompletesAMergedPullRequest(t *testing.T) {
 	}
 	if len(githubAdapter.editedComments) != 1 || workerRuntime.stopCalls != 1 || len(terminalRuntime.notifications) != 1 {
 		t.Fatalf("repeated lifecycle effects = edits %d/stops %d/notifications %d, want no duplicates", len(githubAdapter.editedComments), workerRuntime.stopCalls, len(terminalRuntime.notifications))
+	}
+}
+
+// TestPollLifecycleRetriesAFailedTerminalNotification verifies a delivery
+// failure remains retryable after the terminal state itself is persisted.
+func TestPollLifecycleRetriesAFailedTerminalNotification(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Branch = "factory/run-command"
+	run.PullRequestNumber = 17
+	run.PullRequestURL = "https://github.com/example/project/pull/17"
+	githubAdapter := &lifecycleGitHub{
+		commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: run.StatusCommentID}},
+		pullRequest:   github.PullRequest{Number: 17, State: "closed", Merged: true, MergeCommitSHA: strings.Repeat("d", 40), HeadBranch: run.Branch, BaseBranch: "main"},
+	}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	terminalRuntime := &lifecycleTerminal{notifyErrors: []error{errors.New("cmux unavailable")}}
+	service := newLifecycleService(runStore, githubAdapter, &lifecycleWorker{}, terminalRuntime)
+
+	first, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err == nil {
+		t.Fatal("first PollLifecycle() error = nil, want notification failure")
+	}
+	if first.Run.Status != store.StatusComplete || first.Run.LifecycleNotificationSent {
+		t.Fatalf("first lifecycle result = %#v, want completed run with pending notification", first)
+	}
+
+	second, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err != nil {
+		t.Fatalf("second PollLifecycle() error = %v", err)
+	}
+	if second.Run.Status != store.StatusComplete || !second.Run.LifecycleNotificationSent {
+		t.Fatalf("second lifecycle result = %#v, want completed run with delivered notification", second)
+	}
+	if len(terminalRuntime.notifications) != 2 {
+		t.Fatalf("notification attempts = %d, want one retry", len(terminalRuntime.notifications))
 	}
 }
 
@@ -253,6 +291,40 @@ func TestRetryExplicitlyReopensACancelledRun(t *testing.T) {
 	}
 }
 
+// TestRetryRejectsAClosedPullRequest verifies a PR closure cannot be bypassed
+// by reopening only the parent issue before retrying.
+func TestRetryRejectsAClosedPullRequest(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusCancelled)
+	run.Branch = "factory/run-command"
+	run.PullRequestNumber = 17
+	run.PullRequestURL = "https://github.com/example/project/pull/17"
+	run.LifecycleReason = "pull request #17 closed without merging"
+	run.LifecycleNotificationSent = true
+	githubAdapter := &lifecycleGitHub{
+		commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentCancelled}}, statusComment: github.Comment{ID: run.StatusCommentID}},
+		pullRequest:   github.PullRequest{Number: 17, State: "closed", HeadBranch: run.Branch, BaseBranch: "main"},
+	}
+	runStore := &commandRunStore{latest: &run}
+	service := newLifecycleService(runStore, githubAdapter, &lifecycleWorker{}, &lifecycleTerminal{})
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: run.IssueNumber, Comment: github.Comment{ID: "101", Author: "alice", Body: "/factory retry"}})
+	if err == nil {
+		t.Fatal("HandleCommand() error = nil, want retry policy rejection")
+	}
+	var rejection *factory.PolicyRejection
+	if !errors.As(err, &rejection) || rejection.Code != factory.PolicyRejectionRetryState {
+		t.Fatalf("HandleCommand() error = %v, want retry_state rejection", err)
+	}
+	if result.Outcome != factory.CommandRejected || result.Run.Status != store.StatusCancelled {
+		t.Fatalf("retry result = %#v, want rejected cancelled run", result)
+	}
+	if len(githubAdapter.replacedLabels) != 0 {
+		t.Fatalf("retry labels = %#v, want no state transition", githubAdapter.replacedLabels)
+	}
+}
+
 // factoryLifecycleRequest keeps lifecycle tests independent of the request's
 // concrete field layout while still exercising explicit run selection.
 func factoryLifecycleRequest(runID string) factory.LifecycleRequest {
@@ -326,6 +398,7 @@ func (*lifecycleWorker) Inspect(context.Context, string) (worker.Inspection, err
 // lifecycleTerminal records operator notifications without talking to cmux.
 type lifecycleTerminal struct {
 	notifications []terminal.Notification
+	notifyErrors  []error
 }
 
 // EnsureControlWorkspace returns a stable control workspace for notification.
@@ -354,6 +427,11 @@ func (*lifecycleTerminal) SendInput(context.Context, terminal.SurfaceID, []byte)
 // Notify records one lifecycle notification.
 func (t *lifecycleTerminal) Notify(_ context.Context, notification terminal.Notification) error {
 	t.notifications = append(t.notifications, notification)
+	if len(t.notifyErrors) > 0 {
+		err := t.notifyErrors[0]
+		t.notifyErrors = t.notifyErrors[1:]
+		return err
+	}
 	return nil
 }
 

--- a/internal/factory/lifecycle_test.go
+++ b/internal/factory/lifecycle_test.go
@@ -1,0 +1,364 @@
+package factory_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestPollLifecycleCompletesAMergedPullRequest verifies the public lifecycle
+// seam records merge completion, releases the active slot, and retains the
+// recoverable run identity.
+func TestPollLifecycleCompletesAMergedPullRequest(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Branch = "factory/run-command"
+	run.PullRequestNumber = 17
+	run.PullRequestURL = "https://github.com/example/project/pull/17"
+	githubAdapter := &lifecycleGitHub{
+		commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: run.StatusCommentID}},
+		pullRequest: github.PullRequest{
+			Number:         run.PullRequestNumber,
+			URL:            run.PullRequestURL,
+			State:          "closed",
+			Merged:         true,
+			MergeCommitSHA: strings.Repeat("a", 40),
+			HeadBranch:     run.Branch,
+			BaseBranch:     "main",
+		},
+	}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	workerRuntime := &lifecycleWorker{}
+	terminalRuntime := &lifecycleTerminal{}
+	service := newLifecycleService(runStore, githubAdapter, workerRuntime, terminalRuntime)
+
+	result, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err != nil {
+		t.Fatalf("PollLifecycle() error = %v", err)
+	}
+	if result.Outcome != factory.LifecycleCompleted || result.Run.Status != store.StatusComplete || result.Run.Stage != store.StageReady {
+		t.Fatalf("lifecycle result = %#v, want completed ready run", result)
+	}
+	if result.Run.MergeCommitSHA != githubAdapter.pullRequest.MergeCommitSHA {
+		t.Fatalf("merge commit = %q, want %q", result.Run.MergeCommitSHA, githubAdapter.pullRequest.MergeCommitSHA)
+	}
+	if runStore.current != nil {
+		t.Fatalf("current run = %#v, want active slot released", runStore.current)
+	}
+	if len(githubAdapter.replacedLabels) != 1 || !equalStrings(githubAdapter.replacedLabels, []string{github.LabelAgentComplete}) {
+		t.Fatalf("state labels = %#v, want exactly agent-complete", githubAdapter.replacedLabels)
+	}
+	if len(githubAdapter.editedComments) != 1 {
+		t.Fatalf("status comment edits = %d, want one", len(githubAdapter.editedComments))
+	}
+	for _, expected := range []string{"status: `complete`", "pull request: #17", "merge commit: `" + githubAdapter.pullRequest.MergeCommitSHA + "`"} {
+		if !strings.Contains(githubAdapter.editedComments[0].body, expected) {
+			t.Errorf("status comment %q does not contain %q", githubAdapter.editedComments[0].body, expected)
+		}
+	}
+	if workerRuntime.stopCalls != 1 {
+		t.Fatalf("worker stop calls = %d, want one", workerRuntime.stopCalls)
+	}
+	if len(terminalRuntime.notifications) != 1 {
+		t.Fatalf("notifications = %d, want one completion notification", len(terminalRuntime.notifications))
+	}
+
+	repeated, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err != nil {
+		t.Fatalf("repeated PollLifecycle() error = %v", err)
+	}
+	if repeated.Run.Status != store.StatusComplete || repeated.Outcome != factory.LifecycleUnchanged {
+		t.Fatalf("repeated lifecycle result = %#v, want unchanged completed run", repeated)
+	}
+	if len(githubAdapter.editedComments) != 1 || workerRuntime.stopCalls != 1 || len(terminalRuntime.notifications) != 1 {
+		t.Fatalf("repeated lifecycle effects = edits %d/stops %d/notifications %d, want no duplicates", len(githubAdapter.editedComments), workerRuntime.stopCalls, len(terminalRuntime.notifications))
+	}
+}
+
+// TestAuthorizedCancelStopsAndRetainsAnActiveRun verifies cancellation is a
+// policy-controlled terminal transition rather than workspace cleanup.
+func TestAuthorizedCancelStopsAndRetainsAnActiveRun(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Branch = "factory/run-command"
+	run.Worktree = "/worktrees/run-command"
+	githubAdapter := &lifecycleGitHub{commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: run.StatusCommentID}}}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	workerRuntime := &lifecycleWorker{}
+	terminalRuntime := &lifecycleTerminal{}
+	service := newLifecycleService(runStore, githubAdapter, workerRuntime, terminalRuntime)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: run.IssueNumber, Comment: github.Comment{ID: "99", Author: "alice", Body: "/factory cancel"}})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusCancelled {
+		t.Fatalf("cancel result = %#v, want accepted cancelled run", result)
+	}
+	if runStore.current != nil || workerRuntime.stopCalls != 1 {
+		t.Fatalf("cancel retention state = current %#v/stops %d, want released slot and one stop", runStore.current, workerRuntime.stopCalls)
+	}
+	if len(githubAdapter.replacedLabels) != 1 || !equalStrings(githubAdapter.replacedLabels, []string{github.LabelAgentCancelled}) {
+		t.Fatalf("cancel labels = %#v, want exactly agent-cancelled", githubAdapter.replacedLabels)
+	}
+	if len(githubAdapter.createdComments) != 0 || len(githubAdapter.editedComments) != 1 {
+		t.Fatalf("cancel comments = created %d/edited %d, want one edit and no new comment", len(githubAdapter.createdComments), len(githubAdapter.editedComments))
+	}
+	if !strings.Contains(githubAdapter.editedComments[0].body, "status: `cancelled`") {
+		t.Fatalf("cancel status comment = %q, want cancelled status", githubAdapter.editedComments[0].body)
+	}
+	if len(terminalRuntime.notifications) != 1 {
+		t.Fatalf("cancel notifications = %d, want one", len(terminalRuntime.notifications))
+	}
+
+	replayed, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: run.IssueNumber, Comment: github.Comment{ID: "99", Author: "alice", Body: "/factory cancel"}})
+	if err != nil {
+		t.Fatalf("replayed HandleCommand() error = %v", err)
+	}
+	if replayed.Outcome != factory.CommandReplayed || len(githubAdapter.editedComments) != 1 || workerRuntime.stopCalls != 1 || len(terminalRuntime.notifications) != 1 {
+		t.Fatalf("replayed cancel = %#v, effects edits %d/stops %d/notifications %d, want no duplicate effects", replayed, len(githubAdapter.editedComments), workerRuntime.stopCalls, len(terminalRuntime.notifications))
+	}
+}
+
+// TestPollLifecycleCancelsAnUnmergedClosedPullRequest verifies closed PRs are
+// cancellation signals and are checked after the merged state.
+func TestPollLifecycleCancelsAnUnmergedClosedPullRequest(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Branch = "factory/run-command"
+	run.PullRequestNumber = 17
+	run.PullRequestURL = "https://github.com/example/project/pull/17"
+	githubAdapter := &lifecycleGitHub{
+		commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: run.StatusCommentID}},
+		pullRequest:   github.PullRequest{Number: run.PullRequestNumber, URL: run.PullRequestURL, State: "closed", HeadBranch: run.Branch, BaseBranch: "main"},
+	}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	workerRuntime := &lifecycleWorker{}
+	terminalRuntime := &lifecycleTerminal{}
+	service := newLifecycleService(runStore, githubAdapter, workerRuntime, terminalRuntime)
+
+	result, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err != nil {
+		t.Fatalf("PollLifecycle() error = %v", err)
+	}
+	if result.Outcome != factory.LifecycleCancelled || result.Run.Status != store.StatusCancelled {
+		t.Fatalf("lifecycle result = %#v, want cancelled run", result)
+	}
+	if result.Run.MergeCommitSHA != "" {
+		t.Fatalf("cancelled merge commit = %q, want empty", result.Run.MergeCommitSHA)
+	}
+}
+
+// TestPollLifecycleCancelsAClosedIssueWithoutAPullRequest verifies closure is
+// respected even before a draft pull request exists.
+func TestPollLifecycleCancelsAClosedIssueWithoutAPullRequest(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Branch = "factory/run-command"
+	githubAdapter := &lifecycleGitHub{commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "closed", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: run.StatusCommentID}}}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	workerRuntime := &lifecycleWorker{}
+	terminalRuntime := &lifecycleTerminal{}
+	service := newLifecycleService(runStore, githubAdapter, workerRuntime, terminalRuntime)
+
+	result, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err != nil {
+		t.Fatalf("PollLifecycle() error = %v", err)
+	}
+	if result.Outcome != factory.LifecycleCancelled || result.Run.Status != store.StatusCancelled || result.Reason != "issue #42 closed" {
+		t.Fatalf("lifecycle result = %#v, want issue-closure cancellation", result)
+	}
+}
+
+// TestPollLifecyclePrefersMergeOverClosedIssue verifies a merged PR remains a
+// successful completion even when GitHub has already closed the issue.
+func TestPollLifecyclePrefersMergeOverClosedIssue(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Branch = "factory/run-command"
+	run.PullRequestNumber = 17
+	run.PullRequestURL = "https://github.com/example/project/pull/17"
+	githubAdapter := &lifecycleGitHub{
+		commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "closed", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: run.StatusCommentID}},
+		pullRequest:   github.PullRequest{Number: 17, State: "closed", Merged: true, MergeCommitSHA: strings.Repeat("b", 40), HeadBranch: run.Branch, BaseBranch: "main"},
+	}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newLifecycleService(runStore, githubAdapter, &lifecycleWorker{}, &lifecycleTerminal{})
+
+	result, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(run.ID))
+	if err != nil {
+		t.Fatalf("PollLifecycle() error = %v", err)
+	}
+	if result.Outcome != factory.LifecycleCompleted || result.Run.Status != store.StatusComplete {
+		t.Fatalf("lifecycle result = %#v, want merged completion", result)
+	}
+}
+
+// TestPollCommandsObservesLifecycleBeforeReadingComments verifies the normal
+// production poll path finalizes a run even when no command comment exists.
+func TestPollCommandsObservesLifecycleBeforeReadingComments(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Branch = "factory/run-command"
+	run.PullRequestNumber = 17
+	run.PullRequestURL = "https://github.com/example/project/pull/17"
+	githubAdapter := &lifecycleGitHub{
+		commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: run.StatusCommentID}},
+		pullRequest:   github.PullRequest{Number: 17, State: "closed", Merged: true, MergeCommitSHA: strings.Repeat("c", 40), HeadBranch: run.Branch, BaseBranch: "main"},
+	}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newLifecycleService(runStore, githubAdapter, &lifecycleWorker{}, &lifecycleTerminal{})
+
+	results, err := service.PollCommands(context.Background(), factory.CommandPollRequest{RunID: run.ID})
+	if err != nil {
+		t.Fatalf("PollCommands() error = %v", err)
+	}
+	if len(results) != 0 || runStore.current != nil || runStore.latest.Status != store.StatusComplete {
+		t.Fatalf("poll results = %#v, current = %#v, latest = %#v; want lifecycle completion before comments", results, runStore.current, runStore.latest)
+	}
+}
+
+// TestRetryExplicitlyReopensACancelledRun verifies reopening alone is not a
+// transition, while an authorized retry command is.
+func TestRetryExplicitlyReopensACancelledRun(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusCancelled)
+	run.Branch = "factory/run-command"
+	githubAdapter := &lifecycleGitHub{commandGitHub: commandGitHub{issue: github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentCancelled}}, statusComment: github.Comment{ID: run.StatusCommentID}}}
+	runStore := &commandRunStore{latest: &run}
+	service := newLifecycleService(runStore, githubAdapter, &lifecycleWorker{}, &lifecycleTerminal{})
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: run.IssueNumber, Comment: github.Comment{ID: "100", Author: "alice", Body: "/factory retry"}})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive {
+		t.Fatalf("retry result = %#v, want active retried run", result)
+	}
+	if !equalStrings(githubAdapter.replacedLabels, []string{github.LabelAgentRunning}) {
+		t.Fatalf("retry labels = %#v, want agent-running", githubAdapter.replacedLabels)
+	}
+}
+
+// factoryLifecycleRequest keeps lifecycle tests independent of the request's
+// concrete field layout while still exercising explicit run selection.
+func factoryLifecycleRequest(runID string) factory.LifecycleRequest {
+	return factory.LifecycleRequest{RunID: runID}
+}
+
+// newLifecycleService builds a high-level factory with only lifecycle
+// collaborators replaced by deterministic fakes.
+func newLifecycleService(runStore *commandRunStore, githubAdapter *lifecycleGitHub, workerRuntime worker.WorkerRuntime, terminalRuntime terminal.TerminalRuntime) *factory.Service {
+	return factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &commandConfig{host: commandHost()},
+		OpenStore: func(context.Context, string) (factory.OperationalStore, error) {
+			return runStore, nil
+		},
+		GitHub:       githubAdapter,
+		PullRequests: githubAdapter,
+		Worker:       workerRuntime,
+		Terminal:     terminalRuntime,
+	})
+}
+
+// lifecycleGitHub combines the existing command fake with tracked PR state.
+type lifecycleGitHub struct {
+	commandGitHub
+	pullRequest github.PullRequest
+}
+
+// FindPullRequest returns the one tracked PR projection used by lifecycle
+// observation.
+func (g *lifecycleGitHub) FindPullRequest(context.Context, github.Repository, string, string) (github.PullRequest, error) {
+	return g.pullRequest, nil
+}
+
+// CreatePullRequest satisfies github.PullRequestClient for lifecycle tests.
+func (g *lifecycleGitHub) CreatePullRequest(context.Context, github.Repository, github.PullRequestRequest) (github.PullRequest, error) {
+	return g.pullRequest, nil
+}
+
+// UpdatePullRequest satisfies github.PullRequestClient for lifecycle tests.
+func (g *lifecycleGitHub) UpdatePullRequest(context.Context, github.Repository, int, github.PullRequestRequest) (github.PullRequest, error) {
+	return g.pullRequest, nil
+}
+
+// lifecycleWorker records the retention-preserving worker stop effect.
+type lifecycleWorker struct {
+	stopCalls int
+}
+
+// Start satisfies worker.WorkerRuntime for lifecycle tests.
+func (*lifecycleWorker) Start(context.Context, worker.StartRequest) error { return nil }
+
+// Resume satisfies worker.WorkerRuntime for lifecycle tests.
+func (*lifecycleWorker) Resume(context.Context, worker.ResumeRequest) error { return nil }
+
+// RunCommand satisfies worker.WorkerRuntime for lifecycle tests.
+func (*lifecycleWorker) RunCommand(context.Context, worker.CommandRequest) (worker.CommandResult, error) {
+	return worker.CommandResult{}, nil
+}
+
+// Stop records a stop without deleting the worker's retained state.
+func (w *lifecycleWorker) Stop(context.Context, string) error {
+	w.stopCalls++
+	return nil
+}
+
+// Inspect satisfies worker.WorkerRuntime for lifecycle tests.
+func (*lifecycleWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+	return worker.Inspection{Exists: true, Running: true}, nil
+}
+
+// lifecycleTerminal records operator notifications without talking to cmux.
+type lifecycleTerminal struct {
+	notifications []terminal.Notification
+}
+
+// EnsureControlWorkspace returns a stable control workspace for notification.
+func (*lifecycleTerminal) EnsureControlWorkspace(context.Context, terminal.WorkspaceRequest) (terminal.Workspace, error) {
+	return terminal.Workspace{ID: "control"}, nil
+}
+
+// EnsureRunWorkspace satisfies terminal.TerminalRuntime for lifecycle tests.
+func (*lifecycleTerminal) EnsureRunWorkspace(context.Context, terminal.RunWorkspaceRequest) (terminal.RunWorkspace, error) {
+	return terminal.RunWorkspace{Workspace: terminal.Workspace{ID: "run"}}, nil
+}
+
+// CreateSurface satisfies terminal.TerminalRuntime for lifecycle tests.
+func (*lifecycleTerminal) CreateSurface(context.Context, terminal.SurfaceRequest) (terminal.Surface, error) {
+	return terminal.Surface{ID: "surface"}, nil
+}
+
+// LaunchSurface satisfies terminal.TerminalRuntime for lifecycle tests.
+func (*lifecycleTerminal) LaunchSurface(context.Context, terminal.SurfaceID, terminal.Command) error {
+	return nil
+}
+
+// SendInput satisfies terminal.TerminalRuntime for lifecycle tests.
+func (*lifecycleTerminal) SendInput(context.Context, terminal.SurfaceID, []byte) error { return nil }
+
+// Notify records one lifecycle notification.
+func (t *lifecycleTerminal) Notify(_ context.Context, notification terminal.Notification) error {
+	t.notifications = append(t.notifications, notification)
+	return nil
+}
+
+// CloseSurface satisfies terminal.TerminalRuntime for lifecycle tests.
+func (*lifecycleTerminal) CloseSurface(context.Context, terminal.SurfaceID) error { return nil }
+
+// CloseWorkspace satisfies terminal.TerminalRuntime for lifecycle tests.
+func (*lifecycleTerminal) CloseWorkspace(context.Context, terminal.WorkspaceID) error { return nil }

--- a/internal/factory/recovery_test.go
+++ b/internal/factory/recovery_test.go
@@ -222,8 +222,9 @@ func (w *recoveryWorktree) Inspect(context.Context, string) (gitadapter.Worktree
 
 // recoveryRunStore supplies one persisted run to status and progression seams.
 type recoveryRunStore struct {
-	run   store.Run
-	saved []store.Run
+	run             store.Run
+	saved           []store.Run
+	lifecycleClaims map[string]map[store.Status]bool
 }
 
 // CurrentRun returns the persisted non-terminal run.
@@ -241,6 +242,29 @@ func (s *recoveryRunStore) LatestRun(context.Context) (*store.Run, error) {
 // SaveRun records unexpected progression persistence.
 func (s *recoveryRunStore) SaveRun(_ context.Context, run store.Run) error {
 	s.saved = append(s.saved, run)
+	return nil
+}
+
+// ClaimLifecycleNotification atomically claims notification delivery.
+func (s *recoveryRunStore) ClaimLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) (bool, error) {
+	if s.lifecycleClaims == nil {
+		s.lifecycleClaims = make(map[string]map[store.Status]bool)
+	}
+	if s.lifecycleClaims[runID] == nil {
+		s.lifecycleClaims[runID] = make(map[store.Status]bool)
+	}
+	if s.lifecycleClaims[runID][terminalStatus] {
+		return false, nil
+	}
+	s.lifecycleClaims[runID][terminalStatus] = true
+	return true, nil
+}
+
+// ReleaseLifecycleNotification removes a notification claim.
+func (s *recoveryRunStore) ReleaseLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) error {
+	if s.lifecycleClaims != nil && s.lifecycleClaims[runID] != nil {
+		delete(s.lifecycleClaims[runID], terminalStatus)
+	}
 	return nil
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -100,6 +100,10 @@ type PullRequest struct {
 	State string
 	// Draft reports whether GitHub marks the pull request as a draft.
 	Draft bool
+	// Merged reports whether GitHub has completed the pull request merge.
+	Merged bool
+	// MergeCommitSHA is the immutable commit created by a successful merge.
+	MergeCommitSHA string
 	// HeadBranch is the source branch name.
 	HeadBranch string
 	// BaseBranch is the target branch name.
@@ -547,13 +551,16 @@ func (r commentResponse) comment() Comment {
 
 // pullRequestResponse is the GitHub API subset used by the factory.
 type pullRequestResponse struct {
-	Number  int    `json:"number"`
-	HTMLURL string `json:"html_url"`
-	Title   string `json:"title"`
-	Body    string `json:"body"`
-	State   string `json:"state"`
-	Draft   bool   `json:"draft"`
-	Head    struct {
+	Number         int        `json:"number"`
+	HTMLURL        string     `json:"html_url"`
+	Title          string     `json:"title"`
+	Body           string     `json:"body"`
+	State          string     `json:"state"`
+	Draft          bool       `json:"draft"`
+	Merged         bool       `json:"merged"`
+	MergedAt       *time.Time `json:"merged_at"`
+	MergeCommitSHA string     `json:"merge_commit_sha"`
+	Head           struct {
 		Ref string `json:"ref"`
 	} `json:"head"`
 	Base struct {
@@ -582,7 +589,8 @@ type pullRequestUpdatePayload struct {
 func (r pullRequestResponse) pullRequest() PullRequest {
 	return PullRequest{
 		Number: r.Number, URL: r.HTMLURL, Title: r.Title, Body: r.Body,
-		State: r.State, Draft: r.Draft, HeadBranch: r.Head.Ref, BaseBranch: r.Base.Ref,
+		State: r.State, Draft: r.Draft, Merged: r.Merged || r.MergedAt != nil,
+		MergeCommitSHA: r.MergeCommitSHA, HeadBranch: r.Head.Ref, BaseBranch: r.Base.Ref,
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -551,15 +551,18 @@ func (r commentResponse) comment() Comment {
 
 // pullRequestResponse is the GitHub API subset used by the factory.
 type pullRequestResponse struct {
-	Number         int        `json:"number"`
-	HTMLURL        string     `json:"html_url"`
-	Title          string     `json:"title"`
-	Body           string     `json:"body"`
-	State          string     `json:"state"`
-	Draft          bool       `json:"draft"`
-	Merged         bool       `json:"merged"`
-	MergedAt       *time.Time `json:"merged_at"`
-	MergeCommitSHA string     `json:"merge_commit_sha"`
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	Title   string `json:"title"`
+	Body    string `json:"body"`
+	State   string `json:"state"`
+	Draft   bool   `json:"draft"`
+	// Merged is supplied by pull-specific GitHub responses when available.
+	Merged bool `json:"merged"`
+	// MergedAt is the timestamp GitHub supplies for a successful merge.
+	MergedAt *time.Time `json:"merged_at"`
+	// MergeCommitSHA is the immutable commit recorded by GitHub for the merge.
+	MergeCommitSHA string `json:"merge_commit_sha"`
 	Head           struct {
 		Ref string `json:"ref"`
 	} `json:"head"`

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -228,6 +228,23 @@ func TestGhClientOwnsDraftPullRequestFindCreateAndUpdate(t *testing.T) {
 	}
 }
 
+// TestGhClientDecodesMergedPullRequestLifecycle verifies the adapter preserves
+// both the merged decision and immutable merge commit from GitHub's response.
+func TestGhClientDecodesMergedPullRequestLifecycle(t *testing.T) {
+	t.Parallel()
+
+	client := &github.GhClient{Runner: &fakeCommandRunner{outputs: [][]byte{
+		[]byte(`[{"number":17,"html_url":"https://github.com/example/project/pull/17","state":"closed","merged_at":"2026-08-23T12:00:00Z","merge_commit_sha":"0123456789abcdef0123456789abcdef01234567","head":{"ref":"factory/run-1"},"base":{"ref":"main"}}]`),
+	}}}
+	got, err := client.FindPullRequest(context.Background(), github.Repository{Owner: "example", Name: "project"}, "factory/run-1", "main")
+	if err != nil {
+		t.Fatalf("FindPullRequest() error = %v", err)
+	}
+	if !got.Merged || got.MergeCommitSHA == "" {
+		t.Fatalf("pull request = %#v, want merged lifecycle projection", got)
+	}
+}
+
 // TestValidCommitSHARejectsAbbreviatedObjectIDs verifies checkpoint validation
 // does not accept intermediate-length values as exact commit identities.
 func TestValidCommitSHARejectsAbbreviatedObjectIDs(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 9
+const CurrentSchemaVersion = 10
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -117,6 +117,8 @@ type Run struct {
 	MergeCommitSHA string
 	// LifecycleReason explains an automatic or authorized terminal transition.
 	LifecycleReason string
+	// LifecycleNotificationSent records successful cmux notification delivery.
+	LifecycleNotificationSent bool
 	// Revision is the monotonic coordinator revision used by command replay
 	// prevention and persisted supervision updates.
 	Revision int64
@@ -278,7 +280,7 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
-		       lifecycle_reason,
+		       lifecycle_reason, lifecycle_notification_sent,
 		       revision, processed_comment_id, processed_comment_revision,
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override,
@@ -297,7 +299,7 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
-		       lifecycle_reason,
+		       lifecycle_reason, lifecycle_notification_sent,
 		       revision, processed_comment_id, processed_comment_revision,
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override,
@@ -328,6 +330,7 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&run.PullRequestURL,
 		&run.MergeCommitSHA,
 		&run.LifecycleReason,
+		&run.LifecycleNotificationSent,
 		&run.Revision,
 		&run.ProcessedCommentID,
 		&run.ProcessedCommentRevision,
@@ -432,6 +435,7 @@ func runValues(run Run) []any {
 		run.PullRequestURL,
 		run.MergeCommitSHA,
 		run.LifecycleReason,
+		run.LifecycleNotificationSent,
 		run.Revision,
 		run.ProcessedCommentID,
 		run.ProcessedCommentRevision,
@@ -450,10 +454,11 @@ const saveRunStatement = `
 			id, repository_path, issue_number, stage, status, branch, worktree,
 			checkpoint_sha, image_digest, coordinator, status_comment_id,
 			pull_request_number, pull_request_url, merge_commit_sha, lifecycle_reason,
+			lifecycle_notification_sent,
 			revision, processed_comment_id,
 			processed_comment_revision, last_command_name, last_command_outcome,
 			last_command_message, harness_override, specification_packet, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
 			issue_number = excluded.issue_number,
@@ -469,6 +474,7 @@ const saveRunStatement = `
 			pull_request_url = excluded.pull_request_url,
 			merge_commit_sha = excluded.merge_commit_sha,
 			lifecycle_reason = excluded.lifecycle_reason,
+			lifecycle_notification_sent = excluded.lifecycle_notification_sent,
 			revision = excluded.revision,
 			processed_comment_id = excluded.processed_comment_id,
 			processed_comment_revision = excluded.processed_comment_revision,
@@ -484,6 +490,7 @@ const saveRunIfRevisionStatement = `
 			repository_path = ?, issue_number = ?, stage = ?, status = ?, branch = ?, worktree = ?,
 			checkpoint_sha = ?, image_digest = ?, coordinator = ?, status_comment_id = ?,
 			pull_request_number = ?, pull_request_url = ?, merge_commit_sha = ?, lifecycle_reason = ?,
+			lifecycle_notification_sent = ?,
 			revision = ?, processed_comment_id = ?,
 			processed_comment_revision = ?, last_command_name = ?, last_command_outcome = ?,
 			last_command_message = ?, harness_override = ?, specification_packet = ?,
@@ -846,6 +853,10 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 				if _, err := tx.ExecContext(ctx, statement); err != nil {
 					return fmt.Errorf("apply store migration 9: %w", err)
 				}
+			}
+		case 10:
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN lifecycle_notification_sent INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return fmt.Errorf("apply store migration 10: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 10
+const CurrentSchemaVersion = 11
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -659,6 +659,55 @@ func scanInvocation(row *sql.Row) (*Invocation, error) {
 	return &invocation, nil
 }
 
+// ClaimLifecycleNotification atomically claims the right to send one terminal
+// notification, returning true if the claim succeeded (caller should send),
+// false if the claim already exists (notification already sent or being sent).
+func (s *Store) ClaimLifecycleNotification(ctx context.Context, runID string, terminalStatus Status) (bool, error) {
+	if runID == "" {
+		return false, errors.New("run id is required for lifecycle notification claim")
+	}
+	if !IsTerminalStatus(terminalStatus) {
+		return false, fmt.Errorf("cannot claim lifecycle notification for non-terminal status %q", terminalStatus)
+	}
+	now := time.Now().UTC().Format(runTimestampLayout)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO lifecycle_notifications (run_id, terminal_status, created_at)
+		VALUES (?, ?, ?)`, runID, terminalStatus, now)
+	if err != nil {
+		if isLifecycleNotificationClaimConflict(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("claim lifecycle notification for run %q status %q: %w", runID, terminalStatus, err)
+	}
+	return true, nil
+}
+
+// ReleaseLifecycleNotification removes a notification claim, allowing a future
+// retry to attempt delivery again. This is called when notification delivery
+// fails after the claim was successfully recorded.
+func (s *Store) ReleaseLifecycleNotification(ctx context.Context, runID string, terminalStatus Status) error {
+	if runID == "" {
+		return errors.New("run id is required for lifecycle notification release")
+	}
+	if !IsTerminalStatus(terminalStatus) {
+		return fmt.Errorf("cannot release lifecycle notification for non-terminal status %q", terminalStatus)
+	}
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM lifecycle_notifications
+		WHERE run_id = ? AND terminal_status = ?`, runID, terminalStatus)
+	if err != nil {
+		return fmt.Errorf("release lifecycle notification claim for run %q status %q: %w", runID, terminalStatus, err)
+	}
+	return nil
+}
+
+// isLifecycleNotificationClaimConflict recognizes the primary key violation
+// without depending on a driver-specific SQLite error type.
+func isLifecycleNotificationClaimConflict(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "primary key") || strings.Contains(message, "unique constraint failed: lifecycle_notifications")
+}
+
 // databaseState reports whether the path identifies an existing database file and whether that file is empty.
 func databaseState(path string) (bool, bool, error) {
 	info, err := os.Stat(path)
@@ -857,6 +906,15 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 		case 10:
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN lifecycle_notification_sent INTEGER NOT NULL DEFAULT 0"); err != nil {
 				return fmt.Errorf("apply store migration 10: %w", err)
+			}
+		case 11:
+			if _, err := tx.ExecContext(ctx, `CREATE TABLE lifecycle_notifications (
+				run_id TEXT NOT NULL,
+				terminal_status TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				PRIMARY KEY (run_id, terminal_status)
+			)`); err != nil {
+				return fmt.Errorf("apply store migration 11: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 8
+const CurrentSchemaVersion = 9
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -113,6 +113,10 @@ type Run struct {
 	PullRequestNumber int
 	// PullRequestURL is the operator-facing URL of the draft PR.
 	PullRequestURL string
+	// MergeCommitSHA is the immutable commit recorded when the tracked PR merges.
+	MergeCommitSHA string
+	// LifecycleReason explains an automatic or authorized terminal transition.
+	LifecycleReason string
 	// Revision is the monotonic coordinator revision used by command replay
 	// prevention and persisted supervision updates.
 	Revision int64
@@ -273,7 +277,8 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, image_digest, coordinator, status_comment_id,
-		       pull_request_number, pull_request_url,
+		       pull_request_number, pull_request_url, merge_commit_sha,
+		       lifecycle_reason,
 		       revision, processed_comment_id, processed_comment_revision,
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override,
@@ -291,7 +296,8 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, image_digest, coordinator, status_comment_id,
-		       pull_request_number, pull_request_url,
+		       pull_request_number, pull_request_url, merge_commit_sha,
+		       lifecycle_reason,
 		       revision, processed_comment_id, processed_comment_revision,
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override,
@@ -320,6 +326,8 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&run.StatusCommentID,
 		&run.PullRequestNumber,
 		&run.PullRequestURL,
+		&run.MergeCommitSHA,
+		&run.LifecycleReason,
 		&run.Revision,
 		&run.ProcessedCommentID,
 		&run.ProcessedCommentRevision,
@@ -422,6 +430,8 @@ func runValues(run Run) []any {
 		run.StatusCommentID,
 		run.PullRequestNumber,
 		run.PullRequestURL,
+		run.MergeCommitSHA,
+		run.LifecycleReason,
 		run.Revision,
 		run.ProcessedCommentID,
 		run.ProcessedCommentRevision,
@@ -439,10 +449,11 @@ const saveRunStatement = `
 		INSERT INTO operational_runs (
 			id, repository_path, issue_number, stage, status, branch, worktree,
 			checkpoint_sha, image_digest, coordinator, status_comment_id,
-			pull_request_number, pull_request_url, revision, processed_comment_id,
+			pull_request_number, pull_request_url, merge_commit_sha, lifecycle_reason,
+			revision, processed_comment_id,
 			processed_comment_revision, last_command_name, last_command_outcome,
 			last_command_message, harness_override, specification_packet, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
 			issue_number = excluded.issue_number,
@@ -456,6 +467,8 @@ const saveRunStatement = `
 			status_comment_id = excluded.status_comment_id,
 			pull_request_number = excluded.pull_request_number,
 			pull_request_url = excluded.pull_request_url,
+			merge_commit_sha = excluded.merge_commit_sha,
+			lifecycle_reason = excluded.lifecycle_reason,
 			revision = excluded.revision,
 			processed_comment_id = excluded.processed_comment_id,
 			processed_comment_revision = excluded.processed_comment_revision,
@@ -470,7 +483,8 @@ const saveRunIfRevisionStatement = `
 		UPDATE operational_runs SET
 			repository_path = ?, issue_number = ?, stage = ?, status = ?, branch = ?, worktree = ?,
 			checkpoint_sha = ?, image_digest = ?, coordinator = ?, status_comment_id = ?,
-			pull_request_number = ?, pull_request_url = ?, revision = ?, processed_comment_id = ?,
+			pull_request_number = ?, pull_request_url = ?, merge_commit_sha = ?, lifecycle_reason = ?,
+			revision = ?, processed_comment_id = ?,
 			processed_comment_revision = ?, last_command_name = ?, last_command_outcome = ?,
 			last_command_message = ?, harness_override = ?, specification_packet = ?,
 			created_at = ?, updated_at = ?
@@ -822,6 +836,15 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 			} {
 				if _, err := tx.ExecContext(ctx, statement); err != nil {
 					return fmt.Errorf("apply store migration 8: %w", err)
+				}
+			}
+		case 9:
+			for _, statement := range []string{
+				"ALTER TABLE operational_runs ADD COLUMN merge_commit_sha TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN lifecycle_reason TEXT NOT NULL DEFAULT ''",
+			} {
+				if _, err := tx.ExecContext(ctx, statement); err != nil {
+					return fmt.Errorf("apply store migration 9: %w", err)
 				}
 			}
 		default:

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -280,6 +280,49 @@ func TestOpenReopensAnExistingCurrentVersionStoreWithoutCreatingABackup(t *testi
 	}
 }
 
+// TestRunTerminalProjectionSurvivesStoreReopen verifies merge and lifecycle
+// metadata remain available to status after a terminal transition.
+func TestRunTerminalProjectionSurvivesStoreReopen(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	run := store.Run{
+		ID:                "run-terminal",
+		RepositoryPath:    "/work/repository",
+		IssueNumber:       42,
+		Stage:             store.StageReady,
+		Status:            store.StatusComplete,
+		PullRequestNumber: 17,
+		PullRequestURL:    "https://github.com/example/project/pull/17",
+		MergeCommitSHA:    "0123456789abcdef0123456789abcdef0123456789",
+		LifecycleReason:   "pull request #17 merged",
+	}
+	if err := opened.SaveRun(context.Background(), run); err != nil {
+		_ = opened.Close()
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("reopen error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	latest, err := reopened.LatestRun(context.Background())
+	if err != nil {
+		t.Fatalf("LatestRun() error = %v", err)
+	}
+	if latest == nil || latest.MergeCommitSHA != run.MergeCommitSHA || latest.LifecycleReason != run.LifecycleReason {
+		t.Fatalf("LatestRun() = %#v, want terminal lifecycle projection", latest)
+	}
+}
+
 func TestOpenRejectsAnOperationalStorePathThatIsADirectory(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -291,15 +291,16 @@ func TestRunTerminalProjectionSurvivesStoreReopen(t *testing.T) {
 		t.Fatalf("Open() error = %v", err)
 	}
 	run := store.Run{
-		ID:                "run-terminal",
-		RepositoryPath:    "/work/repository",
-		IssueNumber:       42,
-		Stage:             store.StageReady,
-		Status:            store.StatusComplete,
-		PullRequestNumber: 17,
-		PullRequestURL:    "https://github.com/example/project/pull/17",
-		MergeCommitSHA:    "0123456789abcdef0123456789abcdef0123456789",
-		LifecycleReason:   "pull request #17 merged",
+		ID:                        "run-terminal",
+		RepositoryPath:            "/work/repository",
+		IssueNumber:               42,
+		Stage:                     store.StageReady,
+		Status:                    store.StatusComplete,
+		PullRequestNumber:         17,
+		PullRequestURL:            "https://github.com/example/project/pull/17",
+		MergeCommitSHA:            "0123456789abcdef0123456789abcdef0123456789",
+		LifecycleReason:           "pull request #17 merged",
+		LifecycleNotificationSent: true,
 	}
 	if err := opened.SaveRun(context.Background(), run); err != nil {
 		_ = opened.Close()
@@ -318,7 +319,7 @@ func TestRunTerminalProjectionSurvivesStoreReopen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LatestRun() error = %v", err)
 	}
-	if latest == nil || latest.MergeCommitSHA != run.MergeCommitSHA || latest.LifecycleReason != run.LifecycleReason {
+	if latest == nil || latest.MergeCommitSHA != run.MergeCommitSHA || latest.LifecycleReason != run.LifecycleReason || !latest.LifecycleNotificationSent {
 		t.Fatalf("LatestRun() = %#v, want terminal lifecycle projection", latest)
 	}
 }


### PR DESCRIPTION
Closes #18. Implements merged-PR completion, lifecycle cancellation, authorized /factory cancel, retained terminal state, idempotent status and notification handling, SQLite schema migration, and regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/factory cancel` to stop active runs.
  * Runs now automatically complete when pull requests merge, including merge details.
  * Closed issues and unmerged pull requests now cancel associated runs.
  * Cancelled runs can be retried after reopening the related issue or pull request.
  * Status updates now show lifecycle outcomes and reasons.

* **Bug Fixes**
  * Prevented duplicate terminal notifications and preserved lifecycle details across restarts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->