### PR TITLE
feat: add local evaluation summaries

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,5 +102,7 @@ Checked-in `factory.yaml` that declares the repository's target branch, setup, d
 _Avoid_: Host configuration
 
 **Operational store**:
-The versioned, host-local SQLite store for current run state. It is separate from repository configuration, disposable run artifacts, and local evaluation summaries.
+The versioned, host-local SQLite store for current run state. Its current-state
+tables are separate from repository configuration, disposable run artifacts,
+and the isolated local evaluation-summary projection.
 _Avoid_: Event journal, telemetry, transcript archive

--- a/docs/adr/0001-local-evaluation-without-outbound-telemetry.md
+++ b/docs/adr/0001-local-evaluation-without-outbound-telemetry.md
@@ -8,4 +8,11 @@ The factory stores content-free local evaluation summaries because retry ceiling
 
 Local evaluation summaries are distinct from current operational state and disposable run artifacts. They may retain stage durations, invocation and attempt counts, harness and version identifiers, exhaustion and escalation reasons, available usage estimates, and explicit human dispositions. Their retention and deletion are locally controlled and documented.
 
+The distinction is logical and enforced by the data model: summaries use their
+own projection and isolated usage/disposition tables and APIs, and never add
+work content to current-state, invocation, gate, or artifact records. Keeping
+the projection in the same private versioned SQLite file preserves one
+migration backup and fail-closed schema boundary without making the summary an
+operational-state field.
+
 This accepts a small amount of durable local metadata in exchange for an evidence-based rollout. The measured pilot must use these summaries before the objection cycle, concurrent dual review, and full review-repair loop are treated as justified product complexity.

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -85,6 +85,12 @@ The three valid proposals are:
 - `needs_clarification`, with one or more uniquely identified questions;
 - `cannot_proceed`, with concise observable evidence.
 
+When the harness has reliable measurements or content-free policy signals, it
+may also pass `--input-tokens`, `--output-tokens`, `--total-tokens`,
+`--cost-micros` with `--cost-currency`, `--budget-exhausted`, and repeated
+fixed-category `--exemption`, `--escalation`, or `--blocker` flags. Omitting
+usage leaves it explicitly unavailable; the coordinator never estimates it.
+
 Terminal rendering, scrollback, and screen text are never parsed for stage
 completion. A report is a proposal; only coordinator validation changes the
 run or invocation state.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,9 +106,11 @@ worker_build:
 base_synchronization:
   mode: before_ready
   branch: main
