### PR TITLE
Permit clean claim-to-first-invocation progression

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -23,6 +23,22 @@ live coordinator and gate output rather than duplicate the one-shot
 `factory status` command. The output reports the invocation identifier, run, and opaque terminal
 handles. It does not print the role prompt or terminal contents.
 
+### Clean claim handoff and recovery boundary
+
+`factory issue` completes a claim at `claim/active` and persists the worktree,
+branch, checkpoint, issue projection, and status-comment identity. A separate
+coordinator process may start the first implementation invocation when its
+read-only recovery diagnosis finds that every checked projection agrees and
+the operational store contains no invocation history. This is a completed
+claim awaiting its first invocation, not an interrupted run.
+
+The exception applies only to first-agent startup. Any persisted invocation,
+including a terminal one, or any recovery discrepancy returns the typed
+`recovery-required` result without starting a worker, terminal surface, or
+harness. Gates, reports, transitions, draft pull requests, and other
+progression paths retain the fail-closed boundary until issue #21 provides
+complete reconciliation.
+
 The `TerminalRuntime` seam owns workspace, surface, input, notification, and
 lifecycle behavior. The macOS adapter invokes cmux; workflow code never sees
 cmux or macOS identifiers. The implementation surface launches

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -34,6 +34,12 @@ type ActiveInvocationStore interface {
 	ActiveInvocation(context.Context, string) (*store.Invocation, error)
 }
 
