### PR TITLE
Implement clarification round-trip and packet refresh

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -95,6 +95,17 @@ Terminal rendering, scrollback, and screen text are never parsed for stage
 completion. A report is a proposal; only coordinator validation changes the
 run or invocation state.
 
+An accepted `needs_clarification` report finishes the current harness session,
+stops the worker, and places the run in `waiting_for_human` without consuming a
+retry attempt. The coordinator publishes each question ID and prompt on the
+active issue or pull request, mirrors them in the editable status comment, and
+notifies cmux. An authorized maintainer answers with a structured GitHub
+comment such as `/factory answer clarification-1 use the existing JSON format`.
+The answer is stored in the next specification-packet version, and a fresh
+invocation receives that packet. A `/factory refresh` command similarly
+re-reads the issue, versions the packet, and invalidates downstream results
+before resuming the role.
+
 ## Authentication and session state
 
 Registration may name one explicit host Codex auth file:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,7 +290,7 @@ prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use
 `factory agent-report --invocation-id <id>` to ask the coordinator to validate
 and accept the structured report. Terminal output is never treated as a stage
-result. The operational store schema is version 17 and persists invocation
+result. The operational store schema is version 18 and persists invocation
 identity, opaque surface handles, prompt version, result directory, native
 session identifier, and permitted handoff paths in addition to run state. It
 also persists the draft pull-request number and URL so a restarted command can

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,6 +225,7 @@ mention of “retry” or “refresh” cannot control a run:
 ```text
 /factory status
 /factory refresh
+/factory answer clarification-1 use the existing JSON format
 /factory retry
 /factory cancel
 /factory config harness=codex
@@ -235,15 +236,20 @@ repeating the command is safe because the persisted watermark filters old
 comments.
 
 The author must be present in the registered `authorized_users` list. A status
-or refresh command re-renders the existing supervision comment; retry reopens a
-failed or explicitly cancelled run at its current stage; cancel stops active
-worker activity while retaining the run artifacts; and harness configuration
-records a later invocation override only when the frozen repository
-configuration permits it. A recognized command from an unauthorized author or
-a malformed command is a
+or refresh command re-renders the existing supervision comment; an answer
+command is accepted only from an authorized user while the referenced question
+is pending; retry reopens a failed or explicitly cancelled run at its current
+stage; cancel stops active worker activity while retaining the run artifacts;
+and harness configuration records a later invocation override only when the
+frozen repository configuration permits it. A recognized command from an
+unauthorized author or a malformed command is a
 typed policy rejection. The coordinator leaves workflow stage, status, labels,
 and configuration unchanged for that rejection, while recording the rejection
 in the same editable status comment.
+
+Answer commands normally use `/factory answer <question-id> <answer>`; the
+identifier may also be written as `question=`, `question-id=`, or `id=` for
+automation clients, and an answer may begin with `answer=`.
 
 The command grammar also names `claude` for forward-compatible parsing, but the
 current implementation role has only the Codex adapter; selecting Claude is a
@@ -259,6 +265,18 @@ GitHub effects. The same parser and handler are used for issue comments and
 pull-request comments; later commands can extend the registered verb set
 without duplicating polling or replay logic.
 
+When an implementation report requests clarification, the coordinator pauses
+the run with `agent-needs-input`, renders pending question IDs and prompts in
+the editable status comment, posts the questions on the issue (or tracked pull
+request), and notifies cmux. A command such as
+`/factory answer clarification-1 use the existing JSON format` records the
+authorized answer in a new specification-packet version and resumes a fresh
+implementation invocation with that packet. Clarification pauses do not
+consume retry budget. `/factory refresh` re-reads the issue into another packet
+version, preserves resolved answers, invalidates superseded downstream
+invocations and checkpoint results, and resumes implementation against the new
+snapshot.
+
 The poll command also observes the tracked pull request and issue lifecycle.
 A merged pull request completes the run and records its merge commit; closing
 the issue or an unmerged pull request cancels it. Merge detection takes
@@ -272,7 +290,7 @@ prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use
 `factory agent-report --invocation-id <id>` to ask the coordinator to validate
 and accept the structured report. Terminal output is never treated as a stage
-result. The operational store schema is version 10 and persists invocation
+result. The operational store schema is version 17 and persists invocation
 identity, opaque surface handles, prompt version, result directory, native
 session identifier, and permitted handoff paths in addition to run state. It
 also persists the draft pull-request number and URL so a restarted command can

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -21,6 +21,8 @@ const (
 	Cancel Kind = "cancel"
 	// Refresh asks the coordinator to refresh the supervision projection.
 	Refresh Kind = "refresh"
+	// Answer supplies an authorized answer to one pending clarification question.
+	Answer Kind = "answer"
 	// ConfigureHarness changes the selected harness for a later invocation.
 	ConfigureHarness Kind = "configure_harness"
 )
@@ -41,6 +43,10 @@ type Request struct {
 	Kind Kind
 	// Harness is set only for ConfigureHarness.
 	Harness Harness
+	// QuestionID is set only for Answer and identifies one pending question.
+	QuestionID string
+	// Answer is set only for Answer and contains the maintainer's response.
+	Answer string
 }
 
 // ParseResult distinguishes ordinary discussion from a structured command.
@@ -65,6 +71,10 @@ const (
 	ParseErrorUnexpectedArgument ParseErrorCode = "unexpected_argument"
 	// ParseErrorMissingHarness means a harness configuration had no value.
 	ParseErrorMissingHarness ParseErrorCode = "missing_harness"
+	// ParseErrorMissingAnswer means an answer command omitted required content.
+	ParseErrorMissingAnswer ParseErrorCode = "missing_answer"
+	// ParseErrorInvalidQuestionArgument means an answer question identifier was malformed.
+	ParseErrorInvalidQuestionArgument ParseErrorCode = "invalid_question_argument"
 	// ParseErrorInvalidHarnessArgument means the harness key was malformed.
 	ParseErrorInvalidHarnessArgument ParseErrorCode = "invalid_harness_argument"
 	// ParseErrorUnsupportedHarness means the harness is outside the grammar.
@@ -116,6 +126,8 @@ func Parse(body string) (ParseResult, error) {
 		return parseFixedArity(result, fields, Cancel)
 	case string(Refresh):
 		return parseFixedArity(result, fields, Refresh)
+	case string(Answer):
+		return parseAnswer(result, fields[2:])
 	case "config", "configure", "harness":
 		harness, parseErr := parseHarness(fields[2:])
 		if parseErr != nil {
@@ -126,6 +138,51 @@ func Parse(body string) (ParseResult, error) {
 	default:
 		return result, &ParseError{Code: ParseErrorUnknownVerb, Problem: fmt.Sprintf("command %q is not supported", fields[1])}
 	}
+}
+
+// parseAnswer parses the question identifier and answer text from an answer
+// command while preserving the answer's word boundaries for the coordinator.
+func parseAnswer(result ParseResult, arguments []string) (ParseResult, error) {
+	if len(arguments) < 2 {
+		return result, &ParseError{Code: ParseErrorMissingAnswer, Problem: "answer requires a question identifier and answer text"}
+	}
+	questionID := arguments[0]
+	if key, value, found := strings.Cut(questionID, "="); found {
+		if key != "question" && key != "question-id" && key != "id" {
+			return result, &ParseError{Code: ParseErrorInvalidQuestionArgument, Problem: "the first answer argument must be a question identifier"}
+		}
+		questionID = value
+	}
+	if !safeArgument(questionID) {
+		return result, &ParseError{Code: ParseErrorInvalidQuestionArgument, Problem: "the question identifier must be a nonempty safe value"}
+	}
+	answer := strings.Join(arguments[1:], " ")
+	if key, value, found := strings.Cut(answer, "answer="); found && key == "" {
+		answer = value
+	}
+	if strings.TrimSpace(answer) == "" {
+		return result, &ParseError{Code: ParseErrorMissingAnswer, Problem: "answer text must not be empty"}
+	}
+	if strings.ContainsAny(answer, "\x00\r\n") {
+		return result, &ParseError{Code: ParseErrorControlCharacter, Problem: "the answer contains a control character"}
+	}
+	result.Command = Request{Kind: Answer, QuestionID: questionID, Answer: answer}
+	return result, nil
+}
+
+// safeArgument reports whether a command identifier contains only a bounded
+// single-line token that cannot alter command parsing.
+func safeArgument(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsLetter(character) || unicode.IsDigit(character) || strings.ContainsRune("._-", character) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // parseFixedArity parses a registered verb that accepts no arguments.

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,6 +1,7 @@
 package command_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/Stevie1704/sw-factory/internal/command"
@@ -33,6 +34,34 @@ func TestParseDistinguishesOrdinaryDiscussionFromStructuredCommands(t *testing.T
 	}
 	if !nonBreakingSpace.Recognized || nonBreakingSpace.Command.Kind != command.Status {
 		t.Fatalf("parsed non-breaking-space status = %#v, want recognized status command", nonBreakingSpace)
+	}
+}
+
+// TestAnswerCommandCarriesItsQuestionIdentifierAndText verifies the structured
+// answer payload is distinguishable from ordinary discussion.
+func TestAnswerCommandCarriesItsQuestionIdentifierAndText(t *testing.T) {
+	parsed, err := command.Parse("/factory answer clarification-1 use the existing JSON format")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if !parsed.Recognized || parsed.Command.Kind != command.Answer {
+		t.Fatalf("Parse() = %#v, want recognized answer command", parsed)
+	}
+	if parsed.Command.QuestionID != "clarification-1" || parsed.Command.Answer != "use the existing JSON format" {
+		t.Fatalf("answer command = %#v, want identifier and text", parsed.Command)
+	}
+}
+
+// TestAnswerCommandRejectsAnUnsafeQuestionIdentifier verifies malformed
+// structured input fails closed before it can reach workflow policy.
+func TestAnswerCommandRejectsAnUnsafeQuestionIdentifier(t *testing.T) {
+	parsed, err := command.Parse("/factory answer question-id=clarification/1 yes")
+	if !parsed.Recognized || err == nil {
+		t.Fatalf("Parse() = %#v/%v, want recognized typed rejection", parsed, err)
+	}
+	var parseErr *command.ParseError
+	if !errors.As(err, &parseErr) || parseErr.Code != command.ParseErrorInvalidQuestionArgument {
+		t.Fatalf("Parse() error = %v, want invalid question argument", err)
 	}
 }
 

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -8,16 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/harness"
-	"github.com/Stevie1704/sw-factory/internal/prompt"
 	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/terminal"
-	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
 // InvocationStore is the operational-store seam required by visible agent
@@ -135,237 +132,7 @@ func (s *Service) StartAgent(ctx context.Context, request AgentRequest) (result 
 		return AgentLaunchResult{}, err
 	}
 	defer func() { _ = runStore.Close() }()
-	invocationStore, ok := runStore.(InvocationStore)
-	if !ok {
-		return AgentLaunchResult{}, errors.New("operational store does not support visible invocations")
-	}
-	if run == nil {
-		return AgentLaunchResult{}, errors.New("no active run")
-	}
-	if request.RunID != "" && request.RunID != run.ID {
-		return AgentLaunchResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
-	}
-	if run.CheckRepairPendingAttempt != 0 {
-		return AgentLaunchResult{}, fmt.Errorf("check-repair attempt %d is pending reconciliation", run.CheckRepairPendingAttempt)
-	}
-	if request.Harness == "" && run.HarnessOverride != "" {
-		request.Harness = config.Harness(run.HarnessOverride)
-	}
-	if err := validateAgentRunState(*run); err != nil {
-		return AgentLaunchResult{}, err
-	}
-	if activeStore, ok := invocationStore.(ActiveInvocationStore); ok {
-		active, lookupErr := activeStore.ActiveInvocation(ctx, run.ID)
-		if lookupErr != nil {
-			return AgentLaunchResult{}, fmt.Errorf("look up active visible invocation: %w", lookupErr)
-		}
-		if active != nil {
-			return AgentLaunchResult{}, fmt.Errorf("run %q already has active invocation %q", run.ID, active.ID)
-		}
-	}
-	if !filepath.IsAbs(run.Worktree) {
-		return AgentLaunchResult{}, errors.New("active run worktree must be absolute")
-	}
-	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
-	if err != nil {
-		return AgentLaunchResult{}, err
-	}
-	if err := s.ensureBaselineReady(ctx, runStore, *run, packet); err != nil {
-		return AgentLaunchResult{}, err
-	}
-	harnessName, model, err := resolveAgentPolicy(packet.RepositoryConfig, request)
-	if err != nil {
-		return AgentLaunchResult{}, err
-	}
-	if harnessName != config.HarnessCodex {
-		return AgentLaunchResult{}, fmt.Errorf("harness %q is not supported by the Codex implementation agent", harnessName)
-	}
-	authPath := request.CodexAuthPath
-	if authPath == "" {
-		authPath = registration.Authentication.CodexAuthPath
-	}
-	credentialStoreID := ""
-	var seeder worker.CredentialSeeder
-	if authPath != "" {
-		credentialStoreID = registration.Path
-		var ok bool
-		seeder, ok = s.deps.Worker.(worker.CredentialSeeder)
-		if !ok {
-			return AgentLaunchResult{}, errors.New("worker runtime does not support Codex credential seeding")
-		}
-	}
-	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath)
-	if err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("ensure agent runtime: %w", err)
-	}
-	runID, err := s.deps.NewRunID()
-	if err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("generate invocation identifier: %w", err)
-	}
-	invocationID := "inv-" + runID
-	createdAt := s.deps.Now().UTC()
-	root := filepath.Join(filepath.Dir(run.Worktree), ".factory-agents", run.ID, invocationID)
-	packetDirectory := filepath.Join(root, "packet")
-	resultDirectory := filepath.Join(root, "results")
-	if err := os.MkdirAll(packetDirectory, 0o700); err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("create invocation packet directory: %w", err)
-	}
-	if err := os.MkdirAll(resultDirectory, 0o700); err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("create invocation result directory: %w", err)
-	}
-	role := request.Role
-	stage := request.Stage
-	promptText, err := prompt.Build(prompt.Request{
-		InvocationID:        invocationID,
-		RunID:               run.ID,
-		Role:                role,
-		Stage:               string(stage),
-		SpecificationPacket: run.SpecificationPacket,
-		RepositoryGuidance:  packet.Issue.Body,
-	})
-	if err != nil {
-		return AgentLaunchResult{}, err
-	}
-	if err := writeInvocationPacket(packetDirectory, InvocationPacket{
-		SchemaVersion:       invocationPacketVersion,
-		InvocationID:        invocationID,
-		RunID:               run.ID,
-		Role:                role,
-		Stage:               stage,
-		SpecificationPacket: run.SpecificationPacket,
-		PromptVersion:       prompt.Version,
-		PermittedPaths:      append([]string(nil), request.PermittedPaths...),
-	}); err != nil {
-		return AgentLaunchResult{}, err
-	}
-	invocation := store.Invocation{
-		ID:                  invocationID,
-		RunID:               run.ID,
-		Harness:             string(harnessName),
-		Role:                role,
-		Stage:               stage,
-		Model:               model,
-		ReasoningEffort:     request.ReasoningEffort,
-		CredentialStoreID:   credentialStoreID,
-		InvocationDirectory: packetDirectory,
-		ResultDirectory:     resultDirectory,
-		PermittedPaths:      append([]string(nil), request.PermittedPaths...),
-		PromptVersion:       prompt.Version,
-		Status:              store.InvocationStatusActive,
-		CreatedAt:           createdAt,
-		UpdatedAt:           createdAt,
-	}
-	invocationPersisted := false
-	workerStarted := false
-	cleanupSurface := terminal.Surface{}
-	defer func() {
-		if returnErr == nil || !invocationPersisted {
-			return
-		}
-		rollbackContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		invocation.Status = store.InvocationStatusCannotProceed
-		invocation.UpdatedAt = s.deps.Now().UTC()
-		_ = invocationStore.SaveInvocation(rollbackContext, invocation)
-		if workerStarted {
-			_ = s.deps.Worker.Stop(rollbackContext, run.ID)
-		}
-		if cleanupSurface.ID != "" {
-			_ = terminalRuntime.CloseSurface(rollbackContext, cleanupSurface.ID)
-		}
-	}()
-	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("persist visible invocation: %w", err)
-	}
-	invocationPersisted = true
-	if recorder, ok := runStore.(evaluationRecorder); ok {
-		if err := recorder.EnsureEvaluationSummary(ctx, *run); err != nil {
-			return AgentLaunchResult{}, fmt.Errorf("ensure local evaluation summary: %w", err)
-		}
-		if err := recorder.RecordEvaluationInvocation(ctx, run.ID, invocation, run.ImageDigest, report.SchemaVersion); err != nil {
-			return AgentLaunchResult{}, fmt.Errorf("record local evaluation invocation: %w", err)
-		}
-	}
-	gitMetadataPath, err := prepareGitMetadataProjection(run.ID, registration.Path, run.Worktree)
-	if err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("prepare worker Git metadata: %w", err)
-	}
-	if err := s.deps.Worker.Start(ctx, worker.StartRequest{
-		RunID:             run.ID,
-		WorktreePath:      run.Worktree,
-		GitMetadataPath:   gitMetadataPath,
-		Image:             packet.RepositoryConfig.WorkerBuild.Image,
-		ImageDigest:       run.ImageDigest,
-		Caches:            workerCaches(packet.RepositoryConfig.Caches),
-		InvocationPath:    packetDirectory,
-		ResultPath:        resultDirectory,
-		CredentialStoreID: credentialStoreID,
-		Role:              role,
-	}); err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("start worker for visible agent: %w", err)
-	}
-	workerStarted = true
-	if authPath != "" {
-		if err := seeder.SeedCodexCredentials(ctx, worker.CredentialSeedRequest{RunID: run.ID, AuthPath: authPath}); err != nil {
-			return AgentLaunchResult{}, err
-		}
-	}
-	control, err := terminalRuntime.EnsureControlWorkspace(ctx, terminal.WorkspaceRequest{
-		Name:             defaultString(registration.Cmux.ControlWorkspace, "factory-control"),
-		Description:      "software factory coordinator",
-		WorkingDirectory: registration.Path,
-	})
-	if err != nil {
-		return AgentLaunchResult{}, err
-	}
-	runWorkspace, err := terminalRuntime.EnsureRunWorkspace(ctx, terminal.RunWorkspaceRequest{
-		RunID:            run.ID,
-		Name:             "factory-" + run.ID,
-		Description:      fmt.Sprintf("factory run for issue #%d", run.IssueNumber),
-		WorkingDirectory: run.Worktree,
-	})
-	if err != nil {
-		return AgentLaunchResult{}, err
-	}
-	cleanupSurface = runWorkspace.Implementation
-	invocation.WorkspaceID = string(runWorkspace.ID)
-	invocation.StatusSurfaceID = string(runWorkspace.Status.ID)
-	invocation.ImplementationSurfaceID = string(runWorkspace.Implementation.ID)
-	invocation.ChecksSurfaceID = string(runWorkspace.Checks.ID)
-	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("persist visible terminal handles: %w", err)
-	}
-	if err := terminalRuntime.Notify(ctx, terminal.Notification{WorkspaceID: control.ID, Title: "factory run started", Body: run.ID + " implementation agent active"}); err != nil {
-		return AgentLaunchResult{}, err
-	}
-	session, err := harnessRuntime.Start(ctx, harness.StartRequest{
-		InvocationID:    invocationID,
-		RunID:           run.ID,
-		Role:            role,
-		Stage:           string(stage),
-		WorkspaceID:     runWorkspace.ID,
-		Surface:         runWorkspace.Implementation,
-		Prompt:          promptText,
-		Model:           model,
-		ReasoningEffort: request.ReasoningEffort,
-	})
-	if err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("launch Codex implementation agent: %w", err)
-	}
-	if session.NativeSessionID != "" {
-		invocation.NativeSessionID = session.NativeSessionID
-	}
-	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("persist Codex session identity: %w", err)
-	}
-	previousRun := *run
-	run.Stage = store.StageImplementation
-	run.Status = store.StatusActive
-	run.UpdatedAt = s.deps.Now().UTC()
-	if err := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("persist implementation stage: %w", err)
-	}
-	return AgentLaunchResult{Invocation: invocation, Prompt: promptText}, nil
+	return s.startAgentWithStore(ctx, registration, runStore, run, request)
 }
 
 // AcceptAgentReport reads only the invocation report file, validates its
@@ -447,6 +214,15 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	if err := report.Validate(value, validationContext); err != nil {
 		return AgentResult{}, err
 	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return AgentResult{}, fmt.Errorf("decode specification packet for agent report: %w", err)
+	}
+	if value.Outcome == report.OutcomeNeedsClarification {
+		if err := validateClarificationQuestions(packet, run.PendingQuestions, value.Questions); err != nil {
+			return AgentResult{}, err
+		}
+	}
 	if recorder, ok := runStore.(evaluationRecorder); ok {
 		if err := recorder.EnsureEvaluationSummary(ctx, *run); err != nil {
 			return AgentResult{}, fmt.Errorf("ensure local evaluation summary: %w", err)
@@ -513,6 +289,11 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	if err := harnessRuntime.Finish(ctx, harness.Session{InvocationID: invocation.ID, NativeSessionID: nativeSessionID, Surface: terminal.Surface{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID), Name: invocation.Role}}); err != nil {
 		return AgentResult{}, fmt.Errorf("finish accepted harness session: %w", err)
 	}
+	if value.Outcome == report.OutcomeNeedsClarification {
+		if err := s.stopRunWorker(ctx, run.ID); err != nil {
+			return AgentResult{}, err
+		}
+	}
 	invocation.NativeSessionID = nativeSessionID
 	switch value.Outcome {
 	case report.OutcomeCompleted:
@@ -531,14 +312,30 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	switch value.Outcome {
 	case report.OutcomeNeedsClarification:
 		run.Status = store.StatusWaitingForHuman
+		run.PendingQuestions = pendingQuestionsFromReport(value.Questions)
+		run.ClarificationCommentID = ""
+		run.ClarificationNotificationSent = false
 	case report.OutcomeCannotProceed:
 		run.Status = store.StatusFailed
+		run.PendingQuestions = nil
+		run.ClarificationCommentID = ""
+		run.ClarificationNotificationSent = false
 	default:
 		run.Status = store.StatusActive
+		run.PendingQuestions = nil
+		run.ClarificationCommentID = ""
+		run.ClarificationNotificationSent = false
 	}
 	run.UpdatedAt = s.deps.Now().UTC()
 	if err := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); err != nil {
 		return AgentResult{}, fmt.Errorf("persist accepted agent state: %w", err)
+	}
+	if value.Outcome == report.OutcomeNeedsClarification {
+		published, err := s.ensureClarificationPublication(ctx, registration, runStore, *run)
+		if err != nil {
+			return AgentResult{}, err
+		}
+		*run = published
 	}
 	return AgentResult{Invocation: *invocation, Report: value}, nil
 }

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -1,0 +1,255 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/prompt"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// startAgentWithStore launches one visible implementation invocation using an
+// already-open operational store. Command-driven resumes use this seam to
+// avoid reopening SQLite while the command projection is being applied.
+func (s *Service) startAgentWithStore(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, request AgentRequest) (result AgentLaunchResult, returnErr error) {
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return AgentLaunchResult{}, errors.New("operational store does not support visible invocations")
+	}
+	if run == nil {
+		return AgentLaunchResult{}, errors.New("no active run")
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return AgentLaunchResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
+	}
+	if run.CheckRepairPendingAttempt != 0 {
+		return AgentLaunchResult{}, fmt.Errorf("check-repair attempt %d is pending reconciliation", run.CheckRepairPendingAttempt)
+	}
+	if request.Harness == "" && run.HarnessOverride != "" {
+		request.Harness = config.Harness(run.HarnessOverride)
+	}
+	if err := validateAgentRunState(*run); err != nil {
+		return AgentLaunchResult{}, err
+	}
+	if activeStore, ok := invocationStore.(ActiveInvocationStore); ok {
+		active, lookupErr := activeStore.ActiveInvocation(ctx, run.ID)
+		if lookupErr != nil {
+			return AgentLaunchResult{}, fmt.Errorf("look up active visible invocation: %w", lookupErr)
+		}
+		if active != nil {
+			return AgentLaunchResult{}, fmt.Errorf("run %q already has active invocation %q", run.ID, active.ID)
+		}
+	}
+	if !filepath.IsAbs(run.Worktree) {
+		return AgentLaunchResult{}, errors.New("active run worktree must be absolute")
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return AgentLaunchResult{}, err
+	}
+	if err := s.ensureBaselineReady(ctx, runStore, *run, packet); err != nil {
+		return AgentLaunchResult{}, err
+	}
+	harnessName, model, err := resolveAgentPolicy(packet.RepositoryConfig, request)
+	if err != nil {
+		return AgentLaunchResult{}, err
+	}
+	if harnessName != config.HarnessCodex {
+		return AgentLaunchResult{}, fmt.Errorf("harness %q is not supported by the Codex implementation agent", harnessName)
+	}
+	authPath := request.CodexAuthPath
+	if authPath == "" {
+		authPath = registration.Authentication.CodexAuthPath
+	}
+	credentialStoreID := ""
+	var seeder worker.CredentialSeeder
+	if authPath != "" {
+		credentialStoreID = registration.Path
+		var ok bool
+		seeder, ok = s.deps.Worker.(worker.CredentialSeeder)
+		if !ok {
+			return AgentLaunchResult{}, errors.New("worker runtime does not support Codex credential seeding")
+		}
+	}
+	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath)
+	if err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("ensure agent runtime: %w", err)
+	}
+	runID, err := s.deps.NewRunID()
+	if err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("generate invocation identifier: %w", err)
+	}
+	invocationID := "inv-" + runID
+	createdAt := s.deps.Now().UTC()
+	root := filepath.Join(filepath.Dir(run.Worktree), ".factory-agents", run.ID, invocationID)
+	packetDirectory := filepath.Join(root, "packet")
+	resultDirectory := filepath.Join(root, "results")
+	if err := os.MkdirAll(packetDirectory, 0o700); err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("create invocation packet directory: %w", err)
+	}
+	if err := os.MkdirAll(resultDirectory, 0o700); err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("create invocation result directory: %w", err)
+	}
+	role := request.Role
+	stage := request.Stage
+	promptText, err := prompt.Build(prompt.Request{
+		InvocationID:        invocationID,
+		RunID:               run.ID,
+		Role:                role,
+		Stage:               string(stage),
+		SpecificationPacket: run.SpecificationPacket,
+		RepositoryGuidance:  packet.Issue.Body,
+	})
+	if err != nil {
+		return AgentLaunchResult{}, err
+	}
+	if err := writeInvocationPacket(packetDirectory, InvocationPacket{
+		SchemaVersion:       invocationPacketVersion,
+		InvocationID:        invocationID,
+		RunID:               run.ID,
+		Role:                role,
+		Stage:               stage,
+		SpecificationPacket: run.SpecificationPacket,
+		PromptVersion:       prompt.Version,
+		PermittedPaths:      append([]string(nil), request.PermittedPaths...),
+	}); err != nil {
+		return AgentLaunchResult{}, err
+	}
+	invocation := store.Invocation{
+		ID:                  invocationID,
+		RunID:               run.ID,
+		Harness:             string(harnessName),
+		Role:                role,
+		Stage:               stage,
+		Model:               model,
+		ReasoningEffort:     request.ReasoningEffort,
+		CredentialStoreID:   credentialStoreID,
+		InvocationDirectory: packetDirectory,
+		ResultDirectory:     resultDirectory,
+		PermittedPaths:      append([]string(nil), request.PermittedPaths...),
+		PromptVersion:       prompt.Version,
+		Status:              store.InvocationStatusActive,
+		CreatedAt:           createdAt,
+		UpdatedAt:           createdAt,
+	}
+	invocationPersisted := false
+	workerStarted := false
+	cleanupSurface := terminal.Surface{}
+	defer func() {
+		if returnErr == nil || !invocationPersisted {
+			return
+		}
+		rollbackContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		invocation.Status = store.InvocationStatusCannotProceed
+		invocation.UpdatedAt = s.deps.Now().UTC()
+		_ = invocationStore.SaveInvocation(rollbackContext, invocation)
+		if workerStarted {
+			_ = s.deps.Worker.Stop(rollbackContext, run.ID)
+		}
+		if cleanupSurface.ID != "" {
+			_ = terminalRuntime.CloseSurface(rollbackContext, cleanupSurface.ID)
+		}
+	}()
+	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("persist visible invocation: %w", err)
+	}
+	invocationPersisted = true
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recorder.EnsureEvaluationSummary(ctx, *run); err != nil {
+			return AgentLaunchResult{}, fmt.Errorf("ensure local evaluation summary: %w", err)
+		}
+		if err := recorder.RecordEvaluationInvocation(ctx, run.ID, invocation, run.ImageDigest, report.SchemaVersion); err != nil {
+			return AgentLaunchResult{}, fmt.Errorf("record local evaluation invocation: %w", err)
+		}
+	}
+	gitMetadataPath, err := prepareGitMetadataProjection(run.ID, registration.Path, run.Worktree)
+	if err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("prepare worker Git metadata: %w", err)
+	}
+	if err := s.deps.Worker.Start(ctx, worker.StartRequest{
+		RunID:             run.ID,
+		WorktreePath:      run.Worktree,
+		GitMetadataPath:   gitMetadataPath,
+		Image:             packet.RepositoryConfig.WorkerBuild.Image,
+		ImageDigest:       run.ImageDigest,
+		Caches:            workerCaches(packet.RepositoryConfig.Caches),
+		InvocationPath:    packetDirectory,
+		ResultPath:        resultDirectory,
+		CredentialStoreID: credentialStoreID,
+		Role:              role,
+	}); err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("start worker for visible agent: %w", err)
+	}
+	workerStarted = true
+	if authPath != "" {
+		if err := seeder.SeedCodexCredentials(ctx, worker.CredentialSeedRequest{RunID: run.ID, AuthPath: authPath}); err != nil {
+			return AgentLaunchResult{}, err
+		}
+	}
+	control, err := terminalRuntime.EnsureControlWorkspace(ctx, terminal.WorkspaceRequest{
+		Name:             defaultString(registration.Cmux.ControlWorkspace, "factory-control"),
+		Description:      "software factory coordinator",
+		WorkingDirectory: registration.Path,
+	})
+	if err != nil {
+		return AgentLaunchResult{}, err
+	}
+	runWorkspace, err := terminalRuntime.EnsureRunWorkspace(ctx, terminal.RunWorkspaceRequest{
+		RunID:            run.ID,
+		Name:             "factory-" + run.ID,
+		Description:      fmt.Sprintf("factory run for issue #%d", run.IssueNumber),
+		WorkingDirectory: run.Worktree,
+	})
+	if err != nil {
+		return AgentLaunchResult{}, err
+	}
+	cleanupSurface = runWorkspace.Implementation
+	invocation.WorkspaceID = string(runWorkspace.ID)
+	invocation.StatusSurfaceID = string(runWorkspace.Status.ID)
+	invocation.ImplementationSurfaceID = string(runWorkspace.Implementation.ID)
+	invocation.ChecksSurfaceID = string(runWorkspace.Checks.ID)
+	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("persist visible terminal handles: %w", err)
+	}
+	if err := terminalRuntime.Notify(ctx, terminal.Notification{WorkspaceID: control.ID, Title: "factory run started", Body: run.ID + " implementation agent active"}); err != nil {
+		return AgentLaunchResult{}, err
+	}
+	session, err := harnessRuntime.Start(ctx, harness.StartRequest{
+		InvocationID:    invocationID,
+		RunID:           run.ID,
+		Role:            role,
+		Stage:           string(stage),
+		WorkspaceID:     runWorkspace.ID,
+		Surface:         runWorkspace.Implementation,
+		Prompt:          promptText,
+		Model:           model,
+		ReasoningEffort: request.ReasoningEffort,
+	})
+	if err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("launch Codex implementation agent: %w", err)
+	}
+	if session.NativeSessionID != "" {
+		invocation.NativeSessionID = session.NativeSessionID
+	}
+	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("persist Codex session identity: %w", err)
+	}
+	previousRun := *run
+	run.Stage = store.StageImplementation
+	run.Status = store.StatusActive
+	run.UpdatedAt = s.deps.Now().UTC()
+	if err := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); err != nil {
+		return AgentLaunchResult{}, fmt.Errorf("persist implementation stage: %w", err)
+	}
+	return AgentLaunchResult{Invocation: invocation, Prompt: promptText}, nil
+}

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -263,6 +263,239 @@ func TestAcceptAgentReportUsesOnlyTheStructuredReportAndFinishesTheSession(t *te
 	}
 }
 
+// TestAcceptAgentReportPublishesClarificationAndPausesTheRun verifies a
+// clarification report becomes visible human work without consuming repair
+// budget or leaving the worker running.
+func TestAcceptAgentReportPublishesClarificationAndPausesTheRun(t *testing.T) {
+	service, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	reportValue := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  launch.Invocation.ID,
+		RunID:         launch.Invocation.RunID,
+		Harness:       launch.Invocation.Harness,
+		Role:          launch.Invocation.Role,
+		Stage:         string(launch.Invocation.Stage),
+		Outcome:       report.OutcomeNeedsClarification,
+		Summary:       "product intent is ambiguous",
+		Questions: []report.Question{{
+			ID:     "clarification-1",
+			Prompt: "Should the response use the existing JSON format?",
+		}},
+		NativeSessionID: "session-clarification",
+		ReportedAt:      time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, reportValue); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() error = %v", err)
+	}
+
+	accepted, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: launch.Invocation.ID})
+	if err != nil {
+		t.Fatalf("AcceptAgentReport() error = %v", err)
+	}
+	if accepted.Invocation.Status != store.InvocationStatusWaitingForHuman {
+		t.Fatalf("accepted invocation status = %q, want waiting_for_human", accepted.Invocation.Status)
+	}
+	paused := runStore.runs[launch.Invocation.RunID]
+	if paused.Status != store.StatusWaitingForHuman || len(paused.PendingQuestions) != 1 || paused.PendingQuestions[0].ID != "clarification-1" {
+		t.Fatalf("paused run = %#v, want one pending clarification", paused)
+	}
+	if paused.CheckRepairAttempts != 0 {
+		t.Fatalf("check-repair attempts = %d, want clarification pause to consume none", paused.CheckRepairAttempts)
+	}
+	if len(runStore.github.createdComments) != 2 || !strings.Contains(runStore.github.createdComments[1], "clarification-1") || !strings.Contains(runStore.github.createdComments[1], "Should the response use the existing JSON format?") {
+		t.Fatalf("clarification comments = %#v, want one question comment after claim", runStore.github.createdComments)
+	}
+	if len(runStore.github.editedComments) == 0 || !strings.Contains(runStore.github.editedComments[len(runStore.github.editedComments)-1].body, "clarification-1") {
+		t.Fatalf("status comment edits = %#v, want pending question", runStore.github.editedComments)
+	}
+	if runtime.stops != 1 || len(terminalRuntime.notifications) != 2 || len(harnessRuntime.finished) != 1 {
+		t.Fatalf("clarification effects = stops=%d notifications=%d finished=%d, want 1/2/1", runtime.stops, len(terminalRuntime.notifications), len(harnessRuntime.finished))
+	}
+}
+
+// TestClarificationPublicationCanRetryFromAStatusCommand verifies durable
+// publication markers make a GitHub/cmux failure recoverable after the report
+// itself has already moved the run to waiting_for_human.
+func TestClarificationPublicationCanRetryFromAStatusCommand(t *testing.T) {
+	service, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	reportValue := report.Report{
+		SchemaVersion:   report.SchemaVersion,
+		InvocationID:    launch.Invocation.ID,
+		RunID:           launch.Invocation.RunID,
+		Harness:         launch.Invocation.Harness,
+		Role:            launch.Invocation.Role,
+		Stage:           string(launch.Invocation.Stage),
+		Outcome:         report.OutcomeNeedsClarification,
+		Summary:         "needs product input",
+		Questions:       []report.Question{{ID: "clarification-retry", Prompt: "Which behavior is intended?"}},
+		NativeSessionID: "session-clarification",
+		ReportedAt:      time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, reportValue); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() error = %v", err)
+	}
+	runStore.github.createCommentErr = errors.New("GitHub temporarily unavailable")
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: launch.Invocation.ID}); err == nil {
+		t.Fatal("AcceptAgentReport() succeeded while clarification publication failed")
+	}
+	if runStore.current.ClarificationCommentID != "" || runStore.current.ClarificationNotificationSent {
+		t.Fatalf("failed publication markers = %#v, want no completed effects", runStore.current)
+	}
+	runStore.github.createCommentErr = nil
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 6,
+		Comment:     github.Comment{ID: "status-retry", Author: "alice", Body: "/factory status"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() retry error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || runStore.current.ClarificationCommentID == "" || !runStore.current.ClarificationNotificationSent {
+		t.Fatalf("retry result = %#v, persisted run = %#v, want published clarification", result, runStore.current)
+	}
+	if len(runStore.github.createdComments) != 2 || len(terminalRuntime.notifications) != 2 || runtime.stops != 1 || len(harnessRuntime.finished) != 1 {
+		t.Fatalf("retry effects = comments=%d notifications=%d stops=%d finished=%d, want 2/2/1/1", len(runStore.github.createdComments), len(terminalRuntime.notifications), runtime.stops, len(harnessRuntime.finished))
+	}
+}
+
+// TestAnswerCommandVersionsThePacketAndResumesImplementation verifies only an
+// authorized answer can resolve a pending question and launch a new packet.
+func TestAnswerCommandVersionsThePacketAndResumesImplementation(t *testing.T) {
+	service, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	clarification := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  launch.Invocation.ID,
+		RunID:         launch.Invocation.RunID,
+		Harness:       launch.Invocation.Harness,
+		Role:          launch.Invocation.Role,
+		Stage:         string(launch.Invocation.Stage),
+		Outcome:       report.OutcomeNeedsClarification,
+		Summary:       "intent is ambiguous",
+		Questions: []report.Question{
+			{ID: "clarification-1", Prompt: "Which output format should be used?"},
+			{ID: "clarification-2", Prompt: "Should the response include examples?"},
+		},
+		NativeSessionID: "session-clarification",
+		ReportedAt:      time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, clarification); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() error = %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: launch.Invocation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() error = %v", err)
+	}
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 6,
+		Comment:     github.Comment{ID: "answer-1", Author: "alice", Body: "/factory answer clarification-1 use the existing JSON format"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive || len(result.Run.PendingQuestions) != 1 || result.Run.PendingQuestions[0].ID != "clarification-2" {
+		t.Fatalf("first answer result = %#v, want active run with the second question pending", result)
+	}
+	if runStore.invocations[launch.Invocation.ID].Status != store.InvocationStatusSuperseded {
+		t.Fatalf("old invocation = %#v, want superseded", runStore.invocations[launch.Invocation.ID])
+	}
+	if len(runtime.starts) != 2 || len(harnessRuntime.starts) != 2 || len(terminalRuntime.notifications) != 3 {
+		t.Fatalf("first resume effects = workers=%d harnesses=%d notifications=%d, want 2/2/3", len(runtime.starts), len(harnessRuntime.starts), len(terminalRuntime.notifications))
+	}
+	result, err = service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 6,
+		Comment:     github.Comment{ID: "answer-2", Author: "alice", Body: "/factory answer clarification-2 omit examples"},
+	})
+	if err != nil {
+		t.Fatalf("second HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive || len(result.Run.PendingQuestions) != 0 {
+		t.Fatalf("second answer result = %#v, want active run without pending questions", result)
+	}
+	if len(runtime.starts) != 3 || len(harnessRuntime.starts) != 3 || len(terminalRuntime.notifications) != 4 {
+		t.Fatalf("second resume effects = workers=%d harnesses=%d notifications=%d, want 3/3/4", len(runtime.starts), len(harnessRuntime.starts), len(terminalRuntime.notifications))
+	}
+	packetData, err := os.ReadFile(filepath.Join(runtime.starts[2].InvocationPath, "specification.json"))
+	if err != nil {
+		t.Fatalf("read resumed invocation packet: %v", err)
+	}
+	var invocationPacket factory.InvocationPacket
+	if err := json.Unmarshal(packetData, &invocationPacket); err != nil {
+		t.Fatalf("decode resumed invocation packet: %v", err)
+	}
+	var packet factory.SpecificationPacket
+	if err := json.Unmarshal([]byte(invocationPacket.SpecificationPacket), &packet); err != nil {
+		t.Fatalf("decode resumed specification packet: %v", err)
+	}
+	if packet.Version != 3 || len(packet.Clarifications) != 2 || packet.Clarifications[0].Answer != "use the existing JSON format" || packet.Clarifications[1].Answer != "omit examples" {
+		t.Fatalf("resumed specification packet = %#v, want both versioned answers", packet)
+	}
+}
+
+// TestRefreshCommandReReadsTheIssueAndInvalidatesCheckpointResults verifies a
+// refresh creates a new packet while preserving the independent baseline.
+func TestRefreshCommandReReadsTheIssueAndInvalidatesCheckpointResults(t *testing.T) {
+	service, runStore, runtime, _, _ := newAgentService(t)
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	if _, err := writeAgentTestReport(t, launch, "internal/factory/agent.go"); err != nil {
+		t.Fatalf("writeAgentTestReport() error = %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: launch.Invocation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() error = %v", err)
+	}
+	run := *runStore.current
+	runStore.gateResults[run.ID] = append(runStore.gateResults[run.ID], store.GateResult{
+		RunID: run.ID, CheckpointSHA: run.CheckpointSHA, Phase: store.GatePhaseCheckpoint,
+		Ordinal: 0, GateName: "tests", Outcome: store.GateOutcomePassed,
+	})
+	runStore.github.issueValue.Body = "refreshed product intent"
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 6,
+		Comment:     github.Comment{ID: "refresh-1", Author: "alice", Body: "/factory refresh"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive || len(runtime.starts) != 2 {
+		t.Fatalf("refresh result = %#v, worker starts = %d, want accepted active resume", result, len(runtime.starts))
+	}
+	if runStore.invocations[launch.Invocation.ID].Status != store.InvocationStatusSuperseded {
+		t.Fatalf("refreshed invocation = %#v, want superseded", runStore.invocations[launch.Invocation.ID])
+	}
+	results := runStore.gateResults[run.ID]
+	if len(results) != 1 || results[0].Phase != store.GatePhaseBaseline {
+		t.Fatalf("remaining gate results = %#v, want baseline only", results)
+	}
+	var packet factory.SpecificationPacket
+	packetData, err := os.ReadFile(filepath.Join(runtime.starts[1].InvocationPath, "specification.json"))
+	if err != nil {
+		t.Fatalf("read refreshed invocation packet: %v", err)
+	}
+	var invocationPacket factory.InvocationPacket
+	if err := json.Unmarshal(packetData, &invocationPacket); err != nil {
+		t.Fatalf("decode refreshed invocation packet: %v", err)
+	}
+	if err := json.Unmarshal([]byte(invocationPacket.SpecificationPacket), &packet); err != nil {
+		t.Fatalf("decode refreshed specification packet: %v", err)
+	}
+	if packet.Version != 2 || packet.Issue.Body != "refreshed product intent" {
+		t.Fatalf("refreshed packet = %#v, want issue snapshot version 2", packet)
+	}
+}
+
 // TestAcceptAgentReportTrustsThePersistedNativeSession verifies a report
 // cannot replace the native session identity already bound to the invocation.
 func TestAcceptAgentReportTrustsThePersistedNativeSession(t *testing.T) {
@@ -443,11 +676,12 @@ func newAgentService(t *testing.T) (*factory.Service, *agentRunStore, *agentWork
 	issue := githubIssueFixture()
 	issue.Labels = []string{github.LabelAgentReady}
 	githubRuntime := &fakeGitHub{issueValue: issue}
+	runStore.github = githubRuntime
 	worktree := &inspectingWorktree{
 		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: "base", Branch: "factory/run-agent", Worktree: worktreePath}},
 		state:        gitadapter.WorktreeState{Branch: "factory/run-agent", HeadSHA: "base", ChangedPaths: []string{"internal/factory/agent.go"}},
 	}
-	ids := []string{"run-agent", "generated"}
+	ids := []string{"run-agent", "generated", "generated-2", "generated-3"}
 	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config:         &fakeConfig{value: host},
 		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
@@ -548,6 +782,7 @@ type agentRunStore struct {
 	gateResults     map[string][]store.GateResult
 	lifecycleClaims map[string]map[store.Status]bool
 	events          *[]string
+	github          *fakeGitHub
 }
 
 // CurrentRun returns the configured active run.
@@ -635,6 +870,26 @@ func (s *agentRunStore) ActiveInvocation(_ context.Context, runID string) (*stor
 		}
 	}
 	return nil, nil
+}
+
+// InvalidateRunResults supersedes prior invocations and clears checkpoint
+// results when a new specification packet becomes authoritative.
+func (s *agentRunStore) InvalidateRunResults(_ context.Context, runID string) error {
+	for id, invocation := range s.invocations {
+		if invocation.RunID == runID && invocation.Status != store.InvocationStatusSuperseded {
+			invocation.Status = store.InvocationStatusSuperseded
+			s.invocations[id] = invocation
+		}
+	}
+	results := s.gateResults[runID]
+	baseline := make([]store.GateResult, 0, len(results))
+	for _, result := range results {
+		if result.Phase == store.GatePhaseBaseline {
+			baseline = append(baseline, result)
+		}
+	}
+	s.gateResults[runID] = baseline
+	return nil
 }
 
 // SaveGateResults upserts the fixture's exact gate projections by durable identity.

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -14,18 +14,31 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/store"
 )
 
-// specificationPacketVersion identifies the persisted claim packet shape.
+// specificationPacketVersion is the first instance version assigned at claim.
 const specificationPacketVersion = 1
 
 // stateTransitionRetryDelay bounds the pause before the one persistence retry.
 const stateTransitionRetryDelay = 10 * time.Millisecond
 
-// SpecificationPacket is the immutable issue and resolved repository
-// configuration captured when a run is claimed.
+// Clarification is one accepted human answer retained in a specification
+// packet so later invocations receive the resolved product intent.
+type Clarification struct {
+	// QuestionID identifies the question answered by the maintainer.
+	QuestionID string `json:"question_id"`
+	// Question preserves the prompt that the answer resolves.
+	Question string `json:"question"`
+	// Answer is the authorized maintainer's response.
+	Answer string `json:"answer"`
+}
+
+// SpecificationPacket is the versioned issue snapshot and resolved repository
+// configuration captured when a run is claimed or intentionally refreshed.
 type SpecificationPacket struct {
 	Version          int                     `json:"version"`
 	Issue            github.Issue            `json:"issue"`
 	RepositoryConfig config.RepositoryConfig `json:"repository_config"`
+	// Clarifications contains the authorized answers resolved after claim.
+	Clarifications []Clarification `json:"clarifications,omitempty"`
 }
 
 // BootstrapLabelsResult reports the labels explicitly created for a repository.
@@ -485,6 +498,11 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 		s.startupErr = recoveryRequiredError(diagnosis)
 		return s.startupErr
 	}
+	if run.Status == store.StatusActive && run.Stage == store.StageImplementation &&
+		(run.LastCommandName == "answer" || run.LastCommandName == "refresh") &&
+		run.LastCommandOutcome == string(CommandAccepted) {
+		return nil
+	}
 	if run.Stage != store.StageClaim || run.Status != store.StatusActive {
 		s.startupErr = recoveryRequiredError(diagnosis)
 		return s.startupErr
@@ -580,7 +598,14 @@ func statusCommentBody(run store.Run) string {
 			checkRepair += fmt.Sprintf("- check-repair pending: attempt %d\n", run.CheckRepairPendingAttempt)
 		}
 	}
-	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, checkRepair, pullRequest, lifecycle, harness, commandFeedback)
+	questions := ""
+	if len(run.PendingQuestions) > 0 {
+		questions = "\n### Pending clarification\n\n"
+		for _, question := range run.PendingQuestions {
+			questions += fmt.Sprintf("- `%s`: %s\n", safeStatusCommentValue(question.ID), safeStatusCommentValue(question.Prompt))
+		}
+	}
+	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, checkRepair, pullRequest, lifecycle, harness, questions, commandFeedback)
 }
 
 // safeStatusCommentValue keeps command feedback single-line and prevents

--- a/internal/factory/clarification.go
+++ b/internal/factory/clarification.go
@@ -1,0 +1,164 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// validateClarificationQuestions rejects report questions that would reuse an
+// already-resolved or still-pending identifier in the current packet.
+func validateClarificationQuestions(packet SpecificationPacket, pending []store.PendingQuestion, questions []report.Question) error {
+	if len(questions) == 0 {
+		return errors.New("clarification report must contain at least one question")
+	}
+	seen := make(map[string]struct{}, len(packet.Clarifications)+len(questions))
+	for _, clarification := range packet.Clarifications {
+		if !clarificationIdentifierSafe(clarification.QuestionID) {
+			return fmt.Errorf("specification packet contains unsafe clarification identifier %q", clarification.QuestionID)
+		}
+		if _, exists := seen[clarification.QuestionID]; exists {
+			return fmt.Errorf("specification packet repeats clarification identifier %q", clarification.QuestionID)
+		}
+		seen[clarification.QuestionID] = struct{}{}
+	}
+	for _, question := range pending {
+		if !clarificationIdentifierSafe(question.ID) {
+			return fmt.Errorf("pending clarification identifier %q is unsafe", question.ID)
+		}
+		if _, exists := seen[question.ID]; exists {
+			return fmt.Errorf("pending clarification identifier %q was already resolved", question.ID)
+		}
+		seen[question.ID] = struct{}{}
+	}
+	for _, question := range questions {
+		if !clarificationIdentifierSafe(question.ID) {
+			return fmt.Errorf("clarification question identifier %q is unsafe", question.ID)
+		}
+		if _, exists := seen[question.ID]; exists {
+			return fmt.Errorf("clarification question identifier %q was already resolved", question.ID)
+		}
+		seen[question.ID] = struct{}{}
+	}
+	return nil
+}
+
+// clarificationIdentifierSafe accepts the bounded identifier vocabulary shared
+// by report questions, store projections, and answer commands.
+func clarificationIdentifierSafe(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsLetter(character) || unicode.IsDigit(character) || strings.ContainsRune("._-", character) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// pendingQuestionsFromReport converts the report protocol into the small
+// operational projection persisted on the run.
+func pendingQuestionsFromReport(questions []report.Question) []store.PendingQuestion {
+	pending := make([]store.PendingQuestion, 0, len(questions))
+	for _, question := range questions {
+		pending = append(pending, store.PendingQuestion{
+			ID:     strings.TrimSpace(question.ID),
+			Prompt: strings.TrimSpace(question.Prompt),
+		})
+	}
+	return pending
+}
+
+// postClarification publishes the current questions on the active supervision
+// target, using the pull request once a run has one and the issue beforehand.
+func (s *Service) postClarification(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packetVersion int, questions []store.PendingQuestion) (github.Comment, error) {
+	target := run.IssueNumber
+	if run.PullRequestNumber > 0 {
+		target = run.PullRequestNumber
+	}
+	body := clarificationCommentBody(run, packetVersion, questions)
+	comment, err := s.deps.GitHub.CreateIssueComment(ctx, commandRepository(registration), target, body)
+	if err != nil {
+		return github.Comment{}, fmt.Errorf("post clarification questions on #%d: %w", target, err)
+	}
+	if strings.TrimSpace(comment.ID) == "" {
+		return github.Comment{}, fmt.Errorf("post clarification questions on #%d returned an empty comment id", target)
+	}
+	return comment, nil
+}
+
+// clarificationCommentBody renders a bounded, machine-visible question list
+// without making ordinary prose an executable command.
+func clarificationCommentBody(run store.Run, packetVersion int, questions []store.PendingQuestion) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "<!-- factory-clarification: %s -->\n", run.ID)
+	builder.WriteString("## Factory clarification requested\n\n")
+	fmt.Fprintf(&builder, "This run is waiting for human input for specification packet version `%d`.\n\n", packetVersion)
+	builder.WriteString("Questions:\n")
+	for _, question := range questions {
+		fmt.Fprintf(&builder, "- `%s`: %s\n", safeStatusCommentValue(question.ID), safeStatusCommentValue(question.Prompt))
+	}
+	builder.WriteString("\nTo answer, post a comment beginning with `/factory answer <question-id> <answer>`.\n")
+	return builder.String()
+}
+
+// notifyClarification raises a concise cmux notification after the questions
+// and waiting state have been durably projected.
+func (s *Service) notifyClarification(ctx context.Context, registration config.RepositoryRegistration, run store.Run) error {
+	body := fmt.Sprintf("%s is waiting for answers to %d clarification question(s)", run.ID, len(run.PendingQuestions))
+	return s.notifyWorkspace(ctx, registration, "factory clarification requested", body)
+}
+
+// ensureClarificationPublication retries the two external attention effects
+// from durable run markers, so a GitHub or cmux outage cannot strand a waiting
+// run with no recoverable publication path.
+func (s *Service) ensureClarificationPublication(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, error) {
+	if run.Status != store.StatusWaitingForHuman || len(run.PendingQuestions) == 0 {
+		return run, nil
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return run, fmt.Errorf("decode specification packet for clarification publication: %w", err)
+	}
+	if run.ClarificationCommentID == "" {
+		comment, postErr := s.postClarification(ctx, registration, run, packet.Version, run.PendingQuestions)
+		if postErr != nil {
+			return run, postErr
+		}
+		run.ClarificationCommentID = comment.ID
+		run.UpdatedAt = s.deps.Now().UTC()
+		if err := saveRunWithRetry(ctx, runStore, run); err != nil {
+			return run, fmt.Errorf("persist clarification comment identity: %w", err)
+		}
+	}
+	if !run.ClarificationNotificationSent {
+		if err := s.notifyClarification(ctx, registration, run); err != nil {
+			return run, err
+		}
+		run.ClarificationNotificationSent = true
+		run.UpdatedAt = s.deps.Now().UTC()
+		if err := saveRunWithRetry(ctx, runStore, run); err != nil {
+			return run, fmt.Errorf("persist clarification notification state: %w", err)
+		}
+	}
+	return run, nil
+}
+
+// pendingQuestion returns one run question by its stable identifier.
+func pendingQuestion(questions []store.PendingQuestion, questionID string) (store.PendingQuestion, bool) {
+	for _, question := range questions {
+		if question.ID == questionID {
+			return question, true
+		}
+	}
+	return store.PendingQuestion{}, false
+}

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	commandlanguage "github.com/Stevie1704/sw-factory/internal/command"
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
 )
 
@@ -51,6 +53,12 @@ const (
 	PolicyRejectionHarnessUnavailable PolicyRejectionCode = "harness_unavailable"
 	// PolicyRejectionCancelState means cancellation is not legal for the run.
 	PolicyRejectionCancelState PolicyRejectionCode = "cancel_state"
+	// PolicyRejectionAnswerState means the run is not waiting for clarification.
+	PolicyRejectionAnswerState PolicyRejectionCode = "answer_state"
+	// PolicyRejectionAnswerQuestion means an answer referenced no pending question.
+	PolicyRejectionAnswerQuestion PolicyRejectionCode = "answer_question"
+	// PolicyRejectionRefreshState means refresh is not legal for the run.
+	PolicyRejectionRefreshState PolicyRejectionCode = "refresh_state"
 )
 
 // PolicyRejection is returned after a recognized command is visibly recorded
@@ -155,11 +163,20 @@ func (s *Service) handleRecognizedCommand(ctx context.Context, registration conf
 		rejection := &PolicyRejection{Code: PolicyRejectionMalformed, Problem: parseErr.Error()}
 		return s.persistCommandRejection(ctx, registration, runStore, *run, request.Comment, parsed.Command, rejection)
 	}
+	if published, publicationErr := s.ensureClarificationPublication(ctx, registration, runStore, *run); publicationErr != nil {
+		return CommandResult{Outcome: CommandRejected, Command: parsed.Command, Run: published}, publicationErr
+	} else {
+		*run = published
+	}
 
 	switch parsed.Command.Kind {
-	case commandlanguage.Status, commandlanguage.Refresh:
+	case commandlanguage.Status:
 		updated, persistErr := s.persistCommandProjection(ctx, registration, runStore, *run, request.Comment, parsed.Command, string(parsed.Command.Kind), "command accepted")
 		return CommandResult{Outcome: CommandAccepted, Command: parsed.Command, Run: updated}, persistErr
+	case commandlanguage.Refresh:
+		return s.handleRefreshCommand(ctx, registration, runStore, *run, request.Comment, parsed.Command)
+	case commandlanguage.Answer:
+		return s.handleAnswerCommand(ctx, registration, runStore, *run, request.Comment, parsed.Command)
 	case commandlanguage.Cancel:
 		return s.handleCancelCommand(ctx, registration, runStore, *run, request.Comment, parsed.Command)
 	case commandlanguage.ConfigureHarness:
@@ -170,6 +187,201 @@ func (s *Service) handleRecognizedCommand(ctx context.Context, registration conf
 		rejection := &PolicyRejection{Code: PolicyRejectionMalformed, Problem: "the parsed command is not registered by the coordinator"}
 		return s.persistCommandRejection(ctx, registration, runStore, *run, request.Comment, parsed.Command, rejection)
 	}
+}
+
+// runResultInvalidator is the persistence seam used when a new specification
+// packet makes prior invocations and checkpoint results ineligible.
+type runResultInvalidator interface {
+	InvalidateRunResults(context.Context, string) error
+}
+
+// handleAnswerCommand applies one authorized answer, versions the packet, and
+// resumes the implementation role with that answer mounted in its packet.
+func (s *Service) handleAnswerCommand(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request) (CommandResult, error) {
+	if run.Status != store.StatusWaitingForHuman && !(run.Status == store.StatusActive && len(run.PendingQuestions) > 0) {
+		rejection := &PolicyRejection{Code: PolicyRejectionAnswerState, Problem: fmt.Sprintf("answer is only allowed while the run waits for human input, not status %q", run.Status)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	pending, found := pendingQuestion(run.PendingQuestions, parsed.QuestionID)
+	if !found {
+		rejection := &PolicyRejection{Code: PolicyRejectionAnswerQuestion, Problem: fmt.Sprintf("question %q is not pending for run %q", parsed.QuestionID, run.ID)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("decode specification packet for answer: %w", err)
+	}
+	packet.Clarifications = append(packet.Clarifications, Clarification{QuestionID: pending.ID, Question: pending.Prompt, Answer: parsed.Answer})
+	packet.Version++
+	encodedPacket, err := json.Marshal(packet)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("encode answered specification packet: %w", err)
+	}
+	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; clarification answered")
+	next.Status = store.StatusActive
+	next.Stage = store.StageImplementation
+	next.SpecificationPacket = string(encodedPacket)
+	next.PendingQuestions = removePendingQuestion(run.PendingQuestions, parsed.QuestionID)
+	next.ClarificationCommentID = ""
+	next.ClarificationNotificationSent = false
+	next.UpdatedAt = s.deps.Now().UTC()
+	if err := s.stopRunWorkerIfActive(ctx, runStore, run); err != nil {
+		return CommandResult{}, err
+	}
+	issue, err := s.deps.GitHub.Issue(ctx, commandRepository(registration), run.IssueNumber)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("read issue for answer: %w", err)
+	}
+	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository:           commandRepository(registration),
+		Issue:                issue,
+		Previous:             run,
+		Next:                 next,
+		PersistBeforeEffects: true,
+	})
+	if err != nil {
+		return CommandResult{}, err
+	}
+	if err := invalidateRunResults(ctx, runStore, run.ID); err != nil {
+		return CommandResult{}, err
+	}
+	updated, err = s.resumeAfterPacketChange(ctx, registration, runStore, updated)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("resume implementation after answer: %w", err)
+	}
+	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, nil
+}
+
+// handleRefreshCommand re-reads the issue, creates a new packet version, and
+// resumes implementation against the refreshed specification.
+func (s *Service) handleRefreshCommand(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request) (CommandResult, error) {
+	if store.IsTerminalStatus(run.Status) {
+		rejection := &PolicyRejection{Code: PolicyRejectionRefreshState, Problem: fmt.Sprintf("refresh is not allowed after run status %q", run.Status)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	if run.CheckRepairPendingAttempt != 0 {
+		rejection := &PolicyRejection{Code: PolicyRejectionRefreshState, Problem: fmt.Sprintf("refresh is blocked while check-repair attempt %d awaits reconciliation", run.CheckRepairPendingAttempt)}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	oldPacket, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("decode specification packet for refresh: %w", err)
+	}
+	issue, err := s.deps.GitHub.Issue(ctx, commandRepository(registration), run.IssueNumber)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("read issue for refresh: %w", err)
+	}
+	if issue.Number == 0 {
+		issue.Number = run.IssueNumber
+	}
+	if issue.Number != run.IssueNumber || issue.IsPullRequest {
+		return CommandResult{}, fmt.Errorf("refresh returned an invalid issue identity for #%d", run.IssueNumber)
+	}
+	if !strings.EqualFold(strings.TrimSpace(issue.State), "open") {
+		rejection := &PolicyRejection{Code: PolicyRejectionRefreshState, Problem: fmt.Sprintf("cannot refresh a %s issue", defaultString(issue.State, "non-open"))}
+		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	refreshedPacket := oldPacket
+	refreshedPacket.Version++
+	refreshedPacket.Issue = cloneIssue(issue)
+	encodedPacket, err := json.Marshal(refreshedPacket)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("encode refreshed specification packet: %w", err)
+	}
+	if err := s.stopRunWorkerIfActive(ctx, runStore, run); err != nil {
+		return CommandResult{}, err
+	}
+	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; specification refreshed")
+	next.Status = store.StatusActive
+	next.Stage = store.StageImplementation
+	next.SpecificationPacket = string(encodedPacket)
+	next.PendingQuestions = nil
+	next.ClarificationCommentID = ""
+	next.ClarificationNotificationSent = false
+	next.UpdatedAt = s.deps.Now().UTC()
+	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository:           commandRepository(registration),
+		Issue:                issue,
+		Previous:             run,
+		Next:                 next,
+		PersistBeforeEffects: true,
+	})
+	if err != nil {
+		return CommandResult{}, err
+	}
+	if err := invalidateRunResults(ctx, runStore, run.ID); err != nil {
+		return CommandResult{}, err
+	}
+	updated, err = s.resumeAfterPacketChange(ctx, registration, runStore, updated)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("resume implementation after refresh: %w", err)
+	}
+	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, nil
+}
+
+// resumeAfterPacketChange launches the implementation role when the store has
+// the visible-invocation seam; reduced command-test stores still receive the
+// durable packet/state projection and can resume through StartAgent later.
+func (s *Service) resumeAfterPacketChange(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, error) {
+	if _, ok := runStore.(InvocationStore); !ok {
+		return run, nil
+	}
+	request := normalizeAgentRequest(AgentRequest{RunID: run.ID, Role: "implementation", Stage: store.StageImplementation})
+	if err := validateAgentRequest(request); err != nil {
+		return run, err
+	}
+	if err := report.ValidatePermittedPaths(request.PermittedPaths); err != nil {
+		return run, err
+	}
+	if _, err := s.startAgentWithStore(ctx, registration, runStore, &run, request); err != nil {
+		return run, err
+	}
+	if current, err := runStore.CurrentRun(ctx); err == nil && current != nil {
+		return *current, nil
+	}
+	return run, nil
+}
+
+// stopRunWorkerIfActive stops only a currently active invocation so an answer
+// or refresh does not create a spurious worker-stop side effect after a pause.
+func (s *Service) stopRunWorkerIfActive(ctx context.Context, runStore RunStore, run store.Run) error {
+	activeStore, ok := runStore.(ActiveInvocationStore)
+	if !ok {
+		return nil
+	}
+	active, err := activeStore.ActiveInvocation(ctx, run.ID)
+	if err != nil {
+		return fmt.Errorf("look up active invocation before packet refresh: %w", err)
+	}
+	if active == nil {
+		return nil
+	}
+	return s.stopRunWorker(ctx, run.ID)
+}
+
+// invalidateRunResults makes the packet revision boundary visible to the
+// operational store before a new invocation is launched.
+func invalidateRunResults(ctx context.Context, runStore RunStore, runID string) error {
+	invalidator, ok := runStore.(runResultInvalidator)
+	if !ok {
+		return errors.New("operational store does not support specification result invalidation")
+	}
+	if err := invalidator.InvalidateRunResults(ctx, runID); err != nil {
+		return fmt.Errorf("invalidate superseded specification results: %w", err)
+	}
+	return nil
+}
+
+// removePendingQuestion returns all unresolved questions except the answered
+// identifier, preserving the status-comment order.
+func removePendingQuestion(questions []store.PendingQuestion, questionID string) []store.PendingQuestion {
+	remaining := make([]store.PendingQuestion, 0, len(questions))
+	for _, question := range questions {
+		if question.ID != questionID {
+			remaining = append(remaining, question)
+		}
+	}
+	return remaining
 }
 
 // handleCancelCommand applies an authorized, idempotent cancellation request
@@ -222,6 +434,11 @@ func (s *Service) PollCommands(ctx context.Context, request CommandPollRequest) 
 	if lifecycle.Outcome != LifecycleUnchanged {
 		return nil, nil
 	}
+	published, publicationErr := s.ensureClarificationPublication(ctx, registration, runStore, *run)
+	if publicationErr != nil {
+		return nil, publicationErr
+	}
+	*run = published
 	if s.deps.Comments == nil {
 		return nil, errors.New("GitHub comment reader is required for command polling")
 	}

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -195,6 +195,13 @@ type runResultInvalidator interface {
 	InvalidateRunResults(context.Context, string) error
 }
 
+// atomicPacketTransitionStore is the persistence seam that atomically applies
+// a state transition with result invalidation, ensuring packet persistence,
+// command watermark updates, and result invalidation commit or roll back together.
+type atomicPacketTransitionStore interface {
+	SaveRunAndInvalidateResults(context.Context, int64, store.Run) error
+}
+
 // handleAnswerCommand applies one authorized answer, versions the packet, and
 // resumes the implementation role with that answer mounted in its packet.
 func (s *Service) handleAnswerCommand(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request) (CommandResult, error) {
@@ -225,6 +232,9 @@ func (s *Service) handleAnswerCommand(ctx context.Context, registration config.R
 	next.ClarificationCommentID = ""
 	next.ClarificationNotificationSent = false
 	next.UpdatedAt = s.deps.Now().UTC()
+	// Clear ProcessedCommentID temporarily to defer watermark until after resumption
+	processedCommentID := next.ProcessedCommentID
+	next.ProcessedCommentID = run.ProcessedCommentID
 	if err := s.stopRunWorkerIfActive(ctx, runStore, run); err != nil {
 		return CommandResult{}, err
 	}
@@ -232,22 +242,19 @@ func (s *Service) handleAnswerCommand(ctx context.Context, registration config.R
 	if err != nil {
 		return CommandResult{}, fmt.Errorf("read issue for answer: %w", err)
 	}
-	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
-		Repository:           commandRepository(registration),
-		Issue:                issue,
-		Previous:             run,
-		Next:                 next,
-		PersistBeforeEffects: true,
-	})
+	updated, err := s.applyPacketChangeTransition(ctx, runStore, registration, issue, run, next, processedCommentID)
 	if err != nil {
-		return CommandResult{}, err
-	}
-	if err := invalidateRunResults(ctx, runStore, run.ID); err != nil {
 		return CommandResult{}, err
 	}
 	updated, err = s.resumeAfterPacketChange(ctx, registration, runStore, updated)
 	if err != nil {
 		return CommandResult{}, fmt.Errorf("resume implementation after answer: %w", err)
+	}
+	// Claim the comment watermark only after successful resumption to keep
+	// packet-change resumption retryable when startAgentWithStore fails.
+	updated, err = s.persistPacketChangeWatermark(ctx, runStore, updated, processedCommentID)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("persist answer command watermark: %w", err)
 	}
 	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, nil
 }
@@ -299,22 +306,22 @@ func (s *Service) handleRefreshCommand(ctx context.Context, registration config.
 	next.ClarificationCommentID = ""
 	next.ClarificationNotificationSent = false
 	next.UpdatedAt = s.deps.Now().UTC()
-	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
-		Repository:           commandRepository(registration),
-		Issue:                issue,
-		Previous:             run,
-		Next:                 next,
-		PersistBeforeEffects: true,
-	})
+	// Clear ProcessedCommentID temporarily to defer watermark until after resumption
+	processedCommentID := next.ProcessedCommentID
+	next.ProcessedCommentID = run.ProcessedCommentID
+	updated, err := s.applyPacketChangeTransition(ctx, runStore, registration, issue, run, next, processedCommentID)
 	if err != nil {
-		return CommandResult{}, err
-	}
-	if err := invalidateRunResults(ctx, runStore, run.ID); err != nil {
 		return CommandResult{}, err
 	}
 	updated, err = s.resumeAfterPacketChange(ctx, registration, runStore, updated)
 	if err != nil {
 		return CommandResult{}, fmt.Errorf("resume implementation after refresh: %w", err)
+	}
+	// Claim the comment watermark only after successful resumption to keep
+	// packet-change resumption retryable when startAgentWithStore fails.
+	updated, err = s.persistPacketChangeWatermark(ctx, runStore, updated, processedCommentID)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("persist refresh command watermark: %w", err)
 	}
 	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, nil
 }
@@ -357,6 +364,68 @@ func (s *Service) stopRunWorkerIfActive(ctx context.Context, runStore RunStore, 
 		return nil
 	}
 	return s.stopRunWorker(ctx, run.ID)
+}
+
+// applyPacketChangeTransition atomically applies the state transition and
+// invalidates prior run results, ensuring packet persistence and result
+// invalidation commit or roll back together. The command watermark (ProcessedCommentID)
+// is intentionally not set here; it is deferred until after successful resumption
+// to keep packet-change resumption retryable when startAgentWithStore fails.
+func (s *Service) applyPacketChangeTransition(ctx context.Context, runStore RunStore, registration config.RepositoryRegistration, issue github.Issue, previous, next store.Run, commandName string) (store.Run, error) {
+	repository := commandRepository(registration)
+	next.UpdatedAt = s.deps.Now().UTC()
+	if next.Revision <= previous.Revision {
+		next.Revision = previous.Revision + 1
+	}
+	next.LastCommandName = commandName
+
+	// Apply GitHub effects first (labels and status comment update)
+	oldLabels := append([]string(nil), issue.Labels...)
+	newLabels := replaceFactoryState(oldLabels, factoryLabelForStatus(next.Status))
+	if err := s.deps.GitHub.ReplaceIssueLabels(ctx, repository, next.IssueNumber, newLabels); err != nil {
+		return next, fmt.Errorf("set issue #%d state: %w", next.IssueNumber, err)
+	}
+	if err := s.deps.GitHub.EditIssueComment(ctx, repository, next.StatusCommentID, statusCommentBody(next)); err != nil {
+		_ = s.deps.GitHub.ReplaceIssueLabels(ctx, repository, next.IssueNumber, oldLabels)
+		return next, fmt.Errorf("edit status comment: %w", err)
+	}
+
+	// Atomically persist state and invalidate results, or use fallback
+	if atomicStore, ok := runStore.(atomicPacketTransitionStore); ok {
+		if err := atomicStore.SaveRunAndInvalidateResults(ctx, previous.Revision, next); err != nil {
+			return next, fmt.Errorf("persist packet transition and invalidate results: %w", err)
+		}
+	} else {
+		// Fallback for stores that don't support atomic operation
+		if err := saveCommandRun(ctx, runStore, previous.Revision, next); err != nil {
+			return next, fmt.Errorf("persist packet transition: %w", err)
+		}
+		if err := invalidateRunResults(ctx, runStore, next.ID); err != nil {
+			return next, err
+		}
+	}
+
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recordEvaluationTransition(ctx, recorder, previous, next, next.UpdatedAt); err != nil {
+			return next, fmt.Errorf("record evaluation state transition: %w", err)
+		}
+	}
+
+	return next, nil
+}
+
+// persistPacketChangeWatermark claims the command watermark after successful
+// packet change resumption, ensuring retryability when startAgentWithStore fails.
+func (s *Service) persistPacketChangeWatermark(ctx context.Context, runStore RunStore, run store.Run, commentID string) (store.Run, error) {
+	previousRevision := run.Revision
+	run.ProcessedCommentID = commentID
+	run.ProcessedCommentRevision = run.Revision + 1
+	run.Revision = run.ProcessedCommentRevision
+	run.UpdatedAt = s.deps.Now().UTC()
+	if err := saveCommandRun(ctx, runStore, previousRevision, run); err != nil {
+		return run, fmt.Errorf("persist command watermark after resumption: %w", err)
+	}
+	return run, nil
 }
 
 // invalidateRunResults makes the packet revision boundary visible to the

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -289,6 +289,10 @@ func (s *commandRunStore) SaveRunIfRevision(ctx context.Context, expected int64,
 	return s.SaveRun(ctx, run)
 }
 
+// InvalidateRunResults satisfies the packet-version seam for command tests;
+// this reduced store has no invocation or gate-result tables to clear.
+func (*commandRunStore) InvalidateRunResults(context.Context, string) error { return nil }
+
 // ClaimLifecycleNotification atomically claims notification delivery.
 func (s *commandRunStore) ClaimLifecycleNotification(_ context.Context, runID string, terminalStatus store.Status) (bool, error) {
 	if s.lifecycleClaims == nil {

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -724,7 +724,7 @@ func decodeSpecificationPacket(serialized string) (SpecificationPacket, error) {
 	if err := json.Unmarshal([]byte(serialized), &packet); err != nil {
 		return SpecificationPacket{}, fmt.Errorf("decode frozen specification packet: %w", err)
 	}
-	if packet.Version != specificationPacketVersion {
+	if packet.Version < specificationPacketVersion {
 		return SpecificationPacket{}, fmt.Errorf("unsupported frozen specification packet version %d", packet.Version)
 	}
 	return packet, nil

--- a/internal/factory/lifecycle.go
+++ b/internal/factory/lifecycle.go
@@ -270,12 +270,24 @@ func (s *Service) stopRunWorker(ctx context.Context, runID string) error {
 // notifyTerminal sends one concise cmux notification while retaining all run
 // surfaces for later inspection or explicit resume.
 func (s *Service) notifyTerminal(ctx context.Context, registration config.RepositoryRegistration, run store.Run) error {
+	title := "factory run cancelled"
+	body := fmt.Sprintf("%s cancelled: %s", run.ID, safeStatusCommentValue(run.LifecycleReason))
+	if run.Status == store.StatusComplete {
+		title = "factory run completed"
+		body = fmt.Sprintf("%s completed after pull request #%d merged", run.ID, run.PullRequestNumber)
+	}
+	return s.notifyWorkspace(ctx, registration, title, body)
+}
+
+// notifyWorkspace sends one concise coordinator notification through the
+// registered control workspace, lazily constructing the runtime when needed.
+func (s *Service) notifyWorkspace(ctx context.Context, registration config.RepositoryRegistration, title, body string) error {
 	terminalRuntime := s.deps.Terminal
 	if terminalRuntime == nil {
 		var err error
 		terminalRuntime, _, err = s.ensureAgentRuntime(registration.Cmux.SocketPath)
 		if err != nil {
-			return fmt.Errorf("ensure terminal runtime for lifecycle notification: %w", err)
+			return fmt.Errorf("ensure terminal runtime for notification: %w", err)
 		}
 	}
 	control, err := terminalRuntime.EnsureControlWorkspace(ctx, terminal.WorkspaceRequest{
@@ -284,16 +296,10 @@ func (s *Service) notifyTerminal(ctx context.Context, registration config.Reposi
 		WorkingDirectory: registration.Path,
 	})
 	if err != nil {
-		return fmt.Errorf("ensure control workspace for lifecycle notification: %w", err)
-	}
-	title := "factory run cancelled"
-	body := fmt.Sprintf("%s cancelled: %s", run.ID, safeStatusCommentValue(run.LifecycleReason))
-	if run.Status == store.StatusComplete {
-		title = "factory run completed"
-		body = fmt.Sprintf("%s completed after pull request #%d merged", run.ID, run.PullRequestNumber)
+		return fmt.Errorf("ensure control workspace for notification: %w", err)
 	}
 	if err := terminalRuntime.Notify(ctx, terminal.Notification{WorkspaceID: control.ID, Title: title, Body: body}); err != nil {
-		return fmt.Errorf("notify lifecycle transition: %w", err)
+		return fmt.Errorf("notify coordinator: %w", err)
 	}
 	return nil
 }

--- a/internal/store/invocation_test.go
+++ b/internal/store/invocation_test.go
@@ -176,6 +176,83 @@ func TestStoreFindsInvocationHistoryRegardlessOfStatus(t *testing.T) {
 	}
 }
 
+// TestStoreInvalidatesSupersededResultsRetainsBaseline verifies a packet
+// revision supersedes prior invocation work and checkpoint results without
+// discarding the independent baseline evaluation.
+func TestStoreInvalidatesSupersededResultsRetainsBaseline(t *testing.T) {
+	opened, err := store.Open(context.Background(), filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() { _ = opened.Close() }()
+	for _, status := range []store.InvocationStatus{
+		store.InvocationStatusActive,
+		store.InvocationStatusCompleted,
+		store.InvocationStatusWaitingForHuman,
+		store.InvocationStatusCannotProceed,
+	} {
+		if err := opened.SaveInvocation(context.Background(), store.Invocation{
+			ID: "inv-invalidate-" + string(status), RunID: "run-invalidate", Harness: "codex", Role: "implementation", Stage: store.StageImplementation, Status: status,
+		}); err != nil {
+			t.Fatalf("SaveInvocation(%s) error = %v", status, err)
+		}
+	}
+	if err := opened.SaveInvocation(context.Background(), store.Invocation{
+		ID: "inv-other-run", RunID: "run-other", Harness: "codex", Role: "implementation", Stage: store.StageImplementation, Status: store.InvocationStatusActive,
+	}); err != nil {
+		t.Fatalf("SaveInvocation(other) error = %v", err)
+	}
+	baselineSHA := strings.Repeat("a", 40)
+	checkpointSHA := strings.Repeat("b", 40)
+	if err := opened.SaveGateResults(context.Background(), []store.GateResult{
+		{RunID: "run-invalidate", CheckpointSHA: baselineSHA, Phase: store.GatePhaseBaseline, Ordinal: 0, GateName: "baseline", Outcome: store.GateOutcomePassed, Status: "success"},
+		{RunID: "run-invalidate", CheckpointSHA: checkpointSHA, Phase: store.GatePhaseCheckpoint, Ordinal: 0, GateName: "checkpoint", Outcome: store.GateOutcomePassed, Status: "success"},
+	}); err != nil {
+		t.Fatalf("SaveGateResults() error = %v", err)
+	}
+	if err := opened.InvalidateRunResults(context.Background(), "run-invalidate"); err != nil {
+		t.Fatalf("InvalidateRunResults() error = %v", err)
+	}
+	for _, status := range []store.InvocationStatus{
+		store.InvocationStatusActive,
+		store.InvocationStatusCompleted,
+		store.InvocationStatusWaitingForHuman,
+	} {
+		got, err := opened.Invocation(context.Background(), "run-invalidate", "inv-invalidate-"+string(status))
+		if err != nil {
+			t.Fatalf("Invocation(%s) error = %v", status, err)
+		}
+		if got == nil || got.Status != store.InvocationStatusSuperseded {
+			t.Fatalf("Invocation(%s) = %#v, want superseded", status, got)
+		}
+	}
+	unchanged, err := opened.Invocation(context.Background(), "run-invalidate", "inv-invalidate-"+string(store.InvocationStatusCannotProceed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged == nil || unchanged.Status != store.InvocationStatusSuperseded {
+		t.Fatalf("cannot-proceed invocation = %#v, want superseded", unchanged)
+	}
+	other, err := opened.Invocation(context.Background(), "run-other", "inv-other-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other == nil || other.Status != store.InvocationStatusActive {
+		t.Fatalf("other-run invocation = %#v, want unchanged active", other)
+	}
+	baseline, err := opened.GateResults(context.Background(), "run-invalidate", store.GatePhaseBaseline, baselineSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, err := opened.GateResults(context.Background(), "run-invalidate", store.GatePhaseCheckpoint, checkpointSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(baseline) != 1 || len(checkpoint) != 0 {
+		t.Fatalf("remaining gate results = baseline=%#v checkpoint=%#v, want baseline only", baseline, checkpoint)
+	}
+}
+
 // TestStoreRejectsTwoActiveInvocationsForOneRun verifies the database index,
 // rather than only the coordinator lookup, owns active-invocation uniqueness.
 func TestStoreRejectsTwoActiveInvocationsForOneRun(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,13 +12,14 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	_ "modernc.org/sqlite"
 )
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 16
+const CurrentSchemaVersion = 18
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -74,6 +75,9 @@ const (
 	InvocationStatusWaitingForHuman InvocationStatus = "waiting_for_human"
 	// InvocationStatusCannotProceed means the report contained blocking evidence.
 	InvocationStatusCannotProceed InvocationStatus = "cannot_proceed"
+	// InvocationStatusSuperseded means a later specification packet invalidated
+	// the invocation before its result could be used for progression.
+	InvocationStatusSuperseded InvocationStatus = "superseded"
 )
 
 // GatePhase identifies why a deterministic gate result was recorded.
@@ -121,6 +125,16 @@ func (e *UnversionedDatabaseError) Error() string {
 }
 
 func (e *UnversionedDatabaseError) Unwrap() error { return e.Err }
+
+// PendingQuestion is one clarification request awaiting an authorized answer.
+// It is deliberately small so the operational store retains workflow state
+// rather than a transcript.
+type PendingQuestion struct {
+	// ID is the stable identifier referenced by an answer command.
+	ID string
+	// Prompt is the bounded human-readable clarification request.
+	Prompt string
+}
 
 // Run is the persisted operational identity and current state of one run.
 type Run struct {
@@ -174,8 +188,17 @@ type Run struct {
 	// launch from a successfully consumed attempt.
 	CheckRepairPendingAttempt int
 	SpecificationPacket       string
-	CreatedAt                 time.Time
-	UpdatedAt                 time.Time
+	// PendingQuestions contains clarification requests awaiting authorized
+	// answers for the current specification packet.
+	PendingQuestions []PendingQuestion
+	// ClarificationCommentID identifies the question comment already published
+	// for the current pending clarification set.
+	ClarificationCommentID string
+	// ClarificationNotificationSent records successful cmux notification delivery
+	// for the current pending clarification set.
+	ClarificationNotificationSent bool
+	CreatedAt                     time.Time
+	UpdatedAt                     time.Time
 }
 
 // Invocation is the persisted recoverable identity of one harness session.
@@ -363,7 +386,8 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override, check_repair_attempts, check_repair_budget,
 		       check_repair_pending_attempt,
-		       specification_packet, created_at, updated_at
+		       specification_packet, pending_questions, clarification_comment_id,
+		       clarification_notification_sent, created_at, updated_at
 		FROM operational_runs
 		WHERE status NOT IN (?, ?, ?)
 		ORDER BY updated_at DESC
@@ -383,7 +407,8 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override, check_repair_attempts, check_repair_budget,
 		       check_repair_pending_attempt,
-		       specification_packet, created_at, updated_at
+		       specification_packet, pending_questions, clarification_comment_id,
+		       clarification_notification_sent, created_at, updated_at
 		FROM operational_runs
 		ORDER BY updated_at DESC
 		LIMIT 1`)
@@ -393,7 +418,8 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 // scanRun decodes one operational run row and its RFC3339 timestamps.
 func scanRun(row *sql.Row) (*Run, error) {
 	var run Run
-	var createdAt, updatedAt string
+	var pendingQuestionsJSON, clarificationCommentID, createdAt, updatedAt string
+	var clarificationNotificationSent bool
 	if err := row.Scan(
 		&run.ID,
 		&run.RepositoryPath,
@@ -422,6 +448,9 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&run.CheckRepairBudget,
 		&run.CheckRepairPendingAttempt,
 		&run.SpecificationPacket,
+		&pendingQuestionsJSON,
+		&clarificationCommentID,
+		&clarificationNotificationSent,
 		&createdAt,
 		&updatedAt,
 	); err != nil {
@@ -430,6 +459,13 @@ func scanRun(row *sql.Row) (*Run, error) {
 		}
 		return nil, fmt.Errorf("read run row: %w", err)
 	}
+	if pendingQuestionsJSON != "" {
+		if err := json.Unmarshal([]byte(pendingQuestionsJSON), &run.PendingQuestions); err != nil {
+			return nil, fmt.Errorf("decode pending clarification questions: %w", err)
+		}
+	}
+	run.ClarificationCommentID = clarificationCommentID
+	run.ClarificationNotificationSent = clarificationNotificationSent
 	var err error
 	run.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt)
 	if err != nil {
@@ -508,6 +544,12 @@ func normalizeRun(run Run) (Run, error) {
 	if run.CheckRepairPendingAttempt != 0 && run.CheckRepairPendingAttempt != run.CheckRepairAttempts+1 {
 		return Run{}, errors.New("run pending check-repair attempt must be the next attempt")
 	}
+	if strings.ContainsAny(run.ClarificationCommentID, "\x00\r\n") {
+		return Run{}, errors.New("run clarification comment id contains a control character")
+	}
+	if err := validatePendingQuestions(run.PendingQuestions); err != nil {
+		return Run{}, err
+	}
 	if run.CreatedAt.IsZero() {
 		run.CreatedAt = time.Now().UTC()
 	}
@@ -515,6 +557,59 @@ func normalizeRun(run Run) (Run, error) {
 		run.UpdatedAt = run.CreatedAt
 	}
 	return run, nil
+}
+
+// validatePendingQuestions checks the bounded workflow projection before it is
+// serialized into the operational store.
+func validatePendingQuestions(values []PendingQuestion) error {
+	if len(values) > 32 {
+		return errors.New("run pending questions exceed 32 entries")
+	}
+	seen := make(map[string]struct{}, len(values))
+	for index, value := range values {
+		if !safeQuestionIdentifier(value.ID) {
+			return fmt.Errorf("run pending question %d has an unsafe identifier", index)
+		}
+		if _, exists := seen[value.ID]; exists {
+			return fmt.Errorf("run pending question %q is duplicated", value.ID)
+		}
+		seen[value.ID] = struct{}{}
+		if strings.TrimSpace(value.Prompt) == "" {
+			return fmt.Errorf("run pending question %d has an empty prompt", index)
+		}
+		if strings.ContainsAny(value.Prompt, "\x00\r\n") {
+			return fmt.Errorf("run pending question %q contains a control character", value.ID)
+		}
+	}
+	return nil
+}
+
+// safeQuestionIdentifier reports whether a pending-question ID is safe to
+// reference from the structured GitHub command surface.
+func safeQuestionIdentifier(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsLetter(character) || unicode.IsDigit(character) || strings.ContainsRune("._-", character) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// pendingQuestionsJSON serializes an empty projection as an empty JSON array
+// so migrated and newly created stores have one stable representation.
+func pendingQuestionsJSON(values []PendingQuestion) string {
+	if values == nil {
+		return "[]"
+	}
+	data, err := json.Marshal(values)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
 }
 
 // runValues returns the ordered SQL values shared by normal and revision-safe
@@ -548,6 +643,9 @@ func runValues(run Run) []any {
 		run.CheckRepairBudget,
 		run.CheckRepairPendingAttempt,
 		run.SpecificationPacket,
+		pendingQuestionsJSON(run.PendingQuestions),
+		run.ClarificationCommentID,
+		run.ClarificationNotificationSent,
 		run.CreatedAt.UTC().Format(runTimestampLayout),
 		run.UpdatedAt.UTC().Format(runTimestampLayout),
 	}
@@ -563,8 +661,14 @@ const saveRunStatement = `
 			processed_comment_revision, last_command_name, last_command_outcome,
 			last_command_message, harness_override, check_repair_attempts,
 			check_repair_budget, check_repair_pending_attempt, specification_packet,
-			created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			pending_questions, clarification_comment_id,
+			clarification_notification_sent, created_at, updated_at
+		) VALUES (
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?
+		)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
 			issue_number = excluded.issue_number,
@@ -592,6 +696,9 @@ const saveRunStatement = `
 			check_repair_budget = excluded.check_repair_budget,
 			check_repair_pending_attempt = excluded.check_repair_pending_attempt,
 			specification_packet = excluded.specification_packet,
+			pending_questions = excluded.pending_questions,
+			clarification_comment_id = excluded.clarification_comment_id,
+			clarification_notification_sent = excluded.clarification_notification_sent,
 			updated_at = excluded.updated_at`
 
 const saveRunIfRevisionStatement = `
@@ -604,7 +711,8 @@ const saveRunIfRevisionStatement = `
 			processed_comment_revision = ?, last_command_name = ?, last_command_outcome = ?,
 			last_command_message = ?, harness_override = ?, check_repair_attempts = ?,
 			check_repair_budget = ?, check_repair_pending_attempt = ?, specification_packet = ?,
-			created_at = ?, updated_at = ?
+			pending_questions = ?, clarification_comment_id = ?,
+			clarification_notification_sent = ?, created_at = ?, updated_at = ?
 		WHERE id = ? AND revision = ?`
 
 // SaveInvocation validates and upserts one recoverable harness invocation.
@@ -692,6 +800,35 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 			return fmt.Errorf("save invocation: active invocation already exists for run %q: %w", invocation.RunID, err)
 		}
 		return fmt.Errorf("save invocation: %w", err)
+	}
+	return nil
+}
+
+// InvalidateRunResults supersedes invocations and removes downstream checkpoint
+// results produced before a new specification packet was accepted. Baseline
+// results remain valid because the packet change only revises issue intent and
+// clarifications; the frozen repository configuration and checkpoint remain.
+// The evaluation summary remains intact because it is content-free history.
+func (s *Store) InvalidateRunResults(ctx context.Context, runID string) error {
+	if strings.TrimSpace(runID) == "" {
+		return errors.New("run id is required for result invalidation")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin run-result invalidation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	now := time.Now().UTC().Format(runTimestampLayout)
+	if _, err := tx.ExecContext(ctx, `UPDATE invocations
+		SET status = ?, updated_at = ?
+		WHERE run_id = ? AND status IN (?, ?, ?, ?)`, InvocationStatusSuperseded, now, runID, InvocationStatusActive, InvocationStatusCompleted, InvocationStatusWaitingForHuman, InvocationStatusCannotProceed); err != nil {
+		return fmt.Errorf("supersede invocations for run %q: %w", runID, err)
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM gate_results WHERE run_id = ? AND phase <> ?", runID, GatePhaseBaseline); err != nil {
+		return fmt.Errorf("invalidate gate results for run %q: %w", runID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit run-result invalidation: %w", err)
 	}
 	return nil
 }
@@ -1395,6 +1532,19 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 		case 16:
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN check_repair_pending_attempt INTEGER NOT NULL DEFAULT 0"); err != nil {
 				return fmt.Errorf("apply store migration 16: %w", err)
+			}
+		case 17:
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN pending_questions TEXT NOT NULL DEFAULT '[]'"); err != nil {
+				return fmt.Errorf("apply store migration 17: %w", err)
+			}
+		case 18:
+			for _, statement := range []string{
+				"ALTER TABLE operational_runs ADD COLUMN clarification_comment_id TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN clarification_notification_sent INTEGER NOT NULL DEFAULT 0",
+			} {
+				if _, err := tx.ExecContext(ctx, statement); err != nil {
+					return fmt.Errorf("apply store migration 18: %w", err)
+				}
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -833,6 +833,55 @@ func (s *Store) InvalidateRunResults(ctx context.Context, runID string) error {
 	return nil
 }
 
+// SaveRunAndInvalidateResults atomically persists a run state transition and
+// invalidates prior invocations and checkpoint results when a specification
+// packet revision boundary is crossed. This operation ensures packet updates,
+// command watermark advances, and result invalidation commit or roll back
+// together, preventing inconsistent persistence when resumption is attempted.
+func (s *Store) SaveRunAndInvalidateResults(ctx context.Context, expectedRevision int64, run Run) error {
+	run, err := normalizeRun(run)
+	if err != nil {
+		return err
+	}
+	if run.Revision <= expectedRevision {
+		return fmt.Errorf("%w: got %d, expected greater than %d", ErrRevisionNotAdvanced, run.Revision, expectedRevision)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin atomic run update and result invalidation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Update the run state with revision check
+	result, err := tx.ExecContext(ctx, saveRunIfRevisionStatement, append(runValues(run)[1:], run.ID, expectedRevision)...)
+	if err != nil {
+		return fmt.Errorf("save run at revision %d: %w", expectedRevision, err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("inspect run revision %d update: %w", expectedRevision, err)
+	}
+	if changed != 1 {
+		return fmt.Errorf("%w: run %q no longer has revision %d", ErrRevisionConflict, run.ID, expectedRevision)
+	}
+
+	// Invalidate prior results in the same transaction
+	now := time.Now().UTC().Format(runTimestampLayout)
+	if _, err := tx.ExecContext(ctx, `UPDATE invocations
+		SET status = ?, updated_at = ?
+		WHERE run_id = ? AND status IN (?, ?, ?, ?)`, InvocationStatusSuperseded, now, run.ID, InvocationStatusActive, InvocationStatusCompleted, InvocationStatusWaitingForHuman, InvocationStatusCannotProceed); err != nil {
+		return fmt.Errorf("supersede invocations for run %q: %w", run.ID, err)
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM gate_results WHERE run_id = ? AND phase <> ?", run.ID, GatePhaseBaseline); err != nil {
+		return fmt.Errorf("invalidate gate results for run %q: %w", run.ID, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit atomic run update and result invalidation: %w", err)
+	}
+	return nil
+}
+
 // Invocation loads one persisted invocation only when both identifiers match.
 func (s *Store) Invocation(ctx context.Context, runID, invocationID string) (*Invocation, error) {
 	row := s.db.QueryRowContext(ctx, `

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -668,20 +668,23 @@ func TestCurrentRunPersistsSpecificationAndStatusCommentIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	wanted := store.Run{
-		ID:                  "run-claim",
-		RepositoryPath:      "/work/repository",
-		IssueNumber:         42,
-		Stage:               store.StageClaim,
-		Status:              store.StatusActive,
-		Branch:              "factory/run-claim",
-		Worktree:            "/worktrees/run-claim",
-		CheckpointSHA:       "0123456789abcdef",
-		ImageDigest:         "sha256:worker",
-		Coordinator:         "host-a",
-		StatusCommentID:     "12345",
-		SpecificationPacket: `{"version":1,"issue":{"number":42}}`,
-		CreatedAt:           time.Unix(100, 0).UTC(),
-		UpdatedAt:           time.Unix(200, 0).UTC(),
+		ID:                            "run-claim",
+		RepositoryPath:                "/work/repository",
+		IssueNumber:                   42,
+		Stage:                         store.StageClaim,
+		Status:                        store.StatusActive,
+		Branch:                        "factory/run-claim",
+		Worktree:                      "/worktrees/run-claim",
+		CheckpointSHA:                 "0123456789abcdef",
+		ImageDigest:                   "sha256:worker",
+		Coordinator:                   "host-a",
+		StatusCommentID:               "12345",
+		SpecificationPacket:           `{"version":1,"issue":{"number":42}}`,
+		PendingQuestions:              []store.PendingQuestion{{ID: "clarification-1", Prompt: "Which behavior is intended?"}},
+		ClarificationCommentID:        "67890",
+		ClarificationNotificationSent: true,
+		CreatedAt:                     time.Unix(100, 0).UTC(),
+		UpdatedAt:                     time.Unix(200, 0).UTC(),
 	}
 	if err := opened.SaveRun(context.Background(), wanted); err != nil {
 		_ = opened.Close()
@@ -703,8 +706,8 @@ func TestCurrentRunPersistsSpecificationAndStatusCommentIdentity(t *testing.T) {
 	if got == nil {
 		t.Fatal("CurrentRun() = nil, want persisted run")
 	}
-	if got.Coordinator != wanted.Coordinator || got.StatusCommentID != wanted.StatusCommentID || got.SpecificationPacket != wanted.SpecificationPacket {
-		t.Fatalf("persisted claim metadata = %#v, want coordinator/comment/packet from %#v", got, wanted)
+	if got.Coordinator != wanted.Coordinator || got.StatusCommentID != wanted.StatusCommentID || got.SpecificationPacket != wanted.SpecificationPacket || len(got.PendingQuestions) != 1 || got.ClarificationCommentID != wanted.ClarificationCommentID || !got.ClarificationNotificationSent {
+		t.Fatalf("persisted claim metadata = %#v, want coordinator/comment/packet/clarification state from %#v", got, wanted)
 	}
 }
 


### PR DESCRIPTION
Closes #11

## Summary
- pause runs on needs_clarification reports with persisted question state, status-comment updates, issue/PR question comments, and cmux notification
- add authorized `/factory answer <question-id> <answer>` handling with versioned specification packets and resumed invocations
- implement `/factory refresh` re-read/version/invalidation and durable clarification-publication retry state
- supersede stale invocations and checkpoint results against the refreshed specification packet

## Validation
- `go test ./...`
- `go vet ./...`
- `go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clarification workflows that pause runs and publish questions for maintainer input.
  * Added `/factory answer` to submit answers and resume implementation.
  * Added `/factory refresh` to reread issue specifications and restart work with updated requirements.
  * Clarification answers are retained in versioned specification packets.

* **Bug Fixes**
  * Preserved baseline results while invalidating superseded checkpoint results.
  * Improved retry handling for clarification notifications and resumed runs.

* **Documentation**
  * Documented the new commands, clarification workflow, and updated operational schema version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->