+evaluation:
+  retention: 720h
 ```
 
-The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies, positive durations, positive retry limits, test policy, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, and base-synchronization mode. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
+The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies, positive durations, positive retry limits, test policy, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, base-synchronization mode, and optional positive `evaluation.retention`. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
 
 ## Worker image build and digest pinning
 
@@ -360,6 +362,20 @@ remove the run's local worktree and operational database after inspection.
 
 The operational store contains current workflow state, the active run's frozen specification packet, the status-comment identity needed by later transitions, and the draft pull-request identity needed for idempotent regeneration. Registration and status both reject paths that resolve inside the repository checkout, including symlink aliases; its directory is private (`0700`) and the SQLite file is private (`0600`). A fresh store is initialized directly; an older supported schema is copied to a timestamped `.bak-*` file before its explicit migration runs. Migration backups are not pruned automatically in this foundation; issue #23 owns the visible cleanup and retention policy. A newer or unversioned database refuses to open. There is no silent guessing or destructive migration. GitHub credentials are never columns in this store.
 
-Issue #25 will add separate content-free local evaluation summaries. Those summaries remain local and are not outbound telemetry.
+Issue #25 adds a logically separate `evaluation_summaries` projection inside
+the same versioned SQLite store, plus isolated usage and disposition tables. It stores
+only bounded metadata, counts, durations, fixed categories, hashed human-event
+identities, and reliable harness-reported numeric usage. It never copies issue
+or specification text, prompts, transcripts, diffs, source contents, command
+output, logs, or credentials. Existing stores migrate with the normal private
+`.bak-*` backup and newer schemas still fail closed.
+
+The checked-in `evaluation.retention` duration is an explicit operator policy
+for choosing a cutoff; the factory never deletes summaries automatically. Use
+`factory evaluation` for a local report, `factory evaluation-disposition` to
+attach a human classification, and the separately confirmed
+`factory evaluation-delete --before <RFC3339> --confirm` command to remove only
+selected terminal summaries. Ordinary run-artifact cleanup does not touch this
+projection.
 
 The high-level `Factory` seam injects configuration, repository checking, GitHub, pull requests, `GitWorkspace`, worker, terminal, harness, clock, run-identity, and operational-store adapters. Foundation tests use a real temporary SQLite store and fake the external repository/configuration boundary; issue #4 adds focused fake-adapter tests for the claim seam and a real temporary Git repository test for worktree isolation. Issue #5 owns the `WorkerRuntime` adapter and coordinator worker ownership; issue #6 adds the portable `TerminalRuntime`, Codex harness, invocation packet, and structured report boundary; issue #7 adds host checkpoint, push, and draft-PR orchestration.

--- a/factory.yaml
+++ b/factory.yaml
@@ -61,3 +61,5 @@ worker_build:
   definition: worker/Dockerfile
 base_synchronization:
   mode: never
+evaluation:
+  retention: ""

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/factory"
@@ -35,6 +36,9 @@ var commandTable = []commandDefinition{
 	{name: "draft-pr", handler: runDraftPullRequest},
 	{name: "poll", handler: runPollCommands},
 	{name: "status", handler: runStatus},
+	{name: "evaluation", handler: runEvaluation},
+	{name: "evaluation-delete", handler: runEvaluationDelete},
+	{name: "evaluation-disposition", handler: runEvaluationDisposition},
 }
 
 // Run dispatches the requested CLI command and returns its exit status.
@@ -446,6 +450,146 @@ func runStatus(ctx context.Context, args []string, defaultConfigPath string, out
 				return 1
 			}
 		}
+	}
+	return 0
+}
+
+// runEvaluation reports retained per-run summaries and local aggregate values
+// without making a network call or displaying work content.
+func runEvaluation(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("evaluation", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "one opaque evaluation run identifier")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("evaluation does not accept positional arguments"))
+		return 2
+	}
+	result, err := factory.New(*configPath).EvaluationReport(ctx, factory.EvaluationReportRequest{RunID: *runID})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "evaluation summaries: %d\n", len(result.Summaries)) {
+		return 1
+	}
+	if result.Retention == "" {
+		if !writeOutput(output, errorsOutput, "retention: explicit deletion only\n") {
+			return 1
+		}
+	} else if !writeOutput(output, errorsOutput, "retention: %s (deletion remains explicit)\n", result.Retention) {
+		return 1
+	}
+	for _, summary := range result.Summaries {
+		if !writeOutput(output, errorsOutput, "run: %s outcome=%s started=%s completed=%s wall=%s stages=%v versions=%v invocations=%d gates=%d check_repairs=%d test_revisions=%d review_revisions=%d budget_exhausted=%t exemptions=%v escalations=%v blockers=%v usage_available=%t\n", summary.RunID, summary.Outcome, summary.StartedAt.Format(time.RFC3339Nano), summary.CompletedAt.Format(time.RFC3339Nano), summary.TotalWallTime, summary.StageDurations, summary.InvocationVersions, summary.InvocationCount, summary.GateCount, summary.CheckRepairCount, summary.TestRevisionCount, summary.ReviewRevisionCount, summary.BudgetExhausted, summary.Exemptions, summary.EscalationCategories, summary.RepeatedBlockers, summary.Usage.Available) {
+			return 1
+		}
+		if summary.Usage.Available {
+			if !writeOutput(output, errorsOutput, "run usage: run=%s input_tokens=%d output_tokens=%d total_tokens=%d cost_reported=%t cost_micros=%d currency=%s cost_status=%s\n", summary.RunID, summary.Usage.InputTokens, summary.Usage.OutputTokens, summary.Usage.TotalTokens, summary.Usage.CostReported, summary.Usage.CostMicros, summary.Usage.Currency, evaluationCostStatus(summary.Usage)) {
+				return 1
+			}
+		} else if !writeOutput(output, errorsOutput, "run usage: run=%s unavailable (%s)\n", summary.RunID, summary.Usage.UnavailableReason) {
+			return 1
+		}
+	}
+	aggregate := result.Aggregate
+	if !writeOutput(output, errorsOutput, "aggregate: runs=%d outcomes=%v outcome_rates=%v success_rate=%.4f budget_exhaustion_rate=%.4f total_wall=%s average_wall=%s stages=%v invocations=%d gates=%d check_repairs=%d test_revisions=%d review_revisions=%d escalations=%v escalation_rates=%v dispositions=%v usage_available_runs=%d usage_cost_reported_runs=%d\n", aggregate.RunCount, aggregate.OutcomeCounts, aggregate.OutcomeRates, aggregate.SuccessRate, aggregate.BudgetExhaustionRate, aggregate.TotalWallTime, aggregate.AverageTotalWallTime, aggregate.StageDurations, aggregate.InvocationCount, aggregate.GateCount, aggregate.CheckRepairCount, aggregate.TestRevisionCount, aggregate.ReviewRevisionCount, aggregate.EscalationCounts, aggregate.EscalationRates, aggregate.DispositionCounts, aggregate.UsageAvailableRuns, aggregate.UsageCostReportedRuns) {
+		return 1
+	}
+	if aggregate.Usage.Available {
+		if !writeOutput(output, errorsOutput, "aggregate usage: input_tokens=%d output_tokens=%d total_tokens=%d cost_reported=%t cost_micros=%d currency=%s cost_status=%s\n", aggregate.Usage.InputTokens, aggregate.Usage.OutputTokens, aggregate.Usage.TotalTokens, aggregate.Usage.CostReported, aggregate.Usage.CostMicros, aggregate.Usage.Currency, evaluationCostStatus(aggregate.Usage)) {
+			return 1
+		}
+	} else if !writeOutput(output, errorsOutput, "aggregate usage: unavailable (%s)\n", aggregate.Usage.UnavailableReason) {
+		return 1
+	}
+	return 0
+}
+
+// evaluationCostStatus renders whether aggregate cost was reported or why it
+// remains unavailable, independently of token availability.
+func evaluationCostStatus(usage store.EvaluationUsage) string {
+	if usage.CostReported {
+		return "reported"
+	}
+	if usage.UnavailableReason == "" {
+		return "not_reported"
+	}
+	return "unavailable:" + usage.UnavailableReason
+}
+
+// runEvaluationDelete performs deliberate, visible deletion of selected
+// terminal evaluation summaries and requires an explicit confirmation flag.
+func runEvaluationDelete(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("evaluation-delete", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	before := flags.String("before", "", "RFC3339 cutoff; only terminal summaries before it are deleted")
+	confirm := flags.Bool("confirm", false, "confirm deliberate deletion of evaluation summaries")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("evaluation-delete does not accept positional arguments"))
+		return 2
+	}
+	if !*confirm {
+		writeError(errorsOutput, errors.New("evaluation-delete requires --confirm"))
+		return 2
+	}
+	cutoff, err := time.Parse(time.RFC3339Nano, *before)
+	if err != nil {
+		writeError(errorsOutput, errors.New("evaluation-delete requires --before as an RFC3339 timestamp"))
+		return 2
+	}
+	result, err := factory.New(*configPath).DeleteEvaluation(ctx, factory.EvaluationDeleteRequest{Before: cutoff})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "deleted evaluation summaries: %d (dispositions=%d usage=%d cutoff=%s)\n", result.Deleted.Summaries, result.Deleted.Dispositions, result.Deleted.UsageRows, result.Before.Format(time.RFC3339Nano)) {
+		return 1
+	}
+	return 0
+}
+
+// runEvaluationDisposition attaches one explicit human disposition to a
+// test-dispute or review-finding escalation without retaining finding text.
+func runEvaluationDisposition(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("evaluation-disposition", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "evaluation run identifier")
+	eventID := flags.String("event-id", "", "opaque escalation identity; it is hashed before persistence")
+	category := flags.String("category", "", "test_dispute or review_finding")
+	disposition := flags.String("disposition", "", "upheld, advisory, or overturned")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("evaluation-disposition does not accept positional arguments"))
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" || strings.TrimSpace(*eventID) == "" || strings.TrimSpace(*category) == "" || strings.TrimSpace(*disposition) == "" {
+		writeError(errorsOutput, errors.New("evaluation-disposition requires --run-id, --event-id, --category, and --disposition"))
+		return 2
+	}
+	result, err := factory.New(*configPath).AttachEvaluationDisposition(ctx, factory.EvaluationDispositionRequest{
+		RunID:       *runID,
+		EventID:     *eventID,
+		Category:    store.EvaluationEscalationCategory(*category),
+		Disposition: store.EvaluationDisposition(*disposition),
+		DecidedAt:   time.Now().UTC(),
+	})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "evaluation disposition recorded: run=%s category=%s disposition=%s event_id_hash=%s\n", result.Disposition.RunID, result.Disposition.Category, result.Disposition.Disposition, result.Disposition.EventIDHash) {
+		return 1
 	}
 	return 0
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,8 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/cli"
+	"github.com/Stevie1704/sw-factory/internal/store"
 )
 
 func TestRunInitializesRegistersAndReportsStatus(t *testing.T) {
@@ -370,6 +372,65 @@ func TestRunStatusReportsNoRegisteredRepository(t *testing.T) {
 	}
 	if !strings.Contains(output.String(), "config: "+configPath) {
 		t.Fatalf("output = %q, want it to report the config path", output.String())
+	}
+}
+
+// TestRunEvaluationReportsAndDeliberatelyDeletesLocalSummaries verifies the
+// user-facing local report and explicit deletion commands do not need GitHub.
+func TestRunEvaluationReportsAndDeliberatelyDeletesLocalSummaries(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	configPath := filepath.Join(root, "config.yaml")
+	repositoryPath := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeValidRepositoryConfig(t, repositoryPath)
+	var output bytes.Buffer
+	if code := cli.Run(context.Background(), []string{"init", "--config", configPath}, &output, &output); code != 0 {
+		t.Fatalf("init exit code = %d, output = %s", code, output.String())
+	}
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	output.Reset()
+	if code := cli.Run(context.Background(), []string{"register", "--config", configPath, "--repository", repositoryPath, "--github-owner", "example", "--github-repository", "project", "--authorized-user", "alice", "--operational-data", operationalPath}, &output, &output); code != 0 {
+		t.Fatalf("register exit code = %d, output = %s", code, output.String())
+	}
+	opened, err := store.Open(context.Background(), operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	if err := opened.EnsureEvaluationSummary(context.Background(), store.Run{ID: "run-cli-evaluation", RepositoryPath: repositoryPath, Stage: store.StageClaim, Status: store.StatusActive, CreatedAt: started, UpdatedAt: started}); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.FinalizeEvaluation(context.Background(), "run-cli-evaluation", store.EvaluationOutcomeComplete, started.Add(time.Hour)); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	output.Reset()
+	if code := cli.Run(context.Background(), []string{"evaluation", "--config", configPath}, &output, &output); code != 0 {
+		t.Fatalf("evaluation exit code = %d, output = %s", code, output.String())
+	}
+	if !strings.Contains(output.String(), "evaluation summaries: 1") || !strings.Contains(output.String(), "aggregate: runs=1") || !strings.Contains(output.String(), "success_rate=1.0000") {
+		t.Fatalf("evaluation output = %q, want per-run and aggregate report", output.String())
+	}
+
+	output.Reset()
+	cutoff := started.Add(2 * time.Hour).Format(time.RFC3339Nano)
+	if code := cli.Run(context.Background(), []string{"evaluation-delete", "--config", configPath, "--before", cutoff}, &output, &output); code != 2 || !strings.Contains(output.String(), "--confirm") {
+		t.Fatalf("unconfirmed deletion exit/output = %d/%q, want explicit confirmation error", code, output.String())
+	}
+	output.Reset()
+	if code := cli.Run(context.Background(), []string{"evaluation-delete", "--config", configPath, "--before", cutoff, "--confirm"}, &output, &output); code != 0 {
+		t.Fatalf("confirmed deletion exit code = %d, output = %s", code, output.String())
+	}
+	if !strings.Contains(output.String(), "deleted evaluation summaries: 1") {
+		t.Fatalf("deletion output = %q, want one deleted summary", output.String())
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,17 @@ type RepositoryConfig struct {
 	Caches                 []CacheConfig       `yaml:"caches"`
 	WorkerBuild            WorkerBuildConfig   `yaml:"worker_build"`
 	BaseSynchronization    BaseSynchronization `yaml:"base_synchronization"`
+	// Evaluation controls explicit local evaluation-summary retention. A blank
+	// value retains summaries until a deliberate deletion command is run.
+	Evaluation EvaluationConfig `yaml:"evaluation"`
+}
+
+// EvaluationConfig contains repository-declared retention policy for the
+// separate content-free local evaluation projection.
+type EvaluationConfig struct {
+	// Retention is a positive Go duration used by operators when selecting
+	// deliberate deletion cutoffs; the coordinator never deletes automatically.
+	Retention string `yaml:"retention"`
 }
 
 type EnvironmentPolicy string
@@ -462,6 +473,11 @@ func ValidateRepository(config RepositoryConfig) error {
 	}
 	if config.BaseSynchronization.Mode == BaseSynchronizationBeforeReady && strings.TrimSpace(config.BaseSynchronization.Branch) == "" {
 		return validation("base_synchronization.branch", "is required when synchronization is enabled")
+	}
+	if strings.TrimSpace(config.Evaluation.Retention) != "" {
+		if err := validateDuration("evaluation.retention", config.Evaluation.Retention, false); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -188,6 +188,26 @@ func TestValidateRepositoryRejectsInvalidSetupEnvironmentPolicy(t *testing.T) {
 	}
 }
 
+// TestValidateRepositoryAcceptsExplicitEvaluationRetention verifies local
+// evaluation retention is optional but, when present, must be a positive
+// duration.
+func TestValidateRepositoryAcceptsExplicitEvaluationRetention(t *testing.T) {
+	t.Parallel()
+
+	policy := validRepositoryConfig()
+	policy.Evaluation.Retention = "720h"
+	if err := config.ValidateRepository(policy); err != nil {
+		t.Fatalf("ValidateRepository() error = %v, want valid evaluation retention", err)
+	}
+
+	policy.Evaluation.Retention = "0s"
+	err := config.ValidateRepository(policy)
+	var validationErr *config.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Field != "evaluation.retention" {
+		t.Fatalf("ValidateRepository() error = %v, want evaluation.retention validation", err)
+	}
+}
+
 func TestLoadHostRejectsTheOffendingField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -267,6 +267,14 @@ func (s *Service) StartAgent(ctx context.Context, request AgentRequest) (result 
 		return AgentLaunchResult{}, fmt.Errorf("persist visible invocation: %w", err)
 	}
 	invocationPersisted = true
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recorder.EnsureEvaluationSummary(ctx, *run); err != nil {
+			return AgentLaunchResult{}, fmt.Errorf("ensure local evaluation summary: %w", err)
+		}
+		if err := recorder.RecordEvaluationInvocation(ctx, run.ID, invocation, run.ImageDigest, report.SchemaVersion); err != nil {
+			return AgentLaunchResult{}, fmt.Errorf("record local evaluation invocation: %w", err)
+		}
+	}
 	credentialStoreID := ""
 	if authPath != "" {
 		credentialStoreID = registration.Path
@@ -428,6 +436,54 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	}
 	if err := report.Validate(value, validationContext); err != nil {
 		return AgentResult{}, err
+	}
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recorder.EnsureEvaluationSummary(ctx, *run); err != nil {
+			return AgentResult{}, fmt.Errorf("ensure local evaluation summary: %w", err)
+		}
+		if value.BudgetExhausted {
+			if err := recorder.RecordEvaluationBudgetExhaustion(ctx, run.ID); err != nil {
+				return AgentResult{}, fmt.Errorf("record local evaluation budget exhaustion: %w", err)
+			}
+		}
+		for _, exemption := range value.Exemptions {
+			if err := recorder.RecordEvaluationExemption(ctx, run.ID, store.EvaluationExemption(exemption)); err != nil {
+				return AgentResult{}, fmt.Errorf("record local evaluation exemption: %w", err)
+			}
+		}
+		for _, escalation := range value.Escalations {
+			if err := recorder.RecordEvaluationEscalation(ctx, run.ID, store.EvaluationEscalationCategory(escalation)); err != nil {
+				return AgentResult{}, fmt.Errorf("record local evaluation escalation: %w", err)
+			}
+		}
+		for _, blocker := range value.Blockers {
+			if err := recorder.RecordEvaluationBlocker(ctx, run.ID, store.EvaluationBlockerCategory(blocker)); err != nil {
+				return AgentResult{}, fmt.Errorf("record local evaluation blocker: %w", err)
+			}
+		}
+		if value.Usage != nil {
+			if err := recorder.RecordEvaluationUsage(ctx, run.ID, invocation.ID, store.EvaluationUsage{
+				Available:    value.Usage.Available,
+				InputTokens:  value.Usage.InputTokens,
+				OutputTokens: value.Usage.OutputTokens,
+				TotalTokens:  value.Usage.TotalTokens,
+				CostReported: value.Usage.CostReported,
+				CostMicros:   value.Usage.CostMicros,
+				Currency:     value.Usage.Currency,
+			}); err != nil {
+				return AgentResult{}, fmt.Errorf("record local evaluation usage: %w", err)
+			}
+		}
+		switch value.Outcome {
+		case report.OutcomeNeedsClarification:
+			if err := recorder.RecordEvaluationEscalation(ctx, run.ID, store.EvaluationEscalationClarification); err != nil {
+				return AgentResult{}, fmt.Errorf("record local evaluation clarification: %w", err)
+			}
+		case report.OutcomeCannotProceed:
+			if err := recorder.RecordEvaluationEscalation(ctx, run.ID, store.EvaluationEscalationBlocked); err != nil {
+				return AgentResult{}, fmt.Errorf("record local evaluation blocker escalation: %w", err)
+			}
+		}
 	}
 	_, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath)
 	if err != nil {

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -207,6 +207,12 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 	if err := runStore.SaveRun(ctx, run); err != nil {
 		return IssueResult{}, cleanupWorkspace(fmt.Errorf("persist frozen specification packet: %w", err))
 	}
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recorder.EnsureEvaluationSummary(ctx, run); err != nil {
+			_, failureErr := s.failClaim(ctx, runStore, run, repository, issue, fmt.Errorf("persist local evaluation summary: %w", err))
+			return IssueResult{}, cleanupWorkspace(failureErr)
+		}
+	}
 
 	run, err = s.applyStateTransition(ctx, runStore, stateTransition{
 		Repository:    repository,
@@ -294,6 +300,11 @@ func (s *Service) applyStateTransition(ctx context.Context, runStore RunStore, t
 		if err := saveCommandRun(ctx, runStore, transition.Previous.Revision, next); err != nil {
 			return next, fmt.Errorf("persist state transition before GitHub effects: %w", err)
 		}
+		if recorder, ok := runStore.(evaluationRecorder); ok {
+			if err := recordEvaluationTransition(ctx, recorder, transition.Previous, next, next.UpdatedAt); err != nil {
+				return next, fmt.Errorf("record evaluation state transition: %w", err)
+			}
+		}
 	}
 	oldLabels := append([]string(nil), transition.Issue.Labels...)
 	newLabels := replaceFactoryState(oldLabels, factoryLabelForStatus(next.Status))
@@ -328,6 +339,11 @@ func (s *Service) applyStateTransition(ctx context.Context, runStore RunStore, t
 			return next, errors.Join(append([]error{fmt.Errorf("persist state transition: %w", err)}, compensationErrors...)...)
 		}
 		return next, fmt.Errorf("persist claim state: %w", err)
+	}
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recordEvaluationTransition(ctx, recorder, transition.Previous, next, next.UpdatedAt); err != nil {
+			return next, fmt.Errorf("record evaluation state transition: %w", err)
+		}
 	}
 	return next, nil
 }
@@ -517,6 +533,13 @@ func (s *Service) failClaim(ctx context.Context, runStore RunStore, run store.Ru
 	}
 	if err := runStore.SaveRun(ctx, run); err != nil {
 		compensationErrors = append(compensationErrors, fmt.Errorf("persist failed claim: %w", err))
+	}
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recorder.EnsureEvaluationSummary(ctx, run); err != nil {
+			compensationErrors = append(compensationErrors, fmt.Errorf("ensure failed-claim evaluation summary: %w", err))
+		} else if err := recorder.FinalizeEvaluation(ctx, run.ID, store.EvaluationOutcomeFailed, run.UpdatedAt); err != nil {
+			compensationErrors = append(compensationErrors, fmt.Errorf("finalize failed-claim evaluation summary: %w", err))
+		}
 	}
 	for _, compensationErr := range compensationErrors {
 		if compensationErr != nil {

--- a/internal/factory/evaluation.go
+++ b/internal/factory/evaluation.go
@@ -1,0 +1,236 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// EvaluationReadStore is the local, network-free reporting seam for retained
+// evaluation summaries and their aggregate projection.
+type EvaluationReadStore interface {
+	OperationalStore
+	ListEvaluationSummaries(context.Context, string) ([]store.EvaluationSummary, error)
+	AggregateEvaluation(context.Context) (store.EvaluationAggregate, error)
+	DeleteEvaluationSummariesBefore(context.Context, time.Time) (store.EvaluationDeletionResult, error)
+}
+
+// EvaluationDispositionStore is the local mutation seam for human
+// classifications of already-recorded escalations.
+type EvaluationDispositionStore interface {
+	EvaluationReadStore
+	SaveEvaluationDisposition(context.Context, store.EvaluationDispositionRequest) (store.EvaluationDispositionRecord, error)
+}
+
+// EvaluationReportRequest selects all retained summaries or one opaque run.
+type EvaluationReportRequest struct {
+	RunID string
+}
+
+// EvaluationReportResult contains per-run summaries, aggregate values, and the
+// configured retention declaration used by the operator.
+type EvaluationReportResult struct {
+	Summaries []store.EvaluationSummary
+	Aggregate store.EvaluationAggregate
+	Retention string
+}
+
+// EvaluationDeleteRequest selects a deliberate terminal-summary cutoff.
+type EvaluationDeleteRequest struct {
+	Before time.Time
+}
+
+// EvaluationDeleteResult reports only the local rows removed by explicit
+// evaluation-summary deletion.
+type EvaluationDeleteResult struct {
+	Deleted store.EvaluationDeletionResult
+	Before  time.Time
+}
+
+// EvaluationDispositionRequest selects one opaque escalated event and its
+// human classification.
+type EvaluationDispositionRequest struct {
+	RunID       string
+	EventID     string
+	Category    store.EvaluationEscalationCategory
+	Disposition store.EvaluationDisposition
+	DecidedAt   time.Time
+}
+
+// EvaluationDispositionResult contains the hashed, persisted disposition.
+type EvaluationDispositionResult struct {
+	Disposition store.EvaluationDispositionRecord
+}
+
+// EvaluationReport reads summaries and aggregates without contacting GitHub or
+// any other network service.
+func (s *Service) EvaluationReport(ctx context.Context, request EvaluationReportRequest) (EvaluationReportResult, error) {
+	registration, reader, closeStore, err := s.openEvaluationReader(ctx)
+	if err != nil {
+		return EvaluationReportResult{}, err
+	}
+	defer func() { _ = closeStore() }()
+	summaries, err := reader.ListEvaluationSummaries(ctx, request.RunID)
+	if err != nil {
+		return EvaluationReportResult{}, err
+	}
+	aggregate, err := reader.AggregateEvaluation(ctx)
+	if err != nil {
+		return EvaluationReportResult{}, err
+	}
+	retention := ""
+	if registration.RepositoryConfigPath != "" {
+		repositoryConfig, loadErr := s.deps.LoadRepository(registration.RepositoryConfigPath)
+		if loadErr != nil {
+			return EvaluationReportResult{}, fmt.Errorf("load repository evaluation retention: %w", loadErr)
+		}
+		retention = repositoryConfig.Evaluation.Retention
+	}
+	return EvaluationReportResult{Summaries: summaries, Aggregate: aggregate, Retention: retention}, nil
+}
+
+// DeleteEvaluation removes only terminal evaluation summaries before an
+// explicit cutoff. It is intentionally separate from ordinary run-artifact
+// cleanup and does not infer a cutoff from configuration.
+func (s *Service) DeleteEvaluation(ctx context.Context, request EvaluationDeleteRequest) (EvaluationDeleteResult, error) {
+	if request.Before.IsZero() {
+		return EvaluationDeleteResult{}, errors.New("evaluation deletion requires an explicit cutoff")
+	}
+	_, reader, closeStore, err := s.openEvaluationReader(ctx)
+	if err != nil {
+		return EvaluationDeleteResult{}, err
+	}
+	defer func() { _ = closeStore() }()
+	deleted, err := reader.DeleteEvaluationSummariesBefore(ctx, request.Before)
+	if err != nil {
+		return EvaluationDeleteResult{}, err
+	}
+	return EvaluationDeleteResult{Deleted: deleted, Before: request.Before.UTC()}, nil
+}
+
+// AttachEvaluationDisposition adds an explicit human disposition while
+// persisting only a one-way event identity and fixed vocabulary.
+func (s *Service) AttachEvaluationDisposition(ctx context.Context, request EvaluationDispositionRequest) (EvaluationDispositionResult, error) {
+	_, reader, closeStore, err := s.openEvaluationReader(ctx)
+	if err != nil {
+		return EvaluationDispositionResult{}, err
+	}
+	defer func() { _ = closeStore() }()
+	writer, ok := reader.(EvaluationDispositionStore)
+	if !ok {
+		return EvaluationDispositionResult{}, errors.New("operational store does not support evaluation dispositions")
+	}
+	record, err := writer.SaveEvaluationDisposition(ctx, store.EvaluationDispositionRequest{
+		RunID:       request.RunID,
+		EventID:     request.EventID,
+		Category:    request.Category,
+		Disposition: request.Disposition,
+		DecidedAt:   request.DecidedAt,
+	})
+	if err != nil {
+		return EvaluationDispositionResult{}, err
+	}
+	return EvaluationDispositionResult{Disposition: record}, nil
+}
+
+// openEvaluationReader loads the registered repository and opens the local
+// operational database without invoking any external adapter.
+func (s *Service) openEvaluationReader(ctx context.Context) (config.RepositoryRegistration, EvaluationReadStore, func() error, error) {
+	registration, err := s.registration()
+	if err != nil {
+		return config.RepositoryRegistration{}, nil, func() error { return nil }, err
+	}
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return config.RepositoryRegistration{}, nil, func() error { return nil }, err
+	}
+	reader, ok := opened.(EvaluationReadStore)
+	if !ok {
+		_ = opened.Close()
+		return config.RepositoryRegistration{}, nil, func() error { return nil }, errors.New("operational store does not support local evaluation summaries")
+	}
+	return registration, reader, opened.Close, nil
+}
+
+// evaluationRecorder is the optional coordinator seam implemented by the real
+// SQLite store. Existing focused test doubles remain valid when they omit it.
+type evaluationRecorder interface {
+	EnsureEvaluationSummary(context.Context, store.Run) error
+	RecordEvaluationStageTransition(context.Context, string, store.Stage, store.Stage, time.Time) error
+	RecordEvaluationInvocation(context.Context, string, store.Invocation, string, int) error
+	RecordEvaluationAttempt(context.Context, string, store.EvaluationAttempt) error
+	RecordEvaluationExemption(context.Context, string, store.EvaluationExemption) error
+	RecordEvaluationEscalation(context.Context, string, store.EvaluationEscalationCategory) error
+	RecordEvaluationBlocker(context.Context, string, store.EvaluationBlockerCategory) error
+	RecordEvaluationBudgetExhaustion(context.Context, string) error
+	RecordEvaluationUsage(context.Context, string, string, store.EvaluationUsage) error
+	RefreshEvaluationCounts(context.Context, string) error
+	SetEvaluationOutcome(context.Context, string, store.EvaluationOutcome) error
+	FinalizeEvaluation(context.Context, string, store.EvaluationOutcome, time.Time) error
+	FinalizeEvaluationWithBudget(context.Context, string, store.EvaluationOutcome, time.Time, bool) error
+	ReopenEvaluation(context.Context, string, store.Stage, time.Time) error
+}
+
+// recordEvaluationTransition keeps the optional evaluation projection aligned
+// with a persisted run transition without making fake coordinator stores carry
+// the production SQLite surface.
+func recordEvaluationTransition(ctx context.Context, recorder evaluationRecorder, previous, next store.Run, at time.Time) error {
+	if recorder == nil {
+		return nil
+	}
+	if err := recorder.EnsureEvaluationSummary(ctx, next); err != nil {
+		return err
+	}
+	if store.IsTerminalStatus(previous.Status) && !store.IsTerminalStatus(next.Status) {
+		if err := recorder.ReopenEvaluation(ctx, next.ID, next.Stage, at); err != nil {
+			return err
+		}
+		if attempt := evaluationAttemptForRetry(next.Stage); attempt != "" {
+			if err := recorder.RecordEvaluationAttempt(ctx, next.ID, attempt); err != nil {
+				return err
+			}
+		}
+	}
+	if previous.Stage != "" && previous.Stage != next.Stage {
+		if err := recorder.RecordEvaluationStageTransition(ctx, next.ID, previous.Stage, next.Stage, at); err != nil {
+			return err
+		}
+	}
+	if !store.IsTerminalStatus(next.Status) {
+		if err := recorder.SetEvaluationOutcome(ctx, next.ID, evaluationOutcome(next.Status)); err != nil {
+			return err
+		}
+	}
+	if store.IsTerminalStatus(next.Status) {
+		if err := recorder.FinalizeEvaluation(ctx, next.ID, evaluationOutcome(next.Status), at); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// evaluationOutcome converts the operational status vocabulary to the local
+// evaluation vocabulary without retaining any additional state.
+func evaluationOutcome(status store.Status) store.EvaluationOutcome {
+	return store.EvaluationOutcome(status)
+}
+
+// evaluationAttemptForRetry maps an authorized terminal-run retry to the
+// workflow effort bucket it is revising. Preflight and implementation retries
+// have no more specific policy bucket and therefore remain unclassified.
+func evaluationAttemptForRetry(stage store.Stage) store.EvaluationAttempt {
+	switch stage {
+	case store.StageCheck:
+		return store.EvaluationAttemptCheckRepair
+	case store.StageTest:
+		return store.EvaluationAttemptTestRevision
+	case store.StageReview:
+		return store.EvaluationAttemptReviewRevision
+	default:
+		return ""
+	}
+}

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -46,6 +46,12 @@ type Factory interface {
 	PollCommands(context.Context, CommandPollRequest) ([]CommandResult, error)
 	// PollLifecycle observes merge and closure decisions for the current run.
 	PollLifecycle(context.Context, LifecycleRequest) (LifecycleResult, error)
+	// EvaluationReport reads content-free local evaluation summaries and aggregates.
+	EvaluationReport(context.Context, EvaluationReportRequest) (EvaluationReportResult, error)
+	// DeleteEvaluation deliberately removes selected terminal evaluation summaries.
+	DeleteEvaluation(context.Context, EvaluationDeleteRequest) (EvaluationDeleteResult, error)
+	// AttachEvaluationDisposition records an explicit human escalation disposition.
+	AttachEvaluationDisposition(context.Context, EvaluationDispositionRequest) (EvaluationDispositionResult, error)
 }
 
 // RunCoordinator is the single claim/state-transition seam used by the

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -134,6 +134,11 @@ func (s *Service) RunBaseline(ctx context.Context, request BaselineRequest) (Bas
 		return result, nil
 	}
 	if persistErr == nil && baselineFailureErrorTargeted(packet.Issue.Body, suite, suiteErr) {
+		if recorder, ok := runStore.(evaluationRecorder); ok {
+			if err := recorder.RecordEvaluationExemption(ctx, run.ID, store.EvaluationExemptionBaseline); err != nil {
+				return result, fmt.Errorf("record baseline evaluation exemption: %w", err)
+			}
+		}
 		return result, nil
 	}
 	effectiveErr := errors.Join(suiteErr, persistErr)
@@ -313,6 +318,11 @@ func persistGateSuite(ctx context.Context, runStore RunStore, run store.Run, sui
 	if !ok || len(suite.Gates) == 0 {
 		return nil
 	}
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recorder.EnsureEvaluationSummary(ctx, run); err != nil {
+			return fmt.Errorf("ensure local evaluation summary: %w", err)
+		}
+	}
 	results := make([]store.GateResult, 0, len(suite.Gates))
 	for ordinal, result := range suite.Gates {
 		results = append(results, store.GateResult{
@@ -328,7 +338,29 @@ func persistGateSuite(ctx context.Context, runStore RunStore, run store.Run, sui
 			SetupFingerprint: result.SetupFingerprint,
 		})
 	}
-	return resultStore.SaveGateResults(ctx, results)
+	if err := resultStore.SaveGateResults(ctx, results); err != nil {
+		return err
+	}
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recorder.RefreshEvaluationCounts(ctx, run.ID); err != nil {
+			return fmt.Errorf("refresh local evaluation counts: %w", err)
+		}
+		for _, result := range suite.Gates {
+			var category store.EvaluationBlockerCategory
+			switch result.Outcome {
+			case gate.OutcomeSetupFailed:
+				category = store.EvaluationBlockerSetup
+			case gate.OutcomeFailed, gate.OutcomeError, gate.OutcomeSkipped:
+				category = store.EvaluationBlockerGate
+			default:
+				continue
+			}
+			if err := recorder.RecordEvaluationBlocker(ctx, run.ID, category); err != nil {
+				return fmt.Errorf("record local evaluation blocker: %w", err)
+			}
+		}
+	}
+	return nil
 }
 
 // setupInputFingerprint hashes the configured manifest and lockfile contents

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -38,6 +38,7 @@ const (
 	maxPermittedPaths     = 128
 	maxQuestions          = 32
 	maxEvidenceEntries    = 32
+	maxEvaluationSignals  = 32
 )
 
 // ReportFileName is the only accepted report filename in an invocation result
@@ -94,6 +95,68 @@ type Evidence struct {
 	Detail string `json:"detail"`
 }
 
+// EscalationCategory identifies a content-free workflow escalation that a
+// harness may report for later human disposition.
+type EscalationCategory string
+
+const (
+	// EscalationTestDispute identifies a disputed deterministic test result.
+	EscalationTestDispute EscalationCategory = "test_dispute"
+	// EscalationReviewFinding identifies an escalated review finding.
+	EscalationReviewFinding EscalationCategory = "review_finding"
+)
+
+// Exemption identifies a content-free policy exemption reported by a harness.
+type Exemption string
+
+const (
+	// ExemptionHuman identifies a human-approved exemption.
+	ExemptionHuman Exemption = "human"
+	// ExemptionTechnical identifies an infrastructure exemption.
+	ExemptionTechnical Exemption = "technical"
+	// ExemptionBaseline identifies an accepted pre-existing baseline condition.
+	ExemptionBaseline Exemption = "baseline"
+)
+
+// BlockerCategory identifies a repeated content-free blocker class.
+type BlockerCategory string
+
+const (
+	// BlockerSetup identifies dependency setup blockage.
+	BlockerSetup BlockerCategory = "setup"
+	// BlockerGate identifies deterministic gate blockage.
+	BlockerGate BlockerCategory = "gate"
+	// BlockerTest identifies test-policy blockage.
+	BlockerTest BlockerCategory = "test"
+	// BlockerReview identifies review blockage.
+	BlockerReview BlockerCategory = "review"
+	// BlockerHarness identifies harness blockage.
+	BlockerHarness BlockerCategory = "harness"
+	// BlockerBudget identifies budget blockage.
+	BlockerBudget BlockerCategory = "budget"
+	// BlockerUnknown identifies an unavailable stable blocker class.
+	BlockerUnknown BlockerCategory = "unknown"
+)
+
+// Usage contains only reliable harness-reported measurements. It is optional;
+// an omitted value means the coordinator must retain usage as unavailable.
+type Usage struct {
+	// Available distinguishes reported measurements from an unavailable value.
+	Available bool `json:"available"`
+	// InputTokens is the reported input-token count, when supplied.
+	InputTokens int64 `json:"input_tokens,omitempty"`
+	// OutputTokens is the reported output-token count, when supplied.
+	OutputTokens int64 `json:"output_tokens,omitempty"`
+	// TotalTokens is the reported total-token count, when supplied.
+	TotalTokens int64 `json:"total_tokens,omitempty"`
+	// CostReported distinguishes a reported zero cost from no cost measurement.
+	CostReported bool `json:"cost_reported,omitempty"`
+	// CostMicros is the exact harness-reported cost in millionths of Currency.
+	CostMicros int64 `json:"cost_micros,omitempty"`
+	// Currency is the three-letter uppercase currency for CostMicros.
+	Currency string `json:"currency,omitempty"`
+}
+
 // Report is the schema-versioned proposal written by one invocation.
 type Report struct {
 	// SchemaVersion identifies this report envelope shape.
@@ -118,6 +181,16 @@ type Report struct {
 	Questions []Question `json:"questions,omitempty"`
 	// Evidence is required only for a cannot-proceed outcome.
 	Evidence []Evidence `json:"evidence,omitempty"`
+	// BudgetExhausted is an explicit harness signal, never inferred by the host.
+	BudgetExhausted bool `json:"budget_exhausted,omitempty"`
+	// Exemptions contains only fixed policy-exemption categories.
+	Exemptions []Exemption `json:"exemptions,omitempty"`
+	// Escalations contains only fixed human-disposition categories.
+	Escalations []EscalationCategory `json:"escalations,omitempty"`
+	// Blockers contains repeated fixed blocker categories without blocker text.
+	Blockers []BlockerCategory `json:"blockers,omitempty"`
+	// Usage is optional reliable usage or cost reported by the harness.
+	Usage *Usage `json:"usage,omitempty"`
 	// NativeSessionID is the harness-native continuation identifier, when known.
 	NativeSessionID string `json:"native_session_id,omitempty"`
 	// ReportedAt records when the harness published the proposal.
@@ -362,7 +435,82 @@ func Validate(value Report, context ValidationContext) error {
 	if value.NativeSessionID != "" && !safeIdentifier(value.NativeSessionID) {
 		return errors.New("native_session_id contains unsafe characters")
 	}
+	if value.Usage != nil {
+		if err := validateUsage(*value.Usage); err != nil {
+			return err
+		}
+	}
+	if err := validateEvaluationSignals(value); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateEvaluationSignals accepts only bounded categories and explicit
+// harness-provided budget state, keeping work content outside the report's
+// evaluation projection.
+func validateEvaluationSignals(value Report) error {
+	if len(value.Exemptions) > maxEvaluationSignals || len(value.Escalations) > maxEvaluationSignals || len(value.Blockers) > maxEvaluationSignals {
+		return errors.New("report evaluation signal count exceeds the limit")
+	}
+	for _, exemption := range value.Exemptions {
+		switch exemption {
+		case ExemptionHuman, ExemptionTechnical, ExemptionBaseline:
+		default:
+			return fmt.Errorf("unsupported report exemption %q", exemption)
+		}
+	}
+	for _, escalation := range value.Escalations {
+		switch escalation {
+		case EscalationTestDispute, EscalationReviewFinding:
+		default:
+			return fmt.Errorf("unsupported report escalation %q", escalation)
+		}
+	}
+	for _, blocker := range value.Blockers {
+		switch blocker {
+		case BlockerSetup, BlockerGate, BlockerTest, BlockerReview, BlockerHarness, BlockerBudget, BlockerUnknown:
+		default:
+			return fmt.Errorf("unsupported report blocker %q", blocker)
+		}
+	}
+	return nil
+}
+
+// validateUsage ensures a report never presents guessed or malformed harness
+// measurements as reliable usage or cost.
+func validateUsage(value Usage) error {
+	if !value.Available {
+		return errors.New("reported usage must be marked available")
+	}
+	if value.InputTokens < 0 || value.OutputTokens < 0 || value.TotalTokens < 0 || value.CostMicros < 0 {
+		return errors.New("reported usage values must not be negative")
+	}
+	if value.InputTokens == 0 && value.OutputTokens == 0 && value.TotalTokens == 0 && !value.CostReported {
+		return errors.New("reported usage must contain at least one measurement")
+	}
+	if value.CostReported {
+		if !validCurrency(value.Currency) {
+			return errors.New("reported cost requires a three-letter uppercase currency")
+		}
+	} else if value.CostMicros != 0 || value.Currency != "" {
+		return errors.New("reported cost metadata requires cost_reported")
+	}
+	return nil
+}
+
+// validCurrency accepts the bounded ISO-style identifier used for reported
+// cost metadata without accepting arbitrary content.
+func validCurrency(value string) bool {
+	if len(value) != 3 || strings.ToUpper(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if character < 'A' || character > 'Z' {
+			return false
+		}
+	}
+	return true
 }
 
 // validateHandoff checks handoff text, path safety, permitted prefixes, and

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -96,6 +96,67 @@ func TestValidateRejectsAReportThatDoesNotMatchTheInvocation(t *testing.T) {
 	}
 }
 
+// TestReportedUsageRoundTripsOnlyReliableMeasurements verifies optional
+// harness usage is accepted as numeric metadata and remains separate from the
+// ordinary human-readable handoff text.
+func TestReportedUsageRoundTripsOnlyReliableMeasurements(t *testing.T) {
+	want := completedReport()
+	want.Usage = &report.Usage{Available: true, InputTokens: 12, OutputTokens: 8, TotalTokens: 20, CostReported: true, CostMicros: 15, Currency: "USD"}
+	path, err := report.WriteAtomicForInvocation(filepath.Join(t.TempDir(), "results"), "inv-1", want)
+	if err != nil {
+		t.Fatalf("WriteAtomicForInvocation() error = %v", err)
+	}
+	got, err := report.Read(path)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got.Usage == nil || !got.Usage.Available || got.Usage.TotalTokens != 20 || got.Usage.CostMicros != 15 || got.Usage.Currency != "USD" {
+		t.Fatalf("usage = %#v, want reported numeric usage", got.Usage)
+	}
+}
+
+// TestReportedEvaluationSignalsRoundTripAsFixedMetadata verifies a harness can
+// report budget, escalation, exemption, and blocker categories without adding
+// finding or blocker text to the report envelope.
+func TestReportedEvaluationSignalsRoundTripAsFixedMetadata(t *testing.T) {
+	want := completedReport()
+	want.BudgetExhausted = true
+	want.Exemptions = []report.Exemption{report.ExemptionTechnical}
+	want.Escalations = []report.EscalationCategory{report.EscalationReviewFinding}
+	want.Blockers = []report.BlockerCategory{report.BlockerReview, report.BlockerReview}
+	path, err := report.WriteAtomicForInvocation(filepath.Join(t.TempDir(), "results"), "inv-1", want)
+	if err != nil {
+		t.Fatalf("WriteAtomicForInvocation() error = %v", err)
+	}
+	got, err := report.Read(path)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !got.BudgetExhausted || len(got.Exemptions) != 1 || len(got.Escalations) != 1 || len(got.Blockers) != 2 {
+		t.Fatalf("evaluation signals = %#v, want fixed metadata signals", got)
+	}
+}
+
+// TestValidateRejectsUnknownEvaluationSignals verifies report categories are
+// closed vocabularies rather than a path for arbitrary work content.
+func TestValidateRejectsUnknownEvaluationSignals(t *testing.T) {
+	value := completedReport()
+	value.Escalations = []report.EscalationCategory{"review finding text"}
+	if err := report.Validate(value, report.ValidationContext{InvocationID: "inv-1", RunID: "run-1", Harness: "codex", Role: "implementation", Stage: "implementation"}); err == nil || !strings.Contains(err.Error(), "unsupported report escalation") {
+		t.Fatalf("Validate() error = %v, want fixed escalation vocabulary error", err)
+	}
+}
+
+// TestValidateRejectsUnavailableReportedUsage verifies a report cannot disguise
+// an unavailable measurement as a reliable value.
+func TestValidateRejectsUnavailableReportedUsage(t *testing.T) {
+	value := completedReport()
+	value.Usage = &report.Usage{Available: false, TotalTokens: 20}
+	if err := report.Validate(value, report.ValidationContext{InvocationID: "inv-1", RunID: "run-1", Harness: "codex", Role: "implementation", Stage: "implementation"}); err == nil || !strings.Contains(err.Error(), "available") {
+		t.Fatalf("Validate() error = %v, want unavailable-usage rejection", err)
+	}
+}
+
 // TestValidateRequiresTheStructuredPayloadForEachOutcome verifies that each
 // outcome carries the handoff or evidence needed by the coordinator.
 func TestValidateRequiresTheStructuredPayloadForEachOutcome(t *testing.T) {

--- a/internal/reportcli/reportcli.go
+++ b/internal/reportcli/reportcli.go
@@ -64,6 +64,18 @@ func Run(request Request) int {
 	flags.Var(&questions, "question", "question-id=question text; may be repeated")
 	evidence := pairList{}
 	flags.Var(&evidence, "evidence", "kind=detail; may be repeated")
+	exemptions := stringList{}
+	flags.Var(&exemptions, "exemption", "human, technical, or baseline; may be repeated")
+	escalations := stringList{}
+	flags.Var(&escalations, "escalation", "test_dispute or review_finding; may be repeated")
+	blockers := stringList{}
+	flags.Var(&blockers, "blocker", "setup, gate, test, review, harness, budget, or unknown; may be repeated")
+	budgetExhausted := flags.Bool("budget-exhausted", false, "explicit harness signal that the configured budget was exhausted")
+	inputTokens := flags.Int64("input-tokens", 0, "reliable harness-reported input tokens")
+	outputTokens := flags.Int64("output-tokens", 0, "reliable harness-reported output tokens")
+	totalTokens := flags.Int64("total-tokens", 0, "reliable harness-reported total tokens")
+	costMicros := flags.Int64("cost-micros", 0, "reliable harness-reported cost in millionths of currency")
+	costCurrency := flags.String("cost-currency", "", "three-letter uppercase currency for --cost-micros")
 	nativeSessionID := flags.String("native-session-id", "", "harness-native session identifier")
 	if err := flags.Parse(request.Args); err != nil {
 		return 2
@@ -99,8 +111,29 @@ func Run(request Request) int {
 		Stage:           identity["stage"],
 		Outcome:         report.Outcome(*outcome),
 		Summary:         *summary,
+		BudgetExhausted: *budgetExhausted,
 		NativeSessionID: *nativeSessionID,
 		ReportedAt:      request.Now().UTC(),
+	}
+	for _, item := range exemptions {
+		value.Exemptions = append(value.Exemptions, report.Exemption(item))
+	}
+	for _, item := range escalations {
+		value.Escalations = append(value.Escalations, report.EscalationCategory(item))
+	}
+	for _, item := range blockers {
+		value.Blockers = append(value.Blockers, report.BlockerCategory(item))
+	}
+	if flagWasSet(flags, "input-tokens", "output-tokens", "total-tokens", "cost-micros", "cost-currency") {
+		value.Usage = &report.Usage{
+			Available:    true,
+			InputTokens:  *inputTokens,
+			OutputTokens: *outputTokens,
+			TotalTokens:  *totalTokens,
+			CostReported: flagWasSet(flags, "cost-micros", "cost-currency"),
+			CostMicros:   *costMicros,
+			Currency:     *costCurrency,
+		}
 	}
 	for _, pair := range acceptance {
 		value.Handoff = ensureHandoff(value.Handoff)
@@ -137,6 +170,19 @@ func ensureHandoff(value *report.Handoff) *report.Handoff {
 		return value
 	}
 	return &report.Handoff{}
+}
+
+// flagWasSet reports whether a caller explicitly supplied one of the optional
+// usage flags, preserving the distinction between zero and unavailable data.
+func flagWasSet(flags *flag.FlagSet, names ...string) bool {
+	set := make(map[string]struct{}, len(names))
+	flags.Visit(func(value *flag.Flag) { set[value.Name] = struct{}{} })
+	for _, name := range names {
+		if _, ok := set[name]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // writeError writes one CLI error without exposing credentials or transcripts.

--- a/internal/reportcli/reportcli_test.go
+++ b/internal/reportcli/reportcli_test.go
@@ -72,3 +72,36 @@ func TestRunRejectsAClarificationWithoutQuestions(t *testing.T) {
 		t.Fatalf("Run() status = %d, stderr = %q, want question validation error", status, errorsOutput.String())
 	}
 }
+
+// TestRunAcceptsExplicitHarnessUsage verifies the worker-facing command keeps
+// usage optional and writes only values supplied through numeric flags.
+func TestRunAcceptsExplicitHarnessUsage(t *testing.T) {
+	resultDirectory := t.TempDir()
+	var errorsOutput bytes.Buffer
+	status := reportcli.Run(reportcli.Request{
+		Args: []string{"--outcome", "completed", "--summary", "done", "--change-summary", "changed", "--acceptance", "criterion=evidence", "--production-file", "internal/factory/agent.go", "--focused-command", "go test ./...", "--input-tokens", "12", "--output-tokens", "8", "--total-tokens", "20", "--cost-micros", "15", "--cost-currency", "USD", "--budget-exhausted", "--escalation", "review_finding", "--exemption", "technical", "--blocker", "review"},
+		Environment: map[string]string{
+			"FACTORY_INVOCATION_ID": "inv-1",
+			"FACTORY_RUN_ID":        "run-1",
+			"FACTORY_HARNESS":       "codex",
+			"FACTORY_ROLE":          "implementation",
+			"FACTORY_STAGE":         "implementation",
+			"FACTORY_RESULT_DIR":    resultDirectory,
+		},
+		Output:       &bytes.Buffer{},
+		ErrorsOutput: &errorsOutput,
+	})
+	if status != 0 {
+		t.Fatalf("Run() status = %d, stderr = %s", status, errorsOutput.String())
+	}
+	value, err := report.Read(resultDirectory + "/report.json")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if value.Usage == nil || !value.Usage.Available || value.Usage.TotalTokens != 20 || value.Usage.CostMicros != 15 {
+		t.Fatalf("usage = %#v, want explicit CLI measurements", value.Usage)
+	}
+	if !value.BudgetExhausted || len(value.Escalations) != 1 || len(value.Exemptions) != 1 || len(value.Blockers) != 1 {
+		t.Fatalf("evaluation signals = %#v, want explicit CLI signals", value)
+	}
+}

--- a/internal/store/evaluation.go
+++ b/internal/store/evaluation.go
@@ -1,0 +1,1646 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// EvaluationOutcome identifies the content-free terminal or active state of a
+// local evaluation summary.
+type EvaluationOutcome string
+
+const (
+	// EvaluationOutcomeActive identifies a summary for a run still in progress.
+	EvaluationOutcomeActive EvaluationOutcome = "active"
+	// EvaluationOutcomeWaitingForHuman identifies a run paused for a human.
+	EvaluationOutcomeWaitingForHuman EvaluationOutcome = "waiting_for_human"
+	// EvaluationOutcomeWaitingForHarness identifies a run paused for a harness.
+	EvaluationOutcomeWaitingForHarness EvaluationOutcome = "waiting_for_harness"
+	// EvaluationOutcomeFailed identifies a run that failed.
+	EvaluationOutcomeFailed EvaluationOutcome = "failed"
+	// EvaluationOutcomeCancelled identifies a run cancelled by lifecycle policy.
+	EvaluationOutcomeCancelled EvaluationOutcome = "cancelled"
+	// EvaluationOutcomeComplete identifies a successfully completed run.
+	EvaluationOutcomeComplete EvaluationOutcome = "complete"
+)
+
+// EvaluationAttempt identifies a retry or revision category retained for
+// tuning workflow policy.
+type EvaluationAttempt string
+
+const (
+	// EvaluationAttemptCheckRepair counts a deterministic-check repair attempt.
+	EvaluationAttemptCheckRepair EvaluationAttempt = "check_repair"
+	// EvaluationAttemptTestRevision counts a test-stage revision attempt.
+	EvaluationAttemptTestRevision EvaluationAttempt = "test_revision"
+	// EvaluationAttemptReviewRevision counts a review-stage revision attempt.
+	EvaluationAttemptReviewRevision EvaluationAttempt = "review_revision"
+)
+
+// EvaluationExemption identifies a stable human or technical exemption class.
+type EvaluationExemption string
+
+const (
+	// EvaluationExemptionHuman identifies a human-approved exemption.
+	EvaluationExemptionHuman EvaluationExemption = "human"
+	// EvaluationExemptionTechnical identifies an infrastructure or technical exemption.
+	EvaluationExemptionTechnical EvaluationExemption = "technical"
+	// EvaluationExemptionBaseline identifies an accepted pre-existing baseline condition.
+	EvaluationExemptionBaseline EvaluationExemption = "baseline"
+)
+
+// EvaluationEscalationCategory identifies a stable escalation class without
+// retaining the escalated finding or question.
+type EvaluationEscalationCategory string
+
+const (
+	// EvaluationEscalationTestDispute identifies a disputed test result.
+	EvaluationEscalationTestDispute EvaluationEscalationCategory = "test_dispute"
+	// EvaluationEscalationReviewFinding identifies an escalated review finding.
+	EvaluationEscalationReviewFinding EvaluationEscalationCategory = "review_finding"
+	// EvaluationEscalationClarification identifies a request for clarification.
+	EvaluationEscalationClarification EvaluationEscalationCategory = "clarification"
+	// EvaluationEscalationRuntime identifies a harness or runtime escalation.
+	EvaluationEscalationRuntime EvaluationEscalationCategory = "runtime"
+	// EvaluationEscalationBudget identifies a budget escalation.
+	EvaluationEscalationBudget EvaluationEscalationCategory = "budget"
+	// EvaluationEscalationBlocked identifies an inability to proceed without retaining its evidence.
+	EvaluationEscalationBlocked EvaluationEscalationCategory = "blocked"
+)
+
+// EvaluationBlockerCategory identifies a repeated blocker class without
+// retaining blocker text.
+type EvaluationBlockerCategory string
+
+const (
+	// EvaluationBlockerSetup identifies dependency setup blockers.
+	EvaluationBlockerSetup EvaluationBlockerCategory = "setup"
+	// EvaluationBlockerGate identifies deterministic gate blockers.
+	EvaluationBlockerGate EvaluationBlockerCategory = "gate"
+	// EvaluationBlockerTest identifies test-policy blockers.
+	EvaluationBlockerTest EvaluationBlockerCategory = "test"
+	// EvaluationBlockerReview identifies review blockers.
+	EvaluationBlockerReview EvaluationBlockerCategory = "review"
+	// EvaluationBlockerHarness identifies harness blockers.
+	EvaluationBlockerHarness EvaluationBlockerCategory = "harness"
+	// EvaluationBlockerBudget identifies budget blockers.
+	EvaluationBlockerBudget EvaluationBlockerCategory = "budget"
+	// EvaluationBlockerUnknown identifies a blocker whose stable class is unavailable.
+	EvaluationBlockerUnknown EvaluationBlockerCategory = "unknown"
+)
+
+// EvaluationDisposition is the human classification attached to an escalated
+// test dispute or review finding.
+type EvaluationDisposition string
+
+const (
+	// EvaluationDispositionUpheld means the human agreed with the escalation.
+	EvaluationDispositionUpheld EvaluationDisposition = "upheld"
+	// EvaluationDispositionAdvisory means the human retained it as advisory.
+	EvaluationDispositionAdvisory EvaluationDisposition = "advisory"
+	// EvaluationDispositionOverturned means the human rejected the escalation.
+	EvaluationDispositionOverturned EvaluationDisposition = "overturned"
+)
+
+const (
+	// EvaluationUsageNotReported explains that no harness measurement was supplied.
+	EvaluationUsageNotReported = "not_reported"
+	// EvaluationUsageMixedCurrency explains that cost values could not be combined safely.
+	EvaluationUsageMixedCurrency = "mixed_currency"
+	// EvaluationUsagePartialCost explains that only some available usage reports included cost.
+	EvaluationUsagePartialCost = "partial_cost"
+)
+
+// EvaluationInvocationVersion records version identifiers observed for one
+// invocation. It contains no prompt, transcript, source, or command content.
+type EvaluationInvocationVersion struct {
+	InvocationID        string `json:"invocation_id"`
+	Harness             string `json:"harness"`
+	Model               string `json:"model"`
+	PromptVersion       string `json:"prompt_version"`
+	ReportSchemaVersion int    `json:"report_schema_version"`
+	WorkerVersion       string `json:"worker_version"`
+}
+
+// EvaluationStageDuration records time spent in one coordinator stage.
+type EvaluationStageDuration struct {
+	Stage    Stage         `json:"stage"`
+	Duration time.Duration `json:"duration"`
+}
+
+// EvaluationBlocker records how often a stable blocker category repeated.
+type EvaluationBlocker struct {
+	Category EvaluationBlockerCategory `json:"category"`
+	Count    int                       `json:"count"`
+}
+
+// EvaluationUsage contains only reliable harness-reported measurements. Zero
+// values are not estimates; Available and CostReported identify what was
+// actually supplied by the harness.
+type EvaluationUsage struct {
+	Available         bool   `json:"available"`
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
+	InputTokens       int64  `json:"input_tokens,omitempty"`
+	OutputTokens      int64  `json:"output_tokens,omitempty"`
+	TotalTokens       int64  `json:"total_tokens,omitempty"`
+	CostReported      bool   `json:"cost_reported,omitempty"`
+	CostMicros        int64  `json:"cost_micros,omitempty"`
+	Currency          string `json:"currency,omitempty"`
+}
+
+// EvaluationSummary is the content-free local evidence retained for one run.
+// It is deliberately separate from Run, Invocation, gate output, and run
+// artifacts, and it never contains issue text, prompts, transcripts, diffs,
+// source contents, command output, logs, or credentials.
+type EvaluationSummary struct {
+	RunID                string                         `json:"run_id"`
+	Outcome              EvaluationOutcome              `json:"outcome"`
+	StartedAt            time.Time                      `json:"started_at"`
+	CompletedAt          time.Time                      `json:"completed_at,omitempty"`
+	TotalWallTime        time.Duration                  `json:"total_wall_time"`
+	StageDurations       []EvaluationStageDuration      `json:"stage_durations,omitempty"`
+	InvocationVersions   []EvaluationInvocationVersion  `json:"invocation_versions,omitempty"`
+	InvocationCount      int                            `json:"invocation_count"`
+	GateCount            int                            `json:"gate_count"`
+	CheckRepairCount     int                            `json:"check_repair_count"`
+	TestRevisionCount    int                            `json:"test_revision_count"`
+	ReviewRevisionCount  int                            `json:"review_revision_count"`
+	BudgetExhausted      bool                           `json:"budget_exhausted"`
+	Exemptions           []EvaluationExemption          `json:"exemptions,omitempty"`
+	EscalationCategories []EvaluationEscalationCategory `json:"escalation_categories,omitempty"`
+	RepeatedBlockers     []EvaluationBlocker            `json:"repeated_blockers,omitempty"`
+	Usage                EvaluationUsage                `json:"usage"`
+	CreatedAt            time.Time                      `json:"created_at"`
+	UpdatedAt            time.Time                      `json:"updated_at"`
+}
+
+// EvaluationDispositionRequest attaches a human disposition to an opaque
+// escalation identity. The identity is hashed before persistence so accidental
+// finding text cannot be retained.
+type EvaluationDispositionRequest struct {
+	RunID       string
+	EventID     string
+	Category    EvaluationEscalationCategory
+	Disposition EvaluationDisposition
+	DecidedAt   time.Time
+}
+
+// EvaluationDispositionRecord is the persisted, content-free human
+// classification.
+// EventIDHash is a one-way identity, never the original finding or question.
+type EvaluationDispositionRecord struct {
+	RunID       string                       `json:"run_id"`
+	EventIDHash string                       `json:"event_id_hash"`
+	Category    EvaluationEscalationCategory `json:"category"`
+	Disposition EvaluationDisposition        `json:"disposition"`
+	DecidedAt   time.Time                    `json:"decided_at"`
+}
+
+// EvaluationAggregate contains local aggregate counts, rates, durations, and
+// only the usage measurements that were actually available.
+type EvaluationAggregate struct {
+	RunCount              int                                      `json:"run_count"`
+	OutcomeCounts         map[EvaluationOutcome]int                `json:"outcome_counts"`
+	OutcomeRates          map[EvaluationOutcome]float64            `json:"outcome_rates"`
+	SuccessRate           float64                                  `json:"success_rate"`
+	BudgetExhaustionRate  float64                                  `json:"budget_exhaustion_rate"`
+	TotalWallTime         time.Duration                            `json:"total_wall_time"`
+	AverageTotalWallTime  time.Duration                            `json:"average_total_wall_time"`
+	StageDurations        map[Stage]time.Duration                  `json:"stage_durations"`
+	InvocationCount       int                                      `json:"invocation_count"`
+	GateCount             int                                      `json:"gate_count"`
+	CheckRepairCount      int                                      `json:"check_repair_count"`
+	TestRevisionCount     int                                      `json:"test_revision_count"`
+	ReviewRevisionCount   int                                      `json:"review_revision_count"`
+	EscalationCounts      map[EvaluationEscalationCategory]int     `json:"escalation_counts"`
+	EscalationRates       map[EvaluationEscalationCategory]float64 `json:"escalation_rates"`
+	DispositionCounts     map[EvaluationDisposition]int            `json:"disposition_counts"`
+	UsageAvailableRuns    int                                      `json:"usage_available_runs"`
+	UsageCostReportedRuns int                                      `json:"usage_cost_reported_runs"`
+	Usage                 EvaluationUsage                          `json:"usage"`
+}
+
+// EvaluationDeletionResult reports the visible effect of deliberate summary
+// deletion without exposing any work content.
+type EvaluationDeletionResult struct {
+	Summaries    int `json:"summaries"`
+	Dispositions int `json:"dispositions"`
+	UsageRows    int `json:"usage_rows"`
+}
+
+// EvaluationSummary returns one persisted local evaluation summary, or nil
+// when the run has not produced one.
+func (s *Store) EvaluationSummary(ctx context.Context, runID string) (*EvaluationSummary, error) {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return nil, err
+	}
+	row := s.db.QueryRowContext(ctx, evaluationSummarySelect+" WHERE run_id = ?", runID)
+	return scanEvaluationSummary(row)
+}
+
+// ListEvaluationSummaries returns content-free summaries in completion order.
+// An empty run ID lists every retained summary; a non-empty run ID selects one.
+func (s *Store) ListEvaluationSummaries(ctx context.Context, runID string) ([]EvaluationSummary, error) {
+	if strings.TrimSpace(runID) != "" {
+		one, err := s.EvaluationSummary(ctx, runID)
+		if err != nil {
+			return nil, err
+		}
+		if one == nil {
+			return []EvaluationSummary{}, nil
+		}
+		return []EvaluationSummary{*one}, nil
+	}
+	rows, err := s.db.QueryContext(ctx, evaluationSummarySelect+" ORDER BY completed_at DESC, run_id")
+	if err != nil {
+		return nil, fmt.Errorf("list evaluation summaries: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make([]EvaluationSummary, 0)
+	for rows.Next() {
+		value, err := scanEvaluationSummaryRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, *value)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read evaluation summaries: %w", err)
+	}
+	return result, nil
+}
+
+// SaveEvaluationSummary validates and upserts one content-free local summary.
+// It never accepts or stores issue, specification, prompt, transcript, diff,
+// source, command, log, or credential fields.
+func (s *Store) SaveEvaluationSummary(ctx context.Context, summary EvaluationSummary) error {
+	normalized, values, err := normalizeEvaluationSummary(summary)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO evaluation_summaries (
+			run_id, outcome, started_at, completed_at, total_wall_nanos,
+			stage_durations, invocation_versions, invocation_count, gate_count,
+			check_repair_count, test_revision_count, review_revision_count,
+			budget_exhausted, exemptions, escalation_categories, repeated_blockers,
+			usage_available, usage_unavailable_reason, usage_input_tokens,
+			usage_output_tokens, usage_total_tokens, usage_cost_reported,
+			usage_cost_micros, usage_currency, active_stage,
+			active_stage_started_at, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id) DO UPDATE SET
+			outcome = excluded.outcome,
+			started_at = excluded.started_at,
+			completed_at = excluded.completed_at,
+			total_wall_nanos = excluded.total_wall_nanos,
+			stage_durations = excluded.stage_durations,
+			invocation_versions = excluded.invocation_versions,
+			invocation_count = excluded.invocation_count,
+			gate_count = excluded.gate_count,
+			check_repair_count = excluded.check_repair_count,
+			test_revision_count = excluded.test_revision_count,
+			review_revision_count = excluded.review_revision_count,
+			budget_exhausted = excluded.budget_exhausted,
+			exemptions = excluded.exemptions,
+			escalation_categories = excluded.escalation_categories,
+			repeated_blockers = excluded.repeated_blockers,
+			usage_available = excluded.usage_available,
+			usage_unavailable_reason = excluded.usage_unavailable_reason,
+			usage_input_tokens = excluded.usage_input_tokens,
+			usage_output_tokens = excluded.usage_output_tokens,
+			usage_total_tokens = excluded.usage_total_tokens,
+			usage_cost_reported = excluded.usage_cost_reported,
+			usage_cost_micros = excluded.usage_cost_micros,
+			usage_currency = excluded.usage_currency,
+			updated_at = excluded.updated_at`,
+		values...)
+	if err != nil {
+		return fmt.Errorf("save evaluation summary %q: %w", normalized.RunID, err)
+	}
+	return nil
+}
+
+// EnsureEvaluationSummary creates the active summary for a run exactly once.
+// The worker image digest is retained as a version identifier, never as work
+// content; all other summary fields begin explicitly empty or unavailable.
+func (s *Store) EnsureEvaluationSummary(ctx context.Context, run Run) error {
+	if err := validateEvaluationRunID(run.ID); err != nil {
+		return err
+	}
+	startedAt := run.CreatedAt.UTC()
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+	stage := run.Stage
+	if stage == "" {
+		stage = StageClaim
+	}
+	if err := validateEvaluationStage(stage); err != nil {
+		return err
+	}
+	if run.ImageDigest != "" && !safeEvaluationValue(run.ImageDigest) {
+		return errors.New("evaluation worker version contains unsafe metadata")
+	}
+	versions := []EvaluationInvocationVersion{}
+	if run.ImageDigest != "" {
+		versions = append(versions, EvaluationInvocationVersion{WorkerVersion: run.ImageDigest})
+	}
+	stageStarted := startedAt.Format(runTimestampLayout)
+	versionJSON, err := json.Marshal(versions)
+	if err != nil {
+		return fmt.Errorf("encode initial evaluation versions: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO evaluation_summaries (
+			run_id, outcome, started_at, completed_at, total_wall_nanos,
+			stage_durations, invocation_versions, invocation_count, gate_count,
+			check_repair_count, test_revision_count, review_revision_count,
+			budget_exhausted, exemptions, escalation_categories, repeated_blockers,
+			usage_available, usage_unavailable_reason, usage_input_tokens,
+			usage_output_tokens, usage_total_tokens, usage_cost_reported,
+			usage_cost_micros, usage_currency, active_stage,
+			active_stage_started_at, created_at, updated_at
+		) VALUES (?, ?, ?, '', 0, '[]', ?, 0, 0, 0, 0, 0, 0, '[]', '[]', '[]', 0, ?, 0, 0, 0, 0, 0, '', ?, ?, ?, ?)
+		ON CONFLICT(run_id) DO NOTHING`,
+		run.ID,
+		EvaluationOutcomeActive,
+		startedAt.Format(runTimestampLayout),
+		string(versionJSON),
+		EvaluationUsageNotReported,
+		stage,
+		stageStarted,
+		startedAt.Format(runTimestampLayout),
+		startedAt.Format(runTimestampLayout),
+	)
+	if err != nil {
+		return fmt.Errorf("ensure evaluation summary %q: %w", run.ID, err)
+	}
+	return nil
+}
+
+const evaluationSummarySelect = `SELECT run_id, outcome, started_at, completed_at,
+	total_wall_nanos, stage_durations, invocation_versions, invocation_count,
+	gate_count, check_repair_count, test_revision_count, review_revision_count,
+	budget_exhausted, exemptions, escalation_categories, repeated_blockers,
+	usage_available, usage_unavailable_reason, usage_input_tokens,
+	usage_output_tokens, usage_total_tokens, usage_cost_reported,
+	usage_cost_micros, usage_currency, created_at, updated_at
+	FROM evaluation_summaries`
+
+// scanEvaluationSummary decodes one summary row returned by SQLite.
+func scanEvaluationSummary(row *sql.Row) (*EvaluationSummary, error) {
+	return scanEvaluationSummaryValues(row.Scan)
+}
+
+// scanEvaluationSummaryRows decodes one summary row returned by a row iterator.
+func scanEvaluationSummaryRows(rows *sql.Rows) (*EvaluationSummary, error) {
+	return scanEvaluationSummaryValues(rows.Scan)
+}
+
+// scanEvaluationSummaryValues translates the persisted content-free columns
+// into the public summary model.
+func scanEvaluationSummaryValues(scan func(...any) error) (*EvaluationSummary, error) {
+	var summary EvaluationSummary
+	var outcome string
+	var completedAt, startedAt, createdAt, updatedAt string
+	var totalWallNanos int64
+	var stageDurationsJSON, invocationVersionsJSON, exemptionsJSON string
+	var escalationJSON, blockersJSON string
+	var usageAvailable, usageCostReported int
+	var usageReason, usageCurrency string
+	var usageInput, usageOutput, usageTotal, usageCost int64
+	if err := scan(
+		&summary.RunID, &outcome, &startedAt, &completedAt, &totalWallNanos,
+		&stageDurationsJSON, &invocationVersionsJSON, &summary.InvocationCount,
+		&summary.GateCount, &summary.CheckRepairCount, &summary.TestRevisionCount,
+		&summary.ReviewRevisionCount, &summary.BudgetExhausted, &exemptionsJSON,
+		&escalationJSON, &blockersJSON, &usageAvailable, &usageReason,
+		&usageInput, &usageOutput, &usageTotal, &usageCostReported, &usageCost,
+		&usageCurrency, &createdAt, &updatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read evaluation summary row: %w", err)
+	}
+	summary.Outcome = EvaluationOutcome(outcome)
+	summary.TotalWallTime = time.Duration(totalWallNanos)
+	summary.Usage = EvaluationUsage{
+		Available:         usageAvailable != 0,
+		UnavailableReason: usageReason,
+		InputTokens:       usageInput,
+		OutputTokens:      usageOutput,
+		TotalTokens:       usageTotal,
+		CostReported:      usageCostReported != 0,
+		CostMicros:        usageCost,
+		Currency:          usageCurrency,
+	}
+	if err := decodeEvaluationJSON("stage durations", stageDurationsJSON, &summary.StageDurations); err != nil {
+		return nil, err
+	}
+	if err := decodeEvaluationJSON("invocation versions", invocationVersionsJSON, &summary.InvocationVersions); err != nil {
+		return nil, err
+	}
+	if err := decodeEvaluationJSON("exemptions", exemptionsJSON, &summary.Exemptions); err != nil {
+		return nil, err
+	}
+	if err := decodeEvaluationJSON("escalation categories", escalationJSON, &summary.EscalationCategories); err != nil {
+		return nil, err
+	}
+	if err := decodeEvaluationJSON("repeated blockers", blockersJSON, &summary.RepeatedBlockers); err != nil {
+		return nil, err
+	}
+	var err error
+	if summary.StartedAt, err = parseEvaluationTime("started_at", startedAt); err != nil {
+		return nil, err
+	}
+	if completedAt != "" {
+		if summary.CompletedAt, err = parseEvaluationTime("completed_at", completedAt); err != nil {
+			return nil, err
+		}
+	}
+	if summary.CreatedAt, err = parseEvaluationTime("created_at", createdAt); err != nil {
+		return nil, err
+	}
+	if summary.UpdatedAt, err = parseEvaluationTime("updated_at", updatedAt); err != nil {
+		return nil, err
+	}
+	return &summary, nil
+}
+
+// normalizeEvaluationSummary validates a public summary and returns its SQL
+// values in the exact order used by SaveEvaluationSummary.
+func normalizeEvaluationSummary(summary EvaluationSummary) (EvaluationSummary, []any, error) {
+	if !summary.Usage.Available && summary.Usage.UnavailableReason == "" {
+		summary.Usage.UnavailableReason = EvaluationUsageNotReported
+	}
+	if err := validateEvaluationSummary(summary); err != nil {
+		return EvaluationSummary{}, nil, err
+	}
+	now := time.Now().UTC()
+	if summary.StartedAt.IsZero() {
+		summary.StartedAt = now
+	}
+	if summary.CreatedAt.IsZero() {
+		summary.CreatedAt = summary.StartedAt
+	}
+	if summary.UpdatedAt.IsZero() {
+		summary.UpdatedAt = now
+	}
+	if summary.TotalWallTime == 0 && !summary.CompletedAt.IsZero() {
+		summary.TotalWallTime = summary.CompletedAt.Sub(summary.StartedAt)
+	}
+	stageDurations, err := json.Marshal(nonNilStageDurations(summary.StageDurations))
+	if err != nil {
+		return EvaluationSummary{}, nil, fmt.Errorf("encode evaluation stage durations: %w", err)
+	}
+	versions, err := json.Marshal(nonNilInvocationVersions(summary.InvocationVersions))
+	if err != nil {
+		return EvaluationSummary{}, nil, fmt.Errorf("encode evaluation invocation versions: %w", err)
+	}
+	exemptions, err := json.Marshal(nonNilExemptions(summary.Exemptions))
+	if err != nil {
+		return EvaluationSummary{}, nil, fmt.Errorf("encode evaluation exemptions: %w", err)
+	}
+	escalations, err := json.Marshal(nonNilEscalations(summary.EscalationCategories))
+	if err != nil {
+		return EvaluationSummary{}, nil, fmt.Errorf("encode evaluation escalations: %w", err)
+	}
+	blockers, err := json.Marshal(nonNilBlockers(summary.RepeatedBlockers))
+	if err != nil {
+		return EvaluationSummary{}, nil, fmt.Errorf("encode evaluation blockers: %w", err)
+	}
+	completedAt := ""
+	if !summary.CompletedAt.IsZero() {
+		completedAt = summary.CompletedAt.UTC().Format(runTimestampLayout)
+	}
+	return summary, []any{
+		summary.RunID,
+		summary.Outcome,
+		summary.StartedAt.UTC().Format(runTimestampLayout),
+		completedAt,
+		int64(summary.TotalWallTime),
+		string(stageDurations),
+		string(versions),
+		summary.InvocationCount,
+		summary.GateCount,
+		summary.CheckRepairCount,
+		summary.TestRevisionCount,
+		summary.ReviewRevisionCount,
+		summary.BudgetExhausted,
+		string(exemptions),
+		string(escalations),
+		string(blockers),
+		summary.Usage.Available,
+		summary.Usage.UnavailableReason,
+		summary.Usage.InputTokens,
+		summary.Usage.OutputTokens,
+		summary.Usage.TotalTokens,
+		summary.Usage.CostReported,
+		summary.Usage.CostMicros,
+		summary.Usage.Currency,
+		"",
+		"",
+		summary.CreatedAt.UTC().Format(runTimestampLayout),
+		summary.UpdatedAt.UTC().Format(runTimestampLayout),
+	}, nil
+}
+
+// validateEvaluationSummary validates the privacy-safe vocabulary and numeric
+// bounds before any summary value reaches SQLite.
+func validateEvaluationSummary(summary EvaluationSummary) error {
+	if err := validateEvaluationRunID(summary.RunID); err != nil {
+		return err
+	}
+	if err := validateEvaluationOutcome(summary.Outcome); err != nil {
+		return err
+	}
+	if summary.TotalWallTime < 0 {
+		return errors.New("evaluation total wall time must not be negative")
+	}
+	if !summary.CompletedAt.IsZero() && !summary.StartedAt.IsZero() && summary.CompletedAt.Before(summary.StartedAt) {
+		return errors.New("evaluation completion time must not precede start time")
+	}
+	for _, stage := range summary.StageDurations {
+		if err := validateEvaluationStage(stage.Stage); err != nil {
+			return err
+		}
+		if stage.Duration < 0 {
+			return fmt.Errorf("evaluation stage %q duration must not be negative", stage.Stage)
+		}
+	}
+	for _, version := range summary.InvocationVersions {
+		for field, value := range map[string]string{
+			"invocation id":  version.InvocationID,
+			"harness":        version.Harness,
+			"model":          version.Model,
+			"prompt version": version.PromptVersion,
+			"worker version": version.WorkerVersion,
+		} {
+			if value != "" && !safeEvaluationValue(value) {
+				return fmt.Errorf("evaluation %s contains unsafe metadata", field)
+			}
+		}
+		if version.ReportSchemaVersion < 0 {
+			return errors.New("evaluation report schema version must not be negative")
+		}
+	}
+	for field, value := range map[string]int{
+		"invocation count":      summary.InvocationCount,
+		"gate count":            summary.GateCount,
+		"check repair count":    summary.CheckRepairCount,
+		"test revision count":   summary.TestRevisionCount,
+		"review revision count": summary.ReviewRevisionCount,
+	} {
+		if value < 0 {
+			return fmt.Errorf("evaluation %s must not be negative", field)
+		}
+	}
+	for _, exemption := range summary.Exemptions {
+		if !validEvaluationExemption(exemption) {
+			return fmt.Errorf("unsupported evaluation exemption %q", exemption)
+		}
+	}
+	for _, category := range summary.EscalationCategories {
+		if !validEvaluationEscalation(category) {
+			return fmt.Errorf("unsupported evaluation escalation category %q", category)
+		}
+	}
+	for _, blocker := range summary.RepeatedBlockers {
+		if !validEvaluationBlocker(blocker.Category) || blocker.Count < 1 {
+			return fmt.Errorf("invalid evaluation blocker %q", blocker.Category)
+		}
+	}
+	if err := validateEvaluationUsage(summary.Usage); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateEvaluationUsage rejects guessed, negative, or malformed usage data.
+func validateEvaluationUsage(usage EvaluationUsage) error {
+	if usage.InputTokens < 0 || usage.OutputTokens < 0 || usage.TotalTokens < 0 || usage.CostMicros < 0 {
+		return errors.New("evaluation usage values must not be negative")
+	}
+	if !usage.Available {
+		if usage.InputTokens != 0 || usage.OutputTokens != 0 || usage.TotalTokens != 0 || usage.CostMicros != 0 || usage.CostReported || usage.Currency != "" {
+			return errors.New("unavailable evaluation usage must not contain measurements")
+		}
+		if usage.UnavailableReason == "" {
+			usage.UnavailableReason = EvaluationUsageNotReported
+		}
+		if usage.UnavailableReason != EvaluationUsageNotReported && usage.UnavailableReason != EvaluationUsageMixedCurrency {
+			return fmt.Errorf("unsupported evaluation usage unavailable reason %q", usage.UnavailableReason)
+		}
+		return nil
+	}
+	if usage.InputTokens == 0 && usage.OutputTokens == 0 && usage.TotalTokens == 0 && !usage.CostReported {
+		return errors.New("available evaluation usage must contain a reported measurement")
+	}
+	if usage.CostReported {
+		if usage.UnavailableReason != "" {
+			return errors.New("reported evaluation cost must not have an unavailable reason")
+		}
+		if !validEvaluationCurrency(usage.Currency) {
+			return errors.New("reported evaluation cost requires a three-letter uppercase currency")
+		}
+	} else {
+		if usage.CostMicros != 0 || usage.Currency != "" {
+			return errors.New("evaluation cost metadata requires cost_reported")
+		}
+		if usage.UnavailableReason != "" && usage.UnavailableReason != EvaluationUsageMixedCurrency && usage.UnavailableReason != EvaluationUsagePartialCost {
+			return fmt.Errorf("unsupported evaluation usage unavailable reason %q", usage.UnavailableReason)
+		}
+	}
+	return nil
+}
+
+// validEvaluationCurrency accepts only bounded uppercase currency metadata.
+func validEvaluationCurrency(value string) bool {
+	if len(value) != 3 || strings.ToUpper(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if character < 'A' || character > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
+// validateEvaluationRunID validates an opaque run identifier without allowing
+// content-bearing or path-like values into the projection.
+func validateEvaluationRunID(value string) error {
+	if !safeEvaluationValue(value) {
+		return errors.New("evaluation run id is required and must be safe metadata")
+	}
+	return nil
+}
+
+// safeEvaluationValue accepts bounded, single-line metadata identifiers only.
+func safeEvaluationValue(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 512 || strings.ContainsAny(value, "\x00\r\n") {
+		return false
+	}
+	for _, character := range value {
+		if (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') {
+			continue
+		}
+		switch character {
+		case '-', '_', '.', ':', '/', '+', '@', '=':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// validateEvaluationOutcome validates the persisted outcome vocabulary.
+func validateEvaluationOutcome(value EvaluationOutcome) error {
+	switch value {
+	case EvaluationOutcomeActive, EvaluationOutcomeWaitingForHuman, EvaluationOutcomeWaitingForHarness,
+		EvaluationOutcomeFailed, EvaluationOutcomeCancelled, EvaluationOutcomeComplete:
+		return nil
+	default:
+		return fmt.Errorf("unsupported evaluation outcome %q", value)
+	}
+}
+
+// validateEvaluationStage validates the fixed coordinator stage vocabulary.
+func validateEvaluationStage(value Stage) error {
+	switch value {
+	case StageClaim, StagePreflight, StageTest, StageImplementation, StageCheck, StageDraftPR, StageReview, StageReady:
+		return nil
+	default:
+		return fmt.Errorf("unsupported evaluation stage %q", value)
+	}
+}
+
+// validEvaluationExemption reports whether an exemption category is known.
+func validEvaluationExemption(value EvaluationExemption) bool {
+	return value == EvaluationExemptionHuman || value == EvaluationExemptionTechnical || value == EvaluationExemptionBaseline
+}
+
+// validEvaluationEscalation reports whether an escalation category is known.
+func validEvaluationEscalation(value EvaluationEscalationCategory) bool {
+	switch value {
+	case EvaluationEscalationTestDispute, EvaluationEscalationReviewFinding, EvaluationEscalationClarification, EvaluationEscalationRuntime, EvaluationEscalationBudget, EvaluationEscalationBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+// validEvaluationBlocker reports whether a blocker category is known.
+func validEvaluationBlocker(value EvaluationBlockerCategory) bool {
+	switch value {
+	case EvaluationBlockerSetup, EvaluationBlockerGate, EvaluationBlockerTest, EvaluationBlockerReview, EvaluationBlockerHarness, EvaluationBlockerBudget, EvaluationBlockerUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// parseEvaluationTime parses the fixed-width timestamps used by the store.
+func parseEvaluationTime(field, value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse evaluation %s: %w", field, err)
+	}
+	return parsed, nil
+}
+
+// decodeEvaluationJSON decodes a JSON projection column and rejects malformed
+// persisted data instead of silently dropping evaluation evidence.
+func decodeEvaluationJSON(field, value string, target any) error {
+	if strings.TrimSpace(value) == "" {
+		value = "[]"
+	}
+	if err := json.Unmarshal([]byte(value), target); err != nil {
+		return fmt.Errorf("decode evaluation %s: %w", field, err)
+	}
+	return nil
+}
+
+// nonNilStageDurations keeps empty JSON arrays stable across persistence.
+func nonNilStageDurations(value []EvaluationStageDuration) []EvaluationStageDuration {
+	if value == nil {
+		return []EvaluationStageDuration{}
+	}
+	return value
+}
+
+// nonNilInvocationVersions keeps empty JSON arrays stable across persistence.
+func nonNilInvocationVersions(value []EvaluationInvocationVersion) []EvaluationInvocationVersion {
+	if value == nil {
+		return []EvaluationInvocationVersion{}
+	}
+	return value
+}
+
+// nonNilExemptions keeps empty JSON arrays stable across persistence.
+func nonNilExemptions(value []EvaluationExemption) []EvaluationExemption {
+	if value == nil {
+		return []EvaluationExemption{}
+	}
+	return value
+}
+
+// nonNilEscalations keeps empty JSON arrays stable across persistence.
+func nonNilEscalations(value []EvaluationEscalationCategory) []EvaluationEscalationCategory {
+	if value == nil {
+		return []EvaluationEscalationCategory{}
+	}
+	return value
+}
+
+// nonNilBlockers keeps empty JSON arrays stable across persistence.
+func nonNilBlockers(value []EvaluationBlocker) []EvaluationBlocker {
+	if value == nil {
+		return []EvaluationBlocker{}
+	}
+	return value
+}
+
+// appendUniqueEvaluationString appends a category only when it is new.
+func appendUniqueEvaluationString[T comparable](values []T, value T) []T {
+	for _, current := range values {
+		if current == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+// sortEvaluationStageDurations orders durations by the fixed workflow order.
+func sortEvaluationStageDurations(values []EvaluationStageDuration) {
+	order := map[Stage]int{StageClaim: 0, StagePreflight: 1, StageTest: 2, StageImplementation: 3, StageCheck: 4, StageDraftPR: 5, StageReview: 6, StageReady: 7}
+	sort.Slice(values, func(i, j int) bool {
+		if order[values[i].Stage] == order[values[j].Stage] {
+			return values[i].Stage < values[j].Stage
+		}
+		return order[values[i].Stage] < order[values[j].Stage]
+	})
+}
+
+// addEvaluationStageDuration adds elapsed time to one stage entry.
+func addEvaluationStageDuration(summary *EvaluationSummary, stage Stage, duration time.Duration) {
+	if duration <= 0 {
+		return
+	}
+	for index := range summary.StageDurations {
+		if summary.StageDurations[index].Stage == stage {
+			summary.StageDurations[index].Duration += duration
+			return
+		}
+	}
+	summary.StageDurations = append(summary.StageDurations, EvaluationStageDuration{Stage: stage, Duration: duration})
+	sortEvaluationStageDurations(summary.StageDurations)
+}
+
+// metadataHash produces the one-way identity used for human dispositions.
+func metadataHash(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
+}
+
+// RecordEvaluationStageTransition closes the previous stage interval and
+// starts the next one. It is idempotent for same-stage transitions and leaves
+// all stage names content-free.
+func (s *Store) RecordEvaluationStageTransition(ctx context.Context, runID string, from, to Stage, at time.Time) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if err := validateEvaluationStage(from); err != nil {
+		return err
+	}
+	if err := validateEvaluationStage(to); err != nil {
+		return err
+	}
+	if from == to {
+		return nil
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	summary, err := s.EvaluationSummary(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	var activeStage, activeStartedAt string
+	if err := s.db.QueryRowContext(ctx, `SELECT active_stage, active_stage_started_at FROM evaluation_summaries WHERE run_id = ?`, runID).Scan(&activeStage, &activeStartedAt); err != nil {
+		return fmt.Errorf("read active evaluation stage %q: %w", runID, err)
+	}
+	if activeStage == "" {
+		activeStage = string(from)
+		activeStartedAt = summary.StartedAt.UTC().Format(runTimestampLayout)
+	}
+	if activeStartedAt != "" {
+		startedAt, parseErr := time.Parse(time.RFC3339Nano, activeStartedAt)
+		if parseErr != nil {
+			return fmt.Errorf("parse active evaluation stage for %q: %w", runID, parseErr)
+		}
+		if at.After(startedAt) {
+			addEvaluationStageDuration(summary, Stage(activeStage), at.Sub(startedAt))
+		}
+	}
+	summary.UpdatedAt = at.UTC()
+	stageJSON, err := json.Marshal(nonNilStageDurations(summary.StageDurations))
+	if err != nil {
+		return fmt.Errorf("encode stage durations for %q: %w", runID, err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE evaluation_summaries
+		SET stage_durations = ?, active_stage = ?, active_stage_started_at = ?, updated_at = ?
+		WHERE run_id = ?`, string(stageJSON), to, at.UTC().Format(runTimestampLayout), at.UTC().Format(runTimestampLayout), runID)
+	if err != nil {
+		return fmt.Errorf("record evaluation stage transition %q: %w", runID, err)
+	}
+	return nil
+}
+
+// RecordEvaluationInvocation records one invocation's safe version metadata
+// and refreshes the invocation count from the operational invocation table.
+func (s *Store) RecordEvaluationInvocation(ctx context.Context, runID string, invocation Invocation, workerVersion string, reportSchemaVersion int) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if invocation.ID == "" || invocation.RunID != runID {
+		return errors.New("evaluation invocation identity does not match the run")
+	}
+	if reportSchemaVersion < 0 {
+		return errors.New("evaluation report schema version must not be negative")
+	}
+	for field, value := range map[string]string{
+		"harness":        invocation.Harness,
+		"model":          invocation.Model,
+		"prompt version": invocation.PromptVersion,
+		"worker version": workerVersion,
+	} {
+		if value != "" && !safeEvaluationValue(value) {
+			return fmt.Errorf("evaluation %s contains unsafe metadata", field)
+		}
+	}
+	summary, err := s.EvaluationSummary(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	version := EvaluationInvocationVersion{
+		InvocationID:        invocation.ID,
+		Harness:             invocation.Harness,
+		Model:               invocation.Model,
+		PromptVersion:       invocation.PromptVersion,
+		ReportSchemaVersion: reportSchemaVersion,
+		WorkerVersion:       workerVersion,
+	}
+	found := false
+	for index := range summary.InvocationVersions {
+		if summary.InvocationVersions[index].InvocationID == invocation.ID {
+			summary.InvocationVersions[index] = version
+			found = true
+			break
+		}
+	}
+	filteredVersions := make([]EvaluationInvocationVersion, 0, len(summary.InvocationVersions))
+	for _, existing := range summary.InvocationVersions {
+		if existing.InvocationID != "" {
+			filteredVersions = append(filteredVersions, existing)
+		}
+	}
+	summary.InvocationVersions = filteredVersions
+	if !found {
+		summary.InvocationVersions = append(summary.InvocationVersions, version)
+	}
+	if err := s.RefreshEvaluationCounts(ctx, runID); err != nil {
+		return err
+	}
+	summary.InvocationCount = len(summary.InvocationVersions)
+	summary.UpdatedAt = time.Now().UTC()
+	return s.updateEvaluationSummaryProjection(ctx, *summary)
+}
+
+// RefreshEvaluationCounts derives invocation and gate counts from the existing
+// content-limited operational projections, never from work content.
+func (s *Store) RefreshEvaluationCounts(ctx context.Context, runID string) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	summary, err := s.EvaluationSummary(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	var invocationCount, gateCount int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM invocations WHERE run_id = ?`, runID).Scan(&invocationCount); err != nil {
+		return fmt.Errorf("count evaluation invocations for %q: %w", runID, err)
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM gate_results WHERE run_id = ?`, runID).Scan(&gateCount); err != nil {
+		return fmt.Errorf("count evaluation gates for %q: %w", runID, err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE evaluation_summaries
+		SET invocation_count = ?, gate_count = ?, updated_at = ?
+		WHERE run_id = ?`, invocationCount, gateCount, time.Now().UTC().Format(runTimestampLayout), runID)
+	if err != nil {
+		return fmt.Errorf("refresh evaluation counts for %q: %w", runID, err)
+	}
+	return nil
+}
+
+// RecordEvaluationAttempt increments one policy-relevant repair or revision
+// counter. The category is a fixed vocabulary and no attempt detail is stored.
+func (s *Store) RecordEvaluationAttempt(ctx context.Context, runID string, attempt EvaluationAttempt) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	column := ""
+	switch attempt {
+	case EvaluationAttemptCheckRepair:
+		column = "check_repair_count"
+	case EvaluationAttemptTestRevision:
+		column = "test_revision_count"
+	case EvaluationAttemptReviewRevision:
+		column = "review_revision_count"
+	default:
+		return fmt.Errorf("unsupported evaluation attempt %q", attempt)
+	}
+	if _, err := s.EvaluationSummary(ctx, runID); err != nil {
+		return err
+	}
+	query := fmt.Sprintf("UPDATE evaluation_summaries SET %s = %s + 1, updated_at = ? WHERE run_id = ?", column, column)
+	result, err := s.db.ExecContext(ctx, query, time.Now().UTC().Format(runTimestampLayout), runID)
+	if err != nil {
+		return fmt.Errorf("record evaluation attempt %q for %q: %w", attempt, runID, err)
+	}
+	if changed, rowsErr := result.RowsAffected(); rowsErr == nil && changed != 1 {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	return nil
+}
+
+// SetEvaluationOutcome updates the current non-terminal outcome without
+// finalizing the summary. It keeps waiting-for-human and waiting-for-harness
+// visible in local reporting while the run remains active.
+func (s *Store) SetEvaluationOutcome(ctx context.Context, runID string, outcome EvaluationOutcome) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if err := validateEvaluationOutcome(outcome); err != nil {
+		return err
+	}
+	if outcome != EvaluationOutcomeActive && outcome != EvaluationOutcomeWaitingForHuman && outcome != EvaluationOutcomeWaitingForHarness {
+		return errors.New("SetEvaluationOutcome accepts only non-terminal outcomes")
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE evaluation_summaries SET outcome = ?, updated_at = ? WHERE run_id = ?`, outcome, time.Now().UTC().Format(runTimestampLayout), runID)
+	if err != nil {
+		return fmt.Errorf("set evaluation outcome for %q: %w", runID, err)
+	}
+	if changed, rowsErr := result.RowsAffected(); rowsErr == nil && changed != 1 {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	return nil
+}
+
+// RecordEvaluationBudgetExhaustion records the fact of budget exhaustion
+// without retaining a budget value, prompt, command, or other work content.
+func (s *Store) RecordEvaluationBudgetExhaustion(ctx context.Context, runID string) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	return s.setEvaluationBudgetExhausted(ctx, runID)
+}
+
+// setEvaluationBudgetExhausted applies the idempotent budget flag shared by
+// direct signals and terminal finalization.
+func (s *Store) setEvaluationBudgetExhausted(ctx context.Context, runID string) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE evaluation_summaries SET budget_exhausted = 1, updated_at = ? WHERE run_id = ?`, time.Now().UTC().Format(runTimestampLayout), runID)
+	if err != nil {
+		return fmt.Errorf("record evaluation budget exhaustion for %q: %w", runID, err)
+	}
+	if changed, rowsErr := result.RowsAffected(); rowsErr == nil && changed != 1 {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	return nil
+}
+
+// RecordEvaluationExemption records a stable exemption category once.
+func (s *Store) RecordEvaluationExemption(ctx context.Context, runID string, exemption EvaluationExemption) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if !validEvaluationExemption(exemption) {
+		return fmt.Errorf("unsupported evaluation exemption %q", exemption)
+	}
+	summary, err := s.EvaluationSummary(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	summary.Exemptions = appendUniqueEvaluationString(summary.Exemptions, exemption)
+	summary.UpdatedAt = time.Now().UTC()
+	return s.updateEvaluationSummaryProjection(ctx, *summary)
+}
+
+// RecordEvaluationEscalation records a stable escalation category once. The
+// escalated text remains outside the evaluation projection.
+func (s *Store) RecordEvaluationEscalation(ctx context.Context, runID string, category EvaluationEscalationCategory) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if !validEvaluationEscalation(category) {
+		return fmt.Errorf("unsupported evaluation escalation category %q", category)
+	}
+	summary, err := s.EvaluationSummary(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	summary.EscalationCategories = appendUniqueEvaluationString(summary.EscalationCategories, category)
+	summary.UpdatedAt = time.Now().UTC()
+	return s.updateEvaluationSummaryProjection(ctx, *summary)
+}
+
+// RecordEvaluationBlocker increments a stable repeated-blocker category.
+func (s *Store) RecordEvaluationBlocker(ctx context.Context, runID string, category EvaluationBlockerCategory) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if !validEvaluationBlocker(category) {
+		return fmt.Errorf("unsupported evaluation blocker category %q", category)
+	}
+	summary, err := s.EvaluationSummary(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	found := false
+	for index := range summary.RepeatedBlockers {
+		if summary.RepeatedBlockers[index].Category == category {
+			summary.RepeatedBlockers[index].Count++
+			found = true
+			break
+		}
+	}
+	if !found {
+		summary.RepeatedBlockers = append(summary.RepeatedBlockers, EvaluationBlocker{Category: category, Count: 1})
+	}
+	summary.UpdatedAt = time.Now().UTC()
+	return s.updateEvaluationSummaryProjection(ctx, *summary)
+}
+
+// RecordEvaluationUsage stores one idempotent harness measurement and safely
+// recomputes its summary. Missing measurements remain explicitly unavailable.
+func (s *Store) RecordEvaluationUsage(ctx context.Context, runID, invocationID string, usage EvaluationUsage) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if !safeEvaluationValue(invocationID) {
+		return errors.New("evaluation usage invocation id is required and must be safe metadata")
+	}
+	if err := validateEvaluationUsage(usage); err != nil {
+		return err
+	}
+	if !usage.Available {
+		return nil
+	}
+	if summary, err := s.EvaluationSummary(ctx, runID); err != nil {
+		return err
+	} else if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	now := time.Now().UTC().Format(runTimestampLayout)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO evaluation_usage (
+			run_id, invocation_id, input_tokens, output_tokens, total_tokens,
+			cost_reported, cost_micros, currency, recorded_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id, invocation_id) DO NOTHING`, runID, invocationID,
+		usage.InputTokens, usage.OutputTokens, usage.TotalTokens, usage.CostReported,
+		usage.CostMicros, usage.Currency, now)
+	if err != nil {
+		return fmt.Errorf("record evaluation usage for %q: %w", runID, err)
+	}
+	return s.refreshEvaluationUsage(ctx, runID)
+}
+
+// refreshEvaluationUsage sums only persisted harness measurements and marks
+// mixed currencies unavailable instead of guessing a conversion.
+func (s *Store) refreshEvaluationUsage(ctx context.Context, runID string) error {
+	var rows, costRows, input, output, total, cost int64
+	var currencies int
+	if err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+		COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost_micros), 0),
+		COUNT(CASE WHEN cost_reported = 1 THEN 1 END),
+		COUNT(DISTINCT CASE WHEN cost_reported = 1 THEN currency END)
+		FROM evaluation_usage WHERE run_id = ?`, runID).Scan(&rows, &input, &output, &total, &cost, &costRows, &currencies); err != nil {
+		return fmt.Errorf("aggregate evaluation usage for %q: %w", runID, err)
+	}
+	if rows == 0 {
+		return nil
+	}
+	var currency string
+	if currencies == 1 {
+		if err := s.db.QueryRowContext(ctx, `SELECT currency FROM evaluation_usage WHERE run_id = ? AND cost_reported = 1 ORDER BY invocation_id LIMIT 1`, runID).Scan(&currency); err != nil {
+			return fmt.Errorf("read evaluation usage currency for %q: %w", runID, err)
+		}
+	}
+	usage := EvaluationUsage{Available: true, InputTokens: input, OutputTokens: output, TotalTokens: total}
+	if currencies == 1 {
+		if costRows == rows {
+			usage.CostReported = true
+			usage.CostMicros = cost
+			usage.Currency = currency
+		} else {
+			usage.UnavailableReason = EvaluationUsagePartialCost
+		}
+	} else if currencies == 0 && costRows < rows {
+		usage.UnavailableReason = EvaluationUsagePartialCost
+	} else if currencies > 1 {
+		if input == 0 && output == 0 && total == 0 {
+			usage = EvaluationUsage{UnavailableReason: EvaluationUsageMixedCurrency}
+		} else {
+			usage.UnavailableReason = EvaluationUsageMixedCurrency
+		}
+	}
+	if err := validateEvaluationUsage(usage); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE evaluation_summaries SET usage_available = ?, usage_unavailable_reason = ?,
+		usage_input_tokens = ?, usage_output_tokens = ?, usage_total_tokens = ?,
+		usage_cost_reported = ?, usage_cost_micros = ?, usage_currency = ?, updated_at = ?
+		WHERE run_id = ?`, usage.Available, usage.UnavailableReason, usage.InputTokens,
+		usage.OutputTokens, usage.TotalTokens, usage.CostReported, usage.CostMicros,
+		usage.Currency, time.Now().UTC().Format(runTimestampLayout), runID)
+	if err != nil {
+		return fmt.Errorf("save aggregated evaluation usage for %q: %w", runID, err)
+	}
+	return nil
+}
+
+// FinalizeEvaluation closes the active stage and records the run outcome and
+// wall time. It is safe to call repeatedly with the same terminal values.
+func (s *Store) FinalizeEvaluation(ctx context.Context, runID string, outcome EvaluationOutcome, completedAt time.Time) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if err := validateEvaluationOutcome(outcome); err != nil {
+		return err
+	}
+	if outcome == EvaluationOutcomeActive || outcome == EvaluationOutcomeWaitingForHuman || outcome == EvaluationOutcomeWaitingForHarness {
+		return errors.New("evaluation finalization requires a terminal outcome")
+	}
+	if completedAt.IsZero() {
+		completedAt = time.Now().UTC()
+	}
+	summary, err := s.EvaluationSummary(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	if err := s.RefreshEvaluationCounts(ctx, runID); err != nil {
+		return err
+	}
+	if summary, err = s.EvaluationSummary(ctx, runID); err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	var activeStage, activeStartedAt string
+	if err := s.db.QueryRowContext(ctx, `SELECT active_stage, active_stage_started_at FROM evaluation_summaries WHERE run_id = ?`, runID).Scan(&activeStage, &activeStartedAt); err != nil {
+		return fmt.Errorf("read active evaluation stage for finalization %q: %w", runID, err)
+	}
+	if activeStage != "" && activeStartedAt != "" {
+		startedAt, parseErr := time.Parse(time.RFC3339Nano, activeStartedAt)
+		if parseErr != nil {
+			return fmt.Errorf("parse active evaluation stage for finalization %q: %w", runID, parseErr)
+		}
+		if completedAt.After(startedAt) {
+			addEvaluationStageDuration(summary, Stage(activeStage), completedAt.Sub(startedAt))
+		}
+	}
+	if completedAt.Before(summary.StartedAt) {
+		return errors.New("evaluation completion time must not precede start time")
+	}
+	summary.Outcome = outcome
+	summary.CompletedAt = completedAt.UTC()
+	summary.TotalWallTime = completedAt.Sub(summary.StartedAt)
+	summary.UpdatedAt = completedAt.UTC()
+	stageJSON, err := json.Marshal(nonNilStageDurations(summary.StageDurations))
+	if err != nil {
+		return fmt.Errorf("encode final evaluation stage durations: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE evaluation_summaries
+		SET outcome = ?, completed_at = ?, total_wall_nanos = ?, stage_durations = ?,
+			active_stage = '', active_stage_started_at = '', updated_at = ?
+		WHERE run_id = ?`, summary.Outcome, summary.CompletedAt.Format(runTimestampLayout),
+		int64(summary.TotalWallTime), string(stageJSON), summary.UpdatedAt.Format(runTimestampLayout), runID)
+	if err != nil {
+		return fmt.Errorf("finalize evaluation summary %q: %w", runID, err)
+	}
+	return nil
+}
+
+// ReopenEvaluation marks a previously terminal summary active for an explicit
+// retry while retaining its content-free historical counters.
+func (s *Store) ReopenEvaluation(ctx context.Context, runID string, stage Stage, at time.Time) error {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return err
+	}
+	if err := validateEvaluationStage(stage); err != nil {
+		return err
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE evaluation_summaries
+		SET outcome = ?, completed_at = '', active_stage = ?, active_stage_started_at = ?, updated_at = ?
+		WHERE run_id = ?`, EvaluationOutcomeActive, stage, at.UTC().Format(runTimestampLayout), at.UTC().Format(runTimestampLayout), runID)
+	if err != nil {
+		return fmt.Errorf("reopen evaluation summary %q: %w", runID, err)
+	}
+	if changed, rowsErr := result.RowsAffected(); rowsErr == nil && changed != 1 {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	return nil
+}
+
+// updateEvaluationSummaryProjection updates the public summary columns while
+// preserving the coordinator's internal active-stage cursor.
+func (s *Store) updateEvaluationSummaryProjection(ctx context.Context, summary EvaluationSummary) error {
+	normalized, values, err := normalizeEvaluationSummary(summary)
+	if err != nil {
+		return err
+	}
+	// The first 24 values are the public summary values through usage currency;
+	// the final two are internal active-stage placeholders and the final two are
+	// timestamps. This update intentionally leaves active_stage untouched.
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE evaluation_summaries SET
+			outcome = ?, started_at = ?, completed_at = ?, total_wall_nanos = ?,
+			stage_durations = ?, invocation_versions = ?, invocation_count = ?,
+			gate_count = ?, check_repair_count = ?, test_revision_count = ?,
+			review_revision_count = ?, budget_exhausted = ?, exemptions = ?,
+			escalation_categories = ?, repeated_blockers = ?, usage_available = ?,
+			usage_unavailable_reason = ?, usage_input_tokens = ?, usage_output_tokens = ?,
+			usage_total_tokens = ?, usage_cost_reported = ?, usage_cost_micros = ?,
+			usage_currency = ?, updated_at = ?
+		WHERE run_id = ?`, values[1], values[2], values[3], values[4], values[5], values[6],
+		values[7], values[8], values[9], values[10], values[11], values[12], values[13],
+		values[14], values[15], values[16], values[17], values[18], values[19], values[20],
+		values[21], values[22], values[23], normalized.UpdatedAt.UTC().Format(runTimestampLayout), normalized.RunID)
+	if err != nil {
+		return fmt.Errorf("update evaluation summary %q: %w", normalized.RunID, err)
+	}
+	return nil
+}
+
+// SaveEvaluationDisposition hashes an opaque event identity and records a
+// human disposition only for an already-recorded test dispute or review
+// finding escalation.
+func (s *Store) SaveEvaluationDisposition(ctx context.Context, request EvaluationDispositionRequest) (EvaluationDispositionRecord, error) {
+	if err := validateEvaluationRunID(request.RunID); err != nil {
+		return EvaluationDispositionRecord{}, err
+	}
+	if strings.TrimSpace(request.EventID) == "" || len(request.EventID) > 4096 || strings.ContainsAny(request.EventID, "\x00\r\n") {
+		return EvaluationDispositionRecord{}, errors.New("evaluation disposition event identity is required and bounded")
+	}
+	if request.Category != EvaluationEscalationTestDispute && request.Category != EvaluationEscalationReviewFinding {
+		return EvaluationDispositionRecord{}, errors.New("evaluation disposition category must be a test dispute or review finding")
+	}
+	switch request.Disposition {
+	case EvaluationDispositionUpheld, EvaluationDispositionAdvisory, EvaluationDispositionOverturned:
+	default:
+		return EvaluationDispositionRecord{}, fmt.Errorf("unsupported evaluation disposition %q", request.Disposition)
+	}
+	summary, err := s.EvaluationSummary(ctx, request.RunID)
+	if err != nil {
+		return EvaluationDispositionRecord{}, err
+	}
+	if summary == nil {
+		return EvaluationDispositionRecord{}, fmt.Errorf("evaluation summary %q does not exist", request.RunID)
+	}
+	escalated := false
+	for _, category := range summary.EscalationCategories {
+		if category == request.Category {
+			escalated = true
+			break
+		}
+	}
+	if !escalated {
+		return EvaluationDispositionRecord{}, fmt.Errorf("evaluation run %q has no %q escalation", request.RunID, request.Category)
+	}
+	decidedAt := request.DecidedAt.UTC()
+	if decidedAt.IsZero() {
+		decidedAt = time.Now().UTC()
+	}
+	record := EvaluationDispositionRecord{
+		RunID:       request.RunID,
+		EventIDHash: metadataHash(request.EventID),
+		Category:    request.Category,
+		Disposition: request.Disposition,
+		DecidedAt:   decidedAt,
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO evaluation_dispositions (run_id, event_id_hash, category, disposition, decided_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(run_id, event_id_hash) DO UPDATE SET
+			category = excluded.category, disposition = excluded.disposition, decided_at = excluded.decided_at`,
+		record.RunID, record.EventIDHash, record.Category, record.Disposition, record.DecidedAt.Format(runTimestampLayout))
+	if err != nil {
+		return EvaluationDispositionRecord{}, fmt.Errorf("save evaluation disposition for %q: %w", request.RunID, err)
+	}
+	return record, nil
+}
+
+// RecordEvaluationDisposition is an explicit alias for callers that model a
+// human disposition as an event rather than a saved record.
+func (s *Store) RecordEvaluationDisposition(ctx context.Context, request EvaluationDispositionRequest) (EvaluationDispositionRecord, error) {
+	return s.SaveEvaluationDisposition(ctx, request)
+}
+
+// ListEvaluationDispositions returns only hashed identities and fixed
+// categories for one run.
+func (s *Store) ListEvaluationDispositions(ctx context.Context, runID string) ([]EvaluationDispositionRecord, error) {
+	if err := validateEvaluationRunID(runID); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT run_id, event_id_hash, category, disposition, decided_at
+		FROM evaluation_dispositions WHERE run_id = ? ORDER BY decided_at, event_id_hash`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("list evaluation dispositions for %q: %w", runID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	result := make([]EvaluationDispositionRecord, 0)
+	for rows.Next() {
+		var record EvaluationDispositionRecord
+		var decidedAt string
+		if err := rows.Scan(&record.RunID, &record.EventIDHash, &record.Category, &record.Disposition, &decidedAt); err != nil {
+			return nil, fmt.Errorf("scan evaluation disposition: %w", err)
+		}
+		var parseErr error
+		if record.DecidedAt, parseErr = parseEvaluationTime("disposition decided_at", decidedAt); parseErr != nil {
+			return nil, parseErr
+		}
+		result = append(result, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read evaluation dispositions for %q: %w", runID, err)
+	}
+	return result, nil
+}
+
+// FinalizeEvaluationWithBudget records a terminal outcome and its explicit
+// budget-exhaustion signal. It is a convenience for coordinator paths that
+// know the budget disposition at finalization time.
+func (s *Store) FinalizeEvaluationWithBudget(ctx context.Context, runID string, outcome EvaluationOutcome, completedAt time.Time, budgetExhausted bool) error {
+	if err := s.FinalizeEvaluation(ctx, runID, outcome, completedAt); err != nil {
+		return err
+	}
+	if !budgetExhausted {
+		return nil
+	}
+	return s.setEvaluationBudgetExhausted(ctx, runID)
+}
+
+// AggregateEvaluation computes local counts, rates, durations, dispositions,
+// and available usage without contacting GitHub or any other network service.
+func (s *Store) AggregateEvaluation(ctx context.Context) (EvaluationAggregate, error) {
+	summaries, err := s.ListEvaluationSummaries(ctx, "")
+	if err != nil {
+		return EvaluationAggregate{}, err
+	}
+	aggregate := EvaluationAggregate{
+		OutcomeCounts:     map[EvaluationOutcome]int{},
+		OutcomeRates:      map[EvaluationOutcome]float64{},
+		StageDurations:    map[Stage]time.Duration{},
+		EscalationCounts:  map[EvaluationEscalationCategory]int{},
+		EscalationRates:   map[EvaluationEscalationCategory]float64{},
+		DispositionCounts: map[EvaluationDisposition]int{},
+		Usage:             EvaluationUsage{UnavailableReason: EvaluationUsageNotReported},
+	}
+	aggregate.RunCount = len(summaries)
+	var usageCurrency string
+	var usageCurrencies = map[string]struct{}{}
+	var usageCostIncomplete bool
+	usageUnavailableReason := EvaluationUsageNotReported
+	for _, summary := range summaries {
+		aggregate.OutcomeCounts[summary.Outcome]++
+		aggregate.TotalWallTime += summary.TotalWallTime
+		aggregate.InvocationCount += summary.InvocationCount
+		aggregate.GateCount += summary.GateCount
+		aggregate.CheckRepairCount += summary.CheckRepairCount
+		aggregate.TestRevisionCount += summary.TestRevisionCount
+		aggregate.ReviewRevisionCount += summary.ReviewRevisionCount
+		if summary.BudgetExhausted {
+			aggregate.BudgetExhaustionRate++
+		}
+		if summary.Usage.Available {
+			aggregate.UsageAvailableRuns++
+			aggregate.Usage.InputTokens += summary.Usage.InputTokens
+			aggregate.Usage.OutputTokens += summary.Usage.OutputTokens
+			aggregate.Usage.TotalTokens += summary.Usage.TotalTokens
+			if summary.Usage.CostReported {
+				aggregate.UsageCostReportedRuns++
+				usageCurrencies[summary.Usage.Currency] = struct{}{}
+				usageCurrency = summary.Usage.Currency
+				aggregate.Usage.CostMicros += summary.Usage.CostMicros
+			} else {
+				usageCostIncomplete = true
+			}
+		} else if summary.Usage.UnavailableReason != "" && summary.Usage.UnavailableReason != EvaluationUsageNotReported {
+			usageUnavailableReason = summary.Usage.UnavailableReason
+		}
+		for _, duration := range summary.StageDurations {
+			aggregate.StageDurations[duration.Stage] += duration.Duration
+		}
+		for _, category := range summary.EscalationCategories {
+			aggregate.EscalationCounts[category]++
+		}
+	}
+	if aggregate.RunCount > 0 {
+		aggregate.AverageTotalWallTime = aggregate.TotalWallTime / time.Duration(aggregate.RunCount)
+		aggregate.SuccessRate = float64(aggregate.OutcomeCounts[EvaluationOutcomeComplete]) / float64(aggregate.RunCount)
+		aggregate.BudgetExhaustionRate /= float64(aggregate.RunCount)
+		for outcome, count := range aggregate.OutcomeCounts {
+			aggregate.OutcomeRates[outcome] = float64(count) / float64(aggregate.RunCount)
+		}
+		for category, count := range aggregate.EscalationCounts {
+			aggregate.EscalationRates[category] = float64(count) / float64(aggregate.RunCount)
+		}
+	}
+	if len(usageCurrencies) == 1 && !usageCostIncomplete {
+		aggregate.Usage.Available = aggregate.UsageAvailableRuns > 0
+		aggregate.Usage.UnavailableReason = ""
+		aggregate.Usage.CostReported = true
+		aggregate.Usage.Currency = usageCurrency
+	} else if len(usageCurrencies) == 1 && usageCostIncomplete {
+		aggregate.Usage.Available = aggregate.UsageAvailableRuns > 0
+		aggregate.Usage.UnavailableReason = EvaluationUsagePartialCost
+		aggregate.Usage.CostReported = false
+		aggregate.Usage.CostMicros = 0
+		aggregate.Usage.Currency = ""
+	} else if len(usageCurrencies) > 1 {
+		if aggregate.Usage.InputTokens == 0 && aggregate.Usage.OutputTokens == 0 && aggregate.Usage.TotalTokens == 0 {
+			aggregate.Usage = EvaluationUsage{UnavailableReason: EvaluationUsageMixedCurrency}
+		} else {
+			aggregate.Usage.Available = aggregate.UsageAvailableRuns > 0
+			aggregate.Usage.UnavailableReason = EvaluationUsageMixedCurrency
+			aggregate.Usage.CostReported = false
+			aggregate.Usage.CostMicros = 0
+		}
+	} else if aggregate.UsageAvailableRuns > 0 {
+		aggregate.Usage.Available = true
+		aggregate.Usage.UnavailableReason = EvaluationUsagePartialCost
+	} else {
+		aggregate.Usage.UnavailableReason = usageUnavailableReason
+	}
+	if rows, queryErr := s.db.QueryContext(ctx, `SELECT disposition, COUNT(*) FROM evaluation_dispositions GROUP BY disposition`); queryErr != nil {
+		return EvaluationAggregate{}, fmt.Errorf("aggregate evaluation dispositions: %w", queryErr)
+	} else {
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var disposition EvaluationDisposition
+			var count int
+			if scanErr := rows.Scan(&disposition, &count); scanErr != nil {
+				return EvaluationAggregate{}, fmt.Errorf("scan evaluation disposition aggregate: %w", scanErr)
+			}
+			aggregate.DispositionCounts[disposition] = count
+		}
+		if rowsErr := rows.Err(); rowsErr != nil {
+			return EvaluationAggregate{}, fmt.Errorf("read evaluation disposition aggregate: %w", rowsErr)
+		}
+	}
+	return aggregate, nil
+}
+
+// DeleteEvaluationSummariesBefore deliberately removes only terminal
+// evaluation projections completed before before. It never removes runs,
+// invocation artifacts, logs, worktrees, or any other operational data.
+func (s *Store) DeleteEvaluationSummariesBefore(ctx context.Context, before time.Time) (EvaluationDeletionResult, error) {
+	if before.IsZero() {
+		return EvaluationDeletionResult{}, errors.New("evaluation deletion cutoff is required")
+	}
+	cutoff := before.UTC().Format(runTimestampLayout)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return EvaluationDeletionResult{}, fmt.Errorf("begin evaluation deletion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, `SELECT run_id FROM evaluation_summaries WHERE completed_at <> '' AND completed_at < ?`, cutoff)
+	if err != nil {
+		return EvaluationDeletionResult{}, fmt.Errorf("select evaluation summaries for deletion: %w", err)
+	}
+	ids := make([]string, 0)
+	for rows.Next() {
+		var runID string
+		if err := rows.Scan(&runID); err != nil {
+			_ = rows.Close()
+			return EvaluationDeletionResult{}, fmt.Errorf("scan evaluation deletion id: %w", err)
+		}
+		ids = append(ids, runID)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return EvaluationDeletionResult{}, fmt.Errorf("read evaluation deletion ids: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return EvaluationDeletionResult{}, fmt.Errorf("close evaluation deletion ids: %w", err)
+	}
+	result := EvaluationDeletionResult{}
+	for _, runID := range ids {
+		usageResult, err := tx.ExecContext(ctx, `DELETE FROM evaluation_usage WHERE run_id = ?`, runID)
+		if err != nil {
+			return EvaluationDeletionResult{}, fmt.Errorf("delete evaluation usage for %q: %w", runID, err)
+		}
+		if count, countErr := usageResult.RowsAffected(); countErr == nil {
+			result.UsageRows += int(count)
+		}
+		dispositionResult, err := tx.ExecContext(ctx, `DELETE FROM evaluation_dispositions WHERE run_id = ?`, runID)
+		if err != nil {
+			return EvaluationDeletionResult{}, fmt.Errorf("delete evaluation dispositions for %q: %w", runID, err)
+		}
+		if count, countErr := dispositionResult.RowsAffected(); countErr == nil {
+			result.Dispositions += int(count)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM evaluation_summaries WHERE run_id = ?`, runID); err != nil {
+			return EvaluationDeletionResult{}, fmt.Errorf("delete evaluation summary for %q: %w", runID, err)
+		}
+		result.Summaries++
+	}
+	if err := tx.Commit(); err != nil {
+		return EvaluationDeletionResult{}, fmt.Errorf("commit evaluation deletion: %w", err)
+	}
+	return result, nil
+}