+// InvocationHistoryStore is the operational-store seam used to distinguish a
+// completed claim from a run that has ever attempted a visible invocation.
+type InvocationHistoryStore interface {
+	HasInvocation(context.Context, string) (bool, error)
+}
+
 // AgentRequest selects one coordinator-owned visible role invocation.
 type AgentRequest struct {
 	// RunID selects the active factory run. Empty selects the only active run.
@@ -119,7 +125,7 @@ func (s *Service) StartAgent(ctx context.Context, request AgentRequest) (result 
 	if err := report.ValidatePermittedPaths(request.PermittedPaths); err != nil {
 		return AgentLaunchResult{}, err
 	}
-	registration, runStore, run, err := s.openActiveRunStore(ctx)
+	registration, runStore, run, err := s.openAgentStartRunStore(ctx)
 	if err != nil {
 		return AgentLaunchResult{}, err
 	}

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -69,6 +69,124 @@ func TestStartAgentRejectsADuplicateActiveInvocation(t *testing.T) {
 	}
 }
 
+// TestStartAgentAllowsAClaimedRunAfterCoordinatorRestart verifies the clean
+// claim-to-first-invocation handoff through a freshly opened coordinator.
+func TestStartAgentAllowsAClaimedRunAfterCoordinatorRestart(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	run := *runStore.current
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{Worktree: run.Worktree}},
+		state:        gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA},
+	}
+	fresh := newFreshAgentService(t, runStore, worktree, runtime, terminalRuntime, harnessRuntime)
+
+	launch, err := fresh.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("fresh StartAgent() error = %v, want clean claim handoff", err)
+	}
+	if launch.Invocation.ID == "" || len(runtime.starts) != 1 || len(runStore.invocations) != 1 {
+		t.Fatalf("fresh launch = %#v, worker starts = %#v, invocations = %#v", launch, runtime.starts, runStore.invocations)
+	}
+}
+
+// TestStartAgentPersistsInvocationBeforeStartingTheWorker verifies the
+// durable invocation identity is published before any worker effect begins.
+func TestStartAgentPersistsInvocationBeforeStartingTheWorker(t *testing.T) {
+	service, runStore, runtime, _, _ := newAgentService(t)
+	events := []string{}
+	runStore.events = &events
+	runtime.events = &events
+
+	if _, err := service.StartAgent(context.Background(), factory.AgentRequest{}); err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	persistedAt := eventIndex(events, "persist invocation")
+	startedAt := eventIndex(events, "start worker")
+	if persistedAt < 0 || startedAt < 0 || persistedAt > startedAt {
+		t.Fatalf("effect order = %#v, want invocation persistence before worker start", events)
+	}
+}
+
+// TestStartAgentRefusesARecoveryDiscrepancyBeforeEffects verifies a fresh
+// coordinator returns the typed recovery refusal without starting any effect.
+func TestStartAgentRefusesARecoveryDiscrepancyBeforeEffects(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	run := *runStore.current
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{Worktree: run.Worktree}},
+		state:        gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: "different-checkpoint"},
+	}
+	fresh := newFreshAgentService(t, runStore, worktree, runtime, terminalRuntime, harnessRuntime)
+
+	_, err := fresh.StartAgent(context.Background(), factory.AgentRequest{})
+	var recoveryErr *factory.RecoveryRequiredError
+	if !errors.As(err, &recoveryErr) {
+		t.Fatalf("fresh StartAgent() error = %v, want RecoveryRequiredError", err)
+	}
+	if len(runtime.starts) != 0 || len(terminalRuntime.notifications) != 0 || len(harnessRuntime.starts) != 0 || len(runStore.invocations) != 0 {
+		t.Fatalf("recovery refusal effects: workers=%d notifications=%d harnesses=%d invocations=%d, want none", len(runtime.starts), len(terminalRuntime.notifications), len(harnessRuntime.starts), len(runStore.invocations))
+	}
+}
+
+// TestStartAgentRefusesAnyPreviouslyPersistedInvocation verifies that a
+// terminal or non-terminal invocation keeps a fresh coordinator behind #24.
+func TestStartAgentRefusesAnyPreviouslyPersistedInvocation(t *testing.T) {
+	statuses := []store.InvocationStatus{
+		store.InvocationStatusActive,
+		store.InvocationStatusCompleted,
+		store.InvocationStatusWaitingForHuman,
+		store.InvocationStatusCannotProceed,
+	}
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			_, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+			run := *runStore.current
+			if err := runStore.SaveInvocation(context.Background(), store.Invocation{
+				ID: "inv-existing", RunID: run.ID, Harness: "codex", Role: "implementation", Stage: store.StageClaim,
+				Status: status,
+			}); err != nil {
+				t.Fatalf("SaveInvocation() error = %v", err)
+			}
+			worktree := &inspectingWorktree{
+				fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{Worktree: run.Worktree}},
+				state:        gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA},
+			}
+			fresh := newFreshAgentService(t, runStore, worktree, runtime, terminalRuntime, harnessRuntime)
+
+			_, err := fresh.StartAgent(context.Background(), factory.AgentRequest{})
+			var recoveryErr *factory.RecoveryRequiredError
+			if !errors.As(err, &recoveryErr) {
+				t.Fatalf("fresh StartAgent() error = %v, want RecoveryRequiredError", err)
+			}
+			if len(runtime.starts) != 0 || len(terminalRuntime.notifications) != 0 || len(harnessRuntime.starts) != 0 {
+				t.Fatalf("existing invocation effects: workers=%d notifications=%d harnesses=%d, want none", len(runtime.starts), len(terminalRuntime.notifications), len(harnessRuntime.starts))
+			}
+		})
+	}
+}
+
+// TestStartAgentAppliesTheExceptionOnlyToAClaimStage verifies implementation
+// stage runs still use the #24 startup guard even without an invocation.
+func TestStartAgentAppliesTheExceptionOnlyToAClaimStage(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	runStore.current.Stage = store.StageImplementation
+	run := *runStore.current
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{Worktree: run.Worktree}},
+		state:        gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA},
+	}
+	fresh := newFreshAgentService(t, runStore, worktree, runtime, terminalRuntime, harnessRuntime)
+
+	_, err := fresh.StartAgent(context.Background(), factory.AgentRequest{})
+	var recoveryErr *factory.RecoveryRequiredError
+	if !errors.As(err, &recoveryErr) {
+		t.Fatalf("fresh StartAgent() error = %v, want RecoveryRequiredError", err)
+	}
+	if len(runtime.starts) != 0 || len(terminalRuntime.notifications) != 0 || len(harnessRuntime.starts) != 0 {
+		t.Fatalf("non-claim effects: workers=%d notifications=%d harnesses=%d, want none", len(runtime.starts), len(terminalRuntime.notifications), len(harnessRuntime.starts))
+	}
+}
+
 // TestStartAgentRollsBackASetupFailure verifies a partially launched session
 // cannot remain active after the harness fails to start.
 func TestStartAgentRollsBackASetupFailure(t *testing.T) {
@@ -340,6 +458,50 @@ func newAgentService(t *testing.T) (*factory.Service, *agentRunStore, *agentWork
 	return service, runStore, runtime, terminalRuntime, harnessRuntime
 }
 
+// newFreshAgentService recreates a coordinator around the persisted claim so
+// tests exercise the cross-process startup seam rather than cached service state.
+func newFreshAgentService(t *testing.T, runStore *agentRunStore, worktree *inspectingWorktree, runtime *agentWorker, terminalRuntime *agentTerminal, harnessRuntime *agentHarness) *factory.Service {
+	t.Helper()
+	if runStore.current == nil {
+		t.Fatal("fresh coordinator fixture requires a persisted run")
+	}
+	run := *runStore.current
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path:                 run.RepositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		Polling:              config.PollingConfig{Interval: "30s", Backoff: "5m"},
+		Cmux:                 config.CmuxConfig{ControlWorkspace: "factory-control"},
+		OperationalDataPath:  filepath.Join(filepath.Dir(run.RepositoryPath), "state", "factory.db"),
+		RepositoryConfigPath: filepath.Join(run.RepositoryPath, "factory.yaml"),
+	}}}
+	githubRuntime := &fakeGitHub{
+		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: " + run.ID + " -->"},
+	}
+	return factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return validRepositoryConfig(), nil },
+		Worker:         runtime,
+		Terminal:       terminalRuntime,
+		Harness:        harnessRuntime,
+		GitHub:         githubRuntime,
+		Worktree:       worktree,
+		Now:            func() time.Time { return time.Date(2026, 8, 21, 8, 0, 0, 0, time.UTC) },
+		NewRunID:       func() (string, error) { return "generated", nil },
+	})
+}
+
+// eventIndex returns the first position of one recorded test effect.
+func eventIndex(events []string, wanted string) int {
+	for index, event := range events {
+		if event == wanted {
+			return index
+		}
+	}
+	return -1
+}
+
 // inspectingWorktree adds the read-only report inspection seam to the shared
 // claim-test worktree fake.
 type inspectingWorktree struct {
@@ -363,6 +525,7 @@ type agentRunStore struct {
 	current         *store.Run
 	invocations     map[string]store.Invocation
 	lifecycleClaims map[string]map[store.Status]bool
+	events          *[]string
 }
 
 // CurrentRun returns the configured active run.
@@ -400,8 +563,21 @@ func (s *agentRunStore) ReleaseLifecycleNotification(_ context.Context, runID st
 
 // SaveInvocation stores one updated invocation state.
 func (s *agentRunStore) SaveInvocation(_ context.Context, invocation store.Invocation) error {
+	if s.events != nil {
+		*s.events = append(*s.events, "persist invocation")
+	}
 	s.invocations[invocation.ID] = invocation
 	return nil
+}
+
+// HasInvocation reports whether any invocation history exists for one run.
+func (s *agentRunStore) HasInvocation(_ context.Context, runID string) (bool, error) {
+	for _, value := range s.invocations {
+		if value.RunID == runID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // Invocation loads one invocation only for its owning run.
@@ -431,10 +607,14 @@ func (*agentRunStore) Close() error { return nil }
 type agentWorker struct {
 	starts []worker.StartRequest
 	stops  int
+	events *[]string
 }
 
 // Start records one worker start.
 func (w *agentWorker) Start(_ context.Context, request worker.StartRequest) error {
+	if w.events != nil {
+		*w.events = append(*w.events, "start worker")
+	}
 	w.starts = append(w.starts, request)
 	return nil
 }
@@ -530,6 +710,7 @@ func (h *agentHarness) Finish(_ context.Context, session harness.Session) error 
 }
 
 var _ factory.InvocationStore = (*agentRunStore)(nil)
+var _ factory.InvocationHistoryStore = (*agentRunStore)(nil)
 var _ worker.WorkerRuntime = (*agentWorker)(nil)
 var _ terminal.TerminalRuntime = (*agentTerminal)(nil)
 var _ harness.Runtime = (*agentHarness)(nil)

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -408,10 +408,30 @@ func (s *Service) openActiveRunStore(ctx context.Context) (config.RepositoryRegi
 	return registration, runStore, run, nil
 }
 
-// ensureProgressionStartup performs the one read-only startup guard for a
-// service instance. A service that found no interrupted run may continue a run
-// it claims during that same process; a fresh service refuses every persisted
-// non-terminal run until issue #21 supplies reconciliation.
+// openAgentStartRunStore opens the active run for the one progression seam
+// allowed to cross a clean claim-to-first-invocation process boundary.
+func (s *Service) openAgentStartRunStore(ctx context.Context) (config.RepositoryRegistration, RunStore, *store.Run, error) {
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	run, err := runStore.CurrentRun(ctx)
+	if err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	if err := s.ensureAgentStartup(ctx, registration, runStore, run); err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	return registration, runStore, run, nil
+}
+
+// ensureProgressionStartup performs the read-only startup guard shared by all
+// progression seams except the dedicated first-agent handoff. A service that
+// found no interrupted run may continue a run it claims during that same
+// process; a fresh service refuses every persisted non-terminal run until issue
+// #21 supplies reconciliation.
 func (s *Service) ensureProgressionStartup(ctx context.Context, registration config.RepositoryRegistration, run *store.Run) error {
 	s.startupMu.Lock()
 	defer s.startupMu.Unlock()
@@ -425,6 +445,60 @@ func (s *Service) ensureProgressionStartup(ctx context.Context, registration con
 	diagnosis := s.diagnoseInterruptedRun(ctx, registration, *run)
 	s.startupErr = recoveryRequiredError(diagnosis)
 	return s.startupErr
+}
+
+// ensureAgentStartup permits only a clean persisted claim to cross into its
+// first implementation invocation. Every later or interrupted state retains
+// the typed #24 refusal until issue #21 supplies reconciliation.
+func (s *Service) ensureAgentStartup(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run) error {
+	s.startupMu.Lock()
+	defer s.startupMu.Unlock()
+	if s.startupChecked {
+		return s.startupErr
+	}
+	s.startupChecked = true
+	if run == nil || store.IsTerminalStatus(run.Status) {
+		return nil
+	}
+	diagnosis := s.diagnoseInterruptedRun(ctx, registration, *run)
+	if !diagnosis.SourcesAgree {
+		s.startupErr = recoveryRequiredError(diagnosis)
+		return s.startupErr
+	}
+	if run.Stage != store.StageClaim || run.Status != store.StatusActive {
+		s.startupErr = recoveryRequiredError(diagnosis)
+		return s.startupErr
+	}
+	historyStore, ok := runStore.(InvocationHistoryStore)
+	if !ok {
+		addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+			Source:   "operational store",
+			Field:    "invocation history",
+			Expected: "read-only invocation history lookup",
+			Observed: "store does not support invocation history",
+		})
+		diagnosis.SourcesAgree = false
+		s.startupErr = recoveryRequiredError(diagnosis)
+		return s.startupErr
+	}
+	hasInvocation, err := historyStore.HasInvocation(ctx, run.ID)
+	if err != nil {
+		addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+			Source:   "operational store",
+			Field:    "invocation history",
+			Expected: "read invocation history",
+			Observed: err.Error(),
+		})
+		diagnosis.SourcesAgree = false
+		s.startupErr = recoveryRequiredError(diagnosis)
+		return s.startupErr
+	}
+	if hasInvocation {
+		diagnosis.InvocationExists = true
+		s.startupErr = recoveryRequiredError(diagnosis)
+		return s.startupErr
+	}
+	return nil
 }
 
 // failClaim records a terminal failure and best-effort moves the issue label

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -231,9 +231,9 @@ func (c commandConfig) Create(string) (config.HostConfig, error) { return c.host
 
 // commandRunStore is a restartable in-memory store fixture.
 type commandRunStore struct {
-	current    *store.Run
-	latest     *store.Run
-	saved      []store.Run
+	current *store.Run
+	latest  *store.Run
+	saved   []store.Run
 	// closeCount records store lifetime in polling tests.
 	closeCount int
 	// saveErrors allows tests to inject save failures.

--- a/internal/factory/first_invocation_test.go
+++ b/internal/factory/first_invocation_test.go
@@ -1,0 +1,287 @@
+package factory_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestStartAgentUsesTheRealStoreAcrossAClaimProcessBoundary verifies the
+// permitted clean handoff with a real SQLite store and a freshly opened service.
+func TestStartAgentUsesTheRealStoreAcrossAClaimProcessBoundary(t *testing.T) {
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktree")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	if err := mkdir(filepath.Join(repositoryPath, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	if err := mkdir(worktreePath); err != nil {
+		t.Fatal(err)
+	}
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: "base", Branch: "factory/run-real", Worktree: worktreePath}},
+		state:        gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-real", HeadSHA: "base"},
+	}
+	githubRuntime := &fakeGitHub{issueValue: github.Issue{
+		Number: 42, Title: "Real store handoff", Body: "Repository guidance", State: "open", Labels: []string{github.LabelAgentReady},
+	}}
+	runtime := &agentWorker{}
+	terminalRuntime := &agentTerminal{}
+	harnessRuntime := &agentHarness{}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path:                 repositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		Polling:              config.PollingConfig{Interval: "30s", Backoff: "5m"},
+		Cmux:                 config.CmuxConfig{ControlWorkspace: "factory-control"},
+		OperationalDataPath:  operationalPath,
+		RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+	}}}
+	dependencies := func(runID string) factory.Dependencies {
+		return factory.Dependencies{
+			Config: &fakeConfig{value: host},
+			OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
+				return store.Open(ctx, path)
+			},
+			LoadRepository: func(string) (config.RepositoryConfig, error) { return validRepositoryConfig(), nil },
+			Worker:         runtime, Terminal: terminalRuntime, Harness: harnessRuntime,
+			GitHub: githubRuntime, Worktree: worktree,
+			Now:         func() time.Time { return time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC) },
+			NewRunID:    func() (string, error) { return runID, nil },
+			Coordinator: "coordinator-test",
+		}
+	}
+
+	claimService := factory.NewWithDependencies("/host/config.yaml", dependencies("run-real"))
+	claimed, err := claimService.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+	if err := githubRuntime.setStatusComment(claimed.Run); err != nil {
+		t.Fatal(err)
+	}
+	// A separate service models the next process opening the same host store.
+	startService := factory.NewWithDependencies("/host/config.yaml", dependencies("generated"))
+	launch, err := startService.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() after store reopen error = %v", err)
+	}
+	if launch.Invocation.RunID != claimed.Run.ID || len(runtime.starts) != 1 || len(harnessRuntime.starts) != 1 {
+		t.Fatalf("launch = %#v, worker starts = %d, harness starts = %d", launch.Invocation, len(runtime.starts), len(harnessRuntime.starts))
+	}
+
+	reopened, err := store.Open(context.Background(), operationalPath)
+	if err != nil {
+		t.Fatalf("reopen operational store error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	hasInvocation, err := reopened.HasInvocation(context.Background(), claimed.Run.ID)
+	if err != nil {
+		t.Fatalf("HasInvocation() error = %v", err)
+	}
+	if !hasInvocation {
+		t.Fatal("HasInvocation() = false after first agent start")
+	}
+}
+
+// TestStartAgentUsesTheRealStoreToRefuseADiscrepancy verifies a fresh service
+// returns recovery-required before worker, terminal, or harness effects.
+func TestStartAgentUsesTheRealStoreToRefuseADiscrepancy(t *testing.T) {
+	fixture := newRealHandoffFixture(t)
+	fixture.worktree.state.HeadSHA = "different-checkpoint"
+
+	_, err := fixture.newService("generated").StartAgent(context.Background(), factory.AgentRequest{})
+	var recoveryErr *factory.RecoveryRequiredError
+	if !errors.As(err, &recoveryErr) {
+		t.Fatalf("StartAgent() error = %v, want RecoveryRequiredError", err)
+	}
+	if len(fixture.worker.starts) != 0 || len(fixture.terminal.notifications) != 0 || len(fixture.harness.starts) != 0 {
+		t.Fatalf("recovery effects: workers=%d notifications=%d harnesses=%d, want none", len(fixture.worker.starts), len(fixture.terminal.notifications), len(fixture.harness.starts))
+	}
+}
+
+// TestStartAgentUsesTheRealStoreToRefuseInvocationHistory verifies a terminal
+// invocation is still history that requires issue #21 reconciliation.
+func TestStartAgentUsesTheRealStoreToRefuseInvocationHistory(t *testing.T) {
+	fixture := newRealHandoffFixture(t)
+	opened, err := store.Open(context.Background(), fixture.operationalPath)
+	if err != nil {
+		t.Fatalf("reopen operational store error = %v", err)
+	}
+	if err := opened.SaveInvocation(context.Background(), store.Invocation{
+		ID: "inv-terminal", RunID: fixture.claimed.ID, Harness: "codex", Role: "implementation", Stage: store.StageClaim,
+		Status: store.InvocationStatusCompleted,
+	}); err != nil {
+		_ = opened.Close()
+		t.Fatalf("SaveInvocation() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("close operational store error = %v", err)
+	}
+
+	_, err = fixture.newService("generated").StartAgent(context.Background(), factory.AgentRequest{})
+	var recoveryErr *factory.RecoveryRequiredError
+	if !errors.As(err, &recoveryErr) {
+		t.Fatalf("StartAgent() error = %v, want RecoveryRequiredError", err)
+	}
+	if !recoveryErr.Diagnosis.InvocationExists {
+		t.Fatalf("diagnosis = %#v, want persisted invocation history", recoveryErr.Diagnosis)
+	}
+	if len(fixture.worker.starts) != 0 || len(fixture.terminal.notifications) != 0 || len(fixture.harness.starts) != 0 {
+		t.Fatalf("existing-invocation effects: workers=%d notifications=%d harnesses=%d, want none", len(fixture.worker.starts), len(fixture.terminal.notifications), len(fixture.harness.starts))
+	}
+}
+
+// TestConcurrentFirstAgentAttemptsUseStoreUniqueness verifies two fresh
+// coordinators cannot turn one clean claim into two workers.
+func TestConcurrentFirstAgentAttemptsUseStoreUniqueness(t *testing.T) {
+	fixture := newRealHandoffFixture(t)
+	first, firstWorker, firstHarness := fixture.newIsolatedService("generated-one")
+	second, secondWorker, secondHarness := fixture.newIsolatedService("generated-two")
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	go func() {
+		<-start
+		_, err := first.StartAgent(context.Background(), factory.AgentRequest{})
+		results <- err
+	}()
+	go func() {
+		<-start
+		_, err := second.StartAgent(context.Background(), factory.AgentRequest{})
+		results <- err
+	}()
+	close(start)
+	firstErr, secondErr := <-results, <-results
+	if (firstErr == nil) == (secondErr == nil) {
+		t.Fatalf("concurrent StartAgent() errors = %v, %v, want exactly one success", firstErr, secondErr)
+	}
+	if len(firstWorker.starts)+len(secondWorker.starts) != 1 || len(firstHarness.starts)+len(secondHarness.starts) != 1 {
+		t.Fatalf("concurrent effects: workers=%d harnesses=%d, want one each", len(firstWorker.starts)+len(secondWorker.starts), len(firstHarness.starts)+len(secondHarness.starts))
+	}
+}
+
+// realHandoffFixture contains a claimed run and the external projections used
+// by tests that reopen a real operational store in a new coordinator.
+type realHandoffFixture struct {
+	repositoryPath  string
+	operationalPath string
+	worktree        *inspectingWorktree
+	github          *fakeGitHub
+	worker          *agentWorker
+	terminal        *agentTerminal
+	harness         *agentHarness
+	host            config.HostConfig
+	claimed         store.Run
+}
+
+// newRealHandoffFixture performs a real claim so startup tests begin at the
+// exact persisted state produced by the issue command.
+func newRealHandoffFixture(t *testing.T) *realHandoffFixture {
+	t.Helper()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktree")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	if err := mkdir(filepath.Join(repositoryPath, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	if err := mkdir(worktreePath); err != nil {
+		t.Fatal(err)
+	}
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: "base", Branch: "factory/run-real", Worktree: worktreePath}},
+		state:        gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-real", HeadSHA: "base"},
+	}
+	githubRuntime := &fakeGitHub{issueValue: github.Issue{
+		Number: 42, Title: "Real store handoff", Body: "Repository guidance", State: "open", Labels: []string{github.LabelAgentReady},
+	}}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path:                 repositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		Polling:              config.PollingConfig{Interval: "30s", Backoff: "5m"},
+		Cmux:                 config.CmuxConfig{ControlWorkspace: "factory-control"},
+		OperationalDataPath:  operationalPath,
+		RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+	}}}
+	fixture := &realHandoffFixture{
+		repositoryPath:  repositoryPath,
+		operationalPath: operationalPath,
+		worktree:        worktree,
+		github:          githubRuntime,
+		worker:          &agentWorker{}, terminal: &agentTerminal{}, harness: &agentHarness{}, host: host,
+	}
+	claimed, err := fixture.newService("run-real").ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+	fixture.claimed = claimed.Run
+	if err := githubRuntime.setStatusComment(claimed.Run); err != nil {
+		t.Fatal(err)
+	}
+	return fixture
+}
+
+// newService creates a coordinator with a selected run-id generator while
+// reopening the fixture's real SQLite store on every command.
+func (f *realHandoffFixture) newService(runID string) *factory.Service {
+	return factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfig{value: f.host},
+		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return validRepositoryConfig(), nil },
+		Worker:         f.worker, Terminal: f.terminal, Harness: f.harness,
+		GitHub: f.github, Worktree: f.worktree,
+		Now:         func() time.Time { return time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC) },
+		NewRunID:    func() (string, error) { return runID, nil },
+		Coordinator: "coordinator-test",
+	})
+}
+
+// newIsolatedService creates a coordinator with separate effect recorders but
+// the same reopened operational store and read-only projections.
+func (f *realHandoffFixture) newIsolatedService(runID string) (*factory.Service, *agentWorker, *agentHarness) {
+	githubRuntime := &fakeGitHub{issueValue: f.github.issueValue, statusComment: f.github.statusComment}
+	workerRuntime := &agentWorker{}
+	terminalRuntime := &agentTerminal{}
+	harnessRuntime := &agentHarness{}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfig{value: f.host},
+		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return validRepositoryConfig(), nil },
+		Worker:         workerRuntime, Terminal: terminalRuntime, Harness: harnessRuntime,
+		GitHub: githubRuntime, Worktree: f.worktree,
+		Now:         func() time.Time { return time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC) },
+		NewRunID:    func() (string, error) { return runID, nil },
+		Coordinator: "coordinator-test",
+	})
+	return service, workerRuntime, harnessRuntime
+}
+
+// setStatusComment mirrors the status comment persisted by the claim
+// transition so the reopened coordinator can complete its read-only diagnosis.
+func (f *fakeGitHub) setStatusComment(run store.Run) error {
+	if run.StatusCommentID == "" {
+		return &statusCommentFixtureError{message: "claim did not persist a status comment identity"}
+	}
+	f.statusComment = github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: " + run.ID + " -->"}
+	return nil
+}
+
+// statusCommentFixtureError reports an invalid real-store handoff fixture.
+type statusCommentFixtureError struct {
+	message string
+}
+
+// Error returns the fixture setup failure.
+func (e *statusCommentFixtureError) Error() string { return e.message }

--- a/internal/factory/lifecycle_test.go
+++ b/internal/factory/lifecycle_test.go
@@ -135,7 +135,7 @@ func TestPollLifecycleDoesNotResendAfterNotifySucceedsPersistFails(t *testing.T)
 		pullRequest:   github.PullRequest{Number: 19, State: "closed", Merged: true, MergeCommitSHA: strings.Repeat("f", 40), HeadBranch: run.Branch, BaseBranch: "main"},
 	}
 	// Inject a save error that will occur after notification succeeds.
-	runStore := &commandRunStore{current: &run, latest: &run, saveErrors: []error{errors.New("transient database error")}}
+	runStore := &commandRunStore{current: &run, latest: &run, saveErrors: []error{nil, errors.New("transient database error"), errors.New("transient database error")}}
 	terminalRuntime := &lifecycleTerminal{}
 	service := newLifecycleService(runStore, githubAdapter, &lifecycleWorker{}, terminalRuntime)
 

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -43,6 +43,8 @@ type RecoveryDiagnosis struct {
 	SourcesAgree bool
 	// Discrepancies contains every disagreement found during the read-only check.
 	Discrepancies []RecoveryDiscrepancy
+	// InvocationExists reports persisted invocation history for the diagnosed run.
+	InvocationExists bool
 	// SafeActions identifies operator actions that do not claim recovery.
 	SafeActions []string
 }
@@ -72,6 +74,9 @@ func (e *RecoveryRequiredError) Error() string {
 			details = append(details, fmt.Sprintf("%s.%s expected=%q observed=%q", discrepancy.Source, discrepancy.Field, discrepancy.Expected, discrepancy.Observed))
 		}
 		message += "; discrepancies: " + strings.Join(details, ", ")
+	}
+	if e.Diagnosis.InvocationExists {
+		message += "; persisted invocation history exists"
 	}
 	if len(e.Diagnosis.SafeActions) != 0 {
 		message += "; safe actions: " + strings.Join(e.Diagnosis.SafeActions, "; ")

--- a/internal/store/invocation_test.go
+++ b/internal/store/invocation_test.go
@@ -112,6 +112,41 @@ func TestStoreFindsOnlyTheNewestActiveInvocation(t *testing.T) {
 	}
 }
 
+// TestStoreFindsInvocationHistoryRegardlessOfStatus verifies startup can
+// distinguish a clean claim from a run that already attempted an invocation.
+func TestStoreFindsInvocationHistoryRegardlessOfStatus(t *testing.T) {
+	opened, err := store.Open(context.Background(), filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() { _ = opened.Close() }()
+	for _, status := range []store.InvocationStatus{
+		store.InvocationStatusCompleted,
+		store.InvocationStatusWaitingForHuman,
+		store.InvocationStatusCannotProceed,
+	} {
+		if err := opened.SaveInvocation(context.Background(), store.Invocation{
+			ID: "inv-" + string(status), RunID: "run-history", Harness: "codex", Role: "implementation", Stage: store.StageClaim, Status: status,
+		}); err != nil {
+			t.Fatalf("SaveInvocation(%s) error = %v", status, err)
+		}
+	}
+	found, err := opened.HasInvocation(context.Background(), "run-history")
+	if err != nil {
+		t.Fatalf("HasInvocation() error = %v", err)
+	}
+	if !found {
+		t.Fatal("HasInvocation() = false, want invocation history")
+	}
+	found, err = opened.HasInvocation(context.Background(), "run-without-history")
+	if err != nil {
+		t.Fatalf("HasInvocation(empty) error = %v", err)
+	}
+	if found {
+		t.Fatal("HasInvocation(empty) = true, want no invocation history")
+	}
+}
+
 // TestStoreRejectsTwoActiveInvocationsForOneRun verifies the database index,
 // rather than only the coordinator lookup, owns active-invocation uniqueness.
 func TestStoreRejectsTwoActiveInvocationsForOneRun(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -593,6 +593,20 @@ func (s *Store) Invocation(ctx context.Context, runID, invocationID string) (*In
 	return scanInvocation(row)
 }
 
+// HasInvocation reports whether any invocation, including terminal history,
+// has been persisted for one run.
+func (s *Store) HasInvocation(ctx context.Context, runID string) (bool, error) {
+	if strings.TrimSpace(runID) == "" {
+		return false, errors.New("invocation run id is required")
+	}
+	var found bool
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM invocations WHERE run_id = ?)`, runID).Scan(&found); err != nil {
+		return false, fmt.Errorf("check invocation history: %w", err)
+	}
+	return found, nil
+}
+
 // ActiveInvocation returns the newest active visible invocation for one run.
 // The coordinator uses it to avoid launching duplicate harness sessions after
 // a process restart or a repeated operator command.


### PR DESCRIPTION
## Summary

- allow a fresh coordinator to start only a clean claim/active run's first agent invocation
- keep discrepancies, invocation history, and non-claim startup states behind typed recovery-required
- persist invocation identity before worker effects and verify SQLite uniqueness across concurrent starts
- document the clean claim handoff versus interrupted-run recovery boundary

## Verification

- make check
- go test -race ./...
- real SQLite cross-process and concurrency tests
- two-axis code review: Standards pass; Spec pass

Also corrected a pre-existing lifecycle test fixture and formatting issue so the repository gate is green.

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer recovery handling when restarting agent runs.
  * Clean, claimed runs can resume after a coordinator restart.
  * Recovery now detects prior invocation history and reports it in diagnostics.

* **Bug Fixes**
  * Prevented duplicate or unsafe invocations after interrupted runs, checkpoint discrepancies, or previously attempted execution.
  * Ensured invocation state is recorded before worker execution begins.
  * Preserved notification behavior when later persistence attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->