### PR TITLE
feat: add claude code adapter and validated per-role harness selection

### DIFF
--- a/docs/adr/0002-per-role-harness-selection-fails-closed.md
+++ b/docs/adr/0002-per-role-harness-selection-fails-closed.md
@@ -2,7 +2,7 @@
 status: accepted
 ---
 
-# Select a harness per role and fail closed on settings it cannot honour
+# Select a harness per role and fail closed on settings it cannot honor
 
 Codex and Claude Code are interchangeable so the best harness can be used for
 each stage. The coordinator resolves harness, model, and reasoning effort
@@ -14,23 +14,38 @@ The two harnesses are not feature-identical. Claude Code exposes no
 reasoning-effort process argument, and macOS keeps its credential in the login
 Keychain rather than in a file that a host can hand over. Two rules follow.
 
-An adapter refuses a validated repository setting it cannot represent, rather
-than dropping it. Silently dropping a reasoning effort would run a role at an
-effort the repository policy never authorized, and the operator would see a
-successful launch. A role that runs on Claude Code therefore declares no
-reasoning-effort options.
+A setting a harness cannot represent is refused, not dropped. Silently dropping
+a reasoning effort would run a role at an effort the repository policy never
+authorized, and the operator would see a successful launch.
 
-Credential seeding is modelled per harness, not once for all of them. Each
+The refusal is enforced at three points, each earlier than the last is cheap.
+Configuration validation refuses declaring reasoning-effort options for a role
+whose harness cannot honor them. The coordinator reads the adapter's
+capabilities and refuses a selection as a typed policy rejection before the
+launch creates a directory, a worker, a credential copy, or a surface. The
+adapter refuses it once more at launch, as a fail-closed backstop for a frozen
+packet that predates the validation rule.
+
+Capability discovery, rather than a harness name in workflow code, is what the
+coordinator asks. This keeps the difference between the harnesses in the
+adapter that owns it.
+
+Credential seeding is modeled per harness, not once for all of them. Each
 harness names its own optional host source, and a harness without one keeps the
 credential the worker itself persisted in its role volume. Modelling seeding as
 a single shared capability would make a Claude run on macOS look misconfigured
 when it is merely authenticated differently.
 
-A native session belongs to the harness that created it. A resume runs in that
-harness or not at all, which is what makes mid-session migration between Codex
-and Claude impossible. Capability discovery, rather than a hardcoded harness
-name in workflow code, is what the resume path checks.
+A native session belongs to the harness that created it. A resume dispatches on
+the harness recorded for the session under repair, and refuses to continue when
+the resolved adapter reports a different identity. That is what makes
+mid-session migration between Codex and Claude impossible.
+
+Model options remain per role rather than per harness. A repository that
+permits harness overrides therefore declares model options that every permitted
+harness accepts. Scoping models by harness would be the more complete model,
+but nothing in the current requirement needs it.
 
 This accepts that a repository must declare per-role policy that matches each
 harness's real capabilities, in exchange for refusals that are visible at
-launch instead of silent behavioural drift inside a run.
+launch instead of silent behavioral drift inside a run.

--- a/docs/adr/0002-per-role-harness-selection-fails-closed.md
+++ b/docs/adr/0002-per-role-harness-selection-fails-closed.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+---
+
+# Select a harness per role and fail closed on settings it cannot honour
+
+Codex and Claude Code are interchangeable so the best harness can be used for
+each stage. The coordinator resolves harness, model, and reasoning effort
+independently for each role from the frozen repository policy, and adapters
+translate that neutral selection into native commands. An adapter owns no
+workflow, Git, retry, or terminal-layout decision.
+
+The two harnesses are not feature-identical. Claude Code exposes no
+reasoning-effort process argument, and macOS keeps its credential in the login
+Keychain rather than in a file that a host can hand over. Two rules follow.
+
+An adapter refuses a validated repository setting it cannot represent, rather
+than dropping it. Silently dropping a reasoning effort would run a role at an
+effort the repository policy never authorized, and the operator would see a
+successful launch. A role that runs on Claude Code therefore declares no
+reasoning-effort options.
+
+Credential seeding is modelled per harness, not once for all of them. Each
+harness names its own optional host source, and a harness without one keeps the
+credential the worker itself persisted in its role volume. Modelling seeding as
+a single shared capability would make a Claude run on macOS look misconfigured
+when it is merely authenticated differently.
+
+A native session belongs to the harness that created it. A resume runs in that
+harness or not at all, which is what makes mid-session migration between Codex
+and Claude impossible. Capability discovery, rather than a hardcoded harness
+name in workflow code, is what the resume path checks.
+
+This accepts that a repository must declare per-role policy that matches each
+harness's real capabilities, in exchange for refusals that are visible at
+launch instead of silent behavioural drift inside a run.

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -14,9 +14,12 @@ commands and owns no workflow, Git, retry, or terminal-layout decision.
 
 The coordinator resolves the adapter from the frozen repository policy for the
 role, so workflow code never names a tool. `Capabilities` reports the adapter
-identity and whether it supports native resume; the check-repair path uses it
-to refuse continuing a session in a harness that did not create it. Mid-session
-migration between Codex and Claude is therefore not possible.
+identity and whether the harness can honor a reasoning-effort selection. The
+check-repair path dispatches on the harness recorded for the session under
+repair and refuses to continue when the resolved adapter reports a different
+identity, so mid-session migration between Codex and Claude is not possible.
+The launch path refuses a reasoning effort the selected harness cannot honor
+before it creates any side effect.
 
 The two adapters differ in how a native session identity is obtained:
 
@@ -33,7 +36,7 @@ file. A factory role home is created by the worker image and is never seeded
 from a host harness directory, so a session inherits no personal plugin, hook,
 MCP server, skill, or setting. `DISABLE_AUTOUPDATER=1` keeps Claude Code on the
 version pinned by the run's worker image digest, so a tool upgrade cannot
-change behaviour halfway through a run.
+change behavior halfway through a run.
 
 Harness contract tests drive both adapters through the complete lifecycle
 against controlled stub executables before any live run.

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -1,9 +1,42 @@
 # Visible agent runtime
 
-Issues #6 and #12 add the visible role-agent boundary. The coordinator owns
-the run, invocation identity, stage, policy, and report decision. Codex is an
-interactive proposal-maker; it does not own GitHub mutations, Git history, or
-workflow transitions.
+Issues #6, #12, and #14 add the visible role-agent boundary. The coordinator
+owns the run, invocation identity, stage, policy, and report decision. A
+harness is an interactive proposal-maker; it does not own GitHub mutations, Git
+history, or workflow transitions.
+
+## Harness adapters
+
+Codex and Claude Code are interchangeable. Both implement the same `Runtime`
+seam: capability discovery, launch, native session identification, resume, and
+graceful stop. An adapter translates one harness-neutral invocation into native
+commands and owns no workflow, Git, retry, or terminal-layout decision.
+
+The coordinator resolves the adapter from the frozen repository policy for the
+role, so workflow code never names a tool. `Capabilities` reports the adapter
+identity and whether it supports native resume; the check-repair path uses it
+to refuse continuing a session in a harness that did not create it. Mid-session
+migration between Codex and Claude is therefore not possible.
+
+The two adapters differ in how a native session identity is obtained:
+
+| Harness | Native session identity | Resume |
+| --- | --- | --- |
+| Codex | Persisted by Codex; the adapter snapshots the role home before launch and discovers the new session file | `codex ... resume <uuid>` with the global flags first |
+| Claude Code | Assigned by the adapter with `--session-id <uuid>` before launch, which removes the discovery race | `claude ... --resume <uuid>` |
+
+Both adapters disable the harness's own approval gates, because the worker is
+the security boundary and an inner gate would stall an unattended invocation.
+The Claude launch additionally passes `--strict-mcp-config` with an empty
+`--mcp-config` set, so a session loads no MCP server from any configuration
+file. A factory role home is created by the worker image and is never seeded
+from a host harness directory, so a session inherits no personal plugin, hook,
+MCP server, skill, or setting. `DISABLE_AUTOUPDATER=1` keeps Claude Code on the
+version pinned by the run's worker image digest, so a tool upgrade cannot
+change behaviour halfway through a run.
+
+Harness contract tests drive both adapters through the complete lifecycle
+against controlled stub executables before any live run.
 
 ## Starting an invocation
 
@@ -13,10 +46,13 @@ After an issue has been claimed, start the visible Codex session with:
 factory agent \
   --config /Users/me/.config/factory/config.yaml \
   --run-id run-123 \
-  --codex-auth /Users/me/.codex/auth.json
+  --codex-auth /Users/me/.codex/auth.json \
+  --claude-auth /Users/me/.claude/.credentials.json
 ```
 
-The command selects the active role automatically. For a repository with a
+The command selects the active role automatically, together with the harness,
+model, and reasoning effort declared for that role. Only the credential source
+of the selected harness is used. For a repository with a
 configured `test` role, `factory issue` leaves a healthy run in `test/active`,
 and this command starts the test agent. An implementation agent is started only
 after the test handoff is accepted, or after an authorized exemption. The
@@ -180,23 +216,32 @@ before resuming the role.
 
 ## Authentication and session state
 
-Registration may name one explicit host Codex auth file:
+Registration may name one explicit host credential file per harness:
 
 ```sh
-factory register ... --codex-auth /Users/me/.codex/auth.json
+factory register ... \
+  --codex-auth /Users/me/.codex/auth.json \
+  --claude-auth /Users/me/.claude/.credentials.json
 ```
 
-The worker adapter reads that one file and streams its bytes into a separate,
-factory-managed Codex credential volume. The role home contains only a link to
-that credential copy, while Codex session files remain in the private run/role
-volume. It never mounts the host harness directory and never writes back to the
-host source. A fresh role can reuse the credential volume without inheriting
-another role's session context.
+The worker adapter reads the one file belonging to the selected harness and
+streams its bytes into a separate, factory-managed credential volume. The role
+home contains only a link to that credential copy, while harness session files
+remain in the private run/role volume. It never mounts the host harness
+directory and never writes back to the host source. A fresh role can reuse the
+credential volume without inheriting another role's session context.
+
+Each harness keeps its own source because a host can hold one harness
+credential as a file without holding the other. macOS keeps the Claude Code
+credential in the login Keychain rather than a file, so `--claude-auth` is
+supplied only where a credential file exists; without it, Claude Code uses the
+credential the worker itself persisted in its role volume.
 
 Codex native session identifiers are recovered from its persisted session files,
-not from the terminal screen. Accepted reports retain the native session id and
-opaque surface handle so a later coordinator recovery operation can resume the
-session.
+not from the terminal screen. Claude Code accepts a coordinator-assigned
+identifier at launch, so no discovery is needed. Accepted reports retain the
+native session id and opaque surface handle so a later coordinator recovery
+operation can resume the session in the same harness.
 
 ## Check-repair loop
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ repositories:
       control_workspace: factory-control
     authentication:
       codex_auth_path: /Users/me/.codex/auth.json
+      claude_auth_path: /Users/me/.claude/.credentials.json
     operational_data_path: /Users/me/.local/share/factory/factory.db
     repository_config_path: /Users/me/src/project/factory.yaml
 ```
@@ -47,11 +48,19 @@ All paths persisted in a repository registration are absolute. The coordinator d
 
 `cmux.socket_path` is optional and is passed to the cmux adapter as its
 connection endpoint; the coordinator still keeps cmux identifiers behind the
-`TerminalRuntime` seam. `authentication.codex_auth_path` is optional and names one host-side Codex
-`auth.json` file. The factory stores only this path. During an implementation
-invocation the worker adapter streams the file into a separate,
-factory-managed credential volume and links that copy into the role home; it
-never mounts the host harness directory or writes back to the host source.
+`TerminalRuntime` seam.
+
+`authentication.codex_auth_path` and `authentication.claude_auth_path` are both
+optional and each names one host-side harness credential file. The factory
+stores only these paths. When an invocation selects a harness that has a
+registered source, the worker adapter streams that one file into a separate,
+factory-managed credential volume and links the copy into the role home. It
+never mounts the host harness directory and never writes back to the host
+source. Each harness has its own source because a host can hold one harness
+credential as a file without holding the other: macOS keeps the Claude Code
+credential in the login Keychain, so `claude_auth_path` is declared only where
+a credential file exists. A harness with no registered source keeps the
+credential the worker itself persisted in its role volume.
 
 ## Checked-in repository configuration
 
@@ -77,12 +86,16 @@ gates:
     environment_policy: clean
 role_harness_defaults:
   test: codex
-  implementation: codex
+  implementation: claude
   spec_review: codex
 model_options:
   test: [gpt-5]
-  implementation: [gpt-5]
+  implementation: [claude-opus-5, claude-sonnet-5]
   spec_review: [gpt-5]
+# Optional. A role that declares no values accepts no reasoning-effort
+# selection at all.
+reasoning_effort_options:
+  test: [medium, high]
 timeouts:
   setup: 5m
   agent: 30m
@@ -115,7 +128,38 @@ evaluation:
   retention: 720h
 ```
 
-The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies (including the mandatory `test` role), positive durations, positive retry limits, test policy, supported test-role prefixes, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, base-synchronization mode, and optional positive `evaluation.retention`. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. `test_policy.test_paths` and `test_policy.infrastructure_paths` authorize additional repository-relative paths for the test role; conventional `*_test.go`, `test/`, `tests/`, `test-support/`, and `__tests__/` paths are allowed by default. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
+The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies (including the mandatory `test` role), optional `reasoning_effort_options` for declared roles, positive durations, positive retry limits, test policy, supported test-role prefixes, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, base-synchronization mode, and optional positive `evaluation.retention`. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. `test_policy.test_paths` and `test_policy.infrastructure_paths` authorize additional repository-relative paths for the test role; conventional `*_test.go`, `test/`, `tests/`, `test-support/`, and `__tests__/` paths are allowed by default. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled.
+
+## Per-role harness, model, and reasoning effort
+
+`role_harness_defaults`, `model_options`, and `reasoning_effort_options` are
+selected independently for each role, so the best harness can be used for each
+stage. The supported harness values are `codex` and `claude`.
+
+A request selects one declared option per setting. When it selects nothing, the
+role uses its declared harness, its first declared model, and its first
+declared reasoning effort. A selection outside the declared options needs the
+matching `allowed_overrides` entry; without it the coordinator refuses the
+launch as a typed policy rejection with the code `harness_override`,
+`model_override`, or `reasoning_effort_override`.
+
+Claude Code exposes no reasoning-effort process argument. A role that runs on
+`claude` therefore declares no `reasoning_effort_options`; if one is selected
+anyway, the adapter refuses the launch rather than running the role at an
+effort the policy never authorized.
+
+An authorized maintainer selects a harness for a later invocation with one
+structured comment:
+
+```text
+/factory config harness=claude
+```
+
+The comment grammar accepts nothing else. A recognized command with an extra
+word, a flag, or an unknown key is refused as a typed malformed-command
+rejection, so a comment cannot inject a process argument into a launched
+harness. The recorded choice is still validated against the frozen repository
+policy when the next invocation starts. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
 
 The test stage is default-on for both supported `test_policy.mode` values.
 A human skip requires `allow_human_exemption: true` and the frozen issue marker

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,7 @@ evaluation:
   retention: 720h
 ```
 
-The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies (including the mandatory `test` role), optional `reasoning_effort_options` for declared roles, positive durations, positive retry limits, test policy, supported test-role prefixes, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, base-synchronization mode, and optional positive `evaluation.retention`. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. `test_policy.test_paths` and `test_policy.infrastructure_paths` authorize additional repository-relative paths for the test role; conventional `*_test.go`, `test/`, `tests/`, `test-support/`, and `__tests__/` paths are allowed by default. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled.
+The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies (including the mandatory `test` role), optional `reasoning_effort_options` for declared roles, positive durations, positive retry limits, test policy, supported test-role prefixes, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, base-synchronization mode, and optional positive `evaluation.retention`. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. `test_policy.test_paths` and `test_policy.infrastructure_paths` authorize additional repository-relative paths for the test role; conventional `*_test.go`, `test/`, `tests/`, `test-support/`, and `__tests__/` paths are allowed by default. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
 
 ## Per-role harness, model, and reasoning effort
 
@@ -144,9 +144,17 @@ launch as a typed policy rejection with the code `harness_override`,
 `model_override`, or `reasoning_effort_override`.
 
 Claude Code exposes no reasoning-effort process argument. A role that runs on
-`claude` therefore declares no `reasoning_effort_options`; if one is selected
-anyway, the adapter refuses the launch rather than running the role at an
-effort the policy never authorized.
+`claude` therefore declares no `reasoning_effort_options`, and the validator
+refuses a configuration that declares them anyway. If a selection still reaches
+a launch, the coordinator refuses it as a `reasoning_effort_unsupported`
+rejection before it starts a worker, and the adapter refuses it again as a
+fail-closed backstop.
+
+`model_options` is declared per role, not per harness. A repository that adds
+`harness` to `allowed_overrides` therefore accepts responsibility for declaring
+model options that every permitted harness accepts; otherwise an authorized
+override can pair one harness with another harness's model name, and the
+harness rejects the model at launch.
 
 An authorized maintainer selects a harness for a later invocation with one
 structured comment:
@@ -159,7 +167,7 @@ The comment grammar accepts nothing else. A recognized command with an extra
 word, a flag, or an unknown key is refused as a typed malformed-command
 rejection, so a comment cannot inject a process argument into a launched
 harness. The recorded choice is still validated against the frozen repository
-policy when the next invocation starts. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
+policy when the next invocation starts.
 
 The test stage is default-on for both supported `test_policy.mode` values.
 A human skip requires `allow_human_exemption: true` and the frozen issue marker

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -165,6 +165,7 @@ func runAgent(ctx context.Context, args []string, defaultConfigPath string, outp
 	model := flags.String("model", "", "validated model override")
 	reasoningEffort := flags.String("reasoning-effort", "", "validated reasoning-effort override")
 	codexAuthPath := flags.String("codex-auth", "", "explicit Codex auth.json source")
+	claudeAuthPath := flags.String("claude-auth", "", "explicit Claude credential source")
 	permittedPaths := stringList{}
 	flags.Var(&permittedPaths, "permitted-path", "repository-relative handoff path prefix; may be repeated")
 	if err := flags.Parse(args); err != nil {
@@ -182,6 +183,7 @@ func runAgent(ctx context.Context, args []string, defaultConfigPath string, outp
 		Model:           *model,
 		ReasoningEffort: *reasoningEffort,
 		CodexAuthPath:   *codexAuthPath,
+		ClaudeAuthPath:  *claudeAuthPath,
 		PermittedPaths:  append([]string(nil), permittedPaths...),
 	})
 	if err != nil {
@@ -362,6 +364,7 @@ func runRegister(ctx context.Context, args []string, defaultConfigPath string, o
 	cmuxSocketPath := flags.String("cmux-socket", "", "cmux socket path")
 	cmuxWorkspace := flags.String("cmux-workspace", "", "cmux control workspace")
 	codexAuthPath := flags.String("codex-auth", "", "host Codex auth.json path")
+	claudeAuthPath := flags.String("claude-auth", "", "host Claude credential path")
 	repositoryConfigPath := flags.String("repository-config", "", "checked-in repository configuration path")
 	authorizedUsers := stringList{}
 	flags.Var(&authorizedUsers, "authorized-user", "authorized GitHub username; may be repeated")
@@ -388,6 +391,7 @@ func runRegister(ctx context.Context, args []string, defaultConfigPath string, o
 		CmuxSocketPath:       *cmuxSocketPath,
 		CmuxControlWorkspace: *cmuxWorkspace,
 		CodexAuthPath:        *codexAuthPath,
+		ClaudeAuthPath:       *claudeAuthPath,
 		RepositoryConfigPath: *repositoryConfigPath,
 	})
 	if err != nil {

--- a/internal/config/agent_auth_test.go
+++ b/internal/config/agent_auth_test.go
@@ -51,3 +51,48 @@ func TestValidateHostRejectsControlCharactersInCodexAuthSource(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateHostRequiresAnAbsoluteClaudeAuthSource verifies the Claude
+// credential source is stored on the same narrow terms as the Codex source.
+func TestValidateHostRequiresAnAbsoluteClaudeAuthSource(t *testing.T) {
+	value := config.HostConfig{SchemaVersion: config.CurrentSchemaVersion, Repositories: []config.RepositoryRegistration{{
+		Path:                 "/Users/example/project",
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		AuthorizedUsers:      []string{"alice"},
+		Polling:              config.PollingConfig{Interval: "30s", Backoff: "5m"},
+		Authentication:       config.AuthenticationConfig{ClaudeAuthPath: ".credentials.json"},
+		OperationalDataPath:  "/Users/example/data/factory.db",
+		RepositoryConfigPath: "/Users/example/project/factory.yaml",
+	}}}
+	if err := config.ValidateHost(value); err == nil || !strings.Contains(err.Error(), "authentication.claude_auth_path") {
+		t.Fatalf("ValidateHost() error = %v, want absolute auth path error", err)
+	}
+}
+
+// TestValidateHostRejectsControlCharactersInClaudeAuthSource verifies a host
+// registration cannot persist a path that can alter later command arguments.
+func TestValidateHostRejectsControlCharactersInClaudeAuthSource(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		control string
+	}{
+		{name: "nul", control: "\x00"},
+		{name: "carriage-return", control: "\r"},
+		{name: "newline", control: "\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			value := config.HostConfig{SchemaVersion: config.CurrentSchemaVersion, Repositories: []config.RepositoryRegistration{{
+				Path:                 "/Users/example/project",
+				GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+				AuthorizedUsers:      []string{"alice"},
+				Polling:              config.PollingConfig{Interval: "30s", Backoff: "5m"},
+				Authentication:       config.AuthenticationConfig{ClaudeAuthPath: "/Users/example/.credentials.json" + test.control},
+				OperationalDataPath:  "/Users/example/data/factory.db",
+				RepositoryConfigPath: "/Users/example/project/factory.yaml",
+			}}}
+			if err := config.ValidateHost(value); err == nil || !strings.Contains(err.Error(), "control characters") {
+				t.Fatalf("ValidateHost() error = %v, want control-character rejection", err)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,10 @@ type CmuxConfig struct {
 type AuthenticationConfig struct {
 	// CodexAuthPath is an optional host path to one Codex auth.json file.
 	CodexAuthPath string `yaml:"codex_auth_path"`
+	// ClaudeAuthPath is an optional host path to one Claude Code credential
+	// file. A macOS host keeps this credential in the login Keychain rather
+	// than a file, so the path is declared only where a file exists.
+	ClaudeAuthPath string `yaml:"claude_auth_path"`
 }
 
 type RepositoryConfig struct {
@@ -69,6 +73,10 @@ type RepositoryConfig struct {
 	Gates                  []GateConfig        `yaml:"gates"`
 	RoleHarnessDefaults    map[string]Harness  `yaml:"role_harness_defaults"`
 	ModelOptions           map[string][]string `yaml:"model_options"`
+	// ReasoningEffortOptions declares the validated reasoning-effort values a
+	// role may use. A role that declares none accepts no reasoning-effort
+	// selection at all.
+	ReasoningEffortOptions map[string][]string `yaml:"reasoning_effort_options"`
 	Timeouts               TimeoutConfig       `yaml:"timeouts"`
 	RetryLimits            RetryLimits         `yaml:"retry_limits"`
 	TestPolicy             TestPolicy          `yaml:"test_policy"`
@@ -424,6 +432,25 @@ func ValidateRepository(config RepositoryConfig) error {
 			return validation("role_harness_defaults."+role, "must declare a harness for every model role")
 		}
 	}
+	for role, efforts := range config.ReasoningEffortOptions {
+		if _, exists := config.RoleHarnessDefaults[role]; !exists {
+			return validation("reasoning_effort_options."+role, "must reference a role with a declared harness")
+		}
+		if len(efforts) == 0 {
+			return validation("reasoning_effort_options."+role, "must declare at least one value or be omitted")
+		}
+		seen := make(map[string]struct{}, len(efforts))
+		for index, effort := range efforts {
+			field := fmt.Sprintf("reasoning_effort_options.%s[%d]", role, index)
+			if strings.TrimSpace(effort) == "" || strings.ContainsAny(effort, "\x00\r\n \t") {
+				return validation(field, "must be a nonempty single-token value")
+			}
+			if _, exists := seen[effort]; exists {
+				return validation(field, "must be unique")
+			}
+			seen[effort] = struct{}{}
+		}
+	}
 	if _, exists := config.RoleHarnessDefaults["test"]; !exists {
 		return validation("role_harness_defaults.test", "must declare the mandatory test role")
 	}
@@ -591,12 +618,18 @@ func validateRegistration(prefix string, repository RepositoryRegistration) erro
 	if repository.Cmux.SocketPath != "" && !filepath.IsAbs(repository.Cmux.SocketPath) {
 		return validation(prefix+".cmux.socket_path", "must be absolute when set")
 	}
-	if repository.Authentication.CodexAuthPath != "" {
-		if strings.ContainsAny(repository.Authentication.CodexAuthPath, "\x00\r\n") {
-			return validation(prefix+".authentication.codex_auth_path", "must not contain control characters")
+	for field, path := range map[string]string{
+		prefix + ".authentication.codex_auth_path":  repository.Authentication.CodexAuthPath,
+		prefix + ".authentication.claude_auth_path": repository.Authentication.ClaudeAuthPath,
+	} {
+		if path == "" {
+			continue
 		}
-		if !filepath.IsAbs(repository.Authentication.CodexAuthPath) {
-			return validation(prefix+".authentication.codex_auth_path", "must be absolute when set")
+		if strings.ContainsAny(path, "\x00\r\n") {
+			return validation(field, "must not contain control characters")
+		}
+		if !filepath.IsAbs(path) {
+			return validation(field, "must be absolute when set")
 		}
 	}
 	if strings.TrimSpace(repository.RepositoryConfigPath) == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -433,8 +433,12 @@ func ValidateRepository(config RepositoryConfig) error {
 		}
 	}
 	for role, efforts := range config.ReasoningEffortOptions {
-		if _, exists := config.RoleHarnessDefaults[role]; !exists {
+		harness, exists := config.RoleHarnessDefaults[role]
+		if !exists {
 			return validation("reasoning_effort_options."+role, "must reference a role with a declared harness")
+		}
+		if !harnessHonorsReasoningEffort(harness) {
+			return validation("reasoning_effort_options."+role, fmt.Sprintf("harness %q cannot honor a reasoning-effort selection", harness))
 		}
 		if len(efforts) == 0 {
 			return validation("reasoning_effort_options."+role, "must declare at least one value or be omitted")
@@ -529,6 +533,14 @@ func ValidateRepository(config RepositoryConfig) error {
 		}
 	}
 	return nil
+}
+
+// harnessHonorsReasoningEffort reports whether a harness accepts a
+// reasoning-effort selection. Claude Code exposes no reasoning-effort process
+// argument, so a role that runs on it declares no options rather than
+// declaring options that every launch would refuse.
+func harnessHonorsReasoningEffort(harness Harness) bool {
+	return harness == HarnessCodex
 }
 
 // validateSetupFiles validates optional repository-relative manifest and

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -826,3 +826,54 @@ func validRepositoryConfig() config.RepositoryConfig {
 		BaseSynchronization: config.BaseSynchronization{Mode: config.BaseSynchronizationNever},
 	}
 }
+
+// TestValidateRepositoryAcceptsDeclaredReasoningEffortOptions verifies a role
+// may declare the validated reasoning-effort values its harness accepts.
+func TestValidateRepositoryAcceptsDeclaredReasoningEffortOptions(t *testing.T) {
+	value := validRepositoryConfig()
+	value.ReasoningEffortOptions = map[string][]string{"implementation": {"medium", "high"}}
+	if err := config.ValidateRepository(value); err != nil {
+		t.Fatalf("ValidateRepository() error = %v, want declared reasoning-effort options to be accepted", err)
+	}
+}
+
+// TestValidateRepositoryRejectsReasoningEffortOptionsForAnUndeclaredRole
+// verifies reasoning effort cannot be declared for a role that has no harness.
+func TestValidateRepositoryRejectsReasoningEffortOptionsForAnUndeclaredRole(t *testing.T) {
+	value := validRepositoryConfig()
+	value.ReasoningEffortOptions = map[string][]string{"standards_review": {"high"}}
+	if err := config.ValidateRepository(value); err == nil || !strings.Contains(err.Error(), "reasoning_effort_options.standards_review") {
+		t.Fatalf("ValidateRepository() error = %v, want undeclared-role rejection", err)
+	}
+}
+
+// TestValidateRepositoryRejectsUnsafeReasoningEffortOptions verifies a
+// declared value cannot smuggle separators into a launched process argument.
+func TestValidateRepositoryRejectsUnsafeReasoningEffortOptions(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: "   "},
+		{name: "space", value: "high --flag"},
+		{name: "newline", value: "high\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			value := validRepositoryConfig()
+			value.ReasoningEffortOptions = map[string][]string{"implementation": {test.value}}
+			if err := config.ValidateRepository(value); err == nil || !strings.Contains(err.Error(), "reasoning_effort_options.implementation[0]") {
+				t.Fatalf("ValidateRepository() error = %v, want unsafe-value rejection", err)
+			}
+		})
+	}
+}
+
+// TestValidateRepositoryRejectsDuplicateReasoningEffortOptions verifies a role
+// declares each validated value once.
+func TestValidateRepositoryRejectsDuplicateReasoningEffortOptions(t *testing.T) {
+	value := validRepositoryConfig()
+	value.ReasoningEffortOptions = map[string][]string{"implementation": {"high", "high"}}
+	if err := config.ValidateRepository(value); err == nil || !strings.Contains(err.Error(), "must be unique") {
+		t.Fatalf("ValidateRepository() error = %v, want duplicate rejection", err)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -877,3 +877,15 @@ func TestValidateRepositoryRejectsDuplicateReasoningEffortOptions(t *testing.T) 
 		t.Fatalf("ValidateRepository() error = %v, want duplicate rejection", err)
 	}
 }
+
+// TestValidateRepositoryRejectsReasoningEffortOptionsForAHarnessThatCannotHonorThem
+// verifies a repository cannot declare a setting whose every launch would be
+// refused, because Claude Code exposes no reasoning-effort process argument.
+func TestValidateRepositoryRejectsReasoningEffortOptionsForAHarnessThatCannotHonorThem(t *testing.T) {
+	value := validRepositoryConfig()
+	value.RoleHarnessDefaults["implementation"] = config.HarnessClaude
+	value.ReasoningEffortOptions = map[string][]string{"implementation": {"high"}}
+	if err := config.ValidateRepository(value); err == nil || !strings.Contains(err.Error(), "cannot honor a reasoning-effort selection") {
+		t.Fatalf("ValidateRepository() error = %v, want an unsupported-harness rejection", err)
+	}
+}

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -436,58 +436,102 @@ func validateAgentRequest(request AgentRequest) error {
 	return nil
 }
 
+// AgentPolicy is the frozen repository selection resolved for one role. The
+// three settings are chosen independently, so they travel together rather than
+// as interchangeable bare strings.
+type AgentPolicy struct {
+	// Harness is the adapter that will run the invocation.
+	Harness config.Harness
+	// Model is the validated model selection.
+	Model string
+	// ReasoningEffort is the validated reasoning-effort selection. It is empty
+	// when the role declares none.
+	ReasoningEffort string
+}
+
 // resolveAgentPolicy applies the frozen repository harness, model, and
-// reasoning-effort policy for one role. Harness, model, and reasoning effort
-// are selected independently; each defaults to the role's declared option and
-// only a repository-declared override permission widens it. Every refusal is a
-// typed policy rejection so the coordinator can report it in stable vocabulary.
-func resolveAgentPolicy(repository config.RepositoryConfig, request AgentRequest) (config.Harness, string, string, error) {
-	defaultHarness := repository.RoleHarnessDefaults[request.Role]
-	harnessName := request.Harness
-	if harnessName == "" {
-		harnessName = defaultHarness
+// reasoning-effort policy for one role. Each setting defaults to the role's
+// declared option, and only a repository-declared override permission widens
+// it. Every refusal is a typed policy rejection so the coordinator can report
+// it in stable vocabulary.
+func resolveAgentPolicy(repository config.RepositoryConfig, request AgentRequest) (AgentPolicy, error) {
+	harnessName, err := resolveHarnessPolicy(repository, request)
+	if err != nil {
+		return AgentPolicy{}, err
 	}
-	if harnessName != config.HarnessCodex && harnessName != config.HarnessClaude {
-		return "", "", "", &PolicyRejection{
+	model, err := resolveModelPolicy(repository, request)
+	if err != nil {
+		return AgentPolicy{}, err
+	}
+	effort, err := resolveReasoningEffortPolicy(repository, request)
+	if err != nil {
+		return AgentPolicy{}, err
+	}
+	return AgentPolicy{Harness: harnessName, Model: model, ReasoningEffort: effort}, nil
+}
+
+// resolveHarnessPolicy selects the role's harness and refuses an override the
+// repository has not explicitly permitted.
+func resolveHarnessPolicy(repository config.RepositoryConfig, request AgentRequest) (config.Harness, error) {
+	declared := repository.RoleHarnessDefaults[request.Role]
+	selected := request.Harness
+	if selected == "" {
+		selected = declared
+	}
+	if selected != config.HarnessCodex && selected != config.HarnessClaude {
+		return "", &PolicyRejection{
 			Code:    PolicyRejectionHarnessUnavailable,
 			Problem: fmt.Sprintf("no supported harness policy for role %q", request.Role),
 		}
 	}
-	if request.Harness != "" && request.Harness != defaultHarness && !hasOverride(repository.AllowedOverrides, config.OverrideHarness) {
-		return "", "", "", &PolicyRejection{
+	if request.Harness != "" && request.Harness != declared && !hasOverride(repository.AllowedOverrides, config.OverrideHarness) {
+		return "", &PolicyRejection{
 			Code:    PolicyRejectionHarnessOverride,
-			Problem: fmt.Sprintf("repository configuration does not allow harness override from %q to %q for role %q", defaultHarness, request.Harness, request.Role),
+			Problem: fmt.Sprintf("repository configuration does not allow harness override from %q to %q for role %q", declared, request.Harness, request.Role),
 		}
 	}
+	return selected, nil
+}
+
+// resolveModelPolicy selects the role's model and refuses a value outside its
+// declared options unless the repository permits model overrides.
+func resolveModelPolicy(repository config.RepositoryConfig, request AgentRequest) (string, error) {
 	options := repository.ModelOptions[request.Role]
-	model := request.Model
-	if model == "" && len(options) > 0 {
-		model = options[0]
+	selected := request.Model
+	if selected == "" && len(options) > 0 {
+		selected = options[0]
 	}
-	if model == "" {
-		return "", "", "", &PolicyRejection{
-			Code:    PolicyRejectionModelOverride,
+	if selected == "" {
+		return "", &PolicyRejection{
+			Code:    PolicyRejectionModelUnavailable,
 			Problem: fmt.Sprintf("no model policy for role %q", request.Role),
 		}
 	}
-	if !contains(options, model) && !hasOverride(repository.AllowedOverrides, config.OverrideModel) {
-		return "", "", "", &PolicyRejection{
+	if !contains(options, selected) && !hasOverride(repository.AllowedOverrides, config.OverrideModel) {
+		return "", &PolicyRejection{
 			Code:    PolicyRejectionModelOverride,
-			Problem: fmt.Sprintf("model %q is not a declared option for role %q", model, request.Role),
+			Problem: fmt.Sprintf("model %q is not a declared option for role %q", selected, request.Role),
 		}
 	}
-	efforts := repository.ReasoningEffortOptions[request.Role]
-	effort := request.ReasoningEffort
-	if effort == "" && len(efforts) > 0 {
-		effort = efforts[0]
+	return selected, nil
+}
+
+// resolveReasoningEffortPolicy selects the role's reasoning effort. A role that
+// declares no options accepts no selection unless the repository permits
+// reasoning-effort overrides.
+func resolveReasoningEffortPolicy(repository config.RepositoryConfig, request AgentRequest) (string, error) {
+	options := repository.ReasoningEffortOptions[request.Role]
+	selected := request.ReasoningEffort
+	if selected == "" && len(options) > 0 {
+		selected = options[0]
 	}
-	if effort != "" && !contains(efforts, effort) && !hasOverride(repository.AllowedOverrides, config.OverrideReasoningEffort) {
-		return "", "", "", &PolicyRejection{
+	if selected != "" && !contains(options, selected) && !hasOverride(repository.AllowedOverrides, config.OverrideReasoningEffort) {
+		return "", &PolicyRejection{
 			Code:    PolicyRejectionReasoningEffortOverride,
-			Problem: fmt.Sprintf("reasoning effort %q is not a declared option for role %q", effort, request.Role),
+			Problem: fmt.Sprintf("reasoning effort %q is not a declared option for role %q", selected, request.Role),
 		}
 	}
-	return harnessName, model, effort, nil
+	return selected, nil
 }
 
 // hasOverride reports whether a repository policy explicitly permits a setting.

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -52,8 +52,10 @@ type AgentRequest struct {
 	Model string
 	// ReasoningEffort is an optional policy-validated setting.
 	ReasoningEffort string
-	// CodexAuthPath overrides the registered narrow auth source when set.
+	// CodexAuthPath overrides the registered narrow Codex auth source when set.
 	CodexAuthPath string
+	// ClaudeAuthPath overrides the registered narrow Claude auth source when set.
+	ClaudeAuthPath string
 	// PermittedPaths constrains production paths in the accepted handoff.
 	PermittedPaths []string
 }
@@ -303,7 +305,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 			}
 		}
 	}
-	_, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath)
+	_, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, config.Harness(invocation.Harness))
 	if err != nil {
 		return AgentResult{}, fmt.Errorf("ensure agent runtime: %w", err)
 	}
@@ -423,42 +425,69 @@ func validateAgentRequest(request AgentRequest) error {
 	if request.ReasoningEffort != "" && strings.ContainsAny(request.ReasoningEffort, "\x00\r\n ") {
 		return errors.New("agent reasoning effort contains unsafe characters")
 	}
-	if request.CodexAuthPath != "" {
-		if !filepath.IsAbs(request.CodexAuthPath) || strings.ContainsAny(request.CodexAuthPath, "\x00\r\n") {
-			return errors.New("agent Codex auth path must be absolute and free of control characters")
+	for harnessName, path := range map[string]string{"Codex": request.CodexAuthPath, "Claude": request.ClaudeAuthPath} {
+		if path == "" {
+			continue
+		}
+		if !filepath.IsAbs(path) || strings.ContainsAny(path, "\x00\r\n") {
+			return fmt.Errorf("agent %s auth path must be absolute and free of control characters", harnessName)
 		}
 	}
 	return nil
 }
 
-// resolveAgentPolicy applies frozen repository harness/model policy and only
-// permits explicit overrides declared by that packet.
-func resolveAgentPolicy(repository config.RepositoryConfig, request AgentRequest) (config.Harness, string, error) {
+// resolveAgentPolicy applies the frozen repository harness, model, and
+// reasoning-effort policy for one role. Harness, model, and reasoning effort
+// are selected independently; each defaults to the role's declared option and
+// only a repository-declared override permission widens it. Every refusal is a
+// typed policy rejection so the coordinator can report it in stable vocabulary.
+func resolveAgentPolicy(repository config.RepositoryConfig, request AgentRequest) (config.Harness, string, string, error) {
+	defaultHarness := repository.RoleHarnessDefaults[request.Role]
 	harnessName := request.Harness
 	if harnessName == "" {
-		harnessName = repository.RoleHarnessDefaults[request.Role]
+		harnessName = defaultHarness
 	}
 	if harnessName != config.HarnessCodex && harnessName != config.HarnessClaude {
-		return "", "", fmt.Errorf("no supported harness policy for role %q", request.Role)
+		return "", "", "", &PolicyRejection{
+			Code:    PolicyRejectionHarnessUnavailable,
+			Problem: fmt.Sprintf("no supported harness policy for role %q", request.Role),
+		}
 	}
-	if request.Harness != "" && !hasOverride(repository.AllowedOverrides, config.OverrideHarness) && request.Harness != repository.RoleHarnessDefaults[request.Role] {
-		return "", "", errors.New("harness override is not allowed by repository policy")
+	if request.Harness != "" && request.Harness != defaultHarness && !hasOverride(repository.AllowedOverrides, config.OverrideHarness) {
+		return "", "", "", &PolicyRejection{
+			Code:    PolicyRejectionHarnessOverride,
+			Problem: fmt.Sprintf("repository configuration does not allow harness override from %q to %q for role %q", defaultHarness, request.Harness, request.Role),
+		}
 	}
-	model := request.Model
 	options := repository.ModelOptions[request.Role]
+	model := request.Model
 	if model == "" && len(options) > 0 {
 		model = options[0]
 	}
 	if model == "" {
-		return "", "", fmt.Errorf("no model policy for role %q", request.Role)
+		return "", "", "", &PolicyRejection{
+			Code:    PolicyRejectionModelOverride,
+			Problem: fmt.Sprintf("no model policy for role %q", request.Role),
+		}
 	}
 	if !contains(options, model) && !hasOverride(repository.AllowedOverrides, config.OverrideModel) {
-		return "", "", fmt.Errorf("model %q is not allowed for role %q", model, request.Role)
+		return "", "", "", &PolicyRejection{
+			Code:    PolicyRejectionModelOverride,
+			Problem: fmt.Sprintf("model %q is not a declared option for role %q", model, request.Role),
+		}
 	}
-	if request.ReasoningEffort != "" && !hasOverride(repository.AllowedOverrides, config.OverrideReasoningEffort) {
-		return "", "", errors.New("reasoning_effort override is not allowed by repository policy")
+	efforts := repository.ReasoningEffortOptions[request.Role]
+	effort := request.ReasoningEffort
+	if effort == "" && len(efforts) > 0 {
+		effort = efforts[0]
 	}
-	return harnessName, model, nil
+	if effort != "" && !contains(efforts, effort) && !hasOverride(repository.AllowedOverrides, config.OverrideReasoningEffort) {
+		return "", "", "", &PolicyRejection{
+			Code:    PolicyRejectionReasoningEffortOverride,
+			Problem: fmt.Sprintf("reasoning effort %q is not a declared option for role %q", effort, request.Role),
+		}
+	}
+	return harnessName, model, effort, nil
 }
 
 // hasOverride reports whether a repository policy explicitly permits a setting.

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -89,17 +89,26 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	if request.Role == "implementation" && run.Stage == store.StageClaim && !run.TestStageSkipped {
 		return AgentLaunchResult{}, errors.New("implementation agent cannot bypass the configured test stage")
 	}
-	harnessName, model, reasoningEffort, err := resolveAgentPolicy(packet.RepositoryConfig, request)
+	policy, err := resolveAgentPolicy(packet.RepositoryConfig, request)
 	if err != nil {
 		return AgentLaunchResult{}, err
 	}
-	seedCredentials, credentialStoreID, err := s.credentialSeeding(registration, request, harnessName)
+	seedCredentials, credentialStoreID, err := s.credentialSeeding(registration, request, policy.Harness)
 	if err != nil {
 		return AgentLaunchResult{}, err
 	}
-	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, harnessName)
+	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, policy.Harness)
 	if err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("ensure agent runtime: %w", err)
+	}
+	// A setting the selected harness cannot honor is refused here, before the
+	// launch creates any directory, worker, credential copy, or surface. The
+	// adapter refuses it again at launch as a fail-closed backstop.
+	if policy.ReasoningEffort != "" && !harnessRuntime.Capabilities().ReasoningEffort {
+		return AgentLaunchResult{}, &PolicyRejection{
+			Code:    PolicyRejectionReasoningEffortUnsupported,
+			Problem: fmt.Sprintf("harness %q cannot honor a reasoning-effort selection for role %q", policy.Harness, request.Role),
+		}
 	}
 	runID, err := s.deps.NewRunID()
 	if err != nil {
@@ -156,11 +165,11 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	invocation := store.Invocation{
 		ID:                  invocationID,
 		RunID:               run.ID,
-		Harness:             string(harnessName),
+		Harness:             string(policy.Harness),
 		Role:                role,
 		Stage:               stage,
-		Model:               model,
-		ReasoningEffort:     reasoningEffort,
+		Model:               policy.Model,
+		ReasoningEffort:     policy.ReasoningEffort,
 		CredentialStoreID:   credentialStoreID,
 		InvocationDirectory: packetDirectory,
 		ResultDirectory:     resultDirectory,
@@ -285,11 +294,11 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		WorkspaceID:     runWorkspace.ID,
 		Surface:         agentSurface,
 		Prompt:          promptText,
-		Model:           model,
-		ReasoningEffort: reasoningEffort,
+		Model:           policy.Model,
+		ReasoningEffort: policy.ReasoningEffort,
 	})
 	if err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("launch %s %s agent: %w", harnessName, role, err)
+		return AgentLaunchResult{}, fmt.Errorf("launch %s %s agent: %w", policy.Harness, role, err)
 	}
 	if session.NativeSessionID != "" {
 		invocation.NativeSessionID = session.NativeSessionID
@@ -329,35 +338,30 @@ func reviewCheckpointSHA(review bool, checkpoint string) string {
 // harness and returns the seeding step to run after the worker starts. Each
 // harness keeps its own host source, because a host can hold one harness
 // credential as a file without holding the other. It returns a nil step when
-// no source is registered, leaving the worker's own persisted role state in
-// place.
+// no source is registered, leaving the credential the worker itself persisted
+// in its role volume in place.
 func (s *Service) credentialSeeding(registration config.RepositoryRegistration, request AgentRequest, harnessName config.Harness) (func(context.Context, string) error, string, error) {
-	authPath := ""
+	var authPath string
+	var seed func(context.Context, worker.CredentialSeedRequest) error
 	switch harnessName {
 	case config.HarnessCodex:
 		authPath = defaultString(request.CodexAuthPath, registration.Authentication.CodexAuthPath)
+		if seeder, ok := s.deps.Worker.(worker.CredentialSeeder); ok {
+			seed = seeder.SeedCodexCredentials
+		}
 	case config.HarnessClaude:
 		authPath = defaultString(request.ClaudeAuthPath, registration.Authentication.ClaudeAuthPath)
+		if seeder, ok := s.deps.Worker.(worker.ClaudeCredentialSeeder); ok {
+			seed = seeder.SeedClaudeCredentials
+		}
 	}
 	if authPath == "" {
 		return nil, "", nil
 	}
-	switch harnessName {
-	case config.HarnessCodex:
-		seeder, ok := s.deps.Worker.(worker.CredentialSeeder)
-		if !ok {
-			return nil, "", errors.New("worker runtime does not support Codex credential seeding")
-		}
-		return func(ctx context.Context, runID string) error {
-			return seeder.SeedCodexCredentials(ctx, worker.CredentialSeedRequest{RunID: runID, AuthPath: authPath})
-		}, registration.Path, nil
-	default:
-		seeder, ok := s.deps.Worker.(worker.ClaudeCredentialSeeder)
-		if !ok {
-			return nil, "", errors.New("worker runtime does not support Claude credential seeding")
-		}
-		return func(ctx context.Context, runID string) error {
-			return seeder.SeedClaudeCredentials(ctx, worker.CredentialSeedRequest{RunID: runID, AuthPath: authPath})
-		}, registration.Path, nil
+	if seed == nil {
+		return nil, "", fmt.Errorf("worker runtime does not support %s credential seeding", harnessName)
 	}
+	return func(ctx context.Context, runID string) error {
+		return seed(ctx, worker.CredentialSeedRequest{RunID: runID, AuthPath: authPath})
+	}, registration.Path, nil
 }

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -89,28 +89,15 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	if request.Role == "implementation" && run.Stage == store.StageClaim && !run.TestStageSkipped {
 		return AgentLaunchResult{}, errors.New("implementation agent cannot bypass the configured test stage")
 	}
-	harnessName, model, err := resolveAgentPolicy(packet.RepositoryConfig, request)
+	harnessName, model, reasoningEffort, err := resolveAgentPolicy(packet.RepositoryConfig, request)
 	if err != nil {
 		return AgentLaunchResult{}, err
 	}
-	if harnessName != config.HarnessCodex {
-		return AgentLaunchResult{}, fmt.Errorf("harness %q is not supported by the Codex implementation agent", harnessName)
+	seedCredentials, credentialStoreID, err := s.credentialSeeding(registration, request, harnessName)
+	if err != nil {
+		return AgentLaunchResult{}, err
 	}
-	authPath := request.CodexAuthPath
-	if authPath == "" {
-		authPath = registration.Authentication.CodexAuthPath
-	}
-	credentialStoreID := ""
-	var seeder worker.CredentialSeeder
-	if authPath != "" {
-		credentialStoreID = registration.Path
-		var ok bool
-		seeder, ok = s.deps.Worker.(worker.CredentialSeeder)
-		if !ok {
-			return AgentLaunchResult{}, errors.New("worker runtime does not support Codex credential seeding")
-		}
-	}
-	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath)
+	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, harnessName)
 	if err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("ensure agent runtime: %w", err)
 	}
@@ -173,7 +160,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		Role:                role,
 		Stage:               stage,
 		Model:               model,
-		ReasoningEffort:     request.ReasoningEffort,
+		ReasoningEffort:     reasoningEffort,
 		CredentialStoreID:   credentialStoreID,
 		InvocationDirectory: packetDirectory,
 		ResultDirectory:     resultDirectory,
@@ -248,8 +235,8 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 			return AgentLaunchResult{}, err
 		}
 	}
-	if authPath != "" {
-		if err := seeder.SeedCodexCredentials(ctx, worker.CredentialSeedRequest{RunID: run.ID, AuthPath: authPath}); err != nil {
+	if seedCredentials != nil {
+		if err := seedCredentials(ctx, run.ID); err != nil {
 			return AgentLaunchResult{}, err
 		}
 	}
@@ -274,7 +261,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	if role == "test" {
 		agentSurface = runWorkspace.Checks
 	} else if isReview {
-		// The Codex adapter creates a fresh command-backed surface for the
+		// The harness adapter creates a fresh command-backed surface for the
 		// reviewer, rather than reusing the implementation surface.
 		agentSurface = terminal.Surface{WorkspaceID: runWorkspace.ID, Name: "spec-review"}
 	}
@@ -299,10 +286,10 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		Surface:         agentSurface,
 		Prompt:          promptText,
 		Model:           model,
-		ReasoningEffort: request.ReasoningEffort,
+		ReasoningEffort: reasoningEffort,
 	})
 	if err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("launch Codex %s agent: %w", role, err)
+		return AgentLaunchResult{}, fmt.Errorf("launch %s %s agent: %w", harnessName, role, err)
 	}
 	if session.NativeSessionID != "" {
 		invocation.NativeSessionID = session.NativeSessionID
@@ -313,7 +300,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		invocation.ImplementationSurfaceID = string(agentSurface.ID)
 	}
 	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("persist Codex session identity: %w", err)
+		return AgentLaunchResult{}, fmt.Errorf("persist harness session identity: %w", err)
 	}
 	previousRun := *run
 	run.Stage = stage
@@ -336,4 +323,41 @@ func reviewCheckpointSHA(review bool, checkpoint string) string {
 		return ""
 	}
 	return checkpoint
+}
+
+// credentialSeeding resolves the narrowly scoped credential source for one
+// harness and returns the seeding step to run after the worker starts. Each
+// harness keeps its own host source, because a host can hold one harness
+// credential as a file without holding the other. It returns a nil step when
+// no source is registered, leaving the worker's own persisted role state in
+// place.
+func (s *Service) credentialSeeding(registration config.RepositoryRegistration, request AgentRequest, harnessName config.Harness) (func(context.Context, string) error, string, error) {
+	authPath := ""
+	switch harnessName {
+	case config.HarnessCodex:
+		authPath = defaultString(request.CodexAuthPath, registration.Authentication.CodexAuthPath)
+	case config.HarnessClaude:
+		authPath = defaultString(request.ClaudeAuthPath, registration.Authentication.ClaudeAuthPath)
+	}
+	if authPath == "" {
+		return nil, "", nil
+	}
+	switch harnessName {
+	case config.HarnessCodex:
+		seeder, ok := s.deps.Worker.(worker.CredentialSeeder)
+		if !ok {
+			return nil, "", errors.New("worker runtime does not support Codex credential seeding")
+		}
+		return func(ctx context.Context, runID string) error {
+			return seeder.SeedCodexCredentials(ctx, worker.CredentialSeedRequest{RunID: runID, AuthPath: authPath})
+		}, registration.Path, nil
+	default:
+		seeder, ok := s.deps.Worker.(worker.ClaudeCredentialSeeder)
+		if !ok {
+			return nil, "", errors.New("worker runtime does not support Claude credential seeding")
+		}
+		return func(ctx context.Context, runID string) error {
+			return seeder.SeedClaudeCredentials(ctx, worker.CredentialSeedRequest{RunID: runID, AuthPath: authPath})
+		}, registration.Path, nil
+	}
 }

--- a/internal/factory/agent_policy_internal_test.go
+++ b/internal/factory/agent_policy_internal_test.go
@@ -1,0 +1,139 @@
+package factory
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+)
+
+// policyRepository returns a frozen repository policy that selects a different
+// harness, model, and reasoning effort for each role.
+func policyRepository() config.RepositoryConfig {
+	return config.RepositoryConfig{
+		RoleHarnessDefaults: map[string]config.Harness{
+			"test":           config.HarnessCodex,
+			"implementation": config.HarnessClaude,
+		},
+		ModelOptions: map[string][]string{
+			"test":           {"gpt-5.6-luna"},
+			"implementation": {"claude-opus-5", "claude-sonnet-5"},
+		},
+		ReasoningEffortOptions: map[string][]string{
+			"test": {"medium", "high"},
+		},
+	}
+}
+
+// TestResolveAgentPolicySelectsEachRoleIndependently verifies harness, model,
+// and reasoning effort come from the frozen per-role policy.
+func TestResolveAgentPolicySelectsEachRoleIndependently(t *testing.T) {
+	repository := policyRepository()
+	harnessName, model, effort, err := resolveAgentPolicy(repository, AgentRequest{Role: "test"})
+	if err != nil {
+		t.Fatalf("resolveAgentPolicy(test) error = %v", err)
+	}
+	if harnessName != config.HarnessCodex || model != "gpt-5.6-luna" || effort != "medium" {
+		t.Fatalf("test role policy = %q/%q/%q, want the declared Codex defaults", harnessName, model, effort)
+	}
+	harnessName, model, effort, err = resolveAgentPolicy(repository, AgentRequest{Role: "implementation"})
+	if err != nil {
+		t.Fatalf("resolveAgentPolicy(implementation) error = %v", err)
+	}
+	if harnessName != config.HarnessClaude || model != "claude-opus-5" || effort != "" {
+		t.Fatalf("implementation role policy = %q/%q/%q, want the declared Claude defaults", harnessName, model, effort)
+	}
+}
+
+// TestResolveAgentPolicyAcceptsADeclaredSelection verifies a request may choose
+// any repository-declared option without an override permission.
+func TestResolveAgentPolicyAcceptsADeclaredSelection(t *testing.T) {
+	_, model, _, err := resolveAgentPolicy(policyRepository(), AgentRequest{Role: "implementation", Model: "claude-sonnet-5"})
+	if err != nil {
+		t.Fatalf("resolveAgentPolicy() error = %v", err)
+	}
+	if model != "claude-sonnet-5" {
+		t.Fatalf("model = %q, want the declared alternative", model)
+	}
+	_, _, effort, err := resolveAgentPolicy(policyRepository(), AgentRequest{Role: "test", ReasoningEffort: "high"})
+	if err != nil {
+		t.Fatalf("resolveAgentPolicy() error = %v", err)
+	}
+	if effort != "high" {
+		t.Fatalf("reasoning effort = %q, want the declared alternative", effort)
+	}
+}
+
+// TestResolveAgentPolicyRefusesOverridesOutsidePolicy verifies every
+// out-of-policy selection is refused as a typed policy rejection rather than
+// an untyped error.
+func TestResolveAgentPolicyRefusesOverridesOutsidePolicy(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		request AgentRequest
+		code    PolicyRejectionCode
+	}{
+		{
+			name:    "harness",
+			request: AgentRequest{Role: "test", Harness: config.HarnessClaude},
+			code:    PolicyRejectionHarnessOverride,
+		},
+		{
+			name:    "model",
+			request: AgentRequest{Role: "test", Model: "gpt-9"},
+			code:    PolicyRejectionModelOverride,
+		},
+		{
+			name:    "reasoning effort",
+			request: AgentRequest{Role: "test", ReasoningEffort: "extreme"},
+			code:    PolicyRejectionReasoningEffortOverride,
+		},
+		{
+			name:    "undeclared reasoning effort",
+			request: AgentRequest{Role: "implementation", ReasoningEffort: "high"},
+			code:    PolicyRejectionReasoningEffortOverride,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, _, err := resolveAgentPolicy(policyRepository(), test.request)
+			var rejection *PolicyRejection
+			if !errors.As(err, &rejection) {
+				t.Fatalf("resolveAgentPolicy() error = %v, want a typed policy rejection", err)
+			}
+			if rejection.Code != test.code {
+				t.Fatalf("rejection code = %q, want %q", rejection.Code, test.code)
+			}
+		})
+	}
+}
+
+// TestResolveAgentPolicyHonoursDeclaredOverridePermissions verifies a
+// repository can widen each setting explicitly.
+func TestResolveAgentPolicyHonoursDeclaredOverridePermissions(t *testing.T) {
+	repository := policyRepository()
+	repository.AllowedOverrides = []config.OverrideName{config.OverrideHarness, config.OverrideModel, config.OverrideReasoningEffort}
+	harnessName, model, effort, err := resolveAgentPolicy(repository, AgentRequest{
+		Role:            "test",
+		Harness:         config.HarnessClaude,
+		Model:           "gpt-9",
+		ReasoningEffort: "extreme",
+	})
+	if err != nil {
+		t.Fatalf("resolveAgentPolicy() error = %v", err)
+	}
+	if harnessName != config.HarnessClaude || model != "gpt-9" || effort != "extreme" {
+		t.Fatalf("policy = %q/%q/%q, want the explicitly permitted overrides", harnessName, model, effort)
+	}
+}
+
+// TestResolveAgentPolicyRefusesAnUnsupportedHarness verifies an unknown
+// harness name never reaches an adapter.
+func TestResolveAgentPolicyRefusesAnUnsupportedHarness(t *testing.T) {
+	repository := policyRepository()
+	repository.RoleHarnessDefaults["test"] = config.Harness("gemini")
+	_, _, _, err := resolveAgentPolicy(repository, AgentRequest{Role: "test"})
+	var rejection *PolicyRejection
+	if !errors.As(err, &rejection) || rejection.Code != PolicyRejectionHarnessUnavailable {
+		t.Fatalf("resolveAgentPolicy() error = %v, want a typed harness-unavailable rejection", err)
+	}
+}

--- a/internal/factory/agent_policy_internal_test.go
+++ b/internal/factory/agent_policy_internal_test.go
@@ -29,38 +29,38 @@ func policyRepository() config.RepositoryConfig {
 // and reasoning effort come from the frozen per-role policy.
 func TestResolveAgentPolicySelectsEachRoleIndependently(t *testing.T) {
 	repository := policyRepository()
-	harnessName, model, effort, err := resolveAgentPolicy(repository, AgentRequest{Role: "test"})
+	policy, err := resolveAgentPolicy(repository, AgentRequest{Role: "test"})
 	if err != nil {
 		t.Fatalf("resolveAgentPolicy(test) error = %v", err)
 	}
-	if harnessName != config.HarnessCodex || model != "gpt-5.6-luna" || effort != "medium" {
-		t.Fatalf("test role policy = %q/%q/%q, want the declared Codex defaults", harnessName, model, effort)
+	if policy != (AgentPolicy{Harness: config.HarnessCodex, Model: "gpt-5.6-luna", ReasoningEffort: "medium"}) {
+		t.Fatalf("test role policy = %#v, want the declared Codex defaults", policy)
 	}
-	harnessName, model, effort, err = resolveAgentPolicy(repository, AgentRequest{Role: "implementation"})
+	policy, err = resolveAgentPolicy(repository, AgentRequest{Role: "implementation"})
 	if err != nil {
 		t.Fatalf("resolveAgentPolicy(implementation) error = %v", err)
 	}
-	if harnessName != config.HarnessClaude || model != "claude-opus-5" || effort != "" {
-		t.Fatalf("implementation role policy = %q/%q/%q, want the declared Claude defaults", harnessName, model, effort)
+	if policy != (AgentPolicy{Harness: config.HarnessClaude, Model: "claude-opus-5"}) {
+		t.Fatalf("implementation role policy = %#v, want the declared Claude defaults", policy)
 	}
 }
 
 // TestResolveAgentPolicyAcceptsADeclaredSelection verifies a request may choose
 // any repository-declared option without an override permission.
 func TestResolveAgentPolicyAcceptsADeclaredSelection(t *testing.T) {
-	_, model, _, err := resolveAgentPolicy(policyRepository(), AgentRequest{Role: "implementation", Model: "claude-sonnet-5"})
+	policy, err := resolveAgentPolicy(policyRepository(), AgentRequest{Role: "implementation", Model: "claude-sonnet-5"})
 	if err != nil {
 		t.Fatalf("resolveAgentPolicy() error = %v", err)
 	}
-	if model != "claude-sonnet-5" {
-		t.Fatalf("model = %q, want the declared alternative", model)
+	if policy.Model != "claude-sonnet-5" {
+		t.Fatalf("model = %q, want the declared alternative", policy.Model)
 	}
-	_, _, effort, err := resolveAgentPolicy(policyRepository(), AgentRequest{Role: "test", ReasoningEffort: "high"})
+	policy, err = resolveAgentPolicy(policyRepository(), AgentRequest{Role: "test", ReasoningEffort: "high"})
 	if err != nil {
 		t.Fatalf("resolveAgentPolicy() error = %v", err)
 	}
-	if effort != "high" {
-		t.Fatalf("reasoning effort = %q, want the declared alternative", effort)
+	if policy.ReasoningEffort != "high" {
+		t.Fatalf("reasoning effort = %q, want the declared alternative", policy.ReasoningEffort)
 	}
 }
 
@@ -95,7 +95,7 @@ func TestResolveAgentPolicyRefusesOverridesOutsidePolicy(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, _, _, err := resolveAgentPolicy(policyRepository(), test.request)
+			_, err := resolveAgentPolicy(policyRepository(), test.request)
 			var rejection *PolicyRejection
 			if !errors.As(err, &rejection) {
 				t.Fatalf("resolveAgentPolicy() error = %v, want a typed policy rejection", err)
@@ -112,7 +112,7 @@ func TestResolveAgentPolicyRefusesOverridesOutsidePolicy(t *testing.T) {
 func TestResolveAgentPolicyHonoursDeclaredOverridePermissions(t *testing.T) {
 	repository := policyRepository()
 	repository.AllowedOverrides = []config.OverrideName{config.OverrideHarness, config.OverrideModel, config.OverrideReasoningEffort}
-	harnessName, model, effort, err := resolveAgentPolicy(repository, AgentRequest{
+	policy, err := resolveAgentPolicy(repository, AgentRequest{
 		Role:            "test",
 		Harness:         config.HarnessClaude,
 		Model:           "gpt-9",
@@ -121,8 +121,8 @@ func TestResolveAgentPolicyHonoursDeclaredOverridePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAgentPolicy() error = %v", err)
 	}
-	if harnessName != config.HarnessClaude || model != "gpt-9" || effort != "extreme" {
-		t.Fatalf("policy = %q/%q/%q, want the explicitly permitted overrides", harnessName, model, effort)
+	if policy != (AgentPolicy{Harness: config.HarnessClaude, Model: "gpt-9", ReasoningEffort: "extreme"}) {
+		t.Fatalf("policy = %#v, want the explicitly permitted overrides", policy)
 	}
 }
 
@@ -131,7 +131,7 @@ func TestResolveAgentPolicyHonoursDeclaredOverridePermissions(t *testing.T) {
 func TestResolveAgentPolicyRefusesAnUnsupportedHarness(t *testing.T) {
 	repository := policyRepository()
 	repository.RoleHarnessDefaults["test"] = config.Harness("gemini")
-	_, _, _, err := resolveAgentPolicy(repository, AgentRequest{Role: "test"})
+	_, err := resolveAgentPolicy(repository, AgentRequest{Role: "test"})
 	var rejection *PolicyRejection
 	if !errors.As(err, &rejection) || rejection.Code != PolicyRejectionHarnessUnavailable {
 		t.Fatalf("resolveAgentPolicy() error = %v, want a typed harness-unavailable rejection", err)

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -943,11 +943,14 @@ func (*agentRunStore) Close() error { return nil }
 
 // agentWorker records the worker start request without running Docker.
 type agentWorker struct {
-	starts   []worker.StartRequest
-	stops    int
-	commands []worker.CommandRequest
-	results  []worker.CommandResult
-	events   *[]string
+	starts      []worker.StartRequest
+	stops       int
+	commands    []worker.CommandRequest
+	results     []worker.CommandResult
+	events      *[]string
+	interactive []worker.InteractiveRequest
+	codexSeeds  []worker.CredentialSeedRequest
+	claudeSeeds []worker.CredentialSeedRequest
 }
 
 // Start records one worker start.

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -1034,7 +1034,6 @@ func (*agentTerminal) CloseWorkspace(context.Context, terminal.WorkspaceID) erro
 
 // agentHarness records visible session lifecycle operations.
 type agentHarness struct {
-	name      string
 	starts    []harness.StartRequest
 	resumes   []harness.StartRequest
 	finished  []harness.Session
@@ -1043,12 +1042,8 @@ type agentHarness struct {
 }
 
 // Capabilities reports the harness identity this fake stands in for.
-func (h *agentHarness) Capabilities() harness.Capabilities {
-	name := h.name
-	if name == "" {
-		name = harness.NameCodex
-	}
-	return harness.Capabilities{Name: name, NativeResume: true}
+func (*agentHarness) Capabilities() harness.Capabilities {
+	return harness.Capabilities{Name: harness.NameCodex, ReasoningEffort: true}
 }
 
 // Start records the coordinator-owned prompt request.

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -1031,11 +1031,21 @@ func (*agentTerminal) CloseWorkspace(context.Context, terminal.WorkspaceID) erro
 
 // agentHarness records visible session lifecycle operations.
 type agentHarness struct {
+	name      string
 	starts    []harness.StartRequest
 	resumes   []harness.StartRequest
 	finished  []harness.Session
 	startErr  error
 	resumeErr error
+}
+
+// Capabilities reports the harness identity this fake stands in for.
+func (h *agentHarness) Capabilities() harness.Capabilities {
+	name := h.name
+	if name == "" {
+		name = harness.NameCodex
+	}
+	return harness.Capabilities{Name: name, NativeResume: true}
 }
 
 // Start records the coordinator-owned prompt request.

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -54,9 +54,14 @@ const (
 	// PolicyRejectionModelOverride means the requested model is outside the
 	// role's repository-declared options.
 	PolicyRejectionModelOverride PolicyRejectionCode = "model_override"
+	// PolicyRejectionModelUnavailable means the role declares no model at all.
+	PolicyRejectionModelUnavailable PolicyRejectionCode = "model_unavailable"
 	// PolicyRejectionReasoningEffortOverride means the requested reasoning
 	// effort is outside the role's repository-declared options.
 	PolicyRejectionReasoningEffortOverride PolicyRejectionCode = "reasoning_effort_override"
+	// PolicyRejectionReasoningEffortUnsupported means the selected harness
+	// cannot honor a reasoning-effort selection at all.
+	PolicyRejectionReasoningEffortUnsupported PolicyRejectionCode = "reasoning_effort_unsupported"
 	// PolicyRejectionCancelState means cancellation is not legal for the run.
 	PolicyRejectionCancelState PolicyRejectionCode = "cancel_state"
 	// PolicyRejectionAnswerState means the run is not waiting for clarification.

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -51,6 +51,12 @@ const (
 	// PolicyRejectionHarnessUnavailable means the current role has no adapter
 	// for the requested harness yet.
 	PolicyRejectionHarnessUnavailable PolicyRejectionCode = "harness_unavailable"
+	// PolicyRejectionModelOverride means the requested model is outside the
+	// role's repository-declared options.
+	PolicyRejectionModelOverride PolicyRejectionCode = "model_override"
+	// PolicyRejectionReasoningEffortOverride means the requested reasoning
+	// effort is outside the role's repository-declared options.
+	PolicyRejectionReasoningEffortOverride PolicyRejectionCode = "reasoning_effort_override"
 	// PolicyRejectionCancelState means cancellation is not legal for the run.
 	PolicyRejectionCancelState PolicyRejectionCode = "cancel_state"
 	// PolicyRejectionAnswerState means the run is not waiting for clarification.
@@ -681,7 +687,7 @@ func (s *Service) handleHarnessConfiguration(ctx context.Context, registration c
 		return CommandResult{}, err
 	}
 	wanted := config.Harness(parsed.Harness)
-	if wanted != config.HarnessCodex {
+	if wanted != config.HarnessCodex && wanted != config.HarnessClaude {
 		rejection := &PolicyRejection{Code: PolicyRejectionHarnessUnavailable, Problem: fmt.Sprintf("harness %q is not available for the current implementation role", wanted)}
 		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
 	}

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -142,6 +142,61 @@ func TestHandleCommandPersistsHarnessConfiguration(t *testing.T) {
 	}
 }
 
+// TestHandleCommandPersistsAClaudeHarnessConfiguration verifies an authorized
+// issue comment can select Claude Code now that the adapter exists, and that
+// the run records the choice for the next invocation.
+func TestHandleCommandPersistsAClaudeHarnessConfiguration(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newCommandService(runStore, githubAdapter, nil)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: 42, Comment: github.Comment{ID: "14", Author: "alice", Body: "/factory config harness=claude"}})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.HarnessOverride != "claude" {
+		t.Fatalf("result = %#v, want an accepted Claude harness override", result)
+	}
+}
+
+// TestHandleCommandRefusesIssueSuppliedProcessArguments verifies a comment
+// cannot inject a flag or an extra argument into a launched harness process.
+func TestHandleCommandRefusesIssueSuppliedProcessArguments(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{
+		"/factory config harness=claude --dangerously-skip-permissions",
+		"/factory config harness=claude extra",
+		"/factory config --mcp-config",
+		"/factory retry --model gpt-9",
+		"/factory config model=gpt-9",
+	} {
+		t.Run(body, func(t *testing.T) {
+			t.Parallel()
+
+			run := commandRun(t, store.StatusActive)
+			githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: "status-1"}}
+			runStore := &commandRunStore{current: &run, latest: &run}
+			service := newCommandService(runStore, githubAdapter, nil)
+
+			result, err := service.HandleCommand(context.Background(), factory.CommandRequest{IssueNumber: 42, Comment: github.Comment{ID: "14", Author: "alice", Body: body}})
+			if result.Outcome != factory.CommandRejected {
+				t.Fatalf("outcome = %q, want a rejection of issue-supplied process arguments", result.Outcome)
+			}
+			var rejection *factory.PolicyRejection
+			if !errors.As(err, &rejection) || rejection.Code != factory.PolicyRejectionMalformed {
+				t.Fatalf("HandleCommand() error = %v, want a typed malformed-command rejection", err)
+			}
+			if result.Run.HarnessOverride != "" {
+				t.Fatalf("harness override = %q, want no recorded configuration", result.Run.HarnessOverride)
+			}
+		})
+	}
+}
+
 // TestPollCommandsSkipsThePersistedWatermark verifies polling sees issue
 // comments while a second poll, including after a fresh service, is inert.
 func TestPollCommandsSkipsThePersistedWatermark(t *testing.T) {

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -135,6 +135,7 @@ type Service struct {
 	runtimeMu         sync.Mutex
 	runtimeSocketPath string
 	runtimePathSet    bool
+	harnessRuntimes   map[config.Harness]harness.Runtime
 	startupMu         sync.Mutex
 	startupChecked    bool
 	startupErr        error
@@ -155,7 +156,9 @@ type RegisterRequest struct {
 	CmuxSocketPath       string
 	CmuxControlWorkspace string
 	// CodexAuthPath is an optional host-side Codex auth.json path.
-	CodexAuthPath        string
+	CodexAuthPath string
+	// ClaudeAuthPath is an optional host-side Claude credential file path.
+	ClaudeAuthPath       string
 	RepositoryConfigPath string
 }
 
@@ -254,16 +257,22 @@ func NewWithDependencies(configPath string, dependencies Dependencies) *Service 
 	return &Service{configPath: configPath, deps: dependencies}
 }
 
-// ensureAgentRuntime lazily constructs the default terminal and harness only
-// after registration has supplied the cmux socket path. The mutex keeps the
-// first construction atomic without mutating a live runtime during a launch.
-// A service owns one registered cmux endpoint, so a later conflicting path is
+// ensureTerminalRuntime lazily constructs the default terminal only after
+// registration has supplied the cmux socket path. The mutex keeps the first
+// construction atomic without mutating a live runtime during a launch. A
+// service owns one registered cmux endpoint, so a later conflicting path is
 // rejected rather than silently reusing the wrong terminal adapter.
-func (s *Service) ensureAgentRuntime(socketPath string) (terminal.TerminalRuntime, harness.Runtime, error) {
+func (s *Service) ensureTerminalRuntime(socketPath string) (terminal.TerminalRuntime, error) {
 	s.runtimeMu.Lock()
 	defer s.runtimeMu.Unlock()
+	return s.terminalRuntimeLocked(socketPath)
+}
+
+// terminalRuntimeLocked resolves the cached terminal adapter. Callers hold the
+// runtime mutex.
+func (s *Service) terminalRuntimeLocked(socketPath string) (terminal.TerminalRuntime, error) {
 	if s.runtimePathSet && s.runtimeSocketPath != socketPath {
-		return nil, nil, fmt.Errorf("cmux socket path %q conflicts with cached path %q", socketPath, s.runtimeSocketPath)
+		return nil, fmt.Errorf("cmux socket path %q conflicts with cached path %q", socketPath, s.runtimeSocketPath)
 	}
 	if !s.runtimePathSet {
 		s.runtimeSocketPath = socketPath
@@ -272,10 +281,35 @@ func (s *Service) ensureAgentRuntime(socketPath string) (terminal.TerminalRuntim
 	if s.deps.Terminal == nil {
 		s.deps.Terminal = terminal.NewCmuxRuntime(nil, socketPath)
 	}
-	if s.deps.Harness == nil {
-		s.deps.Harness = harness.NewCodex(s.deps.Worker, s.deps.Terminal)
+	return s.deps.Terminal, nil
+}
+
+// ensureAgentRuntime resolves the terminal and the adapter for one validated
+// harness. An explicitly injected harness runtime always wins, so an embedding
+// caller keeps one seam; otherwise each selected harness gets its own cached
+// adapter.
+func (s *Service) ensureAgentRuntime(socketPath string, selected config.Harness) (terminal.TerminalRuntime, harness.Runtime, error) {
+	s.runtimeMu.Lock()
+	defer s.runtimeMu.Unlock()
+	terminalRuntime, err := s.terminalRuntimeLocked(socketPath)
+	if err != nil {
+		return nil, nil, err
 	}
-	return s.deps.Terminal, s.deps.Harness, nil
+	if s.deps.Harness != nil {
+		return terminalRuntime, s.deps.Harness, nil
+	}
+	if cached, exists := s.harnessRuntimes[selected]; exists {
+		return terminalRuntime, cached, nil
+	}
+	harnessRuntime, err := harness.New(string(selected), s.deps.Worker, terminalRuntime)
+	if err != nil {
+		return nil, nil, err
+	}
+	if s.harnessRuntimes == nil {
+		s.harnessRuntimes = make(map[config.Harness]harness.Runtime, 2)
+	}
+	s.harnessRuntimes[selected] = harnessRuntime
+	return terminalRuntime, harnessRuntime, nil
 }
 
 func (s *Service) Init(_ context.Context) (InitResult, error) {
@@ -337,7 +371,7 @@ func (s *Service) Register(ctx context.Context, request RegisterRequest) (Regist
 		AuthorizedUsers:      request.AuthorizedUsers,
 		Polling:              config.PollingConfig{Interval: defaultString(request.PollingInterval, "30s"), Backoff: defaultString(request.PollingBackoff, "5m")},
 		Cmux:                 config.CmuxConfig{SocketPath: request.CmuxSocketPath, ControlWorkspace: request.CmuxControlWorkspace},
-		Authentication:       config.AuthenticationConfig{CodexAuthPath: request.CodexAuthPath},
+		Authentication:       config.AuthenticationConfig{CodexAuthPath: request.CodexAuthPath, ClaudeAuthPath: request.ClaudeAuthPath},
 		OperationalDataPath:  operationalPath,
 		RepositoryConfigPath: repositoryConfigPath,
 	}

--- a/internal/factory/harness_selection_test.go
+++ b/internal/factory/harness_selection_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/factory"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
@@ -94,7 +94,7 @@ func TestStartAgentRefusesAnIssueHarnessOverrideOutsidePolicy(t *testing.T) {
 }
 
 // TestStartAgentAcceptsAnIssueHarnessOverridePermittedByPolicy verifies the
-// recorded override from a `/factory configure harness=claude` comment selects
+// recorded override from a `/factory config harness=claude` comment selects
 // the Claude adapter once the repository permits harness overrides.
 func TestStartAgentAcceptsAnIssueHarnessOverridePermittedByPolicy(t *testing.T) {
 	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
@@ -117,19 +117,48 @@ func TestStartAgentAcceptsAnIssueHarnessOverridePermittedByPolicy(t *testing.T) 
 	}
 }
 
-// TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonour verifies a
-// validated repository setting is refused rather than silently dropped when
-// the selected harness has no native representation for it.
-func TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonour(t *testing.T) {
+// TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonor verifies a
+// validated repository setting is refused as a typed policy rejection rather
+// than silently dropped, and that the refusal happens before the launch
+// creates a worker, a credential copy, or a visible surface.
+func TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonor(t *testing.T) {
 	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
 	policy := validRepositoryConfig()
 	policy.RoleHarnessDefaults["implementation"] = config.HarnessClaude
 	policy.ModelOptions["implementation"] = []string{"claude-opus-5"}
 	policy.ReasoningEffortOptions = map[string][]string{"implementation": {"high"}}
-	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{})
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{
+		ClaudeAuthPath: filepath.Join(t.TempDir(), ".credentials.json"),
+	})
 
-	if _, err := service.StartAgent(context.Background(), factory.AgentRequest{}); err == nil || !strings.Contains(err.Error(), "reasoning effort") {
-		t.Fatalf("StartAgent() error = %v, want the harness to refuse an unsupported setting", err)
+	_, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	var rejection *factory.PolicyRejection
+	if !errors.As(err, &rejection) || rejection.Code != factory.PolicyRejectionReasoningEffortUnsupported {
+		t.Fatalf("StartAgent() error = %v, want a typed unsupported-setting rejection", err)
+	}
+	if len(runtime.starts) != 0 || len(runtime.claudeSeeds) != 0 || len(runtime.interactive) != 0 {
+		t.Fatal("a refused setting started a worker, seeded a credential, or launched a harness")
+	}
+	if len(runStore.invocations) != 0 {
+		t.Fatalf("persisted invocations = %#v, want none after a refused setting", runStore.invocations)
+	}
+}
+
+// TestClaudeAdapterRefusesAnUnsupportedSettingAsABackstop verifies the adapter
+// itself still fails closed if a caller reaches it with a setting the harness
+// cannot honor.
+func TestClaudeAdapterRefusesAnUnsupportedSettingAsABackstop(t *testing.T) {
+	_, err := harness.NewClaude(&agentWorker{}, &agentTerminal{}).Start(context.Background(), harness.StartRequest{
+		InvocationID:    "inv-backstop",
+		RunID:           "run-backstop",
+		Role:            "implementation",
+		Stage:           "implementation",
+		WorkspaceID:     "workspace-run",
+		Prompt:          "Implement the frozen specification.",
+		ReasoningEffort: "high",
+	})
+	if !errors.Is(err, harness.ErrUnsupportedSetting) {
+		t.Fatalf("Start() error = %v, want the unsupported-setting sentinel", err)
 	}
 }
 

--- a/internal/factory/harness_selection_test.go
+++ b/internal/factory/harness_selection_test.go
@@ -1,0 +1,199 @@
+package factory_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// InteractiveCommand records the harness argv one adapter asked the worker for.
+func (w *agentWorker) InteractiveCommand(_ context.Context, request worker.InteractiveRequest) (worker.InteractiveCommand, error) {
+	w.interactive = append(w.interactive, request)
+	return worker.InteractiveCommand{Executable: "factory-worker-attach", Args: []string{"--run-id", request.RunID}}, nil
+}
+
+// SeedCodexCredentials records one narrowly scoped Codex credential seed.
+func (w *agentWorker) SeedCodexCredentials(_ context.Context, request worker.CredentialSeedRequest) error {
+	w.codexSeeds = append(w.codexSeeds, request)
+	return nil
+}
+
+// SeedClaudeCredentials records one narrowly scoped Claude credential seed.
+func (w *agentWorker) SeedClaudeCredentials(_ context.Context, request worker.CredentialSeedRequest) error {
+	w.claudeSeeds = append(w.claudeSeeds, request)
+	return nil
+}
+
+// TestStartAgentLaunchesTheHarnessDeclaredForTheRole verifies a role declared
+// as Claude reaches the Claude adapter, records the Claude harness identity on
+// the invocation, and seeds only the Claude credential source.
+func TestStartAgentLaunchesTheHarnessDeclaredForTheRole(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
+	policy := validRepositoryConfig()
+	policy.RoleHarnessDefaults["implementation"] = config.HarnessClaude
+	policy.ModelOptions["implementation"] = []string{"claude-opus-5"}
+	claudeAuth := filepath.Join(t.TempDir(), ".credentials.json")
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{
+		CodexAuthPath:  filepath.Join(t.TempDir(), "auth.json"),
+		ClaudeAuthPath: claudeAuth,
+	})
+
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	if launch.Invocation.Harness != string(config.HarnessClaude) {
+		t.Fatalf("invocation harness = %q, want the role's declared Claude harness", launch.Invocation.Harness)
+	}
+	if launch.Invocation.Model != "claude-opus-5" {
+		t.Fatalf("invocation model = %q, want the role's declared Claude model", launch.Invocation.Model)
+	}
+	if len(runtime.interactive) != 1 || runtime.interactive[0].Command[0] != "claude" {
+		t.Fatalf("interactive worker commands = %#v, want one Claude launch", runtime.interactive)
+	}
+	if runtime.interactive[0].Environment["FACTORY_HARNESS"] != string(config.HarnessClaude) {
+		t.Fatalf("interactive environment = %#v, want the Claude harness identity", runtime.interactive[0].Environment)
+	}
+	if len(runtime.claudeSeeds) != 1 || runtime.claudeSeeds[0].AuthPath != claudeAuth {
+		t.Fatalf("Claude credential seeds = %#v, want only the registered Claude source", runtime.claudeSeeds)
+	}
+	if len(runtime.codexSeeds) != 0 {
+		t.Fatalf("Codex credential seeds = %#v, want no seeding for a Claude invocation", runtime.codexSeeds)
+	}
+	if launch.Invocation.NativeSessionID == "" {
+		t.Fatal("invocation has no native session id, want the adapter-assigned Claude session")
+	}
+}
+
+// TestStartAgentRefusesAnIssueHarnessOverrideOutsidePolicy verifies an
+// authorized issue-level override is still validated against the frozen
+// repository policy and refused as a typed policy rejection.
+func TestStartAgentRefusesAnIssueHarnessOverrideOutsidePolicy(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
+	policy := validRepositoryConfig()
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{})
+
+	_, err := service.StartAgent(context.Background(), factory.AgentRequest{Harness: config.HarnessClaude})
+	var rejection *factory.PolicyRejection
+	if !errors.As(err, &rejection) || rejection.Code != factory.PolicyRejectionHarnessOverride {
+		t.Fatalf("StartAgent() error = %v, want a typed harness-override rejection", err)
+	}
+	if len(runtime.interactive) != 0 || len(runtime.starts) != 0 {
+		t.Fatal("a refused override started a worker or a harness")
+	}
+}
+
+// TestStartAgentAcceptsAnIssueHarnessOverridePermittedByPolicy verifies the
+// recorded override from a `/factory configure harness=claude` comment selects
+// the Claude adapter once the repository permits harness overrides.
+func TestStartAgentAcceptsAnIssueHarnessOverridePermittedByPolicy(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
+	policy := validRepositoryConfig()
+	policy.AllowedOverrides = append(policy.AllowedOverrides, config.OverrideHarness)
+	policy.ModelOptions["implementation"] = []string{"claude-opus-5"}
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{})
+
+	run := *runStore.current
+	run.HarnessOverride = string(config.HarnessClaude)
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	if launch.Invocation.Harness != string(config.HarnessClaude) {
+		t.Fatalf("invocation harness = %q, want the authorized override", launch.Invocation.Harness)
+	}
+}
+
+// TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonour verifies a
+// validated repository setting is refused rather than silently dropped when
+// the selected harness has no native representation for it.
+func TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonour(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
+	policy := validRepositoryConfig()
+	policy.RoleHarnessDefaults["implementation"] = config.HarnessClaude
+	policy.ModelOptions["implementation"] = []string{"claude-opus-5"}
+	policy.ReasoningEffortOptions = map[string][]string{"implementation": {"high"}}
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{})
+
+	if _, err := service.StartAgent(context.Background(), factory.AgentRequest{}); err == nil || !strings.Contains(err.Error(), "reasoning effort") {
+		t.Fatalf("StartAgent() error = %v, want the harness to refuse an unsupported setting", err)
+	}
+}
+
+// newDispatchingAgentService recreates the coordinator around a persisted claim
+// without an injected harness runtime, so the service resolves the adapter for
+// the frozen repository policy itself.
+func newDispatchingAgentService(t *testing.T, runStore *agentRunStore, runtime *agentWorker, terminalRuntime *agentTerminal, policy config.RepositoryConfig, authentication config.AuthenticationConfig) *factory.Service {
+	t.Helper()
+	if runStore.current == nil {
+		t.Fatal("dispatching coordinator fixture requires a persisted run")
+	}
+	repackageSpecification(t, runStore, policy)
+	run := *runStore.current
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path:                 run.RepositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		Polling:              config.PollingConfig{Interval: "30s", Backoff: "5m"},
+		Cmux:                 config.CmuxConfig{ControlWorkspace: "factory-control"},
+		Authentication:       authentication,
+		OperationalDataPath:  filepath.Join(filepath.Dir(run.RepositoryPath), "state", "factory.db"),
+		RepositoryConfigPath: filepath.Join(run.RepositoryPath, "factory.yaml"),
+	}}}
+	githubRuntime := &fakeGitHub{
+		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: " + run.ID + " -->"},
+	}
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{Worktree: run.Worktree}},
+		state:        gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA},
+	}
+	return factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		Worker:         runtime,
+		Terminal:       terminalRuntime,
+		GitHub:         githubRuntime,
+		Worktree:       worktree,
+		Now:            func() time.Time { return time.Date(2026, 8, 21, 8, 0, 0, 0, time.UTC) },
+		NewRunID:       func() (string, error) { return "generated-dispatch", nil },
+	})
+}
+
+// repackageSpecification refreezes the claimed run's specification packet with
+// the repository policy under test, because the coordinator reads harness and
+// model policy from the frozen packet rather than the live configuration.
+func repackageSpecification(t *testing.T, runStore *agentRunStore, policy config.RepositoryConfig) {
+	t.Helper()
+	run := *runStore.current
+	var packet factory.SpecificationPacket
+	if err := json.Unmarshal([]byte(run.SpecificationPacket), &packet); err != nil {
+		t.Fatalf("decode frozen specification packet: %v", err)
+	}
+	packet.RepositoryConfig = policy
+	refrozen, err := json.Marshal(packet)
+	if err != nil {
+		t.Fatalf("refreeze specification packet: %v", err)
+	}
+	run.SpecificationPacket = string(refrozen)
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+}
+
+var _ worker.InteractiveRuntime = (*agentWorker)(nil)
+var _ worker.CredentialSeeder = (*agentWorker)(nil)
+var _ worker.ClaudeCredentialSeeder = (*agentWorker)(nil)

--- a/internal/factory/lifecycle.go
+++ b/internal/factory/lifecycle.go
@@ -285,7 +285,7 @@ func (s *Service) notifyWorkspace(ctx context.Context, registration config.Repos
 	terminalRuntime := s.deps.Terminal
 	if terminalRuntime == nil {
 		var err error
-		terminalRuntime, _, err = s.ensureAgentRuntime(registration.Cmux.SocketPath)
+		terminalRuntime, err = s.ensureTerminalRuntime(registration.Cmux.SocketPath)
 		if err != nil {
 			return fmt.Errorf("ensure terminal runtime for notification: %w", err)
 		}

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -470,12 +470,19 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 	if previous.WorkspaceID == "" || previous.ImplementationSurfaceID == "" {
 		return store.Invocation{}, run, fmt.Errorf("%w: latest implementation invocation has no recoverable surface", ErrCheckRepairSessionUnavailable)
 	}
-	if previous.Harness != string(config.HarnessCodex) {
-		return store.Invocation{}, run, fmt.Errorf("%w: harness %q has no native repair adapter", ErrCheckRepairSessionUnavailable, previous.Harness)
-	}
-	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath)
+	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, config.Harness(previous.Harness))
 	if err != nil {
-		return store.Invocation{}, run, fmt.Errorf("ensure check-repair runtime: %w", err)
+		return store.Invocation{}, run, fmt.Errorf("%w: %v", ErrCheckRepairSessionUnavailable, err)
+	}
+	// A native session belongs to the harness that created it, so a repair
+	// continues in that harness or not at all. This is what makes mid-session
+	// migration between Codex and Claude impossible.
+	capabilities := harnessRuntime.Capabilities()
+	if capabilities.Name != previous.Harness {
+		return store.Invocation{}, run, fmt.Errorf("%w: harness %q cannot resume a %q session", ErrCheckRepairSessionUnavailable, capabilities.Name, previous.Harness)
+	}
+	if !capabilities.NativeResume {
+		return store.Invocation{}, run, fmt.Errorf("%w: harness %q has no native repair adapter", ErrCheckRepairSessionUnavailable, previous.Harness)
 	}
 	identifier, err := s.deps.NewRunID()
 	if err != nil {
@@ -656,7 +663,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		ResumeSessionID: previous.NativeSessionID,
 	})
 	if err != nil {
-		return store.Invocation{}, run, fmt.Errorf("resume Codex implementation agent for check repair: %w", err)
+		return store.Invocation{}, run, fmt.Errorf("resume %s implementation agent for check repair: %w", previous.Harness, err)
 	}
 	resumeStarted = true
 	if session.NativeSessionID != "" {

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -481,9 +481,6 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 	if capabilities.Name != previous.Harness {
 		return store.Invocation{}, run, fmt.Errorf("%w: harness %q cannot resume a %q session", ErrCheckRepairSessionUnavailable, capabilities.Name, previous.Harness)
 	}
-	if !capabilities.NativeResume {
-		return store.Invocation{}, run, fmt.Errorf("%w: harness %q has no native repair adapter", ErrCheckRepairSessionUnavailable, previous.Harness)
-	}
 	identifier, err := s.deps.NewRunID()
 	if err != nil {
 		return store.Invocation{}, run, fmt.Errorf("generate check-repair invocation identifier: %w", err)

--- a/internal/factory/repair_test.go
+++ b/internal/factory/repair_test.go
@@ -600,7 +600,7 @@ type repairLaunchHarness struct {
 
 // Capabilities satisfies the harness runtime seam.
 func (*repairLaunchHarness) Capabilities() harness.Capabilities {
-	return harness.Capabilities{Name: string(config.HarnessCodex), NativeResume: true}
+	return harness.Capabilities{Name: string(config.HarnessCodex), ReasoningEffort: true}
 }
 
 // Start satisfies the harness runtime seam.

--- a/internal/factory/repair_test.go
+++ b/internal/factory/repair_test.go
@@ -674,3 +674,33 @@ func (w *repairStateWorker) Stop(context.Context, string) error {
 func (*repairStateWorker) Inspect(context.Context, string) (worker.Inspection, error) {
 	return worker.Inspection{Exists: true}, nil
 }
+
+// TestCheckRepairRefusesMidSessionHarnessMigration verifies a native session
+// can only be continued by the harness that created it, so a repair cannot
+// migrate an implementation session from one harness to another.
+func TestCheckRepairRefusesMidSessionHarnessMigration(t *testing.T) {
+	service, registration, runStore, harnessRuntime := newRepairLaunchService(t, nil, 0, 0)
+	previous := runStore.invocations["inv-initial"]
+	previous.Harness = string(config.HarnessClaude)
+	runStore.invocations["inv-initial"] = previous
+	run := runStore.run
+
+	_, _, err := service.startCheckRepair(context.Background(), registration, runStore, run, SpecificationPacket{
+		Issue: github.Issue{Body: "repair guidance"},
+	}, CheckRepairPacket{
+		Version:       checkRepairPacketVersion,
+		RunID:         run.ID,
+		CheckpointSHA: run.CheckpointSHA,
+		Attempt:       1,
+		Budget:        3,
+	})
+	if !errors.Is(err, ErrCheckRepairSessionUnavailable) {
+		t.Fatalf("startCheckRepair() error = %v, want the unavailable-session sentinel", err)
+	}
+	if !strings.Contains(err.Error(), "cannot resume") {
+		t.Fatalf("startCheckRepair() error = %v, want a harness-mismatch refusal", err)
+	}
+	if harnessRuntime.resumes != 0 {
+		t.Fatalf("resume calls = %d, want no cross-harness resume attempt", harnessRuntime.resumes)
+	}
+}

--- a/internal/factory/repair_test.go
+++ b/internal/factory/repair_test.go
@@ -598,6 +598,11 @@ type repairLaunchHarness struct {
 	resumes   int
 }
 
+// Capabilities satisfies the harness runtime seam.
+func (*repairLaunchHarness) Capabilities() harness.Capabilities {
+	return harness.Capabilities{Name: string(config.HarnessCodex), NativeResume: true}
+}
+
 // Start satisfies the harness runtime seam.
 func (*repairLaunchHarness) Start(context.Context, harness.StartRequest) (harness.Session, error) {
 	return harness.Session{}, nil

--- a/internal/factory/runtime_internal_test.go
+++ b/internal/factory/runtime_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
@@ -13,7 +14,7 @@ import (
 // and caching when the service starts without injected visible runtimes.
 func TestEnsureAgentRuntimeUsesTheRegisteredSocketPath(t *testing.T) {
 	service := NewWithDependencies("", Dependencies{Worker: worker.NewDockerRuntime()})
-	firstTerminal, firstHarness, err := service.ensureAgentRuntime("/tmp/factory-cmux.sock")
+	firstTerminal, firstHarness, err := service.ensureAgentRuntime("/tmp/factory-cmux.sock", config.HarnessCodex)
 	if err != nil {
 		t.Fatalf("ensureAgentRuntime() error = %v", err)
 	}
@@ -28,10 +29,10 @@ func TestEnsureAgentRuntimeUsesTheRegisteredSocketPath(t *testing.T) {
 		t.Fatalf("harness runtime = %T, want *harness.Codex", firstHarness)
 	}
 
-	if _, _, err := service.ensureAgentRuntime("/tmp/other-cmux.sock"); err == nil || !strings.Contains(err.Error(), "conflicts with cached path") {
+	if _, _, err := service.ensureAgentRuntime("/tmp/other-cmux.sock", config.HarnessCodex); err == nil || !strings.Contains(err.Error(), "conflicts with cached path") {
 		t.Fatalf("ensureAgentRuntime() conflict error = %v, want cached-path rejection", err)
 	}
-	cachedTerminal, cachedHarness, err := service.ensureAgentRuntime("/tmp/factory-cmux.sock")
+	cachedTerminal, cachedHarness, err := service.ensureAgentRuntime("/tmp/factory-cmux.sock", config.HarnessCodex)
 	if err != nil {
 		t.Fatalf("ensureAgentRuntime() with original path error = %v", err)
 	}
@@ -40,5 +41,41 @@ func TestEnsureAgentRuntimeUsesTheRegisteredSocketPath(t *testing.T) {
 	}
 	if got := cmuxRuntime.ConfiguredSocketPath(); got != "/tmp/factory-cmux.sock" {
 		t.Fatalf("cached configured socket path = %q, want original registered path", got)
+	}
+}
+
+// TestEnsureAgentRuntimeSelectsTheAdapterForEachHarness verifies each declared
+// harness resolves to its own adapter and that adapters are cached separately.
+func TestEnsureAgentRuntimeSelectsTheAdapterForEachHarness(t *testing.T) {
+	service := NewWithDependencies("", Dependencies{Worker: worker.NewDockerRuntime()})
+	_, codexRuntime, err := service.ensureAgentRuntime("/tmp/factory-cmux.sock", config.HarnessCodex)
+	if err != nil {
+		t.Fatalf("ensureAgentRuntime(codex) error = %v", err)
+	}
+	_, claudeRuntime, err := service.ensureAgentRuntime("/tmp/factory-cmux.sock", config.HarnessClaude)
+	if err != nil {
+		t.Fatalf("ensureAgentRuntime(claude) error = %v", err)
+	}
+	if _, ok := claudeRuntime.(*harness.Claude); !ok {
+		t.Fatalf("harness runtime = %T, want *harness.Claude", claudeRuntime)
+	}
+	if codexRuntime.Capabilities().Name != harness.NameCodex || claudeRuntime.Capabilities().Name != harness.NameClaude {
+		t.Fatalf("capabilities = %q/%q, want distinct harness identities", codexRuntime.Capabilities().Name, claudeRuntime.Capabilities().Name)
+	}
+	_, cached, err := service.ensureAgentRuntime("/tmp/factory-cmux.sock", config.HarnessClaude)
+	if err != nil {
+		t.Fatalf("ensureAgentRuntime(claude) repeat error = %v", err)
+	}
+	if cached != claudeRuntime {
+		t.Fatal("ensureAgentRuntime() did not reuse the cached Claude adapter")
+	}
+}
+
+// TestEnsureAgentRuntimeRefusesAnUnconfiguredHarness verifies an unknown
+// harness never silently falls back to another adapter.
+func TestEnsureAgentRuntimeRefusesAnUnconfiguredHarness(t *testing.T) {
+	service := NewWithDependencies("", Dependencies{Worker: worker.NewDockerRuntime()})
+	if _, _, err := service.ensureAgentRuntime("/tmp/factory-cmux.sock", config.Harness("gemini")); err == nil || !strings.Contains(err.Error(), "gemini") {
+		t.Fatalf("ensureAgentRuntime() error = %v, want an unknown-harness refusal", err)
 	}
 }

--- a/internal/factory/test_stage.go
+++ b/internal/factory/test_stage.go
@@ -473,7 +473,7 @@ func (s *Service) pauseUnverifiableTestReport(ctx context.Context, registration 
 		return AgentResult{}, err
 	}
 	if invocation.NativeSessionID != "" {
-		_, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath)
+		_, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, config.Harness(invocation.Harness))
 		if err != nil {
 			return AgentResult{}, fmt.Errorf("ensure agent runtime for unverifiable test report: %w", err)
 		}

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -1,0 +1,175 @@
+package harness
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// emptyMCPConfiguration is the explicit empty MCP server set passed alongside
+// the strict flag, so a launched session loads no server from any file.
+const emptyMCPConfiguration = `{"mcpServers":{}}`
+
+// Claude implements Runtime for Claude Code using the same portable worker and
+// terminal seams as the Codex adapter.
+type Claude struct {
+	// Worker provides the worker-side interactive command translation.
+	Worker worker.WorkerRuntime
+	// Terminal owns the visible workspace and surface.
+	Terminal terminal.TerminalRuntime
+	// NewSessionID assigns the native session identifier for a fresh launch.
+	// Claude Code accepts a caller-supplied identifier, so the adapter never
+	// has to discover one after the process starts.
+	NewSessionID func() (string, error)
+}
+
+// NewClaude creates a Claude Code harness adapter.
+func NewClaude(runtime worker.WorkerRuntime, terminalRuntime terminal.TerminalRuntime) *Claude {
+	return &Claude{Worker: runtime, Terminal: terminalRuntime, NewSessionID: newSessionID}
+}
+
+// Capabilities reports the Claude adapter identity and native resume support.
+func (*Claude) Capabilities() Capabilities {
+	return Capabilities{Name: NameClaude, NativeResume: true}
+}
+
+// Start launches a fresh Claude Code TUI with an adapter-assigned native
+// session identifier in a worker-backed terminal surface.
+func (c *Claude) Start(ctx context.Context, request StartRequest) (Session, error) {
+	if request.ResumeSessionID != "" {
+		return Session{}, errors.New("fresh Claude start cannot include a resume session")
+	}
+	generate := c.NewSessionID
+	if generate == nil {
+		generate = newSessionID
+	}
+	assigned, err := generate()
+	if err != nil {
+		return Session{}, fmt.Errorf("assign Claude native session id: %w", err)
+	}
+	return c.launch(ctx, request, assigned, false)
+}
+
+// Resume continues the recorded native Claude Code session and never assigns a
+// second identifier for the same session.
+func (c *Claude) Resume(ctx context.Context, request StartRequest) (Session, error) {
+	if strings.TrimSpace(request.ResumeSessionID) == "" {
+		return Session{}, errors.New("Claude resume session id is required")
+	}
+	return c.launch(ctx, request, request.ResumeSessionID, true)
+}
+
+// Finish requests a graceful Claude Code exit while leaving the opaque surface
+// open so cmux can recover it and a later coordinator can reattach or resume.
+func (c *Claude) Finish(ctx context.Context, session Session) error {
+	return requestExit(ctx, c.Terminal, "Claude", session)
+}
+
+// launch builds the safe Claude Code command with its immutable prompt and
+// places it in the coordinator-owned surface. It never uses terminal input or
+// output as a launch protocol.
+func (c *Claude) launch(ctx context.Context, request StartRequest, sessionID string, resume bool) (Session, error) {
+	if err := validateStartRequest("Claude", request); err != nil {
+		return Session{}, err
+	}
+	if request.ReasoningEffort != "" {
+		// Claude Code exposes no reasoning-effort process argument. Dropping a
+		// validated repository selection would run the role at an effort the
+		// policy never authorized, so the launch is refused instead.
+		return Session{}, fmt.Errorf("%w: Claude reasoning effort", ErrUnsupportedSetting)
+	}
+	if !validSessionID(sessionID) {
+		return Session{}, errors.New("Claude native session id must be a version-four UUID")
+	}
+	interactive, ok := c.Worker.(worker.InteractiveRuntime)
+	if !ok {
+		return Session{}, errors.New("worker runtime does not support interactive harnesses")
+	}
+	if c.Terminal == nil {
+		return Session{}, errors.New("Claude terminal runtime is required")
+	}
+	// The worker is the security boundary, so Claude Code runs without its
+	// redundant interactive approval gates, which would stall an unattended
+	// invocation. The strict MCP flags keep a factory session free of any
+	// server declared by an ambient configuration file.
+	command := []string{"claude", "--dangerously-skip-permissions", "--strict-mcp-config", "--mcp-config", emptyMCPConfiguration}
+	if resume {
+		command = append(command, "--resume", sessionID)
+	} else {
+		command = append(command, "--session-id", sessionID)
+	}
+	if request.Model != "" {
+		command = append(command, "--model", request.Model)
+	}
+	command = append(command, strings.TrimSpace(request.Prompt))
+	environment := invocationEnvironment(NameClaude, request)
+	// The harness version is pinned by the worker image. Claude Code otherwise
+	// attempts a self-update at startup, which must never change the tool
+	// halfway through a run.
+	environment["DISABLE_AUTOUPDATER"] = "1"
+	attach, err := interactive.InteractiveCommand(ctx, worker.InteractiveRequest{
+		RunID:             request.RunID,
+		Command:           command,
+		EnvironmentPolicy: worker.EnvironmentPolicyRole,
+		Role:              request.Role,
+		Environment:       environment,
+	})
+	if err != nil {
+		return Session{}, fmt.Errorf("build Claude interactive command: %w", err)
+	}
+	surface, err := launchSurface(ctx, c.Terminal, "Claude", request, attach)
+	if err != nil {
+		return Session{}, err
+	}
+	return Session{InvocationID: request.InvocationID, NativeSessionID: sessionID, Surface: surface}, nil
+}
+
+// newSessionID returns a random RFC 4122 version-four UUID for one fresh
+// Claude Code session.
+func newSessionID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	value[6] = value[6]&0x0f | 0x40
+	value[8] = value[8]&0x3f | 0x80
+	encoded := hex.EncodeToString(value[:])
+	return encoded[0:8] + "-" + encoded[8:12] + "-" + encoded[12:16] + "-" + encoded[16:20] + "-" + encoded[20:32], nil
+}
+
+// validSessionID reports whether value is a version-four UUID. A native
+// session identifier becomes a process argument, so an unexpected shape is
+// refused before any launch rather than passed through.
+func validSessionID(value string) bool {
+	if len(value) != 36 || value[14] != '4' {
+		return false
+	}
+	for index, character := range value {
+		switch index {
+		case 8, 13, 18, 23:
+			if character != '-' {
+				return false
+			}
+		default:
+			isDigit := character >= '0' && character <= '9'
+			isHex := character >= 'a' && character <= 'f'
+			if !isDigit && !isHex {
+				return false
+			}
+		}
+	}
+	switch value[19] {
+	case '8', '9', 'a', 'b':
+		return true
+	default:
+		return false
+	}
+}
+
+var _ Runtime = (*Claude)(nil)

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -34,9 +34,10 @@ func NewClaude(runtime worker.WorkerRuntime, terminalRuntime terminal.TerminalRu
 	return &Claude{Worker: runtime, Terminal: terminalRuntime, NewSessionID: newSessionID}
 }
 
-// Capabilities reports the Claude adapter identity and native resume support.
+// Capabilities reports the Claude adapter identity. Claude Code exposes no
+// reasoning-effort process argument, so it reports that setting unsupported.
 func (*Claude) Capabilities() Capabilities {
-	return Capabilities{Name: NameClaude, NativeResume: true}
+	return Capabilities{Name: NameClaude, ReasoningEffort: false}
 }
 
 // Start launches a fresh Claude Code TUI with an adapter-assigned native
@@ -68,14 +69,14 @@ func (c *Claude) Resume(ctx context.Context, request StartRequest) (Session, err
 // Finish requests a graceful Claude Code exit while leaving the opaque surface
 // open so cmux can recover it and a later coordinator can reattach or resume.
 func (c *Claude) Finish(ctx context.Context, session Session) error {
-	return requestExit(ctx, c.Terminal, "Claude", session)
+	return requestExit(ctx, c.Terminal, NameClaude, session)
 }
 
 // launch builds the safe Claude Code command with its immutable prompt and
 // places it in the coordinator-owned surface. It never uses terminal input or
 // output as a launch protocol.
 func (c *Claude) launch(ctx context.Context, request StartRequest, sessionID string, resume bool) (Session, error) {
-	if err := validateStartRequest("Claude", request); err != nil {
+	if err := validateStartRequest(NameClaude, request); err != nil {
 		return Session{}, err
 	}
 	if request.ReasoningEffort != "" {
@@ -123,7 +124,7 @@ func (c *Claude) launch(ctx context.Context, request StartRequest, sessionID str
 	if err != nil {
 		return Session{}, fmt.Errorf("build Claude interactive command: %w", err)
 	}
-	surface, err := launchSurface(ctx, c.Terminal, "Claude", request, attach)
+	surface, err := launchSurface(ctx, c.Terminal, NameClaude, request, attach)
 	if err != nil {
 		return Session{}, err
 	}

--- a/internal/harness/claude_test.go
+++ b/internal/harness/claude_test.go
@@ -1,0 +1,234 @@
+package harness_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+)
+
+// claudeSurface is the visible role surface used by the Claude contract tests.
+func claudeSurface() terminal.Surface {
+	return terminal.Surface{ID: "surface-implementation", WorkspaceID: "workspace-run", Name: "implementation"}
+}
+
+// TestClaudeStartsAnInteractiveSessionWithAnAssignedNativeSession verifies the
+// coordinator assigns the native session identifier at launch instead of
+// discovering it afterwards, which removes the fresh-launch discovery race.
+func TestClaudeStartsAnInteractiveSessionWithAnAssignedNativeSession(t *testing.T) {
+	workerRuntime := &fakeWorker{}
+	terminalRuntime := &fakeTerminal{surface: claudeSurface()}
+	runtime := harness.NewClaude(workerRuntime, terminalRuntime)
+	runtime.NewSessionID = func() (string, error) { return "3f2504e0-4f89-41d3-9a0c-0305e82c3301", nil }
+	session, err := runtime.Start(context.Background(), harness.StartRequest{
+		InvocationID: "inv-1",
+		RunID:        "run-1",
+		Role:         "implementation",
+		Stage:        "implementation",
+		WorkspaceID:  "workspace-run",
+		Surface:      terminalRuntime.surface,
+		Prompt:       "Implement the frozen specification.",
+		Model:        "claude-opus-5",
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if session.NativeSessionID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("NativeSessionID = %q, want the coordinator-assigned session", session.NativeSessionID)
+	}
+	if len(workerRuntime.requests) != 1 {
+		t.Fatalf("interactive worker requests = %#v, want one", workerRuntime.requests)
+	}
+	request := workerRuntime.requests[0]
+	wantCommand := []string{
+		"claude", "--dangerously-skip-permissions",
+		"--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
+		"--session-id", "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		"--model", "claude-opus-5",
+		"Implement the frozen specification.",
+	}
+	if strings.Join(request.Command, "\x00") != strings.Join(wantCommand, "\x00") {
+		t.Fatalf("Claude command = %#v, want isolated launch followed by the initial prompt argument", request.Command)
+	}
+	if request.Environment["FACTORY_HARNESS"] != "claude" || request.Environment["FACTORY_INVOCATION_ID"] != "inv-1" {
+		t.Fatalf("Claude environment = %#v, want harness and invocation identity", request.Environment)
+	}
+	if request.Environment["DISABLE_AUTOUPDATER"] != "1" {
+		t.Fatalf("Claude environment = %#v, want the pinned harness version protected from self-update", request.Environment)
+	}
+	if len(terminalRuntime.inputs) != 0 {
+		t.Fatalf("surface inputs = %q, want startup to avoid racing terminal input", terminalRuntime.inputs)
+	}
+	if terminalRuntime.launched.Executable != "factory-worker-attach" {
+		t.Fatalf("surface launch = %#v, want attach helper in the existing implementation surface", terminalRuntime.launched)
+	}
+}
+
+// TestClaudeStartRefusesAResumeSessionIdentifier verifies a fresh launch
+// cannot silently continue another invocation's session.
+func TestClaudeStartRefusesAResumeSessionIdentifier(t *testing.T) {
+	_, err := harness.NewClaude(&fakeWorker{}, &fakeTerminal{surface: claudeSurface()}).Start(context.Background(), harness.StartRequest{
+		InvocationID:    "inv-1",
+		RunID:           "run-1",
+		Role:            "implementation",
+		Stage:           "implementation",
+		WorkspaceID:     "workspace-run",
+		Prompt:          "Implement the frozen specification.",
+		ResumeSessionID: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+	})
+	if err == nil || !strings.Contains(err.Error(), "resume session") {
+		t.Fatalf("Start() error = %v, want a fresh-start refusal", err)
+	}
+}
+
+// TestClaudeRefusesAReasoningEffortSelection verifies a validated repository
+// setting is refused rather than silently dropped, because Claude Code exposes
+// no reasoning-effort process argument.
+func TestClaudeRefusesAReasoningEffortSelection(t *testing.T) {
+	workerRuntime := &fakeWorker{}
+	_, err := harness.NewClaude(workerRuntime, &fakeTerminal{surface: claudeSurface()}).Start(context.Background(), harness.StartRequest{
+		InvocationID:    "inv-1",
+		RunID:           "run-1",
+		Role:            "implementation",
+		Stage:           "implementation",
+		WorkspaceID:     "workspace-run",
+		Prompt:          "Implement the frozen specification.",
+		ReasoningEffort: "high",
+	})
+	if !errors.Is(err, harness.ErrUnsupportedSetting) {
+		t.Fatalf("Start() error = %v, want the unsupported-setting sentinel", err)
+	}
+	if len(workerRuntime.requests) != 0 {
+		t.Fatalf("interactive worker requests = %#v, want no launch after a refused setting", workerRuntime.requests)
+	}
+}
+
+// TestClaudeResumesTheNativeSessionWithoutAssigningANewOne verifies resume
+// continues the recorded session and never mints a second identifier.
+func TestClaudeResumesTheNativeSessionWithoutAssigningANewOne(t *testing.T) {
+	workerRuntime := &fakeWorker{}
+	terminalRuntime := &fakeTerminal{surface: claudeSurface()}
+	runtime := harness.NewClaude(workerRuntime, terminalRuntime)
+	runtime.NewSessionID = func() (string, error) { return "", errors.New("resume must not assign a session") }
+	session, err := runtime.Resume(context.Background(), harness.StartRequest{
+		InvocationID:    "inv-2",
+		RunID:           "run-1",
+		Role:            "implementation",
+		Stage:           "implementation",
+		WorkspaceID:     "workspace-run",
+		Surface:         terminalRuntime.surface,
+		Prompt:          "Continue the implementation.",
+		ResumeSessionID: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+	})
+	if err != nil {
+		t.Fatalf("Resume() error = %v", err)
+	}
+	if session.NativeSessionID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("NativeSessionID = %q, want the continued native session", session.NativeSessionID)
+	}
+	wantCommand := []string{
+		"claude", "--dangerously-skip-permissions",
+		"--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
+		"--resume", "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		"Continue the implementation.",
+	}
+	if strings.Join(workerRuntime.requests[0].Command, "\x00") != strings.Join(wantCommand, "\x00") {
+		t.Fatalf("resume command = %#v, want native resume command", workerRuntime.requests[0].Command)
+	}
+	if len(terminalRuntime.inputs) != 0 {
+		t.Fatalf("surface inputs = %q, want resume prompt passed as an argument", terminalRuntime.inputs)
+	}
+}
+
+// TestClaudeResumeRequiresANativeSessionIdentifier verifies resume cannot
+// degrade into an unrelated fresh session.
+func TestClaudeResumeRequiresANativeSessionIdentifier(t *testing.T) {
+	_, err := harness.NewClaude(&fakeWorker{}, &fakeTerminal{surface: claudeSurface()}).Resume(context.Background(), harness.StartRequest{
+		InvocationID: "inv-2",
+		RunID:        "run-1",
+		Role:         "implementation",
+		Stage:        "implementation",
+		WorkspaceID:  "workspace-run",
+		Prompt:       "Continue the implementation.",
+	})
+	if err == nil || !strings.Contains(err.Error(), "resume session id is required") {
+		t.Fatalf("Resume() error = %v, want a missing-session refusal", err)
+	}
+}
+
+// TestClaudeRejectsAnUnsafeNativeSessionIdentifier verifies neither an assigned
+// nor a recorded identifier can introduce a process argument.
+func TestClaudeRejectsAnUnsafeNativeSessionIdentifier(t *testing.T) {
+	workerRuntime := &fakeWorker{}
+	runtime := harness.NewClaude(workerRuntime, &fakeTerminal{surface: claudeSurface()})
+	runtime.NewSessionID = func() (string, error) { return "--dangerously-skip-permissions", nil }
+	if _, err := runtime.Start(context.Background(), harness.StartRequest{
+		InvocationID: "inv-1",
+		RunID:        "run-1",
+		Role:         "implementation",
+		Stage:        "implementation",
+		WorkspaceID:  "workspace-run",
+		Prompt:       "Implement the frozen specification.",
+	}); err == nil || !strings.Contains(err.Error(), "session id") {
+		t.Fatalf("Start() error = %v, want an unsafe assigned-session refusal", err)
+	}
+	if _, err := runtime.Resume(context.Background(), harness.StartRequest{
+		InvocationID:    "inv-2",
+		RunID:           "run-1",
+		Role:            "implementation",
+		Stage:           "implementation",
+		WorkspaceID:     "workspace-run",
+		Prompt:          "Continue the implementation.",
+		ResumeSessionID: "not a uuid",
+	}); err == nil || !strings.Contains(err.Error(), "session id") {
+		t.Fatalf("Resume() error = %v, want an unsafe recorded-session refusal", err)
+	}
+	if len(workerRuntime.requests) != 0 {
+		t.Fatalf("interactive worker requests = %#v, want no launch after an unsafe session id", workerRuntime.requests)
+	}
+}
+
+// TestClaudeFinishLeavesTheSurfaceRecoverable verifies accepted completion
+// exits Claude Code without destroying its cmux surface or worker state.
+func TestClaudeFinishLeavesTheSurfaceRecoverable(t *testing.T) {
+	terminalRuntime := &fakeTerminal{surface: claudeSurface()}
+	runtime := harness.NewClaude(&fakeWorker{}, terminalRuntime)
+	if err := runtime.Finish(context.Background(), harness.Session{Surface: terminalRuntime.surface}); err != nil {
+		t.Fatalf("Finish() error = %v", err)
+	}
+	if terminalRuntime.closed != "" || string(terminalRuntime.inputs[0]) != "/exit\n" {
+		t.Fatalf("finish operations = closed=%q inputs=%q, want graceful exit with recoverable surface", terminalRuntime.closed, terminalRuntime.inputs)
+	}
+}
+
+// TestClaudeAssignsAUniqueDefaultSessionIdentifier verifies the built-in
+// generator produces distinct RFC 4122 version-four identifiers.
+func TestClaudeAssignsAUniqueDefaultSessionIdentifier(t *testing.T) {
+	terminalRuntime := &fakeTerminal{surface: claudeSurface()}
+	runtime := harness.NewClaude(&fakeWorker{}, terminalRuntime)
+	seen := make(map[string]struct{}, 8)
+	for attempt := 0; attempt < 8; attempt++ {
+		session, err := runtime.Start(context.Background(), harness.StartRequest{
+			InvocationID: "inv-1",
+			RunID:        "run-1",
+			Role:         "implementation",
+			Stage:        "implementation",
+			WorkspaceID:  "workspace-run",
+			Surface:      terminalRuntime.surface,
+			Prompt:       "Implement the frozen specification.",
+		})
+		if err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		if len(session.NativeSessionID) != 36 || session.NativeSessionID[14] != '4' {
+			t.Fatalf("NativeSessionID = %q, want a version-four UUID", session.NativeSessionID)
+		}
+		if _, exists := seen[session.NativeSessionID]; exists {
+			t.Fatalf("NativeSessionID %q was assigned twice", session.NativeSessionID)
+		}
+		seen[session.NativeSessionID] = struct{}{}
+	}
+}

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -1,4 +1,3 @@
-// Package harness contains role-specific interactive harness adapters.
 package harness
 
 import (
@@ -6,61 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
-
-// StartRequest contains the coordinator-owned identity and prompt for one
-// visible Codex invocation.
-type StartRequest struct {
-	// InvocationID identifies the exact report-producing invocation.
-	InvocationID string
-	// RunID identifies the worker run.
-	RunID string
-	// Role identifies the workflow role.
-	Role string
-	// Stage identifies the workflow stage.
-	Stage string
-	// CheckpointSHA binds a review invocation to the exact commit under review.
-	// It is optional for non-review roles.
-	CheckpointSHA string
-	// WorkspaceID identifies the terminal workspace receiving the surface.
-	WorkspaceID terminal.WorkspaceID
-	// Surface is an existing role surface in the run workspace. When empty, the
-	// adapter creates a role-named surface.
-	Surface terminal.Surface
-	// Prompt is the initial role prompt passed to the harness process.
-	Prompt string
-	// Model is a validated repository-policy model selection.
-	Model string
-	// ReasoningEffort is a validated repository-policy setting.
-	ReasoningEffort string
-	// ResumeSessionID is set only when a native session is being resumed.
-	ResumeSessionID string
-}
-
-// Session is the recoverable visible state returned after launch.
-type Session struct {
-	// InvocationID identifies the invocation owning the session.
-	InvocationID string
-	// NativeSessionID is known for resumes and may be populated by later
-	// adapter discovery for a newly launched Codex session.
-	NativeSessionID string
-	// Surface is the opaque terminal surface carrying the session.
-	Surface terminal.Surface
-}
-
-// Runtime is the portable harness lifecycle seam used by the coordinator.
-type Runtime interface {
-	// Start launches a fresh interactive harness session.
-	Start(context.Context, StartRequest) (Session, error)
-	// Resume launches a native-resume session.
-	Resume(context.Context, StartRequest) (Session, error)
-	// Finish detaches the visible surface after accepted completion.
-	Finish(context.Context, Session) error
-}
 
 // Codex implements Runtime using WorkerRuntime's opaque interactive command
 // extension and TerminalRuntime's visible surface operations.
@@ -74,6 +22,11 @@ type Codex struct {
 // NewCodex creates a Codex harness adapter.
 func NewCodex(runtime worker.WorkerRuntime, terminalRuntime terminal.TerminalRuntime) *Codex {
 	return &Codex{Worker: runtime, Terminal: terminalRuntime}
+}
+
+// Capabilities reports the Codex adapter identity and native resume support.
+func (*Codex) Capabilities() Capabilities {
+	return Capabilities{Name: NameCodex, NativeResume: true}
 }
 
 // Start launches a fresh Codex TUI in a worker-backed terminal surface.
@@ -96,22 +49,13 @@ func (c *Codex) Resume(ctx context.Context, request StartRequest) (Session, erro
 // Finish requests a graceful Codex exit while leaving the opaque surface open
 // so cmux can recover it and a later coordinator can reattach or resume.
 func (c *Codex) Finish(ctx context.Context, session Session) error {
-	if c.Terminal == nil {
-		return errors.New("Codex terminal runtime is required")
-	}
-	if session.Surface.ID == "" {
-		return errors.New("Codex session surface is required")
-	}
-	if err := c.Terminal.SendInput(ctx, session.Surface.ID, []byte("/exit\n")); err != nil {
-		return fmt.Errorf("request Codex session exit: %w", err)
-	}
-	return nil
+	return requestExit(ctx, c.Terminal, "Codex", session)
 }
 
 // launch builds the safe Codex command with its immutable prompt and creates a
 // visible surface. It never uses terminal input or output as a launch protocol.
 func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, error) {
-	if err := validateStartRequest(request); err != nil {
+	if err := validateStartRequest("Codex", request); err != nil {
 		return Session{}, err
 	}
 	interactive, ok := c.Worker.(worker.InteractiveRuntime)
@@ -135,17 +79,7 @@ func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, erro
 		command = append(command, "resume", request.ResumeSessionID)
 	}
 	command = append(command, strings.TrimSpace(request.Prompt))
-	environment := map[string]string{
-		"FACTORY_HARNESS":       "codex",
-		"FACTORY_INVOCATION_ID": request.InvocationID,
-		"FACTORY_STAGE":         request.Stage,
-	}
-	if request.CheckpointSHA != "" {
-		environment["FACTORY_CHECKPOINT_SHA"] = request.CheckpointSHA
-	}
-	if request.Model != "" {
-		environment["FACTORY_MODEL"] = request.Model
-	}
+	environment := invocationEnvironment(NameCodex, request)
 	if request.ReasoningEffort != "" {
 		environment["FACTORY_REASONING_EFFORT"] = request.ReasoningEffort
 	}
@@ -164,42 +98,27 @@ func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, erro
 	if request.ResumeSessionID == "" {
 		if provider, ok := c.Worker.(worker.NativeSessionSnapshotProvider); ok {
 			snapshotProvider = provider
-			baseline, err = provider.NativeSessionIDs(ctx, worker.NativeSessionRequest{RunID: request.RunID, Harness: "codex"})
+			baseline, err = provider.NativeSessionIDs(ctx, worker.NativeSessionRequest{RunID: request.RunID, Harness: NameCodex})
 			if err != nil {
 				return Session{}, fmt.Errorf("snapshot Codex native sessions: %w", err)
 			}
 		}
 	}
-	surface := request.Surface
-	if surface.ID == "" {
-		surface, err = c.Terminal.CreateSurface(ctx, terminal.SurfaceRequest{
-			WorkspaceID: request.WorkspaceID,
-			Name:        request.Role,
-			Command: terminal.Command{
-				Executable: attach.Executable,
-				Args:       append([]string(nil), attach.Args...),
-			},
-		})
-		if err != nil {
-			return Session{}, fmt.Errorf("create Codex surface: %w", err)
-		}
-	} else if err := c.Terminal.LaunchSurface(ctx, surface.ID, terminal.Command{
-		Executable: attach.Executable,
-		Args:       append([]string(nil), attach.Args...),
-	}); err != nil {
-		return Session{}, fmt.Errorf("launch Codex surface: %w", err)
+	surface, err := launchSurface(ctx, c.Terminal, "Codex", request, attach)
+	if err != nil {
+		return Session{}, err
 	}
 	nativeSessionID := request.ResumeSessionID
 	if nativeSessionID == "" {
 		if snapshotProvider != nil {
-			discovered, discoverErr := discoverNativeSession(ctx, snapshotProvider, baseline, worker.NativeSessionRequest{RunID: request.RunID, Harness: "codex"})
+			discovered, discoverErr := discoverNativeSession(ctx, snapshotProvider, baseline, worker.NativeSessionRequest{RunID: request.RunID, Harness: NameCodex})
 			if discoverErr != nil {
 				_ = c.Terminal.CloseSurface(ctx, surface.ID)
 				return Session{}, fmt.Errorf("discover Codex native session: %w", discoverErr)
 			}
 			nativeSessionID = discovered
 		} else if provider, ok := c.Worker.(worker.NativeSessionProvider); ok {
-			discovered, discoverErr := provider.NativeSessionID(ctx, worker.NativeSessionRequest{RunID: request.RunID, Harness: "codex"})
+			discovered, discoverErr := provider.NativeSessionID(ctx, worker.NativeSessionRequest{RunID: request.RunID, Harness: NameCodex})
 			if discoverErr != nil {
 				_ = c.Terminal.CloseSurface(ctx, surface.ID)
 				return Session{}, fmt.Errorf("discover Codex native session: %w", discoverErr)
@@ -208,104 +127,6 @@ func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, erro
 		}
 	}
 	return Session{InvocationID: request.InvocationID, NativeSessionID: nativeSessionID, Surface: surface}, nil
-}
-
-const (
-	// nativeSessionDiscoveryTimeout bounds how long a fresh launch waits for
-	// Codex to persist its native session file.
-	nativeSessionDiscoveryTimeout = 60 * time.Second
-	// nativeSessionDiscoveryInitialInterval avoids a tight polling loop while
-	// Codex initializes its role home.
-	nativeSessionDiscoveryInitialInterval = 100 * time.Millisecond
-	// nativeSessionDiscoveryMaxInterval keeps discovery responsive without
-	// repeatedly invoking the worker while Codex is still starting.
-	nativeSessionDiscoveryMaxInterval = 500 * time.Millisecond
-)
-
-// ErrNativeSessionUnavailable reports that a fresh Codex launch did not expose
-// a newly persisted native session before discovery timed out or was canceled.
-var ErrNativeSessionUnavailable = errors.New("native Codex session was not discovered before the deadline")
-
-// discoverNativeSession returns a session identifier that was not present
-// before the prompt-bearing command was launched. It returns
-// ErrNativeSessionUnavailable when
-// Codex does not persist a new session before the bounded discovery window
-// expires or the caller cancels discovery.
-func discoverNativeSession(ctx context.Context, provider worker.NativeSessionSnapshotProvider, baseline []string, request worker.NativeSessionRequest) (string, error) {
-	discoveryContext, cancel := context.WithTimeout(ctx, nativeSessionDiscoveryTimeout)
-	defer cancel()
-	known := make(map[string]struct{}, len(baseline))
-	for _, identifier := range baseline {
-		known[identifier] = struct{}{}
-	}
-	interval := nativeSessionDiscoveryInitialInterval
-	for {
-		if err := discoveryContext.Err(); err != nil {
-			return "", fmt.Errorf("%w: %v", ErrNativeSessionUnavailable, err)
-		}
-		identifiers, err := provider.NativeSessionIDs(discoveryContext, request)
-		if err != nil {
-			if discoveryContext.Err() != nil {
-				return "", fmt.Errorf("%w: %v", ErrNativeSessionUnavailable, discoveryContext.Err())
-			}
-			return "", err
-		}
-		for index := len(identifiers) - 1; index >= 0; index-- {
-			if strings.TrimSpace(identifiers[index]) == "" {
-				continue
-			}
-			if _, exists := known[identifiers[index]]; !exists {
-				return identifiers[index], nil
-			}
-		}
-		timer := time.NewTimer(interval)
-		select {
-		case <-discoveryContext.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			return "", fmt.Errorf("%w: %v", ErrNativeSessionUnavailable, discoveryContext.Err())
-		case <-timer.C:
-			if interval < nativeSessionDiscoveryMaxInterval {
-				interval *= 2
-				if interval > nativeSessionDiscoveryMaxInterval {
-					interval = nativeSessionDiscoveryMaxInterval
-				}
-			}
-		}
-	}
-}
-
-// validateStartRequest rejects incomplete identities before any terminal or
-// worker side effect occurs.
-func validateStartRequest(request StartRequest) error {
-	for field, value := range map[string]string{
-		"invocation id": request.InvocationID,
-		"run id":        request.RunID,
-		"role":          request.Role,
-		"stage":         request.Stage,
-		"prompt":        request.Prompt,
-	} {
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("Codex %s is required", field)
-		}
-		if strings.ContainsAny(value, "\x00\r\n") && field != "prompt" {
-			return fmt.Errorf("Codex %s must be a single line", field)
-		}
-	}
-	if request.WorkspaceID == "" {
-		return errors.New("Codex workspace id is required")
-	}
-	if request.Model != "" && strings.ContainsAny(request.Model, "\x00\r\n ") {
-		return errors.New("Codex model contains unsafe characters")
-	}
-	if request.ReasoningEffort != "" && strings.ContainsAny(request.ReasoningEffort, "\x00\r\n ") {
-		return errors.New("Codex reasoning effort contains unsafe characters")
-	}
-	return nil
 }
 
 var _ Runtime = (*Codex)(nil)

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -26,7 +26,7 @@ func NewCodex(runtime worker.WorkerRuntime, terminalRuntime terminal.TerminalRun
 
 // Capabilities reports the Codex adapter identity and native resume support.
 func (*Codex) Capabilities() Capabilities {
-	return Capabilities{Name: NameCodex, NativeResume: true}
+	return Capabilities{Name: NameCodex, ReasoningEffort: true}
 }
 
 // Start launches a fresh Codex TUI in a worker-backed terminal surface.
@@ -49,13 +49,13 @@ func (c *Codex) Resume(ctx context.Context, request StartRequest) (Session, erro
 // Finish requests a graceful Codex exit while leaving the opaque surface open
 // so cmux can recover it and a later coordinator can reattach or resume.
 func (c *Codex) Finish(ctx context.Context, session Session) error {
-	return requestExit(ctx, c.Terminal, "Codex", session)
+	return requestExit(ctx, c.Terminal, NameCodex, session)
 }
 
 // launch builds the safe Codex command with its immutable prompt and creates a
 // visible surface. It never uses terminal input or output as a launch protocol.
 func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, error) {
-	if err := validateStartRequest("Codex", request); err != nil {
+	if err := validateStartRequest(NameCodex, request); err != nil {
 		return Session{}, err
 	}
 	interactive, ok := c.Worker.(worker.InteractiveRuntime)
@@ -104,7 +104,7 @@ func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, erro
 			}
 		}
 	}
-	surface, err := launchSurface(ctx, c.Terminal, "Codex", request, attach)
+	surface, err := launchSurface(ctx, c.Terminal, NameCodex, request, attach)
 	if err != nil {
 		return Session{}, err
 	}

--- a/internal/harness/contract_test.go
+++ b/internal/harness/contract_test.go
@@ -1,0 +1,345 @@
+package harness_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// contractImage is the pinned worker image reference used by the stub adapter.
+const contractImage = "ghcr.io/example/factory-worker@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// stubCodexSession is the native session the Codex stub persists at launch.
+const stubCodexSession = "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+
+// TestHarnessAdaptersSatisfyTheSameContract drives both adapters through the
+// complete lifecycle against controlled stub executables, before any live run.
+// Each adapter builds its command through the real Docker worker adapter, its
+// surface actually launches the stub attach executable, and the report the
+// stub writes is validated against the invocation identity the adapter set.
+func TestHarnessAdaptersSatisfyTheSameContract(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		harness         string
+		wantExecutable  string
+		wantLaunchFlag  string
+		wantResumeFlag  string
+		wantAssignedID  bool
+		wantResumeFirst bool
+	}{
+		{name: "codex", harness: harness.NameCodex, wantExecutable: "codex", wantLaunchFlag: "-s", wantResumeFlag: "resume"},
+		{name: "claude", harness: harness.NameClaude, wantExecutable: "claude", wantLaunchFlag: "--session-id", wantResumeFlag: "--resume", wantAssignedID: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newHarnessFixture(t)
+			runtime, err := harness.New(test.harness, fixture.worker, fixture.terminal)
+			if err != nil {
+				t.Fatalf("New(%q) error = %v", test.harness, err)
+			}
+
+			// Capability discovery.
+			capabilities := runtime.Capabilities()
+			if capabilities.Name != test.harness || !capabilities.NativeResume {
+				t.Fatalf("Capabilities() = %#v, want %q with native resume", capabilities, test.harness)
+			}
+
+			// Launch.
+			request := harness.StartRequest{
+				InvocationID: "inv-contract-1",
+				RunID:        "run-contract",
+				Role:         "implementation",
+				Stage:        "implementation",
+				WorkspaceID:  fixture.terminal.surface.WorkspaceID,
+				Surface:      fixture.terminal.surface,
+				Prompt:       "Implement the frozen specification.",
+			}
+			session, err := runtime.Start(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			launched := fixture.launchedArguments(t)
+			command := harnessCommand(launched)
+			if len(command) == 0 || command[0] != test.wantExecutable {
+				t.Fatalf("launched harness command = %#v, want %q", command, test.wantExecutable)
+			}
+			if !containsArgument(command, test.wantLaunchFlag) {
+				t.Fatalf("launched harness command = %#v, want the %q launch flag", command, test.wantLaunchFlag)
+			}
+			if command[len(command)-1] != request.Prompt {
+				t.Fatalf("last harness argument = %q, want the immutable role prompt", command[len(command)-1])
+			}
+			if containsArgument(launched, "FACTORY_HARNESS="+test.harness) == false {
+				t.Fatalf("attach arguments = %#v, want the harness identity in the invocation environment", launched)
+			}
+
+			// Native session identification.
+			if session.NativeSessionID == "" {
+				t.Fatal("NativeSessionID is empty, want a recoverable native session")
+			}
+			if test.wantAssignedID && !containsArgument(command, session.NativeSessionID) {
+				t.Fatalf("harness command = %#v, want the assigned session %q", command, session.NativeSessionID)
+			}
+			if !test.wantAssignedID && session.NativeSessionID != stubCodexSession {
+				t.Fatalf("NativeSessionID = %q, want the session the stub persisted", session.NativeSessionID)
+			}
+
+			// Result validation against the identity this adapter established.
+			value, err := report.Read(filepath.Join(fixture.resultDirectory, report.ReportFileName))
+			if err != nil {
+				t.Fatalf("report.Read() error = %v", err)
+			}
+			validation := report.ValidationContext{
+				InvocationID:   request.InvocationID,
+				RunID:          request.RunID,
+				Harness:        test.harness,
+				Role:           request.Role,
+				Stage:          request.Stage,
+				WorktreePath:   fixture.worktree,
+				PermittedPaths: []string{"."},
+			}
+			if err := report.Validate(value, validation); err != nil {
+				t.Fatalf("report.Validate() error = %v, want the stub report accepted", err)
+			}
+			foreign := validation
+			foreign.Harness = "other-harness"
+			if err := report.Validate(value, foreign); err == nil {
+				t.Fatal("report.Validate() accepted a report from a different harness")
+			}
+
+			// Resume.
+			resumeRequest := request
+			resumeRequest.InvocationID = "inv-contract-2"
+			resumeRequest.ResumeSessionID = session.NativeSessionID
+			resumed, err := runtime.Resume(context.Background(), resumeRequest)
+			if err != nil {
+				t.Fatalf("Resume() error = %v", err)
+			}
+			if resumed.NativeSessionID != session.NativeSessionID {
+				t.Fatalf("resumed NativeSessionID = %q, want the continued session %q", resumed.NativeSessionID, session.NativeSessionID)
+			}
+			resumeCommand := harnessCommand(fixture.launchedArguments(t))
+			if !containsArgument(resumeCommand, test.wantResumeFlag) || !containsArgument(resumeCommand, session.NativeSessionID) {
+				t.Fatalf("resume command = %#v, want %q with the recorded session", resumeCommand, test.wantResumeFlag)
+			}
+
+			// Graceful stop.
+			if err := runtime.Finish(context.Background(), resumed); err != nil {
+				t.Fatalf("Finish() error = %v", err)
+			}
+			if fixture.terminal.closed != "" {
+				t.Fatalf("closed surface = %q, want the surface left recoverable", fixture.terminal.closed)
+			}
+			if len(fixture.terminal.inputs) != 1 || string(fixture.terminal.inputs[0]) != "/exit\n" {
+				t.Fatalf("surface inputs = %q, want one graceful exit request", fixture.terminal.inputs)
+			}
+		})
+	}
+}
+
+// TestNewRefusesAnUnknownHarness verifies an unconfigured harness name cannot
+// silently fall back to another adapter.
+func TestNewRefusesAnUnknownHarness(t *testing.T) {
+	if _, err := harness.New("gemini", &fakeWorker{}, &fakeTerminal{}); err == nil || !strings.Contains(err.Error(), "gemini") {
+		t.Fatalf("New() error = %v, want an unknown-harness refusal", err)
+	}
+}
+
+// harnessFixture wires the real Docker worker adapter and a launching terminal
+// onto controlled stub executables.
+type harnessFixture struct {
+	worker          *worker.DockerRuntime
+	terminal        *launchingTerminal
+	resultDirectory string
+	worktree        string
+	attachLog       string
+}
+
+// newHarnessFixture writes the stub docker and attach executables and returns
+// the seams an adapter needs.
+func newHarnessFixture(t *testing.T) *harnessFixture {
+	t.Helper()
+	root := t.TempDir()
+	fixture := &harnessFixture{
+		resultDirectory: filepath.Join(root, "results"),
+		worktree:        filepath.Join(root, "worktree"),
+		attachLog:       filepath.Join(root, "attach.log"),
+	}
+	sessionFile := filepath.Join(root, "session")
+	for _, directory := range []string{fixture.resultDirectory, fixture.worktree} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dockerStub := writeStub(t, filepath.Join(root, "docker-stub"), `#!/bin/sh
+set -eu
+case "${1:-}" in
+  container)
+    printf 'true\t%s\t\n' "`+contractImage+`"
+    ;;
+  exec)
+    if [ -f "$HARNESS_SESSION_FILE" ]; then cat "$HARNESS_SESSION_FILE"; fi
+    ;;
+esac
+`)
+	attachStub := writeStub(t, filepath.Join(root, "attach-stub"), `#!/bin/sh
+set -eu
+: > "$HARNESS_ATTACH_LOG"
+run_id=""
+role=""
+harness_name=""
+invocation=""
+stage=""
+previous=""
+separator=0
+for argument in "$@"; do
+  printf '%s\n' "$argument" >> "$HARNESS_ATTACH_LOG"
+  if [ "$separator" = "1" ] && [ "$argument" = "codex" ]; then
+    printf '%s\n' "$HARNESS_CODEX_SESSION" > "$HARNESS_SESSION_FILE"
+  fi
+  case "$previous" in
+    --run-id) run_id="$argument" ;;
+    --role) role="$argument" ;;
+    --env)
+      name="${argument%%=*}"
+      value="${argument#*=}"
+      case "$name" in
+        FACTORY_HARNESS) harness_name="$value" ;;
+        FACTORY_INVOCATION_ID) invocation="$value" ;;
+        FACTORY_STAGE) stage="$value" ;;
+      esac
+      ;;
+  esac
+  if [ "$argument" = "--" ]; then separator=1; fi
+  previous="$argument"
+done
+cat > "$HARNESS_RESULT_DIR/report.json" <<JSON
+{
+  "schema_version": 1,
+  "invocation_id": "$invocation",
+  "run_id": "$run_id",
+  "harness": "$harness_name",
+  "role": "$role",
+  "stage": "$stage",
+  "reported_at": "2026-01-01T00:00:00Z",
+  "outcome": "cannot_proceed",
+  "summary": "stub harness reported no progress",
+  "evidence": [{"kind": "command", "detail": "stub executable produced no change"}]
+}
+JSON
+`)
+	// The stub executables read their fixture paths from the process
+	// environment, exactly as the repository's other stub-driven adapters do.
+	t.Setenv("HARNESS_ATTACH_LOG", fixture.attachLog)
+	t.Setenv("HARNESS_RESULT_DIR", fixture.resultDirectory)
+	t.Setenv("HARNESS_SESSION_FILE", sessionFile)
+	t.Setenv("HARNESS_CODEX_SESSION", stubCodexSession)
+	fixture.worker = &worker.DockerRuntime{DockerBinary: dockerStub, AttachBinary: attachStub}
+	fixture.terminal = &launchingTerminal{
+		surface: terminal.Surface{ID: "surface-implementation", WorkspaceID: "workspace-run", Name: "implementation"},
+	}
+	return fixture
+}
+
+// launchedArguments returns the arguments the stub attach executable received
+// for the most recent launch.
+func (f *harnessFixture) launchedArguments(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile(f.attachLog)
+	if err != nil {
+		t.Fatalf("read stub attach log: %v", err)
+	}
+	return strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+}
+
+// harnessCommand returns the harness argv that follows the attach separator.
+func harnessCommand(arguments []string) []string {
+	for index, argument := range arguments {
+		if argument == "--" {
+			return arguments[index+1:]
+		}
+	}
+	return nil
+}
+
+// containsArgument reports whether an exact argument was passed.
+func containsArgument(arguments []string, wanted string) bool {
+	for _, argument := range arguments {
+		if argument == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+// writeStub writes one executable stub script and returns its path.
+func writeStub(t *testing.T, path, script string) string {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// launchingTerminal runs the adapter's attach command as a real process so the
+// contract test observes the exact argv a live surface would receive.
+type launchingTerminal struct {
+	surface terminal.Surface
+	inputs  [][]byte
+	closed  string
+}
+
+// EnsureControlWorkspace implements TerminalRuntime for the contract test.
+func (*launchingTerminal) EnsureControlWorkspace(context.Context, terminal.WorkspaceRequest) (terminal.Workspace, error) {
+	return terminal.Workspace{ID: "workspace-control"}, nil
+}
+
+// EnsureRunWorkspace implements TerminalRuntime for the contract test.
+func (*launchingTerminal) EnsureRunWorkspace(context.Context, terminal.RunWorkspaceRequest) (terminal.RunWorkspace, error) {
+	return terminal.RunWorkspace{}, nil
+}
+
+// CreateSurface runs the surface command in a new role-named surface.
+func (t *launchingTerminal) CreateSurface(ctx context.Context, request terminal.SurfaceRequest) (terminal.Surface, error) {
+	if err := t.run(ctx, request.Command); err != nil {
+		return terminal.Surface{}, err
+	}
+	return t.surface, nil
+}
+
+// LaunchSurface runs the surface command in the existing role surface.
+func (t *launchingTerminal) LaunchSurface(ctx context.Context, _ terminal.SurfaceID, command terminal.Command) error {
+	return t.run(ctx, command)
+}
+
+// run executes one surface command against the controlled stub executable.
+func (t *launchingTerminal) run(ctx context.Context, command terminal.Command) error {
+	return exec.CommandContext(ctx, command.Executable, command.Args...).Run()
+}
+
+// SendInput records exact bytes sent to the surface.
+func (t *launchingTerminal) SendInput(_ context.Context, _ terminal.SurfaceID, input []byte) error {
+	t.inputs = append(t.inputs, input)
+	return nil
+}
+
+// Notify implements TerminalRuntime for the contract test.
+func (*launchingTerminal) Notify(context.Context, terminal.Notification) error { return nil }
+
+// CloseSurface records the detached surface.
+func (t *launchingTerminal) CloseSurface(_ context.Context, surfaceID terminal.SurfaceID) error {
+	t.closed = string(surfaceID)
+	return nil
+}
+
+// CloseWorkspace implements TerminalRuntime for the contract test.
+func (*launchingTerminal) CloseWorkspace(context.Context, terminal.WorkspaceID) error { return nil }
+
+var _ terminal.TerminalRuntime = (*launchingTerminal)(nil)

--- a/internal/harness/contract_test.go
+++ b/internal/harness/contract_test.go
@@ -27,15 +27,17 @@ const stubCodexSession = "7c9e6679-7425-40de-944b-e07fc1f90ae7"
 // stub writes is validated against the invocation identity the adapter set.
 func TestHarnessAdaptersSatisfyTheSameContract(t *testing.T) {
 	for _, test := range []struct {
-		name            string
-		harness         string
-		wantExecutable  string
-		wantLaunchFlag  string
-		wantResumeFlag  string
-		wantAssignedID  bool
-		wantResumeFirst bool
+		name           string
+		harness        string
+		wantExecutable string
+		wantLaunchFlag string
+		wantResumeFlag string
+		wantAssignedID bool
+		// wantReasoningEffort records the one capability the two adapters do
+		// not share.
+		wantReasoningEffort bool
 	}{
-		{name: "codex", harness: harness.NameCodex, wantExecutable: "codex", wantLaunchFlag: "-s", wantResumeFlag: "resume"},
+		{name: "codex", harness: harness.NameCodex, wantExecutable: "codex", wantLaunchFlag: "-s", wantResumeFlag: "resume", wantReasoningEffort: true},
 		{name: "claude", harness: harness.NameClaude, wantExecutable: "claude", wantLaunchFlag: "--session-id", wantResumeFlag: "--resume", wantAssignedID: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -47,8 +49,11 @@ func TestHarnessAdaptersSatisfyTheSameContract(t *testing.T) {
 
 			// Capability discovery.
 			capabilities := runtime.Capabilities()
-			if capabilities.Name != test.harness || !capabilities.NativeResume {
-				t.Fatalf("Capabilities() = %#v, want %q with native resume", capabilities, test.harness)
+			if capabilities.Name != test.harness {
+				t.Fatalf("Capabilities() = %#v, want harness %q", capabilities, test.harness)
+			}
+			if capabilities.ReasoningEffort != test.wantReasoningEffort {
+				t.Fatalf("Capabilities() = %#v, want reasoning-effort support %t", capabilities, test.wantReasoningEffort)
 			}
 
 			// Launch.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -63,14 +63,17 @@ type Session struct {
 	Surface terminal.Surface
 }
 
-// Capabilities describes what a harness adapter can do, so the coordinator can
-// decide dispatch without naming a specific tool in workflow code.
+// Capabilities describes a harness adapter, so the coordinator can decide
+// dispatch without naming a specific tool in workflow code.
 type Capabilities struct {
-	// Name is the stable harness identity recorded on an invocation.
+	// Name is the stable harness identity recorded on an invocation. A native
+	// session belongs to the harness that created it, so the coordinator
+	// compares this name before it resumes one.
 	Name string
-	// NativeResume reports whether the adapter can continue an existing native
-	// session rather than only starting a fresh one.
-	NativeResume bool
+	// ReasoningEffort reports whether the harness can honor a reasoning-effort
+	// selection. The coordinator refuses a selection the harness cannot honor
+	// before it creates any invocation side effect.
+	ReasoningEffort bool
 }
 
 // Runtime is the portable harness lifecycle seam used by the coordinator.
@@ -120,7 +123,7 @@ const (
 
 // ErrNativeSessionUnavailable reports that a fresh launch did not expose a
 // newly persisted native session before discovery timed out or was canceled.
-var ErrNativeSessionUnavailable = errors.New("native Codex session was not discovered before the deadline")
+var ErrNativeSessionUnavailable = errors.New("native harness session was not discovered before the deadline")
 
 // discoverNativeSession returns a session identifier that was not present
 // before the prompt-bearing command was launched. It returns

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -1,0 +1,261 @@
+// Package harness contains role-specific interactive harness adapters. An
+// adapter translates one harness-neutral invocation into the native commands
+// of a configured coding tool. It owns no workflow, Git, retry, or
+// terminal-layout decision; the coordinator owns all of those.
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+const (
+	// NameCodex identifies the Codex adapter.
+	NameCodex = "codex"
+	// NameClaude identifies the Claude Code adapter.
+	NameClaude = "claude"
+)
+
+// StartRequest contains the coordinator-owned identity and prompt for one
+// visible harness invocation.
+type StartRequest struct {
+	// InvocationID identifies the exact report-producing invocation.
+	InvocationID string
+	// RunID identifies the worker run.
+	RunID string
+	// Role identifies the workflow role.
+	Role string
+	// Stage identifies the workflow stage.
+	Stage string
+	// CheckpointSHA binds a review invocation to the exact commit under review.
+	// It is optional for non-review roles.
+	CheckpointSHA string
+	// WorkspaceID identifies the terminal workspace receiving the surface.
+	WorkspaceID terminal.WorkspaceID
+	// Surface is an existing role surface in the run workspace. When empty, the
+	// adapter creates a role-named surface.
+	Surface terminal.Surface
+	// Prompt is the initial role prompt passed to the harness process.
+	Prompt string
+	// Model is a validated repository-policy model selection.
+	Model string
+	// ReasoningEffort is a validated repository-policy setting.
+	ReasoningEffort string
+	// ResumeSessionID is set only when a native session is being resumed.
+	ResumeSessionID string
+}
+
+// Session is the recoverable visible state returned after launch.
+type Session struct {
+	// InvocationID identifies the invocation owning the session.
+	InvocationID string
+	// NativeSessionID is the harness-native continuation identity. Codex
+	// persists it and the adapter discovers it; Claude Code accepts an
+	// adapter-assigned identifier at launch.
+	NativeSessionID string
+	// Surface is the opaque terminal surface carrying the session.
+	Surface terminal.Surface
+}
+
+// Capabilities describes what a harness adapter can do, so the coordinator can
+// decide dispatch without naming a specific tool in workflow code.
+type Capabilities struct {
+	// Name is the stable harness identity recorded on an invocation.
+	Name string
+	// NativeResume reports whether the adapter can continue an existing native
+	// session rather than only starting a fresh one.
+	NativeResume bool
+}
+
+// Runtime is the portable harness lifecycle seam used by the coordinator.
+type Runtime interface {
+	// Capabilities reports the adapter identity and supported lifecycle.
+	Capabilities() Capabilities
+	// Start launches a fresh interactive harness session.
+	Start(context.Context, StartRequest) (Session, error)
+	// Resume launches a native-resume session.
+	Resume(context.Context, StartRequest) (Session, error)
+	// Finish detaches the visible surface after accepted completion.
+	Finish(context.Context, Session) error
+}
+
+// ErrUnsupportedSetting reports that a validated repository setting has no
+// native representation in the selected harness. The adapter refuses the
+// launch rather than silently dropping a policy selection.
+var ErrUnsupportedSetting = errors.New("harness does not support the requested setting")
+
+// ErrUnknownHarness reports that no adapter implements the requested harness.
+var ErrUnknownHarness = errors.New("no adapter implements the requested harness")
+
+// New creates the adapter for one validated harness name. It is the only place
+// that maps a repository-declared harness onto an implementation.
+func New(name string, workerRuntime worker.WorkerRuntime, terminalRuntime terminal.TerminalRuntime) (Runtime, error) {
+	switch name {
+	case NameCodex:
+		return NewCodex(workerRuntime, terminalRuntime), nil
+	case NameClaude:
+		return NewClaude(workerRuntime, terminalRuntime), nil
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrUnknownHarness, name)
+	}
+}
+
+const (
+	// nativeSessionDiscoveryTimeout bounds how long a fresh launch waits for a
+	// harness to persist its native session file.
+	nativeSessionDiscoveryTimeout = 60 * time.Second
+	// nativeSessionDiscoveryInitialInterval avoids a tight polling loop while
+	// the harness initializes its role home.
+	nativeSessionDiscoveryInitialInterval = 100 * time.Millisecond
+	// nativeSessionDiscoveryMaxInterval keeps discovery responsive without
+	// repeatedly invoking the worker while the harness is still starting.
+	nativeSessionDiscoveryMaxInterval = 500 * time.Millisecond
+)
+
+// ErrNativeSessionUnavailable reports that a fresh launch did not expose a
+// newly persisted native session before discovery timed out or was canceled.
+var ErrNativeSessionUnavailable = errors.New("native Codex session was not discovered before the deadline")
+
+// discoverNativeSession returns a session identifier that was not present
+// before the prompt-bearing command was launched. It returns
+// ErrNativeSessionUnavailable when the harness does not persist a new session
+// before the bounded discovery window expires or the caller cancels discovery.
+func discoverNativeSession(ctx context.Context, provider worker.NativeSessionSnapshotProvider, baseline []string, request worker.NativeSessionRequest) (string, error) {
+	discoveryContext, cancel := context.WithTimeout(ctx, nativeSessionDiscoveryTimeout)
+	defer cancel()
+	known := make(map[string]struct{}, len(baseline))
+	for _, identifier := range baseline {
+		known[identifier] = struct{}{}
+	}
+	interval := nativeSessionDiscoveryInitialInterval
+	for {
+		if err := discoveryContext.Err(); err != nil {
+			return "", fmt.Errorf("%w: %v", ErrNativeSessionUnavailable, err)
+		}
+		identifiers, err := provider.NativeSessionIDs(discoveryContext, request)
+		if err != nil {
+			if discoveryContext.Err() != nil {
+				return "", fmt.Errorf("%w: %v", ErrNativeSessionUnavailable, discoveryContext.Err())
+			}
+			return "", err
+		}
+		for index := len(identifiers) - 1; index >= 0; index-- {
+			if strings.TrimSpace(identifiers[index]) == "" {
+				continue
+			}
+			if _, exists := known[identifiers[index]]; !exists {
+				return identifiers[index], nil
+			}
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-discoveryContext.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return "", fmt.Errorf("%w: %v", ErrNativeSessionUnavailable, discoveryContext.Err())
+		case <-timer.C:
+			if interval < nativeSessionDiscoveryMaxInterval {
+				interval *= 2
+				if interval > nativeSessionDiscoveryMaxInterval {
+					interval = nativeSessionDiscoveryMaxInterval
+				}
+			}
+		}
+	}
+}
+
+// validateStartRequest rejects incomplete identities before any terminal or
+// worker side effect occurs. The harness name only labels the refusal; every
+// adapter enforces the same neutral contract.
+func validateStartRequest(harnessName string, request StartRequest) error {
+	for field, value := range map[string]string{
+		"invocation id": request.InvocationID,
+		"run id":        request.RunID,
+		"role":          request.Role,
+		"stage":         request.Stage,
+		"prompt":        request.Prompt,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s %s is required", harnessName, field)
+		}
+		if strings.ContainsAny(value, "\x00\r\n") && field != "prompt" {
+			return fmt.Errorf("%s %s must be a single line", harnessName, field)
+		}
+	}
+	if request.WorkspaceID == "" {
+		return fmt.Errorf("%s workspace id is required", harnessName)
+	}
+	if request.Model != "" && strings.ContainsAny(request.Model, "\x00\r\n ") {
+		return fmt.Errorf("%s model contains unsafe characters", harnessName)
+	}
+	if request.ReasoningEffort != "" && strings.ContainsAny(request.ReasoningEffort, "\x00\r\n ") {
+		return fmt.Errorf("%s reasoning effort contains unsafe characters", harnessName)
+	}
+	return nil
+}
+
+// invocationEnvironment builds the explicit non-secret identity values that a
+// visible harness receives. It contains no credential, host path, or GitHub
+// token, and every name is an accepted interactive protocol value.
+func invocationEnvironment(harnessName string, request StartRequest) map[string]string {
+	environment := map[string]string{
+		"FACTORY_HARNESS":       harnessName,
+		"FACTORY_INVOCATION_ID": request.InvocationID,
+		"FACTORY_STAGE":         request.Stage,
+	}
+	if request.CheckpointSHA != "" {
+		environment["FACTORY_CHECKPOINT_SHA"] = request.CheckpointSHA
+	}
+	if request.Model != "" {
+		environment["FACTORY_MODEL"] = request.Model
+	}
+	return environment
+}
+
+// launchSurface reuses the coordinator-owned role surface when one exists and
+// otherwise creates a role-named surface for the attach command. Layout choice
+// stays with the coordinator; the adapter only places its own command.
+func launchSurface(ctx context.Context, terminalRuntime terminal.TerminalRuntime, harnessName string, request StartRequest, attach worker.InteractiveCommand) (terminal.Surface, error) {
+	command := terminal.Command{Executable: attach.Executable, Args: append([]string(nil), attach.Args...)}
+	if request.Surface.ID == "" {
+		surface, err := terminalRuntime.CreateSurface(ctx, terminal.SurfaceRequest{
+			WorkspaceID: request.WorkspaceID,
+			Name:        request.Role,
+			Command:     command,
+		})
+		if err != nil {
+			return terminal.Surface{}, fmt.Errorf("create %s surface: %w", harnessName, err)
+		}
+		return surface, nil
+	}
+	if err := terminalRuntime.LaunchSurface(ctx, request.Surface.ID, command); err != nil {
+		return terminal.Surface{}, fmt.Errorf("launch %s surface: %w", harnessName, err)
+	}
+	return request.Surface, nil
+}
+
+// requestExit sends the harness's graceful exit command while leaving the
+// opaque surface open, so cmux can recover it and a later coordinator can
+// reattach or resume.
+func requestExit(ctx context.Context, terminalRuntime terminal.TerminalRuntime, harnessName string, session Session) error {
+	if terminalRuntime == nil {
+		return fmt.Errorf("%s terminal runtime is required", harnessName)
+	}
+	if session.Surface.ID == "" {
+		return fmt.Errorf("%s session surface is required", harnessName)
+	}
+	if err := terminalRuntime.SendInput(ctx, session.Surface.ID, []byte("/exit\n")); err != nil {
+		return fmt.Errorf("request %s session exit: %w", harnessName, err)
+	}
+	return nil
+}

--- a/internal/worker/interactive_contract_test.go
+++ b/internal/worker/interactive_contract_test.go
@@ -225,3 +225,105 @@ func TestDockerRuntimeSeedsCredentialsWithoutPrivilegedOperations(t *testing.T) 
 		t.Fatal("role home symlink was not created as the worker user")
 	}
 }
+
+// TestDockerRuntimeSeedsOnlyTheClaudeCredentialFile verifies Claude Code is
+// seeded on the same narrow terms as Codex: one explicit host file streamed
+// into the factory-managed credential volume, with no host harness directory
+// mounted and no write back to the host source.
+func TestDockerRuntimeSeedsOnlyTheClaudeCredentialFile(t *testing.T) {
+	stub, logPath, _ := writeDockerStub(t)
+	authPath := filepath.Join(t.TempDir(), ".credentials.json")
+	contents := []byte(`{"claudeAiOauth":{"accessToken":"test-only"}}`)
+	if err := os.WriteFile(authPath, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &worker.DockerRuntime{DockerBinary: stub}
+	if err := runtime.Start(context.Background(), worker.StartRequest{
+		RunID:           "run-claude-auth",
+		WorktreePath:    makeDirectory(t, "worktree"),
+		GitMetadataPath: makeDirectory(t, "git-metadata"),
+		Role:            "implementation",
+		Image:           "ghcr.io/example/factory-worker",
+		ImageDigest:     interactiveWorkerDigest,
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := runtime.SeedClaudeCredentials(context.Background(), worker.CredentialSeedRequest{RunID: "run-claude-auth", AuthPath: authPath}); err != nil {
+		t.Fatalf("SeedClaudeCredentials() error = %v", err)
+	}
+	lines := readStubLog(t, logPath)
+	joined := strings.Join(lines, "\n")
+	if strings.Contains(joined, filepath.Dir(authPath)) || strings.Contains(joined, "docker.sock") {
+		t.Fatalf("credential seed leaked the host harness path or Docker socket: %q", joined)
+	}
+	if !strings.Contains(joined, worker.CredentialPath+"/claude-credentials.json") {
+		t.Fatalf("credential seed did not target the factory-managed credential volume: %q", joined)
+	}
+	after, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(contents) {
+		t.Fatal("credential seed wrote back to the host source")
+	}
+	var wroteCredential, linkedRoleHome bool
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "exec ") {
+			continue
+		}
+		if strings.Contains(line, "chown") {
+			t.Fatalf("credential seed requires a capability the worker drops: %q", line)
+		}
+		switch {
+		case strings.Contains(line, "--user 0:0"):
+			if strings.Contains(line, "$HOME/.claude") {
+				t.Fatalf("uid 0 cannot write the factory-owned role home: %q", line)
+			}
+			if strings.Contains(line, "cat > \""+worker.CredentialPath+"/claude-credentials.json\"") {
+				wroteCredential = true
+			}
+		case strings.Contains(line, "--user "+worker.WorkerUser):
+			if strings.Contains(line, "ln -s") && strings.Contains(line, "$HOME/.claude/.credentials.json") {
+				linkedRoleHome = true
+			}
+		}
+	}
+	if !wroteCredential {
+		t.Fatal("credential file was not written as the owner of the credential volume")
+	}
+	if !linkedRoleHome {
+		t.Fatal("role home symlink was not created as the worker user")
+	}
+}
+
+// TestDockerRuntimeRefusesAnUnsafeClaudeCredentialSource verifies the Claude
+// seam applies the same source checks as the Codex seam.
+func TestDockerRuntimeRefusesAnUnsafeClaudeCredentialSource(t *testing.T) {
+	stub, _, _ := writeDockerStub(t)
+	root := t.TempDir()
+	regular := filepath.Join(root, "regular.json")
+	if err := os.WriteFile(regular, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link.json")
+	if err := os.Symlink(regular, link); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &worker.DockerRuntime{DockerBinary: stub}
+	for _, test := range []struct {
+		name    string
+		path    string
+		problem string
+	}{
+		{name: "relative", path: ".credentials.json", problem: "absolute safe path"},
+		{name: "symlink", path: link, problem: "symbolic link"},
+		{name: "empty", path: regular, problem: "empty"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := runtime.SeedClaudeCredentials(context.Background(), worker.CredentialSeedRequest{RunID: "run-claude-auth", AuthPath: test.path})
+			if err == nil || !strings.Contains(err.Error(), test.problem) {
+				t.Fatalf("SeedClaudeCredentials() error = %v, want %q refusal", err, test.problem)
+			}
+		})
+	}
+}

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -453,7 +453,12 @@ func (r *DockerRuntime) InteractiveCommand(_ context.Context, request Interactiv
 // factory-managed credential volume and links only that file into Codex's role
 // home. It never mounts the host file or returns credential contents.
 func (r *DockerRuntime) SeedCodexCredentials(ctx context.Context, request CredentialSeedRequest) error {
-	return r.seedCredentialFile(ctx, request, "Codex", codexCredentialFile, "$HOME/.codex", "$HOME/.codex/auth.json")
+	return r.seedCredentialFile(ctx, request, harnessCredential{
+		Harness:        "codex",
+		CredentialFile: codexCredentialFile,
+		RoleHome:       "$HOME/.codex",
+		LinkName:       "auth.json",
+	})
 }
 
 // SeedClaudeCredentials streams one explicit Claude Code credential file into
@@ -461,56 +466,76 @@ func (r *DockerRuntime) SeedCodexCredentials(ctx context.Context, request Creden
 // Claude's role home. It never mounts the host file or returns credential
 // contents.
 func (r *DockerRuntime) SeedClaudeCredentials(ctx context.Context, request CredentialSeedRequest) error {
-	return r.seedCredentialFile(ctx, request, "Claude", claudeCredentialFile, "$HOME/.claude", "$HOME/.claude/.credentials.json")
+	return r.seedCredentialFile(ctx, request, harnessCredential{
+		Harness:        "claude",
+		CredentialFile: claudeCredentialFile,
+		RoleHome:       "$HOME/.claude",
+		LinkName:       ".credentials.json",
+	})
+}
+
+// harnessCredential locates one harness's credential copy and the role-home
+// link that exposes it. The fields always travel together, so they are one
+// value rather than four positional parameters.
+type harnessCredential struct {
+	// Harness is the lowercase harness identity used in refusals.
+	Harness string
+	// CredentialFile is the file name inside the credential volume.
+	CredentialFile string
+	// RoleHome is the in-worker directory holding the harness role state.
+	RoleHome string
+	// LinkName is the file name the harness reads inside RoleHome.
+	LinkName string
 }
 
 // seedCredentialFile is the one credential-seeding primitive shared by every
 // harness. It reads one explicit host file, streams its bytes into the
 // factory-managed credential volume, and links that copy into the role home.
 // The host source is only ever read.
-func (r *DockerRuntime) seedCredentialFile(ctx context.Context, request CredentialSeedRequest, harnessName, credentialFile, roleHome, linkPath string) error {
+func (r *DockerRuntime) seedCredentialFile(ctx context.Context, request CredentialSeedRequest, credential harnessCredential) error {
 	if err := validateRunID(request.RunID); err != nil {
 		return err
 	}
 	if !filepath.IsAbs(request.AuthPath) || strings.ContainsAny(request.AuthPath, "\x00\r\n") {
-		return fmt.Errorf("%s auth path must be an absolute safe path", strings.ToLower(harnessName))
+		return fmt.Errorf("%s auth path must be an absolute safe path", credential.Harness)
 	}
 	info, err := os.Lstat(request.AuthPath)
 	if err != nil {
-		return fmt.Errorf("inspect %s auth file: %w", strings.ToLower(harnessName), err)
+		return fmt.Errorf("inspect %s auth file: %w", credential.Harness, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("%s auth path must not be a symbolic link", strings.ToLower(harnessName))
+		return fmt.Errorf("%s auth path must not be a symbolic link", credential.Harness)
 	}
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf("%s auth path must be a regular file", strings.ToLower(harnessName))
+		return fmt.Errorf("%s auth path must be a regular file", credential.Harness)
 	}
 	data, err := os.ReadFile(request.AuthPath)
 	if err != nil {
-		return fmt.Errorf("read %s auth file: %w", strings.ToLower(harnessName), err)
+		return fmt.Errorf("read %s auth file: %w", credential.Harness, err)
 	}
 	if len(data) == 0 {
-		return fmt.Errorf("%s auth file is empty", strings.ToLower(harnessName))
+		return fmt.Errorf("%s auth file is empty", credential.Harness)
 	}
 	// The worker drops every capability, so uid 0 holds neither CAP_CHOWN nor
 	// CAP_DAC_OVERRIDE and is less able to write the factory-owned role home
 	// than the worker user itself. Each step therefore runs as the owner of the
 	// directory it writes, and no step changes ownership.
 	name := containerName(request.RunID)
-	credentialPath := CredentialPath + "/" + credentialFile
+	credentialPath := CredentialPath + "/" + credential.CredentialFile
+	linkPath := credential.RoleHome + "/" + credential.LinkName
 	if _, err := r.runDockerWithInput(ctx, []string{
 		"exec", "-i", "--user", "0:0", "--workdir", WorktreePath,
 		name, "/bin/sh", "-c",
 		"umask 077; rm -f \"" + credentialPath + "\"; cat > \"" + credentialPath + "\"; chmod 0444 \"" + credentialPath + "\"",
 	}, data); err != nil {
-		return fmt.Errorf("seed %s credentials: %w", harnessName, dockerStderrDetail(err))
+		return fmt.Errorf("seed %s credentials: %w", credential.Harness, dockerStderrDetail(err))
 	}
 	if _, err := r.runDocker(ctx, []string{
 		"exec", "--user", WorkerUser, "--workdir", WorktreePath,
 		name, "/bin/sh", "-c",
-		"mkdir -p \"" + roleHome + "\"; rm -f \"" + linkPath + "\"; ln -s \"" + credentialPath + "\" \"" + linkPath + "\"",
+		"mkdir -p \"" + credential.RoleHome + "\"; rm -f \"" + linkPath + "\"; ln -s \"" + credentialPath + "\" \"" + linkPath + "\"",
 	}); err != nil {
-		return fmt.Errorf("link %s credentials into the role home: %w", harnessName, dockerStderrDetail(err))
+		return fmt.Errorf("link %s credentials into the role home: %w", credential.Harness, dockerStderrDetail(err))
 	}
 	return nil
 }
@@ -1487,6 +1512,9 @@ func roleVolumeName(runID, role string) string {
 
 // credentialVolumeName derives a persistent factory-managed credential volume
 // without exposing its coordinator-side key or the host auth path to Docker.
+// One volume holds every harness's credential copy under its own file name;
+// the historical name prefix is retained because it is part of the mount
+// contract that Resume validates against an existing worker.
 func credentialVolumeName(runID, storeID string) string {
 	if strings.TrimSpace(storeID) == "" {
 		storeID = runID

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -32,9 +32,16 @@ const (
 	InvocationPath = "/invocation"
 	// ResultPath is the stable writable path for structured invocation reports.
 	ResultPath = "/results"
-	// CredentialPath is the stable worker path for the factory-managed Codex
+	// CredentialPath is the stable worker path for the factory-managed harness
 	// credential volume. It is separate from the role session home.
 	CredentialPath = "/run/factory-auth"
+	// codexCredentialFile is the credential copy Codex reads through a link in
+	// its role home.
+	codexCredentialFile = "auth.json"
+	// claudeCredentialFile is the credential copy Claude Code reads through a
+	// link in its role home. The two harnesses share one volume and never
+	// share a file.
+	claudeCredentialFile = "claude-credentials.json"
 	// WorkerUser is the fixed non-root identity used for worker processes.
 	WorkerUser = "10001:10001"
 	// workerPrimaryGroupID is already present in WorkerUser and does not need
@@ -189,6 +196,16 @@ type InteractiveRuntime interface {
 type CredentialSeeder interface {
 	// SeedCodexCredentials streams one explicit Codex auth file into the worker.
 	SeedCodexCredentials(context.Context, CredentialSeedRequest) error
+}
+
+// ClaudeCredentialSeeder is the optional extension for narrowly scoped Claude
+// Code auth seeding. It is separate from CredentialSeeder because a host can
+// hold one harness credential as a file without holding the other; macOS keeps
+// the Claude Code credential in the login Keychain rather than a file.
+type ClaudeCredentialSeeder interface {
+	// SeedClaudeCredentials streams one explicit Claude credential file into
+	// the worker.
+	SeedClaudeCredentials(context.Context, CredentialSeedRequest) error
 }
 
 // NativeSessionProvider is the optional extension for non-screen session
@@ -436,47 +453,64 @@ func (r *DockerRuntime) InteractiveCommand(_ context.Context, request Interactiv
 // factory-managed credential volume and links only that file into Codex's role
 // home. It never mounts the host file or returns credential contents.
 func (r *DockerRuntime) SeedCodexCredentials(ctx context.Context, request CredentialSeedRequest) error {
+	return r.seedCredentialFile(ctx, request, "Codex", codexCredentialFile, "$HOME/.codex", "$HOME/.codex/auth.json")
+}
+
+// SeedClaudeCredentials streams one explicit Claude Code credential file into
+// the same factory-managed credential volume and links only that file into
+// Claude's role home. It never mounts the host file or returns credential
+// contents.
+func (r *DockerRuntime) SeedClaudeCredentials(ctx context.Context, request CredentialSeedRequest) error {
+	return r.seedCredentialFile(ctx, request, "Claude", claudeCredentialFile, "$HOME/.claude", "$HOME/.claude/.credentials.json")
+}
+
+// seedCredentialFile is the one credential-seeding primitive shared by every
+// harness. It reads one explicit host file, streams its bytes into the
+// factory-managed credential volume, and links that copy into the role home.
+// The host source is only ever read.
+func (r *DockerRuntime) seedCredentialFile(ctx context.Context, request CredentialSeedRequest, harnessName, credentialFile, roleHome, linkPath string) error {
 	if err := validateRunID(request.RunID); err != nil {
 		return err
 	}
 	if !filepath.IsAbs(request.AuthPath) || strings.ContainsAny(request.AuthPath, "\x00\r\n") {
-		return errors.New("codex auth path must be an absolute safe path")
+		return fmt.Errorf("%s auth path must be an absolute safe path", strings.ToLower(harnessName))
 	}
 	info, err := os.Lstat(request.AuthPath)
 	if err != nil {
-		return fmt.Errorf("inspect codex auth file: %w", err)
+		return fmt.Errorf("inspect %s auth file: %w", strings.ToLower(harnessName), err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return errors.New("codex auth path must not be a symbolic link")
+		return fmt.Errorf("%s auth path must not be a symbolic link", strings.ToLower(harnessName))
 	}
 	if !info.Mode().IsRegular() {
-		return errors.New("codex auth path must be a regular file")
+		return fmt.Errorf("%s auth path must be a regular file", strings.ToLower(harnessName))
 	}
 	data, err := os.ReadFile(request.AuthPath)
 	if err != nil {
-		return fmt.Errorf("read codex auth file: %w", err)
+		return fmt.Errorf("read %s auth file: %w", strings.ToLower(harnessName), err)
 	}
 	if len(data) == 0 {
-		return errors.New("codex auth file is empty")
+		return fmt.Errorf("%s auth file is empty", strings.ToLower(harnessName))
 	}
 	// The worker drops every capability, so uid 0 holds neither CAP_CHOWN nor
 	// CAP_DAC_OVERRIDE and is less able to write the factory-owned role home
 	// than the worker user itself. Each step therefore runs as the owner of the
 	// directory it writes, and no step changes ownership.
 	name := containerName(request.RunID)
+	credentialPath := CredentialPath + "/" + credentialFile
 	if _, err := r.runDockerWithInput(ctx, []string{
 		"exec", "-i", "--user", "0:0", "--workdir", WorktreePath,
 		name, "/bin/sh", "-c",
-		"umask 077; rm -f \"" + CredentialPath + "/auth.json\"; cat > \"" + CredentialPath + "/auth.json\"; chmod 0444 \"" + CredentialPath + "/auth.json\"",
+		"umask 077; rm -f \"" + credentialPath + "\"; cat > \"" + credentialPath + "\"; chmod 0444 \"" + credentialPath + "\"",
 	}, data); err != nil {
-		return fmt.Errorf("seed Codex credentials: %w", dockerStderrDetail(err))
+		return fmt.Errorf("seed %s credentials: %w", harnessName, dockerStderrDetail(err))
 	}
 	if _, err := r.runDocker(ctx, []string{
 		"exec", "--user", WorkerUser, "--workdir", WorktreePath,
 		name, "/bin/sh", "-c",
-		"mkdir -p \"$HOME/.codex\"; rm -f \"$HOME/.codex/auth.json\"; ln -s \"" + CredentialPath + "/auth.json\" \"$HOME/.codex/auth.json\"",
+		"mkdir -p \"" + roleHome + "\"; rm -f \"" + linkPath + "\"; ln -s \"" + credentialPath + "\" \"" + linkPath + "\"",
 	}); err != nil {
-		return fmt.Errorf("link Codex credentials into the role home: %w", dockerStderrDetail(err))
+		return fmt.Errorf("link %s credentials into the role home: %w", harnessName, dockerStderrDetail(err))
 	}
 	return nil
 }
@@ -1524,3 +1558,7 @@ func isDockerRuntimeFailure(commandErr *dockerCommandError) bool {
 }
 
 var _ WorkerRuntime = (*DockerRuntime)(nil)
+var _ InteractiveRuntime = (*DockerRuntime)(nil)
+var _ CredentialSeeder = (*DockerRuntime)(nil)
+var _ ClaudeCredentialSeeder = (*DockerRuntime)(nil)
+var _ NativeSessionSnapshotProvider = (*DockerRuntime)(nil)


### PR DESCRIPTION
Closes #14.

Makes Codex and Claude Code interchangeable so the best harness can be used for each stage.

## What changed

| Area | Change |
| --- | --- |
| `internal/harness` | New `harness.go` shared seam: `Capabilities`, `New(name, …)`, and the neutral validation, surface-launch, environment, and graceful-exit helpers. New `claude.go`. `codex.go` keeps only Codex specifics. |
| `internal/config` | `reasoning_effort_options` per role; `authentication.claude_auth_path`. |
| `internal/worker` | `ClaudeCredentialSeeder` and one shared `seedCredentialFile` primitive for both harnesses. |
| `internal/factory` | Per-role harness/model/effort resolution returning an `AgentPolicy`, with typed rejections; adapter selection by harness name; same-harness-only resume. |
| `internal/cli` | `--claude-auth` on `agent` and `register`. |
| `docs` | `configuration.md`, `agent-runtime.md`, and ADR-0002. |

The two adapters differ only in how a native session identity is obtained. Codex persists it, so the adapter snapshots the role home and discovers the new file. Claude Code accepts `--session-id <uuid>`, so the adapter assigns it and the whole fresh-launch discovery race disappears.

## Acceptance criteria

- **Same harness interface** — `Runtime` now covers capability discovery, launch, native session identification, resume, graceful stop; result validation was already harness-neutral and keys off the invocation identity the adapter stamps.
- **Adapters own no workflow decision** — surface layout, retries, Git, and stage transitions stay in the coordinator; adapters only place their own command.
- **Independent per-role selection** — `role_harness_defaults`, `model_options`, and `reasoning_effort_options` resolve separately for each role, and each adapter translates the selection into its own arguments.
- **Out-of-policy override refused** — typed `harness_override`, `model_override`, `reasoning_effort_override`, `model_unavailable`, `harness_unavailable`, `reasoning_effort_unsupported`.
- **No arbitrary process arguments** — the comment grammar accepts `harness=` and nothing else; a test covers flags, extra words, and unknown keys.
- **No ambient personal configuration** — the worker environment is fully explicit, host harness directories cannot cross the boundary as caches, the role home is factory-created, and the Claude launch adds `--strict-mcp-config` with an empty `--mcp-config` set.
- **Versions pinned per run** — the run's worker image digest pins both harnesses; `DISABLE_AUTOUPDATER=1` stops Claude Code attempting a self-update mid-run.
- **No mid-session migration** — the repair path dispatches on the harness recorded for the session and refuses when the resolved adapter reports a different identity.
- **Narrow Claude credential copy** — one explicit host file streamed into the factory-managed credential volume, linked into the role home; a test asserts the host source is byte-identical afterwards.
- **Contract tests against stub executables** — `internal/harness/contract_test.go` drives both adapters through the full lifecycle using a stub `docker` binary and a stub attach executable that the terminal really runs.

## Decisions worth review

**Reasoning effort is validated, not assumed.** Both adapters translate the validated effort into their own argument — Codex uses `-c model_reasoning_effort=`, Claude Code uses `--effort` (`low`, `medium`, `high`, `xhigh`, `max`). The option names do not transfer between harnesses, so `reasoning_effort_options` is declared per role.

This matters more than it looks: Claude Code **warns about an unrecognized effort level and then silently uses its default**, verified against 2.1.232. An invalid value therefore produces a run at an effort nobody authorized, with no error anywhere. The coordinator's declared-options check is the only thing standing between a typo and that outcome, and it refuses an undeclared value as a typed rejection before any worker, credential copy, or surface exists. Adding `reasoning_effort` to `allowed_overrides` deliberately removes that protection.

**"Issue-level model override" is satisfied at the grammar level.** `model=` does not exist in the comment language, so `/factory config model=gpt-9` returns a typed `malformed_command` rejection — covered by a test. Stories 66 and 67 scope issue-level overrides to harness, and adding a model channel would mean a store migration and status-comment rendering beyond this issue. Flagging it in case you read the criterion differently.

**`model_options` and `reasoning_effort_options` stay per role, not per harness.** With `harness` in `allowed_overrides`, an authorized override can pair one harness with another harness's option names. Scoping them by harness is the more complete model but is a schema change nothing in this issue needs; the coupling is documented in `configuration.md` and ADR-0002 instead.

**Not verified against a live TUI.** `/exit` for graceful stop and `claude --resume <id> <prompt>` come from the spike, not from a live run. The stub tests pin what the adapter sends, not how the TUI reacts.

Also note the repair path's capability check cannot fire in production, because the adapter is resolved *from* `previous.Harness`. The dispatch is the mechanism; the check is defence in depth for an injected runtime.

## Testing

`gofmt`, `go vet`, `go test ./...` (434 passing), and `go build` — the same four gates `factory.yaml` declares.

The Claude Code flags were verified against the CLI at the version the worker image pins (2.1.232), not taken from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrDRfPTNz7htCGCEbaFmdr