--- a/internal/store/evaluation.go
+++ b/internal/store/evaluation.go
@@ -934,13 +934,6 @@ func (s *Store) RecordEvaluationInvocation(ctx context.Context, runID string, in
 			return fmt.Errorf("evaluation %s contains unsafe metadata", field)
 		}
 	}
-	summary, err := s.EvaluationSummary(ctx, runID)
-	if err != nil {
-		return err
-	}
-	if summary == nil {
-		return fmt.Errorf("evaluation summary %q does not exist", runID)
-	}
 	version := EvaluationInvocationVersion{
 		InvocationID:        invocation.ID,
 		Harness:             invocation.Harness,
@@ -949,6 +942,18 @@ func (s *Store) RecordEvaluationInvocation(ctx context.Context, runID string, in
 		ReportSchemaVersion: reportSchemaVersion,
 		WorkerVersion:       workerVersion,
 	}
+	if err := s.RefreshEvaluationCounts(ctx, runID); err != nil {
+		return err
+	}
+	// Re-read summary after RefreshEvaluationCounts to get current gate_count and invocation_count
+	summary, err := s.EvaluationSummary(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if summary == nil {
+		return fmt.Errorf("evaluation summary %q does not exist", runID)
+	}
+	// Apply the invocation version changes to the refreshed summary
 	found := false
 	for index := range summary.InvocationVersions {
 		if summary.InvocationVersions[index].InvocationID == invocation.ID {
@@ -966,9 +971,6 @@ func (s *Store) RecordEvaluationInvocation(ctx context.Context, runID string, in
 	summary.InvocationVersions = filteredVersions
 	if !found {
 		summary.InvocationVersions = append(summary.InvocationVersions, version)
-	}
-	if err := s.RefreshEvaluationCounts(ctx, runID); err != nil {
-		return err
 	}
 	summary.InvocationCount = len(summary.InvocationVersions)
 	summary.UpdatedAt = time.Now().UTC()
@@ -1089,6 +1091,10 @@ func (s *Store) RecordEvaluationExemption(ctx context.Context, runID string, exe
 	if !validEvaluationExemption(exemption) {
 		return fmt.Errorf("unsupported evaluation exemption %q", exemption)
 	}
+	if err := s.RefreshEvaluationCounts(ctx, runID); err != nil {
+		return err
+	}
+	// Re-read summary after RefreshEvaluationCounts to get current gate_count and invocation_count
 	summary, err := s.EvaluationSummary(ctx, runID)
 	if err != nil {
 		return err
@@ -1110,6 +1116,10 @@ func (s *Store) RecordEvaluationEscalation(ctx context.Context, runID string, ca
 	if !validEvaluationEscalation(category) {
 		return fmt.Errorf("unsupported evaluation escalation category %q", category)
 	}
+	if err := s.RefreshEvaluationCounts(ctx, runID); err != nil {
+		return err
+	}
+	// Re-read summary after RefreshEvaluationCounts to get current gate_count and invocation_count
 	summary, err := s.EvaluationSummary(ctx, runID)
 	if err != nil {
 		return err
@@ -1130,6 +1140,10 @@ func (s *Store) RecordEvaluationBlocker(ctx context.Context, runID string, categ
 	if !validEvaluationBlocker(category) {
 		return fmt.Errorf("unsupported evaluation blocker category %q", category)
 	}
+	if err := s.RefreshEvaluationCounts(ctx, runID); err != nil {
+		return err
+	}
+	// Re-read summary after RefreshEvaluationCounts to get current gate_count and invocation_count
 	summary, err := s.EvaluationSummary(ctx, runID)
 	if err != nil {
 		return err

--- a/internal/store/evaluation_test.go
+++ b/internal/store/evaluation_test.go
@@ -1,0 +1,330 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+const evaluationCheckpoint = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// TestEvaluationSummaryRecordsContentFreeRunAndAggregates verifies the local
+// evaluation projection records workflow metadata without copying work content
+// and produces useful aggregate counts and rates.
+func TestEvaluationSummaryRecordsContentFreeRunAndAggregates(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+
+	started := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	run := store.Run{ID: "run-evaluation", RepositoryPath: "/repo", Stage: store.StageClaim, Status: store.StatusActive, ImageDigest: "sha256:worker", CreatedAt: started, UpdatedAt: started}
+	if err := opened.EnsureEvaluationSummary(ctx, run); err != nil {
+		t.Fatalf("EnsureEvaluationSummary() error = %v", err)
+	}
+	if err := opened.SaveInvocation(ctx, store.Invocation{ID: "inv-evaluation", RunID: run.ID, Harness: "codex", Role: "implementation", Stage: store.StageImplementation, Model: "gpt-5", PromptVersion: "implementation-v1", Status: store.InvocationStatusCompleted, CreatedAt: started, UpdatedAt: started.Add(2 * time.Minute)}); err != nil {
+		t.Fatalf("SaveInvocation() error = %v", err)
+	}
+	if err := opened.RecordEvaluationInvocation(ctx, run.ID, store.Invocation{ID: "inv-evaluation", RunID: run.ID, Harness: "codex", Role: "implementation", Stage: store.StageImplementation, Model: "gpt-5", PromptVersion: "implementation-v1"}, "sha256:worker", 1); err != nil {
+		t.Fatalf("RecordEvaluationInvocation() error = %v", err)
+	}
+	if err := opened.SaveGateResults(ctx, []store.GateResult{{RunID: run.ID, CheckpointSHA: evaluationCheckpoint, Phase: store.GatePhaseCheckpoint, Ordinal: 0, GateName: "test", Outcome: store.GateOutcomePassed, Status: "success", Blocking: true}}); err != nil {
+		t.Fatalf("SaveGateResults() error = %v", err)
+	}
+	if err := opened.RefreshEvaluationCounts(ctx, run.ID); err != nil {
+		t.Fatalf("RefreshEvaluationCounts() error = %v", err)
+	}
+	if err := opened.RecordEvaluationStageTransition(ctx, run.ID, store.StageClaim, store.StageImplementation, started.Add(time.Minute)); err != nil {
+		t.Fatalf("RecordEvaluationStageTransition() error = %v", err)
+	}
+	if err := opened.RecordEvaluationAttempt(ctx, run.ID, store.EvaluationAttemptCheckRepair); err != nil {
+		t.Fatalf("RecordEvaluationAttempt() error = %v", err)
+	}
+	if err := opened.RecordEvaluationAttempt(ctx, run.ID, store.EvaluationAttemptReviewRevision); err != nil {
+		t.Fatalf("RecordEvaluationAttempt() review error = %v", err)
+	}
+	if err := opened.RecordEvaluationExemption(ctx, run.ID, store.EvaluationExemptionTechnical); err != nil {
+		t.Fatalf("RecordEvaluationExemption() error = %v", err)
+	}
+	if err := opened.RecordEvaluationEscalation(ctx, run.ID, store.EvaluationEscalationReviewFinding); err != nil {
+		t.Fatalf("RecordEvaluationEscalation() error = %v", err)
+	}
+	if err := opened.RecordEvaluationBlocker(ctx, run.ID, store.EvaluationBlockerReview); err != nil {
+		t.Fatalf("RecordEvaluationBlocker() first error = %v", err)
+	}
+	if err := opened.RecordEvaluationBlocker(ctx, run.ID, store.EvaluationBlockerReview); err != nil {
+		t.Fatalf("RecordEvaluationBlocker() second error = %v", err)
+	}
+	if err := opened.RecordEvaluationBudgetExhaustion(ctx, run.ID); err != nil {
+		t.Fatalf("RecordEvaluationBudgetExhaustion() error = %v", err)
+	}
+	if err := opened.RecordEvaluationUsage(ctx, run.ID, "inv-evaluation", store.EvaluationUsage{Available: true, InputTokens: 10, OutputTokens: 20, TotalTokens: 30, CostReported: true, CostMicros: 7, Currency: "USD"}); err != nil {
+		t.Fatalf("RecordEvaluationUsage() error = %v", err)
+	}
+	finished := started.Add(5 * time.Minute)
+	if err := opened.FinalizeEvaluation(ctx, run.ID, store.EvaluationOutcomeComplete, finished); err != nil {
+		t.Fatalf("FinalizeEvaluation() error = %v", err)
+	}
+
+	got, err := opened.EvaluationSummary(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("EvaluationSummary() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("EvaluationSummary() = nil, want a persisted summary")
+	}
+	if got.Outcome != store.EvaluationOutcomeComplete || got.TotalWallTime != 5*time.Minute {
+		t.Fatalf("summary outcome/wall time = %q/%s, want complete/5m", got.Outcome, got.TotalWallTime)
+	}
+	if got.InvocationCount != 1 || got.GateCount != 1 || got.CheckRepairCount != 1 || got.ReviewRevisionCount != 1 || !got.BudgetExhausted {
+		t.Fatalf("summary counts = %#v, want invocation=1 gate=1 check=1 review=1", got)
+	}
+	if len(got.InvocationVersions) != 1 || got.InvocationVersions[0].WorkerVersion != "sha256:worker" {
+		t.Fatalf("summary versions = %#v, want one content-free invocation version", got.InvocationVersions)
+	}
+	if !got.Usage.Available || got.Usage.TotalTokens != 30 || got.Usage.CostMicros != 7 {
+		t.Fatalf("summary usage = %#v, want reported usage", got.Usage)
+	}
+	if len(got.RepeatedBlockers) != 1 || got.RepeatedBlockers[0].Count != 2 {
+		t.Fatalf("summary blockers = %#v, want review count 2", got.RepeatedBlockers)
+	}
+	serialized, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(serialized), "issue text") || strings.Contains(string(serialized), "source contents") || strings.Contains(string(serialized), "command output") {
+		t.Fatalf("evaluation summary contains work content: %s", serialized)
+	}
+
+	secondRun := store.Run{ID: "run-evaluation-failed", RepositoryPath: "/repo", Stage: store.StageClaim, Status: store.StatusActive, CreatedAt: started, UpdatedAt: started}
+	if err := opened.EnsureEvaluationSummary(ctx, secondRun); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.FinalizeEvaluation(ctx, secondRun.ID, store.EvaluationOutcomeFailed, started.Add(10*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	aggregate, err := opened.AggregateEvaluation(ctx)
+	if err != nil {
+		t.Fatalf("AggregateEvaluation() error = %v", err)
+	}
+	if aggregate.RunCount != 2 || aggregate.OutcomeCounts[store.EvaluationOutcomeComplete] != 1 || aggregate.OutcomeCounts[store.EvaluationOutcomeFailed] != 1 {
+		t.Fatalf("aggregate outcomes = %#v, want one complete and one failed", aggregate)
+	}
+	if aggregate.SuccessRate != 0.5 || aggregate.AverageTotalWallTime != 7*time.Minute+30*time.Second {
+		t.Fatalf("aggregate rates/duration = %v/%s, want 0.5/7m30s", aggregate.SuccessRate, aggregate.AverageTotalWallTime)
+	}
+}
+
+// TestEvaluationDispositionHashesTheOpaqueFindingIdentity verifies a human
+// disposition is attached to a category while the finding identity itself is
+// never persisted as content.
+func TestEvaluationDispositionHashesTheOpaqueFindingIdentity(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	run := store.Run{ID: "run-disposition", RepositoryPath: "/repo", Stage: store.StageReview, Status: store.StatusWaitingForHuman}
+	if err := opened.EnsureEvaluationSummary(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.RecordEvaluationEscalation(ctx, run.ID, store.EvaluationEscalationReviewFinding); err != nil {
+		t.Fatal(err)
+	}
+	const findingText = "review finding text must not be retained"
+	disposition, err := opened.SaveEvaluationDisposition(ctx, store.EvaluationDispositionRequest{RunID: run.ID, EventID: findingText, Category: store.EvaluationEscalationReviewFinding, Disposition: store.EvaluationDispositionAdvisory})
+	if err != nil {
+		t.Fatalf("SaveEvaluationDisposition() error = %v", err)
+	}
+	if disposition.EventIDHash == "" || disposition.EventIDHash == findingText {
+		t.Fatalf("disposition event identity = %#v, want a non-content hash", disposition)
+	}
+	if disposition.Disposition != store.EvaluationDispositionAdvisory {
+		t.Fatalf("disposition = %#v, want advisory", disposition)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), findingText) {
+		t.Fatal("operational database retained the finding text")
+	}
+}
+
+// TestEvaluationUsageIsExplicitlyUnavailableUntilReported verifies the store
+// does not manufacture usage or cost when a harness provides no measurement.
+func TestEvaluationUsageIsExplicitlyUnavailableUntilReported(t *testing.T) {
+	ctx := context.Background()
+	opened, err := store.Open(ctx, filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	if err := opened.EnsureEvaluationSummary(ctx, store.Run{ID: "run-no-usage", RepositoryPath: "/repo", Stage: store.StageClaim, Status: store.StatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := opened.EvaluationSummary(ctx, "run-no-usage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Usage.Available || got.Usage.UnavailableReason != store.EvaluationUsageNotReported {
+		t.Fatalf("usage = %#v, want explicitly unavailable/not_reported", got.Usage)
+	}
+}
+
+// TestAggregateEvaluationReportsMixedCurrencyCostUnavailable verifies cost is
+// never combined across currencies even when each harness report is reliable.
+func TestAggregateEvaluationReportsMixedCurrencyCostUnavailable(t *testing.T) {
+	ctx := context.Background()
+	opened, err := store.Open(ctx, filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	for _, fixture := range []struct {
+		runID    string
+		currency string
+	}{
+		{runID: "run-usd", currency: "USD"},
+		{runID: "run-eur", currency: "EUR"},
+	} {
+		run := store.Run{ID: fixture.runID, RepositoryPath: "/repo/" + fixture.runID, Stage: store.StageClaim, Status: store.StatusActive}
+		if err := opened.EnsureEvaluationSummary(ctx, run); err != nil {
+			t.Fatal(err)
+		}
+		if err := opened.RecordEvaluationUsage(ctx, fixture.runID, "inv-"+fixture.runID, store.EvaluationUsage{Available: true, CostReported: true, CostMicros: 1, Currency: fixture.currency}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	aggregate, err := opened.AggregateEvaluation(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if aggregate.Usage.Available || aggregate.Usage.UnavailableReason != store.EvaluationUsageMixedCurrency || aggregate.Usage.CostReported {
+		t.Fatalf("aggregate usage = %#v, want mixed-currency cost unavailable", aggregate.Usage)
+	}
+}
+
+// TestAggregateEvaluationReportsPartialCostUnavailable verifies aggregate cost
+// is not presented as complete when one usage-bearing run omitted cost.
+func TestAggregateEvaluationReportsPartialCostUnavailable(t *testing.T) {
+	ctx := context.Background()
+	opened, err := store.Open(ctx, filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	for _, fixture := range []struct {
+		runID string
+		usage store.EvaluationUsage
+	}{
+		{runID: "run-cost", usage: store.EvaluationUsage{Available: true, TotalTokens: 10, CostReported: true, CostMicros: 1, Currency: "USD"}},
+		{runID: "run-token-only", usage: store.EvaluationUsage{Available: true, TotalTokens: 20}},
+	} {
+		run := store.Run{ID: fixture.runID, RepositoryPath: "/repo/" + fixture.runID, Stage: store.StageClaim, Status: store.StatusActive}
+		if err := opened.EnsureEvaluationSummary(ctx, run); err != nil {
+			t.Fatal(err)
+		}
+		if err := opened.RecordEvaluationUsage(ctx, fixture.runID, "inv-"+fixture.runID, fixture.usage); err != nil {
+			t.Fatal(err)
+		}
+	}
+	perRun, err := opened.EvaluationSummary(ctx, "run-token-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perRun == nil || perRun.Usage.UnavailableReason != store.EvaluationUsagePartialCost {
+		t.Fatalf("per-run token-only usage = %#v, want partial cost unavailable", perRun)
+	}
+	aggregate, err := opened.AggregateEvaluation(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !aggregate.Usage.Available || aggregate.Usage.CostReported || aggregate.Usage.UnavailableReason != store.EvaluationUsagePartialCost || aggregate.Usage.CostMicros != 0 {
+		t.Fatalf("aggregate usage = %#v, want partial cost unavailable with token totals", aggregate.Usage)
+	}
+}
+
+// TestEvaluationSummaryRejectsUnsafeMetadata verifies version fields cannot
+// become a side channel for issue text or other work content.
+func TestEvaluationSummaryRejectsUnsafeMetadata(t *testing.T) {
+	ctx := context.Background()
+	opened, err := store.Open(ctx, filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+
+	if err := opened.EnsureEvaluationSummary(ctx, store.Run{ID: "run-unsafe", RepositoryPath: "/repo", Stage: store.StageClaim, Status: store.StatusActive, ImageDigest: "issue text"}); err == nil {
+		t.Fatal("EnsureEvaluationSummary() error = nil, want unsafe worker metadata rejection")
+	}
+	if err := opened.SaveEvaluationSummary(ctx, store.EvaluationSummary{
+		RunID:   "run-unsafe",
+		Outcome: store.EvaluationOutcomeActive,
+		InvocationVersions: []store.EvaluationInvocationVersion{{
+			Model: "source contents",
+		}},
+	}); err == nil {
+		t.Fatal("SaveEvaluationSummary() error = nil, want unsafe invocation metadata rejection")
+	}
+}
+
+// TestDeleteEvaluationSummariesBeforeOnlyRemovesExplicitlySelectedTerminalData
+// verifies retention deletion is deliberate, bounded, and does not touch active
+// summaries.
+func TestDeleteEvaluationSummariesBeforeOnlyRemovesExplicitlySelectedTerminalData(t *testing.T) {
+	ctx := context.Background()
+	opened, err := store.Open(ctx, filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	old := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	for _, fixture := range []struct {
+		id     string
+		status store.EvaluationOutcome
+		at     time.Time
+	}{
+		{id: "run-old", status: store.EvaluationOutcomeComplete, at: old},
+		{id: "run-new", status: store.EvaluationOutcomeComplete, at: old.Add(48 * time.Hour)},
+		{id: "run-active", status: store.EvaluationOutcomeActive, at: old},
+	} {
+		run := store.Run{ID: fixture.id, RepositoryPath: "/repo/" + fixture.id, Stage: store.StageClaim, Status: store.StatusActive, CreatedAt: fixture.at, UpdatedAt: fixture.at}
+		if err := opened.EnsureEvaluationSummary(ctx, run); err != nil {
+			t.Fatal(err)
+		}
+		if fixture.status != store.EvaluationOutcomeActive {
+			if err := opened.FinalizeEvaluation(ctx, fixture.id, fixture.status, fixture.at.Add(time.Hour)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	deleted, err := opened.DeleteEvaluationSummariesBefore(ctx, old.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("DeleteEvaluationSummariesBefore() error = %v", err)
+	}
+	if deleted.Summaries != 1 {
+		t.Fatalf("deleted summaries = %#v, want one old terminal summary", deleted)
+	}
+	for _, id := range []string{"run-old", "run-new", "run-active"} {
+		got, err := opened.EvaluationSummary(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantPresent := id != "run-old"
+		if (got != nil) != wantPresent {
+			t.Fatalf("summary %q present=%t, want %t", id, got != nil, wantPresent)
+		}
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,7 +18,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 12
+const CurrentSchemaVersion = 13
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -1177,6 +1177,71 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 			if _, err := tx.ExecContext(ctx, `CREATE INDEX gate_results_by_run
 					ON gate_results (run_id, phase, checkpoint_sha, ordinal)`); err != nil {
 				return fmt.Errorf("apply store migration 12 index: %w", err)
+			}
+		case 13:
+			if _, err := tx.ExecContext(ctx, `CREATE TABLE evaluation_summaries (
+				run_id TEXT PRIMARY KEY,
+				outcome TEXT NOT NULL,
+				started_at TEXT NOT NULL,
+				completed_at TEXT NOT NULL DEFAULT '',
+				total_wall_nanos INTEGER NOT NULL DEFAULT 0,
+				stage_durations TEXT NOT NULL DEFAULT '[]',
+				invocation_versions TEXT NOT NULL DEFAULT '[]',
+				invocation_count INTEGER NOT NULL DEFAULT 0,
+				gate_count INTEGER NOT NULL DEFAULT 0,
+				check_repair_count INTEGER NOT NULL DEFAULT 0,
+				test_revision_count INTEGER NOT NULL DEFAULT 0,
+				review_revision_count INTEGER NOT NULL DEFAULT 0,
+				budget_exhausted INTEGER NOT NULL DEFAULT 0,
+				exemptions TEXT NOT NULL DEFAULT '[]',
+				escalation_categories TEXT NOT NULL DEFAULT '[]',
+				repeated_blockers TEXT NOT NULL DEFAULT '[]',
+				usage_available INTEGER NOT NULL DEFAULT 0,
+				usage_unavailable_reason TEXT NOT NULL DEFAULT 'not_reported',
+				usage_input_tokens INTEGER NOT NULL DEFAULT 0,
+				usage_output_tokens INTEGER NOT NULL DEFAULT 0,
+				usage_total_tokens INTEGER NOT NULL DEFAULT 0,
+				usage_cost_reported INTEGER NOT NULL DEFAULT 0,
+				usage_cost_micros INTEGER NOT NULL DEFAULT 0,
+				usage_currency TEXT NOT NULL DEFAULT '',
+				active_stage TEXT NOT NULL DEFAULT '',
+				active_stage_started_at TEXT NOT NULL DEFAULT '',
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)`); err != nil {
+				return fmt.Errorf("apply store migration 13 evaluation summaries: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `CREATE TABLE evaluation_usage (
+				run_id TEXT NOT NULL,
+				invocation_id TEXT NOT NULL,
+				input_tokens INTEGER NOT NULL DEFAULT 0,
+				output_tokens INTEGER NOT NULL DEFAULT 0,
+				total_tokens INTEGER NOT NULL DEFAULT 0,
+				cost_reported INTEGER NOT NULL DEFAULT 0,
+				cost_micros INTEGER NOT NULL DEFAULT 0,
+				currency TEXT NOT NULL DEFAULT '',
+				recorded_at TEXT NOT NULL,
+				PRIMARY KEY (run_id, invocation_id)
+			)`); err != nil {
+				return fmt.Errorf("apply store migration 13 evaluation usage: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `CREATE INDEX evaluation_usage_by_run
+					ON evaluation_usage (run_id, recorded_at)`); err != nil {
+				return fmt.Errorf("apply store migration 13 evaluation usage index: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `CREATE TABLE evaluation_dispositions (
+				run_id TEXT NOT NULL,
+				event_id_hash TEXT NOT NULL,
+				category TEXT NOT NULL,
+				disposition TEXT NOT NULL,
+				decided_at TEXT NOT NULL,
+				PRIMARY KEY (run_id, event_id_hash)
+			)`); err != nil {
+				return fmt.Errorf("apply store migration 13 evaluation dispositions: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `CREATE INDEX evaluation_dispositions_by_run
+					ON evaluation_dispositions (run_id, decided_at)`); err != nil {
+				return fmt.Errorf("apply store migration 13 evaluation dispositions index: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)


### PR DESCRIPTION
Closes #25

## Summary
- add a content-free local evaluation projection with stage timing, outcomes, versions, effort counters, budget signals, exemptions, escalations, blockers, dispositions, and reliable harness usage
- add privacy-bounded report signals and explicit partial or mixed-cost availability handling
- add local per-run and aggregate evaluation commands plus deliberate confirmed deletion
- migrate existing stores with backup and preserve fail-closed newer-schema behavior
- document the local retention and no-telemetry boundary

## Verification
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

Evaluation data stays local and content-free; no GitHub or other network call is made by the reporting commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local evaluation reporting with per-run and aggregate metrics.
  * Reports can include token usage, cost, budget status, exemptions, escalations, and blockers when explicitly provided.
  * Added human disposition recording with timestamped, privacy-preserving finding references.
  * Added configurable evaluation-summary retention and explicit deletion before a selected cutoff.
* **Documentation**
  * Clarified local evaluation storage, telemetry behavior, retention rules, reporting, and cleanup boundaries.
* **Validation**
  * Added validation for retention settings, usage data, evaluation signals, and cost information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->