### PR TITLE
feat: implement full gate model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,6 +21,14 @@ _Avoid_: Live issue, prompt
 An immutable commit representing accepted work at a stage boundary and identifying the exact subject of gates or review.
 _Avoid_: Snapshot, latest code
 
+**Baseline**:
+The repository-declared setup and gate suite evaluated against the claimed run's base checkpoint before any agent edit; a blocking failure moves the run to failed preflight unless the frozen issue explicitly targets it.
+_Avoid_: Preflight assumption, agent diagnosis
+
+**Setup fingerprint**:
+The SHA-256 identity of the configured manifest and lockfile contents observed by setup for one run phase and exact checkpoint.
+_Avoid_: Dependency cache key, mutable latest state
+
 **Recovery diagnosis**:
 A read-only comparison of one persisted non-terminal run with its registered repository, worktree, Git projection, and GitHub projections.
 _Avoid_: Reconciliation, recovery

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,8 @@ The default checked-in file is `factory.yaml` at the repository root. It is pars
 schema_version: 1
 target_branch: main
 setup: scripts/worker-go.sh mod download
+setup_files: [go.mod, go.sum]
+setup_environment_policy: clean
 gates:
   - name: format
     command: gofmt -l .
@@ -106,7 +108,7 @@ base_synchronization:
   branch: main
 ```
 
-The validator checks the schema version, target branch, setup, ordered unique gates and earlier dependencies, matching role harness/model policies, positive durations, positive retry limits, test policy, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, and base-synchronization mode. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
+The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies, positive durations, positive retry limits, test policy, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, and base-synchronization mode. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
 
 ## Worker image build and digest pinning
 
@@ -157,14 +159,21 @@ configuration variables, keeps Git prompts disabled, and turns off Go VCS
 stamping; this lets local Git fixtures in `go test` run without touching the
 worker's read-only `/git` projection.
 
-Issue #3 establishes and validates this repository-declared gate contract. Issue #5 adds the worker runtime and the coordinator path that runs setup plus one selected gate in the pinned worker and publishes its result to the exact checkpoint SHA. Issue #7 uses that same frozen gate contract to run every declared gate before the first branch push. Full baseline health, dependency skipping, independent-gate execution, manifest-triggered setup, and retained checkpoint-keyed gate results remain the expanded gate model in issue #9. The commands declared by this repository's `factory.yaml` are also run as part of the repository verification suite.
+Issue #3 establishes and validates this repository-declared gate contract. Issue #5 adds the worker runtime and the coordinator path that runs setup plus one selected gate in the pinned worker and publishes its result to the exact checkpoint SHA. Issue #7 uses that same frozen gate contract to run every declared gate before the first branch push. The issue #9 gate model runs one baseline suite before the first agent invocation, runs setup once per suite, continues independent gates after a failure, records dependency skips, reruns setup for every new dependency-input fingerprint, and retains results by phase and exact checkpoint SHA. The commands declared by this repository's `factory.yaml` are also run as part of the repository verification suite.
+
+An issue may explicitly accept a known pre-existing blocking baseline failure by
+including one exact marker in its frozen body, for example
+`<!-- factory-baseline-target: test -->`. The special `all` target accepts all
+blocking baseline failures, and `setup` targets a setup failure. Without a
+matching marker, the baseline moves the run to failed preflight and no agent
+invocation is permitted.
 
 Worker execution uses stable in-container paths (`/work`, `/git`, and
 `/cache/<name>`), a non-root uid, dropped capabilities, disabled privilege
 escalation, and no Docker socket. The coordinator prepares `/git` as a
 credential-free projection of Git history, refs, and run worktree state while
-omitting Git configuration, remotes, and hooks. Setup and gates receive a clean
-explicit environment; they do not inherit the coordinator's host environment
+omitting Git configuration, remotes, and hooks. Setup and gates receive their
+configured clean or role environment explicitly; they do not inherit the coordinator's host environment
 or credentials. Explicit worker mounts receive owner-plus-group permissions,
 and the runtime passes their existing non-root host groups to Docker as
 supplemental groups; other-user access is removed. See [Worker runtime](worker-runtime.md)

--- a/factory.yaml
+++ b/factory.yaml
@@ -1,6 +1,8 @@
 schema_version: 1
 target_branch: main
 setup: scripts/worker-go.sh mod download
+setup_files: [go.mod, go.sum]
+setup_environment_policy: clean
 gates:
   - name: format
     command: test -z "$(gofmt -l .)"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -131,12 +131,18 @@ func runIssue(ctx context.Context, args []string, defaultConfigPath string, outp
 		writeError(errorsOutput, errors.New("issue requires a positive issue number"))
 		return 2
 	}
-	result, err := factory.New(*configPath).ClaimIssue(ctx, issueNumber)
+	service := factory.New(*configPath)
+	result, err := service.ClaimIssue(ctx, issueNumber)
 	if err != nil {
 		writeError(errorsOutput, err)
 		return 1
 	}
-	if !writeOutput(output, errorsOutput, "claimed issue #%d\nrun: %s\nbranch: %s\nworktree: %s\nstage: %s\nstatus: %s\n", result.Run.IssueNumber, result.Run.ID, result.Run.Branch, result.Run.Worktree, result.Run.Stage, result.Run.Status) {
+	baseline, err := service.RunBaseline(ctx, factory.BaselineRequest{RunID: result.Run.ID})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "claimed issue #%d\nrun: %s\nbranch: %s\nworktree: %s\nstage: %s\nstatus: %s\nbaseline gates: %d\n", baseline.Run.IssueNumber, baseline.Run.ID, baseline.Run.Branch, baseline.Run.Worktree, baseline.Run.Stage, baseline.Run.Status, len(baseline.Gates)) {
 		return 1
 	}
 	return 0

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -23,6 +23,7 @@ func TestRunInitializesRegistersAndReportsStatus(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repositoryPath, "factory.yaml"), []byte(`schema_version: 1
 target_branch: main
 setup: go mod download
+setup_environment_policy: clean
 gates:
   - name: test
     command: go test ./...
@@ -377,6 +378,7 @@ func writeValidRepositoryConfig(t *testing.T, repositoryPath string) {
 	contents := `schema_version: 1
 target_branch: main
 setup: go mod download
+setup_environment_policy: clean
 gates:
   - name: test
     command: go test ./...

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,19 +58,23 @@ type AuthenticationConfig struct {
 }
 
 type RepositoryConfig struct {
-	SchemaVersion       int                 `yaml:"schema_version"`
-	TargetBranch        string              `yaml:"target_branch"`
-	Setup               string              `yaml:"setup"`
-	Gates               []GateConfig        `yaml:"gates"`
-	RoleHarnessDefaults map[string]Harness  `yaml:"role_harness_defaults"`
-	ModelOptions        map[string][]string `yaml:"model_options"`
-	Timeouts            TimeoutConfig       `yaml:"timeouts"`
-	RetryLimits         RetryLimits         `yaml:"retry_limits"`
-	TestPolicy          TestPolicy          `yaml:"test_policy"`
-	AllowedOverrides    []OverrideName      `yaml:"allowed_overrides"`
-	Caches              []CacheConfig       `yaml:"caches"`
-	WorkerBuild         WorkerBuildConfig   `yaml:"worker_build"`
-	BaseSynchronization BaseSynchronization `yaml:"base_synchronization"`
+	SchemaVersion int    `yaml:"schema_version"`
+	TargetBranch  string `yaml:"target_branch"`
+	Setup         string `yaml:"setup"`
+	// SetupFiles identifies checked-in manifests and lockfiles used to fingerprint setup.
+	SetupFiles []string `yaml:"setup_files"`
+	// SetupEnvironmentPolicy selects the checked-in worker environment for setup.
+	SetupEnvironmentPolicy EnvironmentPolicy   `yaml:"setup_environment_policy"`
+	Gates                  []GateConfig        `yaml:"gates"`
+	RoleHarnessDefaults    map[string]Harness  `yaml:"role_harness_defaults"`
+	ModelOptions           map[string][]string `yaml:"model_options"`
+	Timeouts               TimeoutConfig       `yaml:"timeouts"`
+	RetryLimits            RetryLimits         `yaml:"retry_limits"`
+	TestPolicy             TestPolicy          `yaml:"test_policy"`
+	AllowedOverrides       []OverrideName      `yaml:"allowed_overrides"`
+	Caches                 []CacheConfig       `yaml:"caches"`
+	WorkerBuild            WorkerBuildConfig   `yaml:"worker_build"`
+	BaseSynchronization    BaseSynchronization `yaml:"base_synchronization"`
 }
 
 type EnvironmentPolicy string
@@ -330,6 +334,12 @@ func ValidateRepository(config RepositoryConfig) error {
 	if strings.TrimSpace(config.Setup) == "" {
 		return validation("setup", "is required")
 	}
+	if err := validateSetupFiles(config.SetupFiles); err != nil {
+		return err
+	}
+	if config.SetupEnvironmentPolicy != EnvironmentPolicyClean && config.SetupEnvironmentPolicy != EnvironmentPolicyRole {
+		return validation("setup_environment_policy", "must be clean or role")
+	}
 	if len(config.Gates) == 0 {
 		return validation("gates", "must declare at least one ordered gate")
 	}
@@ -451,6 +461,33 @@ func ValidateRepository(config RepositoryConfig) error {
 	}
 	if config.BaseSynchronization.Mode == BaseSynchronizationBeforeReady && strings.TrimSpace(config.BaseSynchronization.Branch) == "" {
 		return validation("base_synchronization.branch", "is required when synchronization is enabled")
+	}
+	return nil
+}
+
+// validateSetupFiles validates optional repository-relative manifest and
+// lockfile paths whose contents identify the dependency graph used by setup.
+func validateSetupFiles(values []string) error {
+	seen := make(map[string]struct{}, len(values))
+	for index, value := range values {
+		field := fmt.Sprintf("setup_files[%d]", index)
+		if strings.TrimSpace(value) == "" {
+			return validation(field, "must not be empty")
+		}
+		if strings.ContainsAny(value, "\x00\r\n") {
+			return validation(field, "must not contain control characters")
+		}
+		if filepath.IsAbs(value) {
+			return validation(field, "must be relative to the repository checkout")
+		}
+		normalized := filepath.Clean(filepath.FromSlash(value))
+		if normalized == ".." || strings.HasPrefix(normalized, ".."+string(filepath.Separator)) {
+			return validation(field, "must remain inside the repository checkout")
+		}
+		if _, exists := seen[normalized]; exists {
+			return validation(field, "must be unique")
+		}
+		seen[normalized] = struct{}{}
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"gopkg.in/yaml.v3"
 )
@@ -474,7 +475,7 @@ func validateSetupFiles(values []string) error {
 		if strings.TrimSpace(value) == "" {
 			return validation(field, "must not be empty")
 		}
-		if strings.ContainsAny(value, "\x00\r\n") {
+		if strings.IndexFunc(value, unicode.IsControl) >= 0 {
 			return validation(field, "must not contain control characters")
 		}
 		if filepath.IsAbs(value) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -156,6 +156,8 @@ func TestValidateRepositoryRejectsUnsafeSetupFiles(t *testing.T) {
 		{name: "absolute", files: []string{"/tmp/go.mod"}, field: "setup_files[0]"},
 		{name: "parent traversal", files: []string{"../go.mod"}, field: "setup_files[0]"},
 		{name: "duplicate", files: []string{"go.mod", "go.mod"}, field: "setup_files[1]"},
+		{name: "tab control character", files: []string{"go\t.mod"}, field: "setup_files[0]"},
+		{name: "unicode control character", files: []string{"go\u0085.mod"}, field: "setup_files[0]"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			policy := validRepositoryConfig()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,8 @@ func TestLoadRepositoryConfigValidatesAndPreservesTheDeclaredWorkflow(t *testing
 	contents := `schema_version: 1
 target_branch: main
 setup: go mod download
+setup_environment_policy: clean
+setup_files: [go.mod, go.sum]
 gates:
   - name: format
     command: gofmt -l .
@@ -76,6 +78,12 @@ base_synchronization:
 	if len(got.Gates) != 2 || got.Gates[1].DependsOn[0] != "format" {
 		t.Fatalf("Gates = %#v, want ordered dependency", got.Gates)
 	}
+	if len(got.SetupFiles) != 2 || got.SetupFiles[0] != "go.mod" || got.SetupFiles[1] != "go.sum" {
+		t.Fatalf("SetupFiles = %#v, want configured manifest and lockfile", got.SetupFiles)
+	}
+	if got.SetupEnvironmentPolicy != config.EnvironmentPolicyClean {
+		t.Fatalf("SetupEnvironmentPolicy = %q, want clean", got.SetupEnvironmentPolicy)
+	}
 	if got.RetryLimits.CheckRepair != 3 || got.TestPolicy.Mode != "required" {
 		t.Fatalf("workflow policy was not preserved: %#v %#v", got.RetryLimits, got.TestPolicy)
 	}
@@ -132,6 +140,49 @@ func TestValidateRepositoryRejectsUnsupportedOverrides(t *testing.T) {
 	}
 	if validationErr.Field != "allowed_overrides[0]" {
 		t.Fatalf("field = %q, want allowed_overrides[0]", validationErr.Field)
+	}
+}
+
+// TestValidateRepositoryRejectsUnsafeSetupFiles verifies setup dependency
+// inputs remain repository-relative and unique.
+func TestValidateRepositoryRejectsUnsafeSetupFiles(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		files []string
+		field string
+	}{
+		{name: "absolute", files: []string{"/tmp/go.mod"}, field: "setup_files[0]"},
+		{name: "parent traversal", files: []string{"../go.mod"}, field: "setup_files[0]"},
+		{name: "duplicate", files: []string{"go.mod", "go.mod"}, field: "setup_files[1]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := validRepositoryConfig()
+			policy.SetupFiles = tc.files
+			err := config.ValidateRepository(policy)
+			var validationErr *config.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("ValidateRepository() error = %v, want ValidationError", err)
+			}
+			if validationErr.Field != tc.field {
+				t.Fatalf("field = %q, want %q", validationErr.Field, tc.field)
+			}
+		})
+	}
+}
+
+// TestValidateRepositoryRejectsInvalidSetupEnvironmentPolicy verifies setup
+// cannot silently select an unconfigured worker environment.
+func TestValidateRepositoryRejectsInvalidSetupEnvironmentPolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := validRepositoryConfig()
+	policy.SetupEnvironmentPolicy = "host"
+	err := config.ValidateRepository(policy)
+	var validationErr *config.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Field != "setup_environment_policy" {
+		t.Fatalf("ValidateRepository() error = %v, want setup_environment_policy validation", err)
 	}
 }
 
@@ -703,9 +754,10 @@ func TestUnknownSchemaVersionErrorMessageUsesTheProvidedKindAndField(t *testing.
 
 func validRepositoryConfig() config.RepositoryConfig {
 	return config.RepositoryConfig{
-		SchemaVersion: 1,
-		TargetBranch:  "main",
-		Setup:         "go mod download",
+		SchemaVersion:          1,
+		TargetBranch:           "main",
+		Setup:                  "go mod download",
+		SetupEnvironmentPolicy: config.EnvironmentPolicyClean,
 		Gates: []config.GateConfig{{
 			Name:              "test",
 			Command:           "go test ./...",

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -601,6 +601,23 @@ func validateAgentRunState(run store.Run) error {
 	}
 }
 
+// ensureTransitionBaseline prevents a checkpoint created during the check
+// stage from re-entering test or implementation without a matching baseline
+// projection for that exact checkpoint.
+func (s *Service) ensureTransitionBaseline(ctx context.Context, runStore RunStore, run store.Run, request TransitionRequest) error {
+	if run.Stage != store.StageCheck || (request.Stage != store.StageTest && request.Stage != store.StageImplementation) {
+		return nil
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return fmt.Errorf("validate baseline before %q transition: %w", request.Stage, err)
+	}
+	if err := s.ensureBaselineReady(ctx, runStore, run, packet); err != nil {
+		return fmt.Errorf("cannot transition from check to %q at checkpoint %q without complete baseline results: %w", request.Stage, run.CheckpointSHA, err)
+	}
+	return nil
+}
+
 // persistAgentRunState uses the coordinator's GitHub label/comment transition
 // when the claimed run has a status comment, retaining a direct-store fallback
 // for legacy runs that predate that supervision record.

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -162,6 +162,9 @@ func (s *Service) StartAgent(ctx context.Context, request AgentRequest) (result 
 	if err != nil {
 		return AgentLaunchResult{}, err
 	}
+	if err := s.ensureBaselineReady(ctx, runStore, *run, packet); err != nil {
+		return AgentLaunchResult{}, err
+	}
 	harnessName, model, err := resolveAgentPolicy(packet.RepositoryConfig, request)
 	if err != nil {
 		return AgentLaunchResult{}, err

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -89,6 +89,21 @@ func TestStartAgentAllowsAClaimedRunAfterCoordinatorRestart(t *testing.T) {
 	}
 }
 
+// TestTransitionRejectsAChangedCheckCheckpointWithoutABaseline verifies a
+// failed check cannot re-enter implementation with an unproven checkpoint.
+func TestTransitionRejectsAChangedCheckCheckpointWithoutABaseline(t *testing.T) {
+	service, runStore, _, _, _ := newAgentService(t)
+	runStore.current.Stage = store.StageCheck
+	runStore.current.CheckpointSHA = factoryGateCheckpoint
+
+	if _, err := service.Transition(context.Background(), factory.TransitionRequest{Stage: store.StageImplementation, Status: store.StatusActive}); err == nil || !strings.Contains(err.Error(), "without complete baseline results") {
+		t.Fatalf("Transition() error = %v, want incomplete-baseline refusal", err)
+	}
+	if runStore.current.Stage != store.StageCheck {
+		t.Fatalf("run stage = %q, want unchanged check stage", runStore.current.Stage)
+	}
+}
+
 // TestStartAgentPersistsInvocationBeforeStartingTheWorker verifies the
 // durable invocation identity is published before any worker effect begins.
 func TestStartAgentPersistsInvocationBeforeStartingTheWorker(t *testing.T) {
@@ -607,13 +622,26 @@ func (s *agentRunStore) ActiveInvocation(_ context.Context, runID string) (*stor
 	return nil, nil
 }
 
-// SaveGateResults stores the fixture's exact baseline projection.
+// SaveGateResults upserts the fixture's exact gate projections by durable identity.
 func (s *agentRunStore) SaveGateResults(_ context.Context, results []store.GateResult) error {
 	if len(results) == 0 {
 		return errors.New("at least one gate result is required")
 	}
-	copyResults := append([]store.GateResult(nil), results...)
-	s.gateResults[results[0].RunID] = copyResults
+	for _, incoming := range results {
+		runResults := s.gateResults[incoming.RunID]
+		replaced := false
+		for index, existing := range runResults {
+			if existing.RunID == incoming.RunID && existing.CheckpointSHA == incoming.CheckpointSHA && existing.Phase == incoming.Phase && existing.GateName == incoming.GateName {
+				runResults[index] = incoming
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			runResults = append(runResults, incoming)
+		}
+		s.gateResults[incoming.RunID] = runResults
+	}
 	return nil
 }
 

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -421,7 +421,7 @@ func newAgentService(t *testing.T) (*factory.Service, *agentRunStore, *agentWork
 	policy := validRepositoryConfig()
 	created := time.Date(2026, 8, 21, 8, 0, 0, 0, time.UTC)
 	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{Path: repositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"}, AuthorizedUsers: []string{"alice"}, Polling: config.PollingConfig{Interval: "30s", Backoff: "5m"}, Cmux: config.CmuxConfig{ControlWorkspace: "factory-control"}, OperationalDataPath: filepath.Join(root, "state", "factory.db"), RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml")}}}
-	runStore := &agentRunStore{runs: map[string]store.Run{}, invocations: map[string]store.Invocation{}}
+	runStore := &agentRunStore{runs: map[string]store.Run{}, invocations: map[string]store.Invocation{}, gateResults: map[string][]store.GateResult{}}
 	runtime := &agentWorker{}
 	terminalRuntime := &agentTerminal{}
 	harnessRuntime := &agentHarness{}
@@ -455,6 +455,12 @@ func newAgentService(t *testing.T) (*factory.Service, *agentRunStore, *agentWork
 	if _, err := service.ClaimIssue(context.Background(), 6); err != nil {
 		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
 	}
+	run := *runStore.current
+	runStore.gateResults[run.ID] = []store.GateResult{{
+		RunID: run.ID, CheckpointSHA: run.CheckpointSHA, Phase: store.GatePhaseBaseline,
+		Ordinal: 0, GateName: policy.Gates[0].Name, Outcome: store.GateOutcomePassed,
+		Status: string(github.CommitStatusSuccess), Blocking: policy.Gates[0].Blocking,
+	}}
 	return service, runStore, runtime, terminalRuntime, harnessRuntime
 }
 
@@ -524,6 +530,7 @@ type agentRunStore struct {
 	runs            map[string]store.Run
 	current         *store.Run
 	invocations     map[string]store.Invocation
+	gateResults     map[string][]store.GateResult
 	lifecycleClaims map[string]map[store.Status]bool
 	events          *[]string
 }
@@ -598,6 +605,28 @@ func (s *agentRunStore) ActiveInvocation(_ context.Context, runID string) (*stor
 		}
 	}
 	return nil, nil
+}
+
+// SaveGateResults stores the fixture's exact baseline projection.
+func (s *agentRunStore) SaveGateResults(_ context.Context, results []store.GateResult) error {
+	if len(results) == 0 {
+		return errors.New("at least one gate result is required")
+	}
+	copyResults := append([]store.GateResult(nil), results...)
+	s.gateResults[results[0].RunID] = copyResults
+	return nil
+}
+
+// GateResults returns the fixture's exact phase and checkpoint projection.
+func (s *agentRunStore) GateResults(_ context.Context, runID string, phase store.GatePhase, checkpointSHA string) ([]store.GateResult, error) {
+	results := s.gateResults[runID]
+	filtered := make([]store.GateResult, 0, len(results))
+	for _, result := range results {
+		if result.Phase == phase && result.CheckpointSHA == checkpointSHA {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered, nil
 }
 
 // Close implements the operational-store seam.

--- a/internal/factory/baseline_test.go
+++ b/internal/factory/baseline_test.go
@@ -1,0 +1,256 @@
+package factory_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	"github.com/Stevie1704/sw-factory/internal/gate"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestRunBaselineRecordsAHealthyPreEditSuiteBeforeAgentProgression verifies
+// the real claim/store boundary records a baseline at the base checkpoint.
+func TestRunBaselineRecordsAHealthyPreEditSuiteBeforeAgentProgression(t *testing.T) {
+	fixture := newBaselineFixture(t, "", []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}})
+	claimed, err := fixture.service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+
+	baseline, err := fixture.service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID})
+	if err != nil {
+		t.Fatalf("RunBaseline() error = %v", err)
+	}
+	if baseline.Run.Status != store.StatusActive || baseline.Run.Stage != store.StageClaim || len(baseline.Gates) != 1 || baseline.Gates[0].Phase != gate.PhaseBaseline {
+		t.Fatalf("baseline = %#v, want active claim with one baseline result", baseline)
+	}
+	if len(fixture.worker.commands) != 2 || fixture.worker.commands[0].Command != fixture.policy.Setup || fixture.worker.commands[1].Command != fixture.policy.Gates[0].Command {
+		t.Fatalf("baseline commands = %#v, want setup then declared gate", fixture.worker.commands)
+	}
+	results, err := fixture.openedGateResults(t, claimed.Run.ID, store.GatePhaseBaseline, claimed.Run.CheckpointSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Outcome != store.GateOutcomePassed || results[0].Status != string(github.CommitStatusSuccess) {
+		t.Fatalf("stored baseline results = %#v, want exact-checkpoint success", results)
+	}
+}
+
+// TestStartAgentRejectsAClaimWithoutBaselineResults verifies the agent seam
+// cannot bypass the pre-edit gate boundary when the CLI is not involved.
+func TestStartAgentRejectsAClaimWithoutBaselineResults(t *testing.T) {
+	fixture := newBaselineFixture(t, "", []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}})
+	claimed, err := fixture.service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+	_, err = fixture.service.StartAgent(context.Background(), factory.AgentRequest{RunID: claimed.Run.ID})
+	if err == nil || !strings.Contains(err.Error(), "baseline gate results are incomplete") {
+		t.Fatalf("StartAgent() error = %v, want missing baseline refusal", err)
+	}
+	if len(fixture.worker.starts) != 0 {
+		t.Fatalf("worker starts = %#v, want no agent effect", fixture.worker.starts)
+	}
+}
+
+// TestRunBaselineReusesSetupForAnUnchangedDependencyFingerprint verifies the
+// durable setup cache is scoped to one exact checkpoint and phase.
+func TestRunBaselineReusesSetupForAnUnchangedDependencyFingerprint(t *testing.T) {
+	fixture := newBaselineFixture(t, "", []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}})
+	manifest := filepath.Join(fixture.worktreePath, "go.mod")
+	if err := os.WriteFile(manifest, []byte("module unchanged\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture.policy.SetupFiles = []string{"go.mod"}
+	claimed, err := fixture.service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+	if first, err := fixture.service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID}); err != nil {
+		t.Fatalf("first RunBaseline() error = %v", err)
+	} else if len(first.Gates) != 1 || !first.Gates[0].SetupRan {
+		t.Fatalf("first baseline gates = %#v, want setup execution", first.Gates)
+	}
+	if second, err := fixture.service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID}); err != nil {
+		t.Fatalf("second RunBaseline() error = %v", err)
+	} else if len(second.Gates) != 1 || second.Gates[0].SetupRan {
+		t.Fatalf("second baseline gates = %#v, want cached setup", second.Gates)
+	}
+	if len(fixture.worker.commands) != 3 || fixture.worker.commands[0].Command != fixture.policy.Setup || fixture.worker.commands[1].Command != fixture.policy.Gates[0].Command || fixture.worker.commands[2].Command != fixture.policy.Gates[0].Command {
+		t.Fatalf("setup reuse commands = %#v, want setup then two gate commands", fixture.worker.commands)
+	}
+}
+
+// TestRunBaselineBlocksAnUnhealthyPreEditSuite verifies a blocking baseline
+// failure becomes visible and cannot proceed to an agent invocation.
+func TestRunBaselineBlocksAnUnhealthyPreEditSuite(t *testing.T) {
+	fixture := newBaselineFixture(t, "", []worker.CommandResult{{ExitCode: 0}, {ExitCode: 9}})
+	claimed, err := fixture.service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+
+	baseline, err := fixture.service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID})
+	if err == nil {
+		t.Fatal("RunBaseline() succeeded for an unhealthy blocking baseline")
+	}
+	var suiteFailure *gate.SuiteFailure
+	if !errors.As(err, &suiteFailure) {
+		t.Fatalf("RunBaseline() error = %v, want SuiteFailure", err)
+	}
+	if baseline.Run.Status != store.StatusFailed || baseline.Run.Stage != store.StagePreflight {
+		t.Fatalf("blocked baseline run = %#v, want failed preflight", baseline.Run)
+	}
+	if got := fixture.github.replacedHistory[len(fixture.github.replacedHistory)-1]; len(got) != 1 || got[0] != github.LabelAgentFailed {
+		t.Fatalf("baseline failure labels = %#v, want agent-failed", got)
+	}
+	results, err := fixture.openedGateResults(t, claimed.Run.ID, store.GatePhaseBaseline, claimed.Run.CheckpointSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Outcome != store.GateOutcomeFailed {
+		t.Fatalf("stored failed baseline results = %#v, want failed result", results)
+	}
+}
+
+// TestRunBaselineAllowsOnlyTheExplicitlyTargetedFailure verifies the frozen
+// issue marker is the sole exception to the unhealthy-baseline boundary.
+func TestRunBaselineAllowsAnExplicitlyTargetedFailure(t *testing.T) {
+	fixture := newBaselineFixture(t, "<!-- factory-baseline-target: test -->", []worker.CommandResult{{ExitCode: 0}, {ExitCode: 9}})
+	claimed, err := fixture.service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+
+	baseline, err := fixture.service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID})
+	if err != nil {
+		t.Fatalf("RunBaseline() error = %v, want explicit baseline target to permit progression", err)
+	}
+	if baseline.Run.Status != store.StatusActive || baseline.Run.Stage != store.StageClaim {
+		t.Fatalf("targeted baseline run = %#v, want active claim", baseline.Run)
+	}
+}
+
+// TestRunBaselineRerunsSetupWhenAConfiguredDependencyInputChanges verifies
+// setup fingerprints change when a manifest changes between baseline suites.
+func TestRunBaselineRerunsSetupWhenAConfiguredDependencyInputChanges(t *testing.T) {
+	fixture := newBaselineFixture(t, "", []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}})
+	manifest := filepath.Join(fixture.worktreePath, "go.mod")
+	if err := os.WriteFile(manifest, []byte("module before\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture.policy.SetupFiles = []string{"go.mod"}
+	claimed, err := fixture.service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+	if first, err := fixture.service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID}); err != nil {
+		t.Fatalf("first RunBaseline() error = %v", err)
+	} else if len(first.Gates) != 1 || !first.Gates[0].SetupRan {
+		t.Fatalf("first baseline gates = %#v, want setup execution", first.Gates)
+	}
+	firstResults, err := fixture.openedGateResults(t, claimed.Run.ID, store.GatePhaseBaseline, claimed.Run.CheckpointSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(firstResults) != 1 || firstResults[0].SetupFingerprint == "" {
+		t.Fatalf("stored first result = %#v, want dependency fingerprint", firstResults)
+	}
+	firstFingerprint := firstResults[0].SetupFingerprint
+	if err := os.WriteFile(manifest, []byte("module after\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if second, err := fixture.service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID}); err != nil {
+		t.Fatalf("second RunBaseline() error = %v", err)
+	} else if len(second.Gates) != 1 || !second.Gates[0].SetupRan {
+		t.Fatalf("second baseline gates = %#v, want setup after fingerprint change", second.Gates)
+	}
+	if len(fixture.worker.commands) != 4 || fixture.worker.commands[0].Command != fixture.policy.Setup || fixture.worker.commands[2].Command != fixture.policy.Setup {
+		t.Fatalf("setup rerun commands = %#v, want setup before both suites", fixture.worker.commands)
+	}
+	results, err := fixture.openedGateResults(t, claimed.Run.ID, store.GatePhaseBaseline, claimed.Run.CheckpointSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].SetupFingerprint == "" || results[0].SetupFingerprint == firstFingerprint {
+		t.Fatalf("stored rerun result = %#v, want changed dependency fingerprint", results)
+	}
+}
+
+// baselineFixture wires a real SQLite operational store to controlled external
+// seams so baseline behavior is tested at the factory boundary.
+type baselineFixture struct {
+	service         *factory.Service
+	worktreePath    string
+	operationalPath string
+	policy          *config.RepositoryConfig
+	worker          *gateWorker
+	github          *fakeGitHub
+}
+
+// newBaselineFixture creates a claimable repository and a deterministic gate
+// worker without using Docker or a live GitHub connection.
+func newBaselineFixture(t *testing.T, issueBody string, results []worker.CommandResult) *baselineFixture {
+	t.Helper()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktree")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	policy := validRepositoryConfig()
+	policy.Gates = []config.GateConfig{{Name: "test", Command: "test", Timeout: "1m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean}}
+	policyRef := &policy
+	githubRuntime := &fakeGitHub{issueValue: github.Issue{Number: 42, Title: "Baseline", Body: issueBody, State: "open", Labels: []string{github.LabelAgentReady}}}
+	workerRuntime := &gateWorker{results: results}
+	worktree := &draftGitWorkspace{
+		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-baseline", Worktree: worktreePath},
+		state:     gitadapter.WorktreeState{Branch: "factory/run-baseline", HeadSHA: factoryGateCheckpoint},
+	}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path:                 repositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		OperationalDataPath:  operationalPath,
+		RepositoryConfigPath: filepath.Join(repositoryPath, config.RepositoryConfigFileName),
+	}}}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(ctx context.Context, path string) (factory.OperationalStore, error) { return store.Open(ctx, path) },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return *policyRef, nil },
+		GitHub:         githubRuntime, Worktree: worktree, GitWorkspace: worktree, Worker: workerRuntime,
+		CommitStatuses: &gateStatuses{},
+		Now:            func() time.Time { return time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC) },
+		NewRunID:       func() (string, error) { return "run-baseline", nil },
+		Coordinator:    "coordinator-test",
+	})
+	return &baselineFixture{service: service, worktreePath: worktreePath, operationalPath: operationalPath, policy: policyRef, worker: workerRuntime, github: githubRuntime}
+}
+
+// openedGateResults reopens the real store and selects one exact baseline
+// projection for assertions about checkpoint identity and setup fingerprints.
+func (f *baselineFixture) openedGateResults(t *testing.T, runID string, phase store.GatePhase, checkpoint string) ([]store.GateResult, error) {
+	t.Helper()
+	opened, err := store.Open(context.Background(), f.operationalPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = opened.Close() }()
+	return opened.GateResults(context.Background(), runID, phase, checkpoint)
+}

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -242,6 +242,9 @@ func (s *Service) Transition(ctx context.Context, request TransitionRequest) (st
 	if request.RunID != "" && request.RunID != run.ID {
 		return store.Run{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
 	}
+	if err := s.ensureTransitionBaseline(ctx, runStore, *run, request); err != nil {
+		return store.Run{}, err
+	}
 	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
 	issue, err := s.deps.GitHub.Issue(ctx, repository, run.IssueNumber)
 	if err != nil {

--- a/internal/factory/claim_test.go
+++ b/internal/factory/claim_test.go
@@ -370,9 +370,10 @@ func newClaimService(githubAdapter *fakeGitHub, worktree *fakeWorktree, runStore
 // claim tests.
 func validRepositoryConfig() config.RepositoryConfig {
 	return config.RepositoryConfig{
-		SchemaVersion: 1,
-		TargetBranch:  "main",
-		Setup:         "go mod download",
+		SchemaVersion:          1,
+		TargetBranch:           "main",
+		Setup:                  "go mod download",
+		SetupEnvironmentPolicy: config.EnvironmentPolicyClean,
 		Gates: []config.GateConfig{{
 			Name:              "test",
 			Command:           "go test ./...",

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -122,7 +122,7 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 		return DraftPullRequestResult{}, err
 	}
 
-	gates, gateErr := s.runConfiguredGates(ctx, registration, next, packet)
+	gates, gateErr := s.runConfiguredGates(ctx, registration, runStore, next, packet)
 	result := DraftPullRequestResult{Run: next, Gates: gates}
 	if gateErr != nil {
 		return result, gateErr
@@ -163,20 +163,17 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 	return DraftPullRequestResult{Run: next, Gates: gates, PullRequest: pullRequest}, nil
 }
 
-// runConfiguredGates executes every gate from the frozen specification in
-// declaration order and joins failures so the operator sees the complete
-// deterministic result set from one checkpoint.
-func (s *Service) runConfiguredGates(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packet SpecificationPacket) ([]gate.Result, error) {
-	results := make([]gate.Result, 0, len(packet.RepositoryConfig.Gates))
-	var failures []error
-	for _, declared := range packet.RepositoryConfig.Gates {
-		result, err := s.runGate(ctx, registration, run, packet, declared)
-		results = append(results, result)
-		if err != nil {
-			failures = append(failures, fmt.Errorf("gate %q: %w", declared.Name, err))
-		}
+// runConfiguredGates executes the frozen gate suite once and joins blocking
+// failures while retaining every independent and skipped result.
+func (s *Service) runConfiguredGates(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, packet SpecificationPacket) ([]gate.Result, error) {
+	if err := s.verifyGateCheckpoint(ctx, run); err != nil {
+		return nil, err
 	}
-	return results, errors.Join(failures...)
+	suite, suiteErr := s.runGateSuite(ctx, registration, runStore, run, packet, gate.PhaseCheckpoint, packet.RepositoryConfig.Gates)
+	if persistErr := persistGateSuite(ctx, runStore, run, suite); persistErr != nil {
+		suiteErr = errors.Join(suiteErr, persistErr)
+	}
+	return suite.Gates, suiteErr
 }
 
 // upsertDraftPullRequest finds a prior branch pull request before creating one
@@ -298,17 +295,24 @@ func generatedPullRequestBody(run store.Run, packet SpecificationPacket, gates [
 	gateLines := make([]string, 0, len(gates))
 	for _, result := range gates {
 		var status string
-		switch result.Status.State {
-		case github.CommitStatusSuccess:
-			status = "passed"
-		case github.CommitStatusFailure:
-			status = "failed"
-		case github.CommitStatusError:
-			status = "error"
-		case github.CommitStatusPending:
-			status = "pending"
-		default:
-			status = "unknown"
+		if result.Skipped {
+			status = "skipped"
+			if strings.TrimSpace(result.SkipReason) != "" {
+				status += ": " + result.SkipReason
+			}
+		} else {
+			switch result.Status.State {
+			case github.CommitStatusSuccess:
+				status = "passed"
+			case github.CommitStatusFailure:
+				status = "failed"
+			case github.CommitStatusError:
+				status = "error"
+			case github.CommitStatusPending:
+				status = "pending"
+			default:
+				status = "unknown"
+			}
 		}
 		gateName := result.GateName
 		if gateName == "" {

--- a/internal/factory/draft_pr_test.go
+++ b/internal/factory/draft_pr_test.go
@@ -48,7 +48,7 @@ func TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft(t *
 		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-draft", Worktree: worktreePath},
 		state:     gitadapter.WorktreeState{Branch: "factory/run-draft", HeadSHA: factoryGateCheckpoint, ChangedPaths: []string{"internal/factory.go"}},
 	}
-	workerRuntime := &gateWorker{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}}}
+	workerRuntime := &gateWorker{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}}}
 	statuses := &gateStatuses{}
 	pullRequests := &fakePullRequests{created: github.PullRequest{Number: 17, URL: "https://github.com/example/project/pull/17", State: "open", Draft: true, HeadBranch: "factory/run-draft", BaseBranch: "main"}}
 
@@ -92,8 +92,8 @@ func TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft(t *
 	if len(pullRequests.createdRequests) != 1 || len(pullRequests.updatedRequests) != 0 {
 		t.Fatalf("PR effects = creates %#v updates %#v, want one create", pullRequests.createdRequests, pullRequests.updatedRequests)
 	}
-	if len(workerRuntime.commands) != 4 || workerRuntime.commands[1].Command != "format" || workerRuntime.commands[3].Command != "test" {
-		t.Fatalf("gate commands = %#v, want setup/gate for each declared gate", workerRuntime.commands)
+	if len(workerRuntime.commands) != 3 || workerRuntime.commands[0].Command != policy.Setup || workerRuntime.commands[1].Command != "format" || workerRuntime.commands[2].Command != "test" {
+		t.Fatalf("gate commands = %#v, want one setup followed by ordered gates", workerRuntime.commands)
 	}
 	body := pullRequests.createdRequests[0].Body
 	for _, expected := range []string{

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -27,6 +27,8 @@ type Factory interface {
 	Register(context.Context, RegisterRequest) (RegisterResult, error)
 	BootstrapLabels(context.Context) (BootstrapLabelsResult, error)
 	RunCoordinator
+	// RunBaseline evaluates the frozen repository gate model before agent edits.
+	RunBaseline(context.Context, BaselineRequest) (BaselineResult, error)
 	RunGate(context.Context, RunGateRequest) (gate.Result, error)
 	// StartAgent launches the visible Codex implementation role for an active run.
 	StartAgent(context.Context, AgentRequest) (AgentLaunchResult, error)

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -699,6 +699,7 @@ func writeRepositoryConfig(t *testing.T, repositoryPath string) {
 	contents := `schema_version: 1
 target_branch: main
 setup: go mod download
+setup_environment_policy: clean
 gates:
   - name: test
     command: go test ./...

--- a/internal/factory/first_invocation_test.go
+++ b/internal/factory/first_invocation_test.go
@@ -28,8 +28,8 @@ func TestStartAgentUsesTheRealStoreAcrossAClaimProcessBoundary(t *testing.T) {
 		t.Fatal(err)
 	}
 	worktree := &inspectingWorktree{
-		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: "base", Branch: "factory/run-real", Worktree: worktreePath}},
-		state:        gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-real", HeadSHA: "base"},
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-real", Worktree: worktreePath}},
+		state:        gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-real", HeadSHA: factoryGateCheckpoint},
 	}
 	githubRuntime := &fakeGitHub{issueValue: github.Issue{
 		Number: 42, Title: "Real store handoff", Body: "Repository guidance", State: "open", Labels: []string{github.LabelAgentReady},
@@ -68,6 +68,7 @@ func TestStartAgentUsesTheRealStoreAcrossAClaimProcessBoundary(t *testing.T) {
 	if err := githubRuntime.setStatusComment(claimed.Run); err != nil {
 		t.Fatal(err)
 	}
+	recordReadyBaseline(t, operationalPath, claimed.Run)
 	// A separate service models the next process opening the same host store.
 	startService := factory.NewWithDependencies("/host/config.yaml", dependencies("generated"))
 	launch, err := startService.StartAgent(context.Background(), factory.AgentRequest{})
@@ -197,8 +198,8 @@ func newRealHandoffFixture(t *testing.T) *realHandoffFixture {
 		t.Fatal(err)
 	}
 	worktree := &inspectingWorktree{
-		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: "base", Branch: "factory/run-real", Worktree: worktreePath}},
-		state:        gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-real", HeadSHA: "base"},
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-real", Worktree: worktreePath}},
+		state:        gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-real", HeadSHA: factoryGateCheckpoint},
 	}
 	githubRuntime := &fakeGitHub{issueValue: github.Issue{
 		Number: 42, Title: "Real store handoff", Body: "Repository guidance", State: "open", Labels: []string{github.LabelAgentReady},
@@ -226,7 +227,30 @@ func newRealHandoffFixture(t *testing.T) *realHandoffFixture {
 	if err := githubRuntime.setStatusComment(claimed.Run); err != nil {
 		t.Fatal(err)
 	}
+	recordReadyBaseline(t, operationalPath, claimed.Run)
 	return fixture
+}
+
+// recordReadyBaseline seeds the persisted projection representing the issue
+// command's successful pre-edit gate suite for handoff-only tests.
+func recordReadyBaseline(t *testing.T, operationalPath string, run store.Run) {
+	t.Helper()
+	opened, err := store.Open(context.Background(), operationalPath)
+	if err != nil {
+		t.Fatalf("open baseline fixture store: %v", err)
+	}
+	err = opened.SaveGateResults(context.Background(), []store.GateResult{{
+		RunID: run.ID, CheckpointSHA: run.CheckpointSHA, Phase: store.GatePhaseBaseline,
+		Ordinal: 0, GateName: "test", Outcome: store.GateOutcomePassed,
+		Status: string(github.CommitStatusSuccess), Blocking: true,
+	}})
+	closeErr := opened.Close()
+	if err != nil {
+		t.Fatalf("save baseline fixture result: %v", err)
+	}
+	if closeErr != nil {
+		t.Fatalf("close baseline fixture store: %v", closeErr)
+	}
 }
 
 // newService creates a coordinator with a selected run-id generator while

--- a/internal/factory/first_invocation_test.go
+++ b/internal/factory/first_invocation_test.go
@@ -235,14 +235,19 @@ func newRealHandoffFixture(t *testing.T) *realHandoffFixture {
 // command's successful pre-edit gate suite for handoff-only tests.
 func recordReadyBaseline(t *testing.T, operationalPath string, run store.Run) {
 	t.Helper()
+	policy := validRepositoryConfig()
+	if len(policy.Gates) == 0 {
+		t.Fatal("baseline fixture policy has no declared gates")
+	}
+	declared := policy.Gates[0]
 	opened, err := store.Open(context.Background(), operationalPath)
 	if err != nil {
 		t.Fatalf("open baseline fixture store: %v", err)
 	}
 	err = opened.SaveGateResults(context.Background(), []store.GateResult{{
 		RunID: run.ID, CheckpointSHA: run.CheckpointSHA, Phase: store.GatePhaseBaseline,
-		Ordinal: 0, GateName: "test", Outcome: store.GateOutcomePassed,
-		Status: string(github.CommitStatusSuccess), Blocking: true,
+		Ordinal: 0, GateName: declared.Name, Outcome: store.GateOutcomePassed,
+		Status: string(github.CommitStatusSuccess), Blocking: declared.Blocking,
 	}})
 	closeErr := opened.Close()
 	if err != nil {

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -141,7 +141,11 @@ func (s *Service) RunBaseline(ctx context.Context, request BaselineRequest) (Bas
 	next := *run
 	next.Stage = store.StagePreflight
 	next.Status = store.StatusFailed
-	next.LifecycleReason = "baseline gate failure"
+	if suiteErr == nil && persistErr != nil {
+		next.LifecycleReason = "baseline gate result persistence failure"
+	} else {
+		next.LifecycleReason = "baseline gate failure"
+	}
 	next.UpdatedAt = s.deps.Now().UTC()
 	issue := packet.Issue
 	updated, transitionErr := s.applyStateTransition(ctx, runStore, stateTransition{
@@ -354,7 +358,7 @@ func setupInputFingerprint(worktree string, files []string) (string, error) {
 func baselineFailureTargeted(body string, suite gate.SuiteResult) bool {
 	body = strings.ToLower(body)
 	for _, result := range suite.Gates {
-		if result.Outcome != gate.OutcomeFailed && result.Outcome != gate.OutcomeError && result.Outcome != gate.OutcomeSetupFailed {
+		if result.Outcome != gate.OutcomeFailed && result.Outcome != gate.OutcomeError && result.Outcome != gate.OutcomeSkipped && result.Outcome != gate.OutcomeSetupFailed {
 			continue
 		}
 		if !result.Blocking {
@@ -388,7 +392,8 @@ func baselineFailureErrorTargeted(body string, suite gate.SuiteResult, suiteErr 
 	for _, cause := range failure.Failures {
 		var gateFailure *gate.GateFailure
 		var setupFailure *gate.SetupFailure
-		if errors.As(cause, &gateFailure) || errors.As(cause, &setupFailure) {
+		var dependencyFailure *gate.DependencyFailure
+		if errors.As(cause, &gateFailure) || errors.As(cause, &setupFailure) || errors.As(cause, &dependencyFailure) {
 			continue
 		}
 		return false
@@ -411,7 +416,7 @@ func baselineSetupFailureTargeted(body string, suite gate.SuiteResult) bool {
 // result that required baseline disposition.
 func suiteErrHasBlockingFailure(suite gate.SuiteResult) bool {
 	for _, result := range suite.Gates {
-		if result.Blocking && (result.Outcome == gate.OutcomeFailed || result.Outcome == gate.OutcomeError || result.Outcome == gate.OutcomeSetupFailed) {
+		if result.Blocking && (result.Outcome == gate.OutcomeFailed || result.Outcome == gate.OutcomeError || result.Outcome == gate.OutcomeSkipped || result.Outcome == gate.OutcomeSetupFailed) {
 			return true
 		}
 	}

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -2,6 +2,8 @@ package factory
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/gate"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/worker"
@@ -28,9 +31,33 @@ type RunGateRequest struct {
 	GateName string
 }
 
+// BaselineRequest selects the active run whose frozen gate model should be
+// evaluated before the first agent edit.
+type BaselineRequest struct {
+	// RunID optionally identifies the active run.
+	RunID string
+}
+
+// BaselineResult reports the persisted run and every pre-edit gate outcome.
+type BaselineResult struct {
+	// Run is the run after baseline evaluation and any blocking transition.
+	Run store.Run
+	// Gates contains one result for every configured gate.
+	Gates []gate.Result
+}
+
+// GateResultStore is the optional durable projection used to retain gate
+// outcomes by phase and exact checkpoint without coupling the gate package to
+// SQLite.
+type GateResultStore interface {
+	SaveGateResults(context.Context, []store.GateResult) error
+	GateResults(context.Context, string, store.GatePhase, string) ([]store.GateResult, error)
+}
+
 // RunGate starts the active run's pinned worker and executes repository setup
-// plus exactly one gate from its frozen specification packet. The resulting
-// status is attached to the run's exact checkpoint SHA.
+// plus the requested gate and its declared prerequisites from the frozen
+// specification packet. The resulting statuses are attached to the exact
+// checkpoint SHA.
 func (s *Service) RunGate(ctx context.Context, request RunGateRequest) (gate.Result, error) {
 	if strings.TrimSpace(request.GateName) == "" {
 		return gate.Result{}, errors.New("gate name is required")
@@ -50,26 +77,177 @@ func (s *Service) RunGate(ctx context.Context, request RunGateRequest) (gate.Res
 	if err != nil {
 		return gate.Result{}, err
 	}
-	declaredGate, ok := declaredGate(packet, request.GateName)
-	if !ok {
+	if _, ok := declaredGate(packet, request.GateName); !ok {
 		return gate.Result{}, fmt.Errorf("gate %q is not declared in the frozen specification packet", request.GateName)
 	}
-	return s.runGate(ctx, registration, *run, packet, declaredGate)
+	if err := s.verifyGateCheckpoint(ctx, *run); err != nil {
+		return gate.Result{}, err
+	}
+	plan, err := gateDependencyPlan(packet.RepositoryConfig.Gates, request.GateName)
+	if err != nil {
+		return gate.Result{}, err
+	}
+	suite, err := s.runGateSuite(ctx, registration, runStore, *run, packet, gate.PhaseCheckpoint, plan)
+	if persistErr := persistGateSuite(ctx, runStore, *run, suite); persistErr != nil {
+		err = errors.Join(err, persistErr)
+	}
+	for _, result := range suite.Gates {
+		if result.GateName == request.GateName {
+			return result, err
+		}
+	}
+	if len(suite.Gates) == 0 {
+		return gate.Result{}, err
+	}
+	return gate.Result{}, errors.Join(err, fmt.Errorf("gate %q was not evaluated", request.GateName))
 }
 
-// runGate executes one frozen gate for an already selected run. Keeping the
-// run selection outside this helper lets the draft-PR boundary run every
-// configured gate without re-reading mutable state between gates.
-func (s *Service) runGate(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packet SpecificationPacket, declared config.GateConfig) (gate.Result, error) {
+// RunBaseline evaluates every frozen gate before agent edits. A blocking
+// baseline failure moves the run to a visible failed preflight state unless
+// the frozen issue explicitly targets each failed baseline gate.
+func (s *Service) RunBaseline(ctx context.Context, request BaselineRequest) (BaselineResult, error) {
+	registration, runStore, run, err := s.openActiveRunStore(ctx)
+	if err != nil {
+		return BaselineResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	if run == nil {
+		return BaselineResult{}, errors.New("no active run")
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return BaselineResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
+	}
+	if run.Stage != store.StageClaim || run.Status != store.StatusActive {
+		return BaselineResult{}, fmt.Errorf("run %q must be in claim/active state for baseline, not %s/%s", run.ID, run.Stage, run.Status)
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return BaselineResult{}, err
+	}
+	if err := s.verifyGateCheckpoint(ctx, *run); err != nil {
+		return BaselineResult{}, err
+	}
+	suite, suiteErr := s.runGateSuite(ctx, registration, runStore, *run, packet, gate.PhaseBaseline, packet.RepositoryConfig.Gates)
+	result := BaselineResult{Run: *run, Gates: suite.Gates}
+	persistErr := persistGateSuite(ctx, runStore, *run, suite)
+	if suiteErr == nil && persistErr == nil {
+		return result, nil
+	}
+	if persistErr == nil && baselineFailureErrorTargeted(packet.Issue.Body, suite, suiteErr) {
+		return result, nil
+	}
+	effectiveErr := errors.Join(suiteErr, persistErr)
+
+	next := *run
+	next.Stage = store.StagePreflight
+	next.Status = store.StatusFailed
+	next.LifecycleReason = "baseline gate failure"
+	next.UpdatedAt = s.deps.Now().UTC()
+	issue := packet.Issue
+	updated, transitionErr := s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository: commandRepository(registration),
+		Issue:      issue,
+		Previous:   *run,
+		Next:       next,
+	})
+	result.Run = updated
+	return result, errors.Join(fmt.Errorf("baseline is unhealthy: %w", effectiveErr), transitionErr)
+}
+
+// ensureBaselineReady requires the durable pre-edit suite before a visible
+// agent can start. It checks the frozen gate set, exact checkpoint, and current
+// dependency-input fingerprint so an old baseline cannot authorize new edits.
+func (s *Service) ensureBaselineReady(ctx context.Context, runStore RunStore, run store.Run, packet SpecificationPacket) error {
+	resultStore, ok := runStore.(GateResultStore)
+	if !ok {
+		return errors.New("operational store does not support baseline gate results")
+	}
+	fingerprint, err := setupInputFingerprint(run.Worktree, packet.RepositoryConfig.SetupFiles)
+	if err != nil {
+		return fmt.Errorf("fingerprint baseline setup files: %w", err)
+	}
+	stored, err := resultStore.GateResults(ctx, run.ID, store.GatePhaseBaseline, run.CheckpointSHA)
+	if err != nil {
+		return fmt.Errorf("read baseline gate results: %w", err)
+	}
+	if len(stored) != len(packet.RepositoryConfig.Gates) {
+		return fmt.Errorf("baseline gate results are incomplete: got %d, want %d", len(stored), len(packet.RepositoryConfig.Gates))
+	}
+	suite := gate.SuiteResult{CheckpointSHA: run.CheckpointSHA, Phase: gate.PhaseBaseline}
+	setupFailed := false
+	for index, declared := range packet.RepositoryConfig.Gates {
+		result := stored[index]
+		if result.RunID != run.ID || result.CheckpointSHA != run.CheckpointSHA || result.Phase != store.GatePhaseBaseline || result.GateName != declared.Name || result.Blocking != declared.Blocking || result.SetupFingerprint != fingerprint {
+			return fmt.Errorf("baseline gate result %q does not match the frozen run identity", declared.Name)
+		}
+		outcome := gate.Outcome(result.Outcome)
+		suite.Gates = append(suite.Gates, gate.Result{
+			CheckpointSHA:    result.CheckpointSHA,
+			GateName:         result.GateName,
+			Phase:            gate.PhaseBaseline,
+			Blocking:         result.Blocking,
+			SetupFingerprint: result.SetupFingerprint,
+			Outcome:          outcome,
+		})
+		switch outcome {
+		case gate.OutcomePassed, gate.OutcomeFailed, gate.OutcomeError, gate.OutcomeSkipped, gate.OutcomeSetupFailed:
+		default:
+			return fmt.Errorf("baseline gate result %q has unsupported outcome %q", declared.Name, outcome)
+		}
+		if outcome == gate.OutcomeSetupFailed {
+			setupFailed = true
+		}
+	}
+	if setupFailed && !baselineSetupTargeted(packet.Issue.Body) {
+		return errors.New("baseline setup failed and is not explicitly targeted by the issue")
+	}
+	if suiteErrHasBlockingFailure(suite) && !baselineFailureTargeted(packet.Issue.Body, suite) {
+		return errors.New("baseline has an untargeted blocking gate failure")
+	}
+	return nil
+}
+
+// verifyGateCheckpoint refuses to evaluate a mutable or dirty worktree under
+// a stale checkpoint identity.
+func (s *Service) verifyGateCheckpoint(ctx context.Context, run store.Run) error {
+	var inspector gitadapter.WorktreeInspector
+	if s.deps.GitWorkspace != nil {
+		inspector = s.deps.GitWorkspace
+	} else if candidate, ok := s.deps.Worktree.(gitadapter.WorktreeInspector); ok {
+		inspector = candidate
+	}
+	if inspector == nil {
+		return errors.New("a GitWorkspace inspector is required before running gates")
+	}
+	state, err := inspector.Inspect(ctx, run.Worktree)
+	if err != nil {
+		return fmt.Errorf("inspect gate worktree: %w", err)
+	}
+	if state.HeadSHA != run.CheckpointSHA {
+		return fmt.Errorf("worktree HEAD %q does not match gate checkpoint %q", state.HeadSHA, run.CheckpointSHA)
+	}
+	if len(state.ChangedPaths) != 0 {
+		return errors.New("worktree has uncommitted changes; checkpoint it before running gates")
+	}
+	return nil
+}
+
+// runGateSuite starts the pinned gate worker and evaluates one frozen ordered
+// gate suite with setup shared across every gate.
+func (s *Service) runGateSuite(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, packet SpecificationPacket, phase gate.Phase, gates []config.GateConfig) (gate.SuiteResult, error) {
 	if run.ImageDigest != packet.RepositoryConfig.WorkerBuild.Digest {
-		return gate.Result{}, fmt.Errorf("run %q image digest %q differs from frozen packet digest %q", run.ID, run.ImageDigest, packet.RepositoryConfig.WorkerBuild.Digest)
+		return gate.SuiteResult{}, fmt.Errorf("run %q image digest %q differs from frozen packet digest %q", run.ID, run.ImageDigest, packet.RepositoryConfig.WorkerBuild.Digest)
 	}
 	if s.deps.CommitStatuses == nil {
-		return gate.Result{}, errors.New("GitHub client does not support Commit Statuses")
+		return gate.SuiteResult{}, errors.New("GitHub client does not support Commit Statuses")
+	}
+	fingerprint, err := setupInputFingerprint(run.Worktree, packet.RepositoryConfig.SetupFiles)
+	if err != nil {
+		return gate.SuiteResult{}, fmt.Errorf("fingerprint configured setup files: %w", err)
 	}
 	gitMetadataPath, err := prepareGitMetadataProjection(run.ID, registration.Path, run.Worktree)
 	if err != nil {
-		return gate.Result{}, fmt.Errorf("prepare worker git metadata: %w", err)
+		return gate.SuiteResult{}, fmt.Errorf("prepare worker git metadata: %w", err)
 	}
 	if err := s.deps.Worker.Start(ctx, worker.StartRequest{
 		RunID:           run.ID,
@@ -80,19 +258,164 @@ func (s *Service) runGate(ctx context.Context, registration config.RepositoryReg
 		Caches:          workerCaches(packet.RepositoryConfig.Caches),
 		Role:            "gate",
 	}); err != nil {
-		return gate.Result{}, err
+		return gate.SuiteResult{}, err
 	}
+	skipSetup := setupAlreadySucceeded(ctx, runStore, run, phase, fingerprint)
 	return (gate.Runner{
 		Runtime:    s.deps.Worker,
 		Repository: github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository},
 		Statuses:   s.deps.CommitStatuses,
-	}).Run(ctx, gate.Request{
-		RunID:         run.ID,
-		CheckpointSHA: run.CheckpointSHA,
-		Setup:         packet.RepositoryConfig.Setup,
-		SetupTimeout:  packet.RepositoryConfig.Timeouts.Setup,
-		Gate:          declared,
+	}).RunSuite(ctx, gate.SuiteRequest{
+		RunID:                  run.ID,
+		CheckpointSHA:          run.CheckpointSHA,
+		Setup:                  packet.RepositoryConfig.Setup,
+		SetupEnvironmentPolicy: packet.RepositoryConfig.SetupEnvironmentPolicy,
+		SetupTimeout:           packet.RepositoryConfig.Timeouts.Setup,
+		Gates:                  gates,
+		Phase:                  phase,
+		SetupFingerprint:       fingerprint,
+		SkipSetup:              skipSetup,
 	})
+}
+
+// setupAlreadySucceeded reports whether durable results prove setup completed
+// for this exact run, phase, checkpoint, and configured dependency fingerprint.
+// An empty fingerprint deliberately disables reuse because no dependency-input
+// contract exists for that configuration.
+func setupAlreadySucceeded(ctx context.Context, runStore RunStore, run store.Run, phase gate.Phase, fingerprint string) bool {
+	if runStore == nil || fingerprint == "" {
+		return false
+	}
+	resultStore, ok := runStore.(GateResultStore)
+	if !ok {
+		return false
+	}
+	results, err := resultStore.GateResults(ctx, run.ID, store.GatePhase(phase), run.CheckpointSHA)
+	if err != nil || len(results) == 0 {
+		return false
+	}
+	for _, result := range results {
+		if result.SetupFingerprint != fingerprint || result.Outcome == store.GateOutcomeSetupFailed {
+			return false
+		}
+	}
+	return true
+}
+
+// persistGateSuite records content-limited gate projections when the selected
+// operational store supports the issue #9 result table.
+func persistGateSuite(ctx context.Context, runStore RunStore, run store.Run, suite gate.SuiteResult) error {
+	resultStore, ok := runStore.(GateResultStore)
+	if !ok || len(suite.Gates) == 0 {
+		return nil
+	}
+	results := make([]store.GateResult, 0, len(suite.Gates))
+	for ordinal, result := range suite.Gates {
+		results = append(results, store.GateResult{
+			RunID:            run.ID,
+			CheckpointSHA:    result.CheckpointSHA,
+			Phase:            store.GatePhase(result.Phase),
+			Ordinal:          ordinal,
+			GateName:         result.GateName,
+			Outcome:          store.GateOutcome(result.Outcome),
+			Status:           string(result.Status.State),
+			Blocking:         result.Blocking,
+			SkipReason:       result.SkipReason,
+			SetupFingerprint: result.SetupFingerprint,
+		})
+	}
+	return resultStore.SaveGateResults(ctx, results)
+}
+
+// setupInputFingerprint hashes the configured manifest and lockfile contents
+// so each suite records which dependency graph setup evaluated.
+func setupInputFingerprint(worktree string, files []string) (string, error) {
+	if len(files) == 0 {
+		return "", nil
+	}
+	hasher := sha256.New()
+	for _, relative := range files {
+		path := filepath.Join(worktree, filepath.FromSlash(relative))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read %q: %w", relative, err)
+		}
+		_, _ = hasher.Write([]byte(relative))
+		_, _ = hasher.Write([]byte{0})
+		_, _ = hasher.Write(data)
+		_, _ = hasher.Write([]byte{0})
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// baselineFailureTargeted recognizes the coordinator-owned issue marker for an
+// explicitly accepted pre-existing gate failure. The marker is intentionally
+// exact so ordinary issue prose cannot silently bypass the baseline boundary.
+func baselineFailureTargeted(body string, suite gate.SuiteResult) bool {
+	body = strings.ToLower(body)
+	for _, result := range suite.Gates {
+		if result.Outcome != gate.OutcomeFailed && result.Outcome != gate.OutcomeError && result.Outcome != gate.OutcomeSetupFailed {
+			continue
+		}
+		if !result.Blocking {
+			continue
+		}
+		if !strings.Contains(body, "<!-- factory-baseline-target: all -->") && !strings.Contains(body, "<!-- factory-baseline-target: "+strings.ToLower(result.GateName)+" -->") && !(result.Outcome == gate.OutcomeSetupFailed && strings.Contains(body, "<!-- factory-baseline-target: setup -->")) {
+			return false
+		}
+	}
+	return suiteErrHasBlockingFailure(suite)
+}
+
+// baselineSetupTargeted reports whether the frozen issue explicitly accepts a
+// pre-existing setup failure, including the all-failures shorthand.
+func baselineSetupTargeted(body string) bool {
+	body = strings.ToLower(body)
+	return strings.Contains(body, "<!-- factory-baseline-target: all -->") || strings.Contains(body, "<!-- factory-baseline-target: setup -->")
+}
+
+// baselineFailureErrorTargeted ensures an issue marker suppresses only the
+// declared baseline failure, never status publication or other infrastructure
+// errors that happen to accompany it.
+func baselineFailureErrorTargeted(body string, suite gate.SuiteResult, suiteErr error) bool {
+	if suiteErr == nil || (!baselineFailureTargeted(body, suite) && !baselineSetupFailureTargeted(body, suite)) {
+		return false
+	}
+	var failure *gate.SuiteFailure
+	if !errors.As(suiteErr, &failure) {
+		return false
+	}
+	for _, cause := range failure.Failures {
+		var gateFailure *gate.GateFailure
+		var setupFailure *gate.SetupFailure
+		if errors.As(cause, &gateFailure) || errors.As(cause, &setupFailure) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// baselineSetupFailureTargeted recognizes a setup-only exemption when setup
+// prevented every declared gate from running, including all-advisory suites.
+func baselineSetupFailureTargeted(body string, suite gate.SuiteResult) bool {
+	for _, result := range suite.Gates {
+		if result.Outcome == gate.OutcomeSetupFailed {
+			return baselineSetupTargeted(body)
+		}
+	}
+	return false
+}
+
+// suiteErrHasBlockingFailure reports whether the suite contains a blocking
+// result that required baseline disposition.
+func suiteErrHasBlockingFailure(suite gate.SuiteResult) bool {
+	for _, result := range suite.Gates {
+		if result.Blocking && (result.Outcome == gate.OutcomeFailed || result.Outcome == gate.OutcomeError || result.Outcome == gate.OutcomeSetupFailed) {
+			return true
+		}
+	}
+	return false
 }
 
 // prepareGitMetadataProjection creates or reuses a sanitized Git metadata
@@ -352,6 +675,37 @@ func declaredGate(packet SpecificationPacket, name string) (config.GateConfig, b
 		}
 	}
 	return config.GateConfig{}, false
+}
+
+// gateDependencyPlan returns the requested gate and every declared prerequisite
+// in repository order, preserving the ordered dependency contract for the
+// single-gate compatibility API.
+func gateDependencyPlan(gates []config.GateConfig, target string) ([]config.GateConfig, error) {
+	required := map[string]bool{target: true}
+	for changed := true; changed; {
+		changed = false
+		for _, candidate := range gates {
+			if !required[candidate.Name] {
+				continue
+			}
+			for _, dependency := range candidate.DependsOn {
+				if !required[dependency] {
+					required[dependency] = true
+					changed = true
+				}
+			}
+		}
+	}
+	plan := make([]config.GateConfig, 0, len(required))
+	for _, candidate := range gates {
+		if required[candidate.Name] {
+			plan = append(plan, candidate)
+		}
+	}
+	if len(plan) == 0 {
+		return nil, fmt.Errorf("gate %q is not declared in the frozen specification packet", target)
+	}
+	return plan, nil
 }
 
 // workerCaches converts repository cache configurations into worker cache mounts.

--- a/internal/factory/gate_test.go
+++ b/internal/factory/gate_test.go
@@ -117,6 +117,13 @@ func TestRunGateStartsThePinnedWorkerAndUsesTheFrozenGate(t *testing.T) {
 	if len(statuses.values) != 1 || statuses.repositories[0] != (github.Repository{Owner: "example", Name: "project"}) || statuses.values[0].SHA != factoryGateCheckpoint || statuses.values[0].Context != "factory/gate/test" {
 		t.Fatalf("published statuses = %#v, want exact stable status", statuses.values)
 	}
+	workspace.state.HeadSHA = "stale-checkpoint"
+	if _, err := service.RunGate(context.Background(), factory.RunGateRequest{RunID: run.ID, GateName: policy.Gates[0].Name}); err == nil {
+		t.Fatal("RunGate() succeeded with a worktree HEAD that differs from the persisted checkpoint")
+	}
+	if len(statuses.values) != 1 {
+		t.Fatalf("statuses after stale checkpoint = %#v, want no additional gate evaluation", statuses.values)
+	}
 }
 
 // gateWorker is a WorkerRuntime adapter that records coordinator requests.

--- a/internal/gate/runner.go
+++ b/internal/gate/runner.go
@@ -198,8 +198,25 @@ func (e *GateFailure) Unwrap() error {
 	return e.Cause
 }
 
+// DependencyFailure identifies a blocking gate that could not run because a
+// declared prerequisite failed, including when that prerequisite was advisory.
+type DependencyFailure struct {
+	// Name is the blocked declared gate.
+	Name string
+	// Dependency is the failed declared prerequisite.
+	Dependency string
+}
+
+// Error describes why a blocking gate was skipped.
+func (e *DependencyFailure) Error() string {
+	if e == nil {
+		return "gate dependency failed"
+	}
+	return fmt.Sprintf("gate %q skipped because dependency %q failed", e.Name, e.Dependency)
+}
+
 // SuiteFailure aggregates all blocking failures from one ordered suite while
-// retaining independent gate failures for errors.As and diagnostics.
+// retaining gate and dependency failures for errors.As and diagnostics.
 type SuiteFailure struct {
 	// Failures contains setup or blocking gate failures in evaluation order.
 	Failures []error
@@ -314,6 +331,9 @@ func (r Runner) RunSuite(ctx context.Context, request SuiteRequest) (SuiteResult
 			result.Gates = append(result.Gates, gateResult)
 			if err := r.publish(ctx, gateResult.Status); err != nil {
 				blockingFailures = append(blockingFailures, err)
+			}
+			if declared.Blocking {
+				blockingFailures = append(blockingFailures, &DependencyFailure{Name: declared.Name, Dependency: dependency})
 			}
 			failed[declared.Name] = true
 			continue

--- a/internal/gate/runner.go
+++ b/internal/gate/runner.go
@@ -1,5 +1,5 @@
-// Package gate runs the repository-declared setup command and one declared
-// deterministic gate through the WorkerRuntime seam.
+// Package gate runs repository-declared setup and deterministic gates through
+// the WorkerRuntime seam.
 package gate
 
 import (
@@ -14,9 +14,35 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
+// Phase identifies why a gate suite was evaluated.
+type Phase string
+
+const (
+	// PhaseBaseline identifies the pre-edit health evaluation.
+	PhaseBaseline Phase = "baseline"
+	// PhaseCheckpoint identifies an evaluation of an implementation checkpoint.
+	PhaseCheckpoint Phase = "checkpoint"
+)
+
+// Outcome identifies the coordinator-owned result of one declared gate.
+type Outcome string
+
+const (
+	// OutcomePassed means the declared command exited successfully.
+	OutcomePassed Outcome = "passed"
+	// OutcomeFailed means the declared command failed or timed out.
+	OutcomeFailed Outcome = "failed"
+	// OutcomeError means the worker could not execute the declared command.
+	OutcomeError Outcome = "error"
+	// OutcomeSkipped means the gate was not run because a prerequisite failed.
+	OutcomeSkipped Outcome = "skipped"
+	// OutcomeSetupFailed means setup prevented the gate from being evaluated.
+	OutcomeSetupFailed Outcome = "setup_failed"
+)
+
 // Request selects one setup-and-gate execution against an immutable
-// checkpoint. The repository configuration is supplied by the caller from the
-// frozen specification packet rather than re-read from live files.
+// checkpoint. It is retained as the small compatibility seam for callers that
+// need one named gate rather than a complete ordered suite.
 type Request struct {
 	// RunID selects the already-started worker.
 	RunID string
@@ -24,25 +50,88 @@ type Request struct {
 	CheckpointSHA string
 	// Setup is the checked-in repository setup command.
 	Setup string
+	// SetupEnvironmentPolicy is the checked-in worker environment for setup.
+	SetupEnvironmentPolicy config.EnvironmentPolicy
 	// SetupTimeout is the checked-in setup timeout.
 	SetupTimeout string
 	// Gate is the one checked-in gate selected by the coordinator.
 	Gate config.GateConfig
+	// Phase identifies why this gate was evaluated.
+	Phase Phase
+	// SetupFingerprint records the configured dependency inputs used for setup.
+	SetupFingerprint string
 }
 
-// Result contains both command outcomes and the exact status that was
-// published for the checkpoint.
+// SuiteRequest selects setup and all ordered gates for one immutable checkpoint.
+type SuiteRequest struct {
+	// RunID selects the already-started worker.
+	RunID string
+	// CheckpointSHA is the exact commit to which every status is attached.
+	CheckpointSHA string
+	// Setup is the checked-in repository setup command.
+	Setup string
+	// SetupEnvironmentPolicy is the checked-in worker environment for setup.
+	SetupEnvironmentPolicy config.EnvironmentPolicy
+	// SetupTimeout is the checked-in setup timeout.
+	SetupTimeout string
+	// Gates is the ordered repository-declared gate list.
+	Gates []config.GateConfig
+	// Phase identifies whether this is a baseline or checkpoint evaluation.
+	Phase Phase
+	// SetupFingerprint identifies the configured manifest and lockfile contents
+	// observed for this evaluation.
+	SetupFingerprint string
+	// SkipSetup reuses a previously successful setup for the same checkpoint and
+	// dependency-input fingerprint.
+	SkipSetup bool
+}
+
+// Result contains one deterministic gate outcome and its exact checkpoint
+// status. Command output remains available to the in-process caller only.
 type Result struct {
 	// CheckpointSHA is the immutable commit evaluated by the run.
 	CheckpointSHA string
 	// GateName identifies the declared gate.
 	GateName string
-	// Setup is the deterministic setup command result.
+	// Phase identifies why the gate was evaluated.
+	Phase Phase
+	// Blocking records the repository policy for this gate.
+	Blocking bool
+	// Setup is the setup command result observed before this gate.
 	Setup worker.CommandResult
-	// Gate is the deterministic gate command result.
+	// Gate is the deterministic gate command result when the gate ran.
 	Gate worker.CommandResult
+	// SetupRan reports whether this suite executed setup for the checkpoint.
+	SetupRan bool
+	// SetupFingerprint records the configured dependency inputs used by setup.
+	SetupFingerprint string
+	// Outcome is the coordinator-owned semantic result.
+	Outcome Outcome
+	// Skipped reports that the gate command was not executed.
+	Skipped bool
+	// SkipReason explains a dependency or setup skip without reporting a failure.
+	SkipReason string
 	// Status is the final exact-SHA Commit Status request.
 	Status github.CommitStatus
+}
+
+// SuiteResult contains setup and every declared gate result in declaration
+// order. It is returned even when one or more blocking gates fail.
+type SuiteResult struct {
+	// CheckpointSHA is the immutable commit evaluated by the suite.
+	CheckpointSHA string
+	// Phase identifies why the suite was evaluated.
+	Phase Phase
+	// Setup is the one setup command result.
+	Setup worker.CommandResult
+	// SetupRan reports whether setup was executed.
+	SetupRan bool
+	// SetupFingerprint records the configured dependency inputs used by setup.
+	SetupFingerprint string
+	// Gates contains one result for every declared gate.
+	Gates []Result
+
+	runID string
 }
 
 // SetupFailure identifies a setup command or setup runtime failure separately
@@ -56,6 +145,9 @@ type SetupFailure struct {
 
 // Error describes the setup failure without including command output.
 func (e *SetupFailure) Error() string {
+	if e == nil {
+		return "setup failed"
+	}
 	if e.Cause != nil {
 		return fmt.Sprintf("setup execution failed: %v", e.Cause)
 	}
@@ -63,7 +155,12 @@ func (e *SetupFailure) Error() string {
 }
 
 // Unwrap exposes the setup runtime cause when one exists.
-func (e *SetupFailure) Unwrap() error { return e.Cause }
+func (e *SetupFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
 
 // GateFailure identifies a declared gate command or gate runtime failure.
 type GateFailure struct {
@@ -73,10 +170,20 @@ type GateFailure struct {
 	Result worker.CommandResult
 	// Cause is the runtime error when command execution itself failed.
 	Cause error
+	// TimedOut reports that the configured gate timeout expired.
+	TimedOut bool
+	// Blocking records whether this failure blocks the suite.
+	Blocking bool
 }
 
 // Error describes the gate failure without including command output.
 func (e *GateFailure) Error() string {
+	if e == nil {
+		return "gate failed"
+	}
+	if e.TimedOut {
+		return fmt.Sprintf("gate %q timed out", e.Name)
+	}
 	if e.Cause != nil {
 		return fmt.Sprintf("gate %q execution failed: %v", e.Name, e.Cause)
 	}
@@ -84,105 +191,310 @@ func (e *GateFailure) Error() string {
 }
 
 // Unwrap exposes the gate runtime cause when one exists.
-func (e *GateFailure) Unwrap() error { return e.Cause }
+func (e *GateFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
 
-// Runner executes setup and one declared gate using a worker and publishes
-// one stable Commit Status context for the exact checkpoint.
+// SuiteFailure aggregates all blocking failures from one ordered suite while
+// retaining independent gate failures for errors.As and diagnostics.
+type SuiteFailure struct {
+	// Failures contains setup or blocking gate failures in evaluation order.
+	Failures []error
+}
+
+// Error describes the complete deterministic failure set without command
+// output, which remains in the structured in-process results.
+func (e *SuiteFailure) Error() string {
+	if e == nil || len(e.Failures) == 0 {
+		return "gate suite failed"
+	}
+	parts := make([]string, 0, len(e.Failures))
+	for _, failure := range e.Failures {
+		if failure != nil {
+			parts = append(parts, failure.Error())
+		}
+	}
+	return "gate suite failed: " + strings.Join(parts, "; ")
+}
+
+// Unwrap exposes every retained failure to errors.Is and errors.As.
+func (e *SuiteFailure) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	return e.Failures
+}
+
+// Runner executes setup and declared gates using a worker and publishes exact
+// checkpoint statuses. It never asks an agent to interpret command output.
 type Runner struct {
 	// Runtime is the portable worker execution seam.
 	Runtime worker.WorkerRuntime
 	// Repository is the host-side GitHub repository receiving statuses.
 	Repository github.Repository
-	// Statuses publishes the exact-SHA GitHub result.
+	// Statuses publishes exact-SHA GitHub results.
 	Statuses github.CommitStatusPublisher
 }
 
-// Run executes setup first, then the selected gate, and publishes a final
-// status even when a command exits unsuccessfully. It never asks an agent to
-// interpret command output.
+// Run executes setup followed by one declared gate at the compatibility seam.
+// New workflow code should use RunSuite so setup is shared across all gates.
 func (r Runner) Run(ctx context.Context, request Request) (Result, error) {
+	phase := request.Phase
+	if phase == "" {
+		phase = PhaseCheckpoint
+	}
+	suite, err := r.RunSuite(ctx, SuiteRequest{
+		RunID:                  request.RunID,
+		CheckpointSHA:          request.CheckpointSHA,
+		Setup:                  request.Setup,
+		SetupEnvironmentPolicy: request.SetupEnvironmentPolicy,
+		SetupTimeout:           request.SetupTimeout,
+		Gates:                  []config.GateConfig{request.Gate},
+		Phase:                  phase,
+		SetupFingerprint:       request.SetupFingerprint,
+	})
+	if len(suite.Gates) == 0 {
+		return Result{}, err
+	}
+	return suite.Gates[0], err
+}
+
+// RunSuite executes setup once, then evaluates every declared gate in order.
+// Independent gates continue after a failure; gates depending on a failed gate
+// receive an explicit skipped result instead of a failure.
+func (r Runner) RunSuite(ctx context.Context, request SuiteRequest) (SuiteResult, error) {
+	if err := r.validateSuiteRequest(request); err != nil {
+		return SuiteResult{}, err
+	}
+	phase := request.Phase
+	if phase == "" {
+		phase = PhaseCheckpoint
+	}
+	result := SuiteResult{
+		CheckpointSHA:    request.CheckpointSHA,
+		Phase:            phase,
+		SetupFingerprint: request.SetupFingerprint,
+		Gates:            make([]Result, 0, len(request.Gates)),
+		runID:            request.RunID,
+	}
+
+	var setupErr error
+	if !request.SkipSetup {
+		setupContext, cancelSetup := context.WithTimeout(ctx, requestSetupTimeout(request))
+		result.SetupRan = true
+		result.Setup, setupErr = r.Runtime.RunCommand(setupContext, worker.CommandRequest{
+			RunID:             request.RunID,
+			Command:           request.Setup,
+			EnvironmentPolicy: workerEnvironmentPolicy(request.SetupEnvironmentPolicy),
+			Role:              "coordinator",
+		})
+		cancelSetup()
+	}
+	if setupErr != nil || result.Setup.ExitCode != 0 {
+		failure := &SetupFailure{Result: result.Setup, Cause: setupErr}
+		publishFailures := make([]error, 0, len(request.Gates))
+		for index, declared := range request.Gates {
+			gateResult := r.setupFailedResult(result, declared, index, failure)
+			result.Gates = append(result.Gates, gateResult)
+			if err := r.publish(ctx, gateResult.Status); err != nil {
+				publishFailures = append(publishFailures, err)
+			}
+		}
+		return result, &SuiteFailure{Failures: append([]error{failure}, publishFailures...)}
+	}
+
+	failed := make(map[string]bool, len(request.Gates))
+	blockingFailures := make([]error, 0)
+	for index, declared := range request.Gates {
+		if dependency, reason := failedDependency(declared, failed); dependency != "" {
+			gateResult := r.skippedResult(result, declared, index, reason)
+			result.Gates = append(result.Gates, gateResult)
+			if err := r.publish(ctx, gateResult.Status); err != nil {
+				blockingFailures = append(blockingFailures, err)
+			}
+			failed[declared.Name] = true
+			continue
+		}
+
+		gateResult, failure := r.runDeclaredGate(ctx, result, declared)
+		result.Gates = append(result.Gates, gateResult)
+		if err := r.publish(ctx, gateResult.Status); err != nil {
+			blockingFailures = append(blockingFailures, err)
+		}
+		if failure != nil {
+			failed[declared.Name] = true
+			if declared.Blocking {
+				blockingFailures = append(blockingFailures, failure)
+			}
+		}
+	}
+	if len(blockingFailures) != 0 {
+		return result, &SuiteFailure{Failures: blockingFailures}
+	}
+	return result, nil
+}
+
+// validateSuiteRequest validates the public gate execution contract before
+// creating a worker command or publishing a status.
+func (r Runner) validateSuiteRequest(request SuiteRequest) error {
 	if r.Runtime == nil {
-		return Result{}, errors.New("gate runner worker runtime is required")
+		return errors.New("gate runner worker runtime is required")
 	}
 	if r.Statuses == nil {
-		return Result{}, errors.New("gate runner commit status publisher is required")
+		return errors.New("gate runner commit status publisher is required")
 	}
 	if strings.TrimSpace(request.RunID) == "" {
-		return Result{}, errors.New("gate run id is required")
+		return errors.New("gate run id is required")
 	}
 	if !github.ValidCommitSHA(request.CheckpointSHA) {
-		return Result{}, errors.New("gate checkpoint SHA must contain exactly 40 or 64 lowercase hexadecimal characters")
+		return errors.New("gate checkpoint SHA must contain exactly 40 or 64 lowercase hexadecimal characters")
 	}
 	if strings.TrimSpace(request.Setup) == "" {
-		return Result{}, errors.New("gate setup command is required")
+		return errors.New("gate setup command is required")
 	}
-	setupTimeout, err := positiveDuration("setup timeout", request.SetupTimeout)
-	if err != nil {
-		return Result{}, err
+	if request.SetupEnvironmentPolicy != "" && request.SetupEnvironmentPolicy != config.EnvironmentPolicyClean && request.SetupEnvironmentPolicy != config.EnvironmentPolicyRole {
+		return errors.New("gate setup environment policy must be clean or role")
 	}
-	gateTimeout, err := positiveDuration("gate timeout", request.Gate.Timeout)
-	if err != nil {
-		return Result{}, err
+	if _, err := positiveDuration("setup timeout", request.SetupTimeout); err != nil {
+		return err
 	}
-	if strings.TrimSpace(request.Gate.Name) == "" {
-		return Result{}, errors.New("gate name is required")
+	if request.Phase != "" && request.Phase != PhaseBaseline && request.Phase != PhaseCheckpoint {
+		return fmt.Errorf("unsupported gate phase %q", request.Phase)
 	}
-	if strings.ContainsAny(request.Gate.Name, "\r\n") {
-		return Result{}, errors.New("gate name must be a single line")
+	if len(request.Gates) == 0 {
+		return errors.New("at least one declared gate is required")
 	}
-	if strings.TrimSpace(request.Gate.Command) == "" {
-		return Result{}, errors.New("gate command is required")
+	seen := make(map[string]struct{}, len(request.Gates))
+	for index, declared := range request.Gates {
+		if strings.TrimSpace(declared.Name) == "" {
+			return fmt.Errorf("gate %d name is required", index)
+		}
+		if strings.ContainsAny(declared.Name, "\r\n") {
+			return fmt.Errorf("gate %q name must be a single line", declared.Name)
+		}
+		if _, exists := seen[declared.Name]; exists {
+			return fmt.Errorf("gate %q is declared more than once", declared.Name)
+		}
+		seen[declared.Name] = struct{}{}
+		if strings.TrimSpace(declared.Command) == "" {
+			return fmt.Errorf("gate %q command is required", declared.Name)
+		}
+		if _, err := positiveDuration(fmt.Sprintf("gate %q timeout", declared.Name), declared.Timeout); err != nil {
+			return err
+		}
+		if declared.EnvironmentPolicy != config.EnvironmentPolicyClean && declared.EnvironmentPolicy != config.EnvironmentPolicyRole {
+			return fmt.Errorf("gate %q environment policy must be clean or role", declared.Name)
+		}
+		for _, dependency := range declared.DependsOn {
+			if _, exists := seen[dependency]; !exists {
+				return fmt.Errorf("gate %q depends on undeclared or later gate %q", declared.Name, dependency)
+			}
+		}
 	}
-	if request.Gate.EnvironmentPolicy != config.EnvironmentPolicyClean && request.Gate.EnvironmentPolicy != config.EnvironmentPolicyRole {
-		return Result{}, errors.New("gate environment policy must be clean or role")
-	}
+	return nil
+}
 
-	result := Result{
-		CheckpointSHA: request.CheckpointSHA,
-		GateName:      request.Gate.Name,
-		Status: github.CommitStatus{
-			SHA:     request.CheckpointSHA,
-			Context: statusContext(request.Gate.Name),
-		},
-	}
-	setupContext, cancelSetup := context.WithTimeout(ctx, setupTimeout)
-	result.Setup, err = r.Runtime.RunCommand(setupContext, worker.CommandRequest{
-		RunID:             request.RunID,
-		Command:           request.Setup,
-		EnvironmentPolicy: worker.EnvironmentPolicyClean,
-		Role:              "coordinator",
-	})
-	cancelSetup()
-	if err != nil || result.Setup.ExitCode != 0 {
-		failure := &SetupFailure{Result: result.Setup, Cause: err}
-		result.Status.State = github.CommitStatusError
-		result.Status.Description = "factory setup failed"
-		return result, errors.Join(failure, r.publish(ctx, result.Status))
-	}
-
-	gateContext, cancelGate := context.WithTimeout(ctx, gateTimeout)
-	result.Gate, err = r.Runtime.RunCommand(gateContext, worker.CommandRequest{
-		RunID:             request.RunID,
-		Command:           request.Gate.Command,
-		EnvironmentPolicy: workerEnvironmentPolicy(request.Gate.EnvironmentPolicy),
+// runDeclaredGate executes one gate and maps command and timeout outcomes to a
+// typed result and failure without stopping independent gates.
+func (r Runner) runDeclaredGate(ctx context.Context, suite SuiteResult, declared config.GateConfig) (Result, error) {
+	gateResult := baseResult(suite, declared)
+	gateContext, cancelGate := context.WithTimeout(ctx, requestGateTimeout(declared))
+	var commandErr error
+	gateResult.Gate, commandErr = r.Runtime.RunCommand(gateContext, worker.CommandRequest{
+		RunID:             suite.runID,
+		Command:           declared.Command,
+		EnvironmentPolicy: workerEnvironmentPolicy(declared.EnvironmentPolicy),
 		Role:              "gate",
 	})
+	timedOut := gateContext.Err() == context.DeadlineExceeded
 	cancelGate()
-	if err != nil || result.Gate.ExitCode != 0 {
-		failure := &GateFailure{Name: request.Gate.Name, Result: result.Gate, Cause: err}
-		if err != nil {
-			result.Status.State = github.CommitStatusError
-			result.Status.Description = "factory gate execution failed"
-		} else {
-			result.Status.State = github.CommitStatusFailure
-			result.Status.Description = "factory gate failed"
-		}
-		return result, errors.Join(failure, r.publish(ctx, result.Status))
+	if commandErr == nil && gateResult.Gate.ExitCode == 0 {
+		gateResult.Outcome = OutcomePassed
+		gateResult.Status.State = github.CommitStatusSuccess
+		gateResult.Status.Description = "factory gate passed"
+		return gateResult, nil
 	}
+	timedOut = timedOut || errors.Is(commandErr, context.DeadlineExceeded)
+	failure := &GateFailure{Name: declared.Name, Result: gateResult.Gate, Cause: commandErr, TimedOut: timedOut, Blocking: declared.Blocking}
+	gateResult.Outcome = OutcomeFailed
+	if timedOut {
+		gateResult.Status.State = github.CommitStatusFailure
+		gateResult.Status.Description = "factory gate timed out"
+	} else if commandErr != nil {
+		gateResult.Outcome = OutcomeError
+		gateResult.Status.State = github.CommitStatusError
+		gateResult.Status.Description = "factory gate execution failed"
+	} else {
+		gateResult.Status.State = github.CommitStatusFailure
+		gateResult.Status.Description = "factory gate failed"
+	}
+	return gateResult, failure
+}
 
-	result.Status.State = github.CommitStatusSuccess
-	result.Status.Description = "factory setup and gate passed"
-	return result, r.publish(ctx, result.Status)
+// setupFailedResult records every declared gate without misclassifying it as a
+// gate failure when setup itself failed.
+func (r Runner) setupFailedResult(suite SuiteResult, declared config.GateConfig, _ int, failure *SetupFailure) Result {
+	result := baseResult(suite, declared)
+	result.Outcome = OutcomeSetupFailed
+	result.Skipped = true
+	result.SkipReason = "setup failed"
+	result.Status.State = github.CommitStatusError
+	result.Status.Description = "factory setup failed"
+	result.Setup = failure.Result
+	return result
+}
+
+// skippedResult records a dependency skip as a non-failure status.
+func (r Runner) skippedResult(suite SuiteResult, declared config.GateConfig, _ int, reason string) Result {
+	result := baseResult(suite, declared)
+	result.Outcome = OutcomeSkipped
+	result.Skipped = true
+	result.SkipReason = reason
+	result.Status.State = github.CommitStatusPending
+	result.Status.Description = trimDescription("factory gate skipped: " + reason)
+	return result
+}
+
+// baseResult creates the shared exact-checkpoint result envelope for one gate.
+func baseResult(suite SuiteResult, declared config.GateConfig) Result {
+	return Result{
+		CheckpointSHA:    suite.CheckpointSHA,
+		GateName:         declared.Name,
+		Phase:            suite.Phase,
+		Blocking:         declared.Blocking,
+		Setup:            suite.Setup,
+		SetupRan:         suite.SetupRan,
+		SetupFingerprint: suite.SetupFingerprint,
+		Status: github.CommitStatus{
+			SHA:     suite.CheckpointSHA,
+			Context: statusContext(suite.Phase, declared.Name),
+		},
+	}
+}
+
+// failedDependency returns the first declared prerequisite that failed.
+func failedDependency(declared config.GateConfig, failed map[string]bool) (string, string) {
+	for _, dependency := range declared.DependsOn {
+		if failed[dependency] {
+			return dependency, fmt.Sprintf("dependency %q failed", dependency)
+		}
+	}
+	return "", ""
+}
+
+// requestSetupTimeout parses the already validated setup timeout.
+func requestSetupTimeout(request SuiteRequest) time.Duration {
+	duration, _ := time.ParseDuration(strings.TrimSpace(request.SetupTimeout))
+	return duration
+}
+
+// requestGateTimeout parses the already validated gate timeout.
+func requestGateTimeout(declared config.GateConfig) time.Duration {
+	duration, _ := time.ParseDuration(strings.TrimSpace(declared.Timeout))
+	return duration
 }
 
 // publish sends one status and preserves the exact checkpoint identity.
@@ -204,7 +516,7 @@ func positiveDuration(field, value string) (time.Duration, error) {
 }
 
 // workerEnvironmentPolicy converts a configured environment policy to the
-// corresponding worker policy, defaulting unknown values to a clean environment.
+// corresponding worker policy.
 func workerEnvironmentPolicy(policy config.EnvironmentPolicy) worker.EnvironmentPolicy {
 	switch policy {
 	case config.EnvironmentPolicyClean:
@@ -216,5 +528,20 @@ func workerEnvironmentPolicy(policy config.EnvironmentPolicy) worker.Environment
 	}
 }
 
-// statusContext returns the stable status context for the specified gate name.
-func statusContext(name string) string { return "factory/gate/" + strings.TrimSpace(name) }
+// statusContext returns a stable status context for one gate and evaluation
+// phase, keeping baseline and checkpoint results from overwriting one another.
+func statusContext(phase Phase, name string) string {
+	if phase == PhaseBaseline {
+		return "factory/baseline/" + strings.TrimSpace(name)
+	}
+	return "factory/gate/" + strings.TrimSpace(name)
+}
+
+// trimDescription keeps generated GitHub status descriptions within the API
+// limit while retaining the typed skip reason.
+func trimDescription(value string) string {
+	if len(value) <= 140 {
+		return value
+	}
+	return value[:137] + "..."
+}

--- a/internal/gate/runner_contract_test.go
+++ b/internal/gate/runner_contract_test.go
@@ -217,6 +217,44 @@ func TestRunnerDoesNotBlockOnANonBlockingIndependentFailure(t *testing.T) {
 	}
 }
 
+// TestRunnerFailsWhenABlockingGateDependsOnANonBlockingFailure verifies an
+// advisory failure still blocks a required dependent gate from continuation.
+func TestRunnerFailsWhenABlockingGateDependsOnANonBlockingFailure(t *testing.T) {
+	t.Parallel()
+
+	runtime := &fakeRuntime{results: []worker.CommandResult{
+		{ExitCode: 0}, // setup
+		{ExitCode: 3}, // advisory prerequisite
+	}}
+	statuses := &fakeStatusPublisher{}
+	runner := gate.Runner{Runtime: runtime, Statuses: statuses}
+
+	result, err := runner.RunSuite(context.Background(), gate.SuiteRequest{
+		RunID:         "run-suite-dependent-advisory",
+		CheckpointSHA: gateCheckpoint,
+		Setup:         "setup",
+		SetupTimeout:  "1m",
+		Gates: []config.GateConfig{
+			{Name: "advisory", Command: "advisory", Timeout: "1m", Blocking: false, EnvironmentPolicy: config.EnvironmentPolicyClean},
+			{Name: "required", Command: "required", Timeout: "1m", Blocking: true, DependsOn: []string{"advisory"}, EnvironmentPolicy: config.EnvironmentPolicyClean},
+		},
+	})
+	var suiteFailure *gate.SuiteFailure
+	if !errors.As(err, &suiteFailure) {
+		t.Fatalf("RunSuite() error = %v, want blocking dependency failure", err)
+	}
+	var dependencyFailure *gate.DependencyFailure
+	if !errors.As(err, &dependencyFailure) {
+		t.Fatalf("RunSuite() error = %v, want DependencyFailure", err)
+	}
+	if len(result.Gates) != 2 || !result.Gates[1].Skipped || result.Gates[1].Outcome != gate.OutcomeSkipped {
+		t.Fatalf("suite gates = %#v, want required gate skipped", result.Gates)
+	}
+	if len(runtime.commands) != 2 {
+		t.Fatalf("commands = %#v, want setup and advisory only", runtime.commands)
+	}
+}
+
 // TestRunnerAggregatesIndependentBlockingFailures verifies one suite error
 // carries every independent blocking failure for one repair decision.
 func TestRunnerAggregatesIndependentBlockingFailures(t *testing.T) {

--- a/internal/gate/runner_contract_test.go
+++ b/internal/gate/runner_contract_test.go
@@ -3,6 +3,7 @@ package gate_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
@@ -26,10 +27,11 @@ func TestRunnerExecutesSetupAndOneDeclaredGatePublishesTheExactCheckpoint(t *tes
 	runner := gate.Runner{Runtime: runtime, Statuses: statuses}
 
 	result, err := runner.Run(context.Background(), gate.Request{
-		RunID:         "run-gate-1",
-		CheckpointSHA: gateCheckpoint,
-		Setup:         "go mod download",
-		SetupTimeout:  "1m",
+		RunID:                  "run-gate-1",
+		CheckpointSHA:          gateCheckpoint,
+		Setup:                  "go mod download",
+		SetupEnvironmentPolicy: config.EnvironmentPolicyRole,
+		SetupTimeout:           "1m",
 		Gate: config.GateConfig{
 			Name:              "test",
 			Command:           "go test ./...",
@@ -52,8 +54,8 @@ func TestRunnerExecutesSetupAndOneDeclaredGatePublishesTheExactCheckpoint(t *tes
 	if runtime.commands[0].Command != "go mod download" || runtime.commands[1].Command != "go test ./..." {
 		t.Fatalf("commands = %#v, want declared setup and gate", runtime.commands)
 	}
-	if runtime.commands[0].EnvironmentPolicy != worker.EnvironmentPolicyClean || runtime.commands[1].EnvironmentPolicy != worker.EnvironmentPolicyClean {
-		t.Fatalf("command policies = %#v, want clean coordinator environments", runtime.commands)
+	if runtime.commands[0].EnvironmentPolicy != worker.EnvironmentPolicyRole || runtime.commands[1].EnvironmentPolicy != worker.EnvironmentPolicyClean {
+		t.Fatalf("command policies = %#v, want configured setup role and clean gate environments", runtime.commands)
 	}
 	if len(statuses.statuses) != 1 || statuses.statuses[0] != result.Status {
 		t.Fatalf("published statuses = %#v, want one final status", statuses.statuses)
@@ -114,6 +116,7 @@ func TestRunnerClassifiesGateFailure(t *testing.T) {
 			Name:              "test",
 			Command:           "test",
 			Timeout:           "2m",
+			Blocking:          true,
 			EnvironmentPolicy: config.EnvironmentPolicyRole,
 		},
 	})
@@ -129,10 +132,158 @@ func TestRunnerClassifiesGateFailure(t *testing.T) {
 	}
 }
 
+// TestRunnerRunsIndependentGatesAndSkipsFailedDependencies verifies one setup
+// command feeds the ordered gate graph without allowing one failure to hide
+// an independent result.
+func TestRunnerRunsIndependentGatesAndSkipsFailedDependencies(t *testing.T) {
+	t.Parallel()
+
+	runtime := &fakeRuntime{results: []worker.CommandResult{
+		{ExitCode: 0}, // setup
+		{ExitCode: 7}, // format
+		{ExitCode: 0}, // lint
+	}}
+	statuses := &fakeStatusPublisher{}
+	runner := gate.Runner{Runtime: runtime, Statuses: statuses}
+
+	result, err := runner.RunSuite(context.Background(), gate.SuiteRequest{
+		RunID:            "run-suite-1",
+		CheckpointSHA:    gateCheckpoint,
+		Setup:            "setup",
+		SetupTimeout:     "1m",
+		SetupFingerprint: "setup-fingerprint-1",
+		Phase:            gate.PhaseCheckpoint,
+		Gates: []config.GateConfig{
+			{Name: "format", Command: "format", Timeout: "1m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean},
+			{Name: "lint", Command: "lint", Timeout: "1m", Blocking: false, EnvironmentPolicy: config.EnvironmentPolicyRole},
+			{Name: "test", Command: "test", Timeout: "1m", Blocking: true, DependsOn: []string{"format"}, EnvironmentPolicy: config.EnvironmentPolicyClean},
+		},
+	})
+	if err == nil {
+		t.Fatal("RunSuite() succeeded, want the blocking format failure")
+	}
+	var formatFailure *gate.GateFailure
+	if !errors.As(err, &formatFailure) {
+		t.Fatalf("RunSuite() error = %v, want GateFailure", err)
+	}
+	if len(result.Gates) != 3 || result.Gates[0].Status.State != github.CommitStatusFailure {
+		t.Fatalf("suite gates = %#v, want all declared gate results", result.Gates)
+	}
+	if result.Gates[1].Status.State != github.CommitStatusSuccess || result.Gates[1].SetupFingerprint != "setup-fingerprint-1" {
+		t.Fatalf("independent lint result = %#v, want success with setup fingerprint", result.Gates[1])
+	}
+	if !result.Gates[2].Skipped || !strings.Contains(result.Gates[2].SkipReason, "format") {
+		t.Fatalf("dependent test result = %#v, want dependency skip reason", result.Gates[2])
+	}
+	if len(runtime.commands) != 3 || runtime.commands[0].Command != "setup" || runtime.commands[1].Command != "format" || runtime.commands[2].Command != "lint" {
+		t.Fatalf("commands = %#v, want one setup plus independent gates", runtime.commands)
+	}
+	if len(statuses.statuses) != 3 {
+		t.Fatalf("published statuses = %#v, want one result per declared gate", statuses.statuses)
+	}
+}
+
+// TestRunnerDoesNotBlockOnANonBlockingIndependentFailure verifies the declared
+// blocking policy controls suite disposition without hiding later results.
+func TestRunnerDoesNotBlockOnANonBlockingIndependentFailure(t *testing.T) {
+	t.Parallel()
+
+	runtime := &fakeRuntime{results: []worker.CommandResult{
+		{ExitCode: 0}, // setup
+		{ExitCode: 3}, // advisory
+		{ExitCode: 0}, // independent required gate
+	}}
+	statuses := &fakeStatusPublisher{}
+	runner := gate.Runner{Runtime: runtime, Statuses: statuses}
+
+	result, err := runner.RunSuite(context.Background(), gate.SuiteRequest{
+		RunID:         "run-suite-advisory",
+		CheckpointSHA: gateCheckpoint,
+		Setup:         "setup",
+		SetupTimeout:  "1m",
+		Gates: []config.GateConfig{
+			{Name: "advisory", Command: "advisory", Timeout: "1m", Blocking: false, EnvironmentPolicy: config.EnvironmentPolicyClean},
+			{Name: "required", Command: "required", Timeout: "1m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunSuite() error = %v, want nonblocking failure to remain advisory", err)
+	}
+	if len(result.Gates) != 2 || result.Gates[0].Outcome != gate.OutcomeFailed || result.Gates[1].Outcome != gate.OutcomePassed {
+		t.Fatalf("suite gates = %#v, want advisory failure and required success", result.Gates)
+	}
+	if len(runtime.commands) != 3 || len(statuses.statuses) != 2 {
+		t.Fatalf("commands = %#v statuses = %#v, want setup plus both gates", runtime.commands, statuses.statuses)
+	}
+}
+
+// TestRunnerAggregatesIndependentBlockingFailures verifies one suite error
+// carries every independent blocking failure for one repair decision.
+func TestRunnerAggregatesIndependentBlockingFailures(t *testing.T) {
+	t.Parallel()
+
+	runtime := &fakeRuntime{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 4}, {ExitCode: 5}}}
+	statuses := &fakeStatusPublisher{}
+	runner := gate.Runner{Runtime: runtime, Statuses: statuses}
+	result, err := runner.RunSuite(context.Background(), gate.SuiteRequest{
+		RunID:         "run-suite-failures",
+		CheckpointSHA: gateCheckpoint,
+		Setup:         "setup",
+		SetupTimeout:  "1m",
+		Gates: []config.GateConfig{
+			{Name: "format", Command: "format", Timeout: "1m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean},
+			{Name: "lint", Command: "lint", Timeout: "1m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean},
+		},
+	})
+	var suiteFailure *gate.SuiteFailure
+	if !errors.As(err, &suiteFailure) || len(suiteFailure.Failures) != 2 {
+		t.Fatalf("RunSuite() error = %v, want two independent failures", err)
+	}
+	if len(result.Gates) != 2 || result.Gates[0].Outcome != gate.OutcomeFailed || result.Gates[1].Outcome != gate.OutcomeFailed {
+		t.Fatalf("suite gates = %#v, want both independent failures retained", result.Gates)
+	}
+}
+
+// TestRunnerClassifiesACommandTimeoutAsATypedGateFailure verifies a timeout is
+// a deterministic gate result rather than worker infrastructure failure.
+func TestRunnerClassifiesACommandTimeoutAsATypedGateFailure(t *testing.T) {
+	t.Parallel()
+
+	runtime := &fakeRuntime{
+		results: []worker.CommandResult{{ExitCode: 0}},
+		errors:  []error{nil, context.DeadlineExceeded},
+	}
+	statuses := &fakeStatusPublisher{}
+	runner := gate.Runner{Runtime: runtime, Statuses: statuses}
+
+	result, err := runner.RunSuite(context.Background(), gate.SuiteRequest{
+		RunID:         "run-timeout",
+		CheckpointSHA: gateCheckpoint,
+		Setup:         "setup",
+		SetupTimeout:  "1m",
+		Phase:         gate.PhaseCheckpoint,
+		Gates: []config.GateConfig{{
+			Name: "test", Command: "test", Timeout: "1ms", Blocking: true,
+			EnvironmentPolicy: config.EnvironmentPolicyClean,
+		}},
+	})
+	var gateFailure *gate.GateFailure
+	if !errors.As(err, &gateFailure) {
+		t.Fatalf("RunSuite() error = %v, want GateFailure", err)
+	}
+	if !gateFailure.TimedOut || result.Gates[0].Status.State != github.CommitStatusFailure {
+		t.Fatalf("timeout failure = %#v, result = %#v, want typed failure status", gateFailure, result.Gates[0])
+	}
+	if result.Gates[0].Status.Description != "factory gate timed out" {
+		t.Fatalf("timeout description = %q, want typed gate timeout", result.Gates[0].Status.Description)
+	}
+}
+
 // fakeRuntime is a WorkerRuntime adapter used at the gate module's public seam.
 type fakeRuntime struct {
 	commands []worker.CommandRequest
 	results  []worker.CommandResult
+	errors   []error
 }
 
 // Start implements WorkerRuntime for the gate contract tests.
@@ -144,9 +295,17 @@ func (f *fakeRuntime) Resume(context.Context, worker.ResumeRequest) error { retu
 // RunCommand records the coordinator command and returns the next fixture.
 func (f *fakeRuntime) RunCommand(_ context.Context, request worker.CommandRequest) (worker.CommandResult, error) {
 	f.commands = append(f.commands, request)
-	result := f.results[0]
-	f.results = f.results[1:]
-	return result, nil
+	var result worker.CommandResult
+	if len(f.results) != 0 {
+		result = f.results[0]
+		f.results = f.results[1:]
+	}
+	var err error
+	if len(f.errors) != 0 {
+		err = f.errors[0]
+		f.errors = f.errors[1:]
+	}
+	return result, err
 }
 
 // Stop implements WorkerRuntime for the gate contract tests.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 11
+const CurrentSchemaVersion = 12
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -74,6 +74,32 @@ const (
 	InvocationStatusWaitingForHuman InvocationStatus = "waiting_for_human"
 	// InvocationStatusCannotProceed means the report contained blocking evidence.
 	InvocationStatusCannotProceed InvocationStatus = "cannot_proceed"
+)
+
+// GatePhase identifies why a deterministic gate result was recorded.
+type GatePhase string
+
+const (
+	// GatePhaseBaseline identifies the pre-edit health evaluation.
+	GatePhaseBaseline GatePhase = "baseline"
+	// GatePhaseCheckpoint identifies an implementation checkpoint evaluation.
+	GatePhaseCheckpoint GatePhase = "checkpoint"
+)
+
+// GateOutcome identifies the coordinator-owned semantic result of one gate.
+type GateOutcome string
+
+const (
+	// GateOutcomePassed records a successful declared command.
+	GateOutcomePassed GateOutcome = "passed"
+	// GateOutcomeFailed records a declared command failure or timeout.
+	GateOutcomeFailed GateOutcome = "failed"
+	// GateOutcomeError records a worker/runtime execution error.
+	GateOutcomeError GateOutcome = "error"
+	// GateOutcomeSkipped records a dependency that was not evaluated.
+	GateOutcomeSkipped GateOutcome = "skipped"
+	// GateOutcomeSetupFailed records a gate blocked by setup failure.
+	GateOutcomeSetupFailed GateOutcome = "setup_failed"
 )
 
 type UnknownSchemaVersionError struct {
@@ -182,6 +208,36 @@ type Invocation struct {
 	// CreatedAt is the immutable invocation creation time.
 	CreatedAt time.Time
 	// UpdatedAt is the latest coordinator update time.
+	UpdatedAt time.Time
+}
+
+// GateResult is the content-limited durable projection of one deterministic
+// gate outcome. Its primary identity includes the exact checkpoint and phase,
+// so a later code change cannot reuse an earlier result.
+type GateResult struct {
+	// RunID identifies the factory run.
+	RunID string
+	// CheckpointSHA identifies the exact evaluated commit.
+	CheckpointSHA string
+	// Phase distinguishes baseline from checkpoint evaluation.
+	Phase GatePhase
+	// Ordinal preserves repository declaration order.
+	Ordinal int
+	// GateName identifies the repository-declared gate.
+	GateName string
+	// Outcome is the coordinator-owned semantic result.
+	Outcome GateOutcome
+	// Status is the published exact-SHA status state.
+	Status string
+	// Blocking records the repository policy for the gate.
+	Blocking bool
+	// SkipReason explains a dependency or setup skip.
+	SkipReason string
+	// SetupFingerprint identifies the configured dependency inputs used by setup.
+	SetupFingerprint string
+	// CreatedAt is the first persistence time for this result identity.
+	CreatedAt time.Time
+	// UpdatedAt is the latest persistence time for this result identity.
 	UpdatedAt time.Time
 }
 
@@ -673,6 +729,174 @@ func scanInvocation(row *sql.Row) (*Invocation, error) {
 	return &invocation, nil
 }
 
+// SaveGateResults atomically upserts the ordered deterministic results from
+// one suite while preserving their exact run, phase, and checkpoint identity.
+func (s *Store) SaveGateResults(ctx context.Context, results []GateResult) error {
+	if len(results) == 0 {
+		return errors.New("at least one gate result is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin gate-result save: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, result := range results {
+		if err := validateGateResult(result); err != nil {
+			return err
+		}
+		createdAt := result.CreatedAt
+		if createdAt.IsZero() {
+			createdAt = time.Now().UTC()
+		}
+		updatedAt := result.UpdatedAt
+		if updatedAt.IsZero() {
+			updatedAt = createdAt
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO gate_results (
+				run_id, checkpoint_sha, phase, ordinal, gate_name, outcome, status,
+				blocking, skip_reason, setup_fingerprint, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(run_id, checkpoint_sha, phase, gate_name) DO UPDATE SET
+				ordinal = excluded.ordinal,
+				outcome = excluded.outcome,
+				status = excluded.status,
+				blocking = excluded.blocking,
+				skip_reason = excluded.skip_reason,
+				setup_fingerprint = excluded.setup_fingerprint,
+				updated_at = excluded.updated_at`,
+			result.RunID,
+			result.CheckpointSHA,
+			result.Phase,
+			result.Ordinal,
+			result.GateName,
+			result.Outcome,
+			result.Status,
+			result.Blocking,
+			result.SkipReason,
+			result.SetupFingerprint,
+			createdAt.UTC().Format(runTimestampLayout),
+			updatedAt.UTC().Format(runTimestampLayout),
+		); err != nil {
+			return fmt.Errorf("save gate result %q: %w", result.GateName, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit gate-result save: %w", err)
+	}
+	return nil
+}
+
+// GateResults returns results only for the requested exact checkpoint and
+// phase, ordered as declared in the frozen repository configuration.
+func (s *Store) GateResults(ctx context.Context, runID string, phase GatePhase, checkpointSHA string) ([]GateResult, error) {
+	if strings.TrimSpace(runID) == "" {
+		return nil, errors.New("gate result run id is required")
+	}
+	if err := validateGatePhase(phase); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(checkpointSHA) == "" {
+		return nil, errors.New("gate result checkpoint SHA is required")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT run_id, checkpoint_sha, phase, ordinal, gate_name, outcome, status,
+		       blocking, skip_reason, setup_fingerprint, created_at, updated_at
+		FROM gate_results
+		WHERE run_id = ? AND phase = ? AND checkpoint_sha = ?
+		ORDER BY ordinal, gate_name`, runID, phase, checkpointSHA)
+	if err != nil {
+		return nil, fmt.Errorf("read gate results: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	results := []GateResult{}
+	for rows.Next() {
+		var result GateResult
+		var createdAt, updatedAt string
+		if err := rows.Scan(
+			&result.RunID,
+			&result.CheckpointSHA,
+			&result.Phase,
+			&result.Ordinal,
+			&result.GateName,
+			&result.Outcome,
+			&result.Status,
+			&result.Blocking,
+			&result.SkipReason,
+			&result.SetupFingerprint,
+			&createdAt,
+			&updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan gate result: %w", err)
+		}
+		var parseErr error
+		result.CreatedAt, parseErr = time.Parse(time.RFC3339Nano, createdAt)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse gate result created_at: %w", parseErr)
+		}
+		result.UpdatedAt, parseErr = time.Parse(time.RFC3339Nano, updatedAt)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse gate result updated_at: %w", parseErr)
+		}
+		results = append(results, result)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read gate results: %w", err)
+	}
+	return results, nil
+}
+
+// validateGateResult validates the durable result identity and vocabulary.
+func validateGateResult(result GateResult) error {
+	if strings.TrimSpace(result.RunID) == "" {
+		return errors.New("gate result run id is required")
+	}
+	if !validGateCheckpointSHA(result.CheckpointSHA) {
+		return errors.New("gate result checkpoint SHA must contain exactly 40 or 64 lowercase hexadecimal characters")
+	}
+	if err := validateGatePhase(result.Phase); err != nil {
+		return err
+	}
+	if result.Ordinal < 0 {
+		return errors.New("gate result ordinal must not be negative")
+	}
+	if strings.TrimSpace(result.GateName) == "" {
+		return errors.New("gate result gate name is required")
+	}
+	switch result.Outcome {
+	case GateOutcomePassed, GateOutcomeFailed, GateOutcomeError, GateOutcomeSkipped, GateOutcomeSetupFailed:
+	default:
+		return fmt.Errorf("unsupported gate result outcome %q", result.Outcome)
+	}
+	if strings.TrimSpace(result.Status) == "" {
+		return errors.New("gate result status is required")
+	}
+	return nil
+}
+
+// validGateCheckpointSHA validates the exact commit identity retained by a
+// durable gate result without importing the host-side GitHub adapter.
+func validGateCheckpointSHA(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, character := range value {
+		if (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// validateGatePhase validates the durable baseline/checkpoint phase vocabulary.
+func validateGatePhase(phase GatePhase) error {
+	if phase != GatePhaseBaseline && phase != GatePhaseCheckpoint {
+		return fmt.Errorf("unsupported gate result phase %q", phase)
+	}
+	return nil
+}
+
 // ClaimLifecycleNotification atomically claims the right to send one terminal
 // notification, returning true if the claim succeeded (caller should send),
 // false if the claim already exists (notification already sent or being sent).
@@ -923,12 +1147,34 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 			}
 		case 11:
 			if _, err := tx.ExecContext(ctx, `CREATE TABLE lifecycle_notifications (
-				run_id TEXT NOT NULL,
-				terminal_status TEXT NOT NULL,
-				created_at TEXT NOT NULL,
-				PRIMARY KEY (run_id, terminal_status)
-			)`); err != nil {
+					run_id TEXT NOT NULL,
+					terminal_status TEXT NOT NULL,
+					created_at TEXT NOT NULL,
+					PRIMARY KEY (run_id, terminal_status)
+				)`); err != nil {
 				return fmt.Errorf("apply store migration 11: %w", err)
+			}
+		case 12:
+			if _, err := tx.ExecContext(ctx, `CREATE TABLE gate_results (
+					run_id TEXT NOT NULL,
+					checkpoint_sha TEXT NOT NULL,
+					phase TEXT NOT NULL,
+					ordinal INTEGER NOT NULL,
+					gate_name TEXT NOT NULL,
+					outcome TEXT NOT NULL,
+					status TEXT NOT NULL,
+					blocking INTEGER NOT NULL,
+					skip_reason TEXT NOT NULL DEFAULT '',
+					setup_fingerprint TEXT NOT NULL DEFAULT '',
+					created_at TEXT NOT NULL,
+					updated_at TEXT NOT NULL,
+					PRIMARY KEY (run_id, checkpoint_sha, phase, gate_name)
+				)`); err != nil {
+				return fmt.Errorf("apply store migration 12: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `CREATE INDEX gate_results_by_run
+					ON gate_results (run_id, phase, checkpoint_sha, ordinal)`); err != nil {
+				return fmt.Errorf("apply store migration 12 index: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -735,15 +735,17 @@ func (s *Store) SaveGateResults(ctx context.Context, results []GateResult) error
 	if len(results) == 0 {
 		return errors.New("at least one gate result is required")
 	}
+	for _, result := range results {
+		if err := validateGateResult(result); err != nil {
+			return err
+		}
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin gate-result save: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 	for _, result := range results {
-		if err := validateGateResult(result); err != nil {
-			return err
-		}
 		createdAt := result.CreatedAt
 		if createdAt.IsZero() {
 			createdAt = time.Now().UTC()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -280,6 +280,44 @@ func TestOpenReopensAnExistingCurrentVersionStoreWithoutCreatingABackup(t *testi
 	}
 }
 
+// TestGateResultsSurviveReopenAndRemainKeyedByPhaseAndCheckpoint verifies
+// deterministic results cannot be reused after the evaluated commit changes.
+func TestGateResultsSurviveReopenAndRemainKeyedByPhaseAndCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstSHA := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	secondSHA := "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	if err := opened.SaveGateResults(context.Background(), []store.GateResult{
+		{RunID: "run-gates", CheckpointSHA: firstSHA, Phase: store.GatePhaseBaseline, Ordinal: 0, GateName: "format", Outcome: store.GateOutcomePassed, Status: "success", Blocking: true, SetupFingerprint: "deps-a"},
+		{RunID: "run-gates", CheckpointSHA: firstSHA, Phase: store.GatePhaseCheckpoint, Ordinal: 0, GateName: "format", Outcome: store.GateOutcomeFailed, Status: "failure", Blocking: true, SetupFingerprint: "deps-a"},
+		{RunID: "run-gates", CheckpointSHA: secondSHA, Phase: store.GatePhaseCheckpoint, Ordinal: 0, GateName: "format", Outcome: store.GateOutcomePassed, Status: "success", Blocking: true, SetupFingerprint: "deps-b"},
+	}); err != nil {
+		_ = opened.Close()
+		t.Fatalf("SaveGateResults() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.GateResults(context.Background(), "run-gates", store.GatePhaseCheckpoint, secondSHA)
+	if err != nil {
+		t.Fatalf("GateResults() error = %v", err)
+	}
+	if len(got) != 1 || got[0].GateName != "format" || got[0].Outcome != store.GateOutcomePassed || got[0].SetupFingerprint != "deps-b" {
+		t.Fatalf("GateResults() = %#v, want only the second checkpoint result", got)
+	}
+}
+
 // TestRunTerminalProjectionSurvivesStoreReopen verifies merge and lifecycle
 // metadata remain available to status after a terminal transition.
 func TestRunTerminalProjectionSurvivesStoreReopen(t *testing.T) {

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -46,8 +46,8 @@ const (
 )
 
 // EnvironmentPolicy controls which explicit environment a worker command may
-// receive. Clean commands are used for coordinator setup and gates; role
-// commands additionally identify the workflow role that owns the invocation.
+// receive. The repository config selects clean or role for setup and gates;
+// role commands additionally identify the workflow role that owns invocation.
 type EnvironmentPolicy string
 
 const (


### PR DESCRIPTION
## Summary

- run one frozen baseline suite before agent startup and block unhealthy baselines unless explicitly targeted
- execute ordered configured suites with independent continuation, dependency skips, typed setup/timeout outcomes, and one setup per fingerprint
- persist exact phase/checkpoint gate results and enforce checkpoint/baseline handoff boundaries

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added baseline preflight checks before agent work begins.
  * Added configurable setup files and clean or role-specific execution environments.
  * Added dependency-aware gate suites with passed, failed, skipped, and setup-failure outcomes.
  * Added setup reuse when dependency inputs are unchanged.
  * Added durable gate-result tracking by phase and checkpoint.

* **Bug Fixes**
  * Prevented gate execution when the working copy no longer matches its recorded checkpoint.
  * Issue execution now reports baseline gate counts and fails clearly when preflight checks fail.

* **Documentation**
  * Documented baseline evaluation, setup fingerprints, configuration options, and gate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->