### PR TITLE
fix: pass the validated reasoning effort to claude code

### DIFF
--- a/docs/adr/0002-per-role-harness-selection-fails-closed.md
+++ b/docs/adr/0002-per-role-harness-selection-fails-closed.md
@@ -2,7 +2,7 @@
 status: accepted
 ---
 
-# Select a harness per role and fail closed on settings it cannot honor
+# Select harness, model, and reasoning effort per role from declared options
 
 Codex and Claude Code are interchangeable so the best harness can be used for
 each stage. The coordinator resolves harness, model, and reasoning effort
@@ -10,42 +10,36 @@ independently for each role from the frozen repository policy, and adapters
 translate that neutral selection into native commands. An adapter owns no
 workflow, Git, retry, or terminal-layout decision.
 
-The two harnesses are not feature-identical. Claude Code exposes no
-reasoning-effort process argument, and macOS keeps its credential in the login
-Keychain rather than in a file that a host can hand over. Two rules follow.
+The two harnesses accept the same three settings through different arguments,
+and their option names do not match. Codex takes effort through
+`model_reasoning_effort`; Claude Code takes `low`, `medium`, `high`, `xhigh`,
+or `max` through `--effort`. Neither model names nor effort names transfer.
 
-A setting a harness cannot represent is refused, not dropped. Silently dropping
-a reasoning effort would run a role at an effort the repository policy never
-authorized, and the operator would see a successful launch.
+The repository therefore declares the valid options per role rather than the
+factory hardcoding a per-harness table. A per-role declaration is what the
+requirement asks for, and it keeps a new harness or a renamed level from
+becoming a code change. The cost is that a repository permitting `harness`
+overrides must declare options every permitted harness accepts; nothing in the
+current requirement needs models and efforts scoped by harness, so they are
+not.
 
-The refusal is enforced at three points, each earlier than the last is cheap.
-Configuration validation refuses declaring reasoning-effort options for a role
-whose harness cannot honor them. The coordinator reads the adapter's
-capabilities and refuses a selection as a typed policy rejection before the
-launch creates a directory, a worker, a credential copy, or a surface. The
-adapter refuses it once more at launch, as a fail-closed backstop for a frozen
-packet that predates the validation rule.
-
-Capability discovery, rather than a harness name in workflow code, is what the
-coordinator asks. This keeps the difference between the harnesses in the
-adapter that owns it.
+Validation happens where it binds. Claude Code warns about an unrecognized
+effort level and then silently uses its default, so an invalid value produces a
+run at an effort nobody authorized and no error anywhere. The coordinator's
+declared-options check is the only thing standing between a typo and that
+outcome, and it refuses an undeclared selection as a typed policy rejection
+before the launch creates a directory, a worker, a credential copy, or a
+surface. Adding `reasoning_effort` to `allowed_overrides` deliberately removes
+that protection for an operator who wants it.
 
 Credential seeding is modeled per harness, not once for all of them. Each
 harness names its own optional host source, and a harness without one keeps the
-credential the worker itself persisted in its role volume. Modelling seeding as
+credential the worker itself persisted in its role volume. Modeling seeding as
 a single shared capability would make a Claude run on macOS look misconfigured
-when it is merely authenticated differently.
+when it is merely authenticated differently: macOS keeps the Claude Code
+credential in the login Keychain rather than in a file a host can hand over.
 
 A native session belongs to the harness that created it. A resume dispatches on
 the harness recorded for the session under repair, and refuses to continue when
 the resolved adapter reports a different identity. That is what makes
 mid-session migration between Codex and Claude impossible.
-
-Model options remain per role rather than per harness. A repository that
-permits harness overrides therefore declares model options that every permitted
-harness accepts. Scoping models by harness would be the more complete model,
-but nothing in the current requirement needs it.
-
-This accepts that a repository must declare per-role policy that matches each
-harness's real capabilities, in exchange for refusals that are visible at
-launch instead of silent behavioral drift inside a run.

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -257,8 +257,8 @@ runs the complete frozen gate suite and retains each result under that exact
 checkpoint SHA. Typed deterministic gate failures are assembled into one
 bounded check-repair packet containing all gate outcomes, skipped dependency
 reasons, and bounded command diagnostics. The next implementation invocation
-uses the existing worker role volume, implementation surface, and native Codex
-session through the harness resume seam.
+uses the existing worker role volume, implementation surface, and native
+session for the recorded harness through the harness resume seam.
 
 The repository's `retry_limits.check_repair` value is frozen into the run. A
 repair reservation is durable before native resume, but the consumed attempt

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -14,12 +14,16 @@ commands and owns no workflow, Git, retry, or terminal-layout decision.
 
 The coordinator resolves the adapter from the frozen repository policy for the
 role, so workflow code never names a tool. `Capabilities` reports the adapter
-identity and whether the harness can honor a reasoning-effort selection. The
-check-repair path dispatches on the harness recorded for the session under
-repair and refuses to continue when the resolved adapter reports a different
-identity, so mid-session migration between Codex and Claude is not possible.
-The launch path refuses a reasoning effort the selected harness cannot honor
-before it creates any side effect.
+identity. The check-repair path dispatches on the harness recorded for the
+session under repair and refuses to continue when the resolved adapter reports
+a different identity, so mid-session migration between Codex and Claude is not
+possible.
+
+Each adapter translates the validated model and reasoning effort into its own
+arguments: Codex uses `-m` and `-c model_reasoning_effort=`, Claude Code uses
+`--model` and `--effort`. The effort names differ between the two, and Claude
+Code silently falls back to its default for a level it does not recognize, so
+the repository-declared options per role are what constrain the value.
 
 The two adapters differ in how a native session identity is obtained:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,8 +92,9 @@ model_options:
   test: [gpt-5]
   implementation: [claude-opus-5, claude-sonnet-5]
   spec_review: [gpt-5]
-# Optional. A role that declares no values accepts no reasoning-effort
-# selection at all.
+# Optional, and harness-specific: these are Codex effort names because the
+# test role runs on Codex. A role that declares no values accepts no
+# reasoning-effort selection at all.
 reasoning_effort_options:
   test: [medium, high]
 timeouts:
@@ -143,18 +144,19 @@ matching `allowed_overrides` entry; without it the coordinator refuses the
 launch as a typed policy rejection with the code `harness_override`,
 `model_override`, or `reasoning_effort_override`.
 
-Claude Code exposes no reasoning-effort process argument. A role that runs on
-`claude` therefore declares no `reasoning_effort_options`, and the validator
-refuses a configuration that declares them anyway. If a selection still reaches
-a launch, the coordinator refuses it as a `reasoning_effort_unsupported`
-rejection before it starts a worker, and the adapter refuses it again as a
-fail-closed backstop.
+Declared values must match what the role's harness accepts. Codex takes its own
+effort names through `model_reasoning_effort`; Claude Code takes `low`,
+`medium`, `high`, `xhigh`, or `max` through `--effort`. Claude Code warns about
+an unrecognized level and then silently uses its default, so
+`reasoning_effort_options` is the only thing that actually constrains the
+value. Declare it, and keep `reasoning_effort` out of `allowed_overrides`
+unless an operator is meant to bypass that check.
 
-`model_options` is declared per role, not per harness. A repository that adds
-`harness` to `allowed_overrides` therefore accepts responsibility for declaring
-model options that every permitted harness accepts; otherwise an authorized
-override can pair one harness with another harness's model name, and the
-harness rejects the model at launch.
+`model_options` and `reasoning_effort_options` are declared per role, not per
+harness. A repository that adds `harness` to `allowed_overrides` therefore accepts
+responsibility for declaring model and effort options that every permitted
+harness accepts; otherwise an authorized override can pair one harness with
+another harness's option names.
 
 An authorized maintainer selects a harness for a later invocation with one
 structured comment:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,11 +146,11 @@ launch as a typed policy rejection with the code `harness_override`,
 
 Declared values must match what the role's harness accepts. Codex takes its own
 effort names through `model_reasoning_effort`; Claude Code takes `low`,
-`medium`, `high`, `xhigh`, or `max` through `--effort`. Claude Code warns about
-an unrecognized level and then silently uses its default, so
-`reasoning_effort_options` is the only thing that actually constrains the
-value. Declare it, and keep `reasoning_effort` out of `allowed_overrides`
-unless an operator is meant to bypass that check.
+`medium`, `high`, `xhigh`, or `max` through `--effort`. `ValidateRepository`
+rejects Claude Code `reasoning_effort_options` with unsupported values before
+launch, so an invalid declaration never reaches the harness. Declare
+`reasoning_effort_options` for every role, and keep `reasoning_effort` out of
+`allowed_overrides` unless an operator is meant to bypass that check.
 
 `model_options` and `reasoning_effort_options` are declared per role, not per
 harness. A repository that adds `harness` to `allowed_overrides` therefore accepts

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -433,12 +433,8 @@ func ValidateRepository(config RepositoryConfig) error {
 		}
 	}
 	for role, efforts := range config.ReasoningEffortOptions {
-		harness, exists := config.RoleHarnessDefaults[role]
-		if !exists {
+		if _, exists := config.RoleHarnessDefaults[role]; !exists {
 			return validation("reasoning_effort_options."+role, "must reference a role with a declared harness")
-		}
-		if !harnessHonorsReasoningEffort(harness) {
-			return validation("reasoning_effort_options."+role, fmt.Sprintf("harness %q cannot honor a reasoning-effort selection", harness))
 		}
 		if len(efforts) == 0 {
 			return validation("reasoning_effort_options."+role, "must declare at least one value or be omitted")
@@ -533,14 +529,6 @@ func ValidateRepository(config RepositoryConfig) error {
 		}
 	}
 	return nil
-}
-
-// harnessHonorsReasoningEffort reports whether a harness accepts a
-// reasoning-effort selection. Claude Code exposes no reasoning-effort process
-// argument, so a role that runs on it declares no options rather than
-// declaring options that every launch would refuse.
-func harnessHonorsReasoningEffort(harness Harness) bool {
-	return harness == HarnessCodex
 }
 
 // validateSetupFiles validates optional repository-relative manifest and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -449,6 +449,16 @@ func ValidateRepository(config RepositoryConfig) error {
 				return validation(field, "must be unique")
 			}
 			seen[effort] = struct{}{}
+			// Claude Code accepts only low, medium, high, xhigh, or max.
+			// Validate Claude roles against these supported values.
+			if harness := config.RoleHarnessDefaults[role]; harness == HarnessClaude {
+				switch effort {
+				case "low", "medium", "high", "xhigh", "max":
+					// Supported value
+				default:
+					return validation(field, "must be low, medium, high, xhigh, or max for Claude Code")
+				}
+			}
 		}
 	}
 	if _, exists := config.RoleHarnessDefaults["test"]; !exists {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -877,15 +877,3 @@ func TestValidateRepositoryRejectsDuplicateReasoningEffortOptions(t *testing.T) 
 		t.Fatalf("ValidateRepository() error = %v, want duplicate rejection", err)
 	}
 }
-
-// TestValidateRepositoryRejectsReasoningEffortOptionsForAHarnessThatCannotHonorThem
-// verifies a repository cannot declare a setting whose every launch would be
-// refused, because Claude Code exposes no reasoning-effort process argument.
-func TestValidateRepositoryRejectsReasoningEffortOptionsForAHarnessThatCannotHonorThem(t *testing.T) {
-	value := validRepositoryConfig()
-	value.RoleHarnessDefaults["implementation"] = config.HarnessClaude
-	value.ReasoningEffortOptions = map[string][]string{"implementation": {"high"}}
-	if err := config.ValidateRepository(value); err == nil || !strings.Contains(err.Error(), "cannot honor a reasoning-effort selection") {
-		t.Fatalf("ValidateRepository() error = %v, want an unsupported-harness rejection", err)
-	}
-}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -877,3 +877,41 @@ func TestValidateRepositoryRejectsDuplicateReasoningEffortOptions(t *testing.T) 
 		t.Fatalf("ValidateRepository() error = %v, want duplicate rejection", err)
 	}
 }
+
+// TestValidateRepositoryRejectsInvalidClaudeCodeReasoningEffort verifies Claude
+// Code roles declare only the supported reasoning effort values.
+func TestValidateRepositoryRejectsInvalidClaudeCodeReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	value := validRepositoryConfig()
+	// Add a Claude role with an invalid reasoning effort
+	value.RoleHarnessDefaults["spec_review"] = config.HarnessClaude
+	value.ModelOptions["spec_review"] = []string{"claude-opus-4-5"}
+	value.ReasoningEffortOptions = map[string][]string{
+		"spec_review": {"bogus"},
+	}
+	err := config.ValidateRepository(value)
+	var validationErr *config.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("ValidateRepository() error = %v, want ValidationError for invalid Claude Code reasoning effort", err)
+	}
+	if validationErr.Field != "reasoning_effort_options.spec_review[0]" {
+		t.Fatalf("field = %q, want reasoning_effort_options.spec_review[0]", validationErr.Field)
+	}
+	if !strings.Contains(validationErr.Message, "low, medium, high, xhigh, or max") {
+		t.Fatalf("message = %q, want it to list the supported Claude Code values", validationErr.Message)
+	}
+
+	// Verify valid Codex and Claude configurations are accepted
+	validMixed := validRepositoryConfig()
+	validMixed.RoleHarnessDefaults["spec_review"] = config.HarnessClaude
+	validMixed.ModelOptions["spec_review"] = []string{"claude-opus-4-5"}
+	validMixed.ReasoningEffortOptions = map[string][]string{
+		"test":           {"codex-effort"},       // Codex role can use any value
+		"implementation": {"another-codex"},      // Codex role can use any value
+		"spec_review":    {"low", "high", "max"}, // Claude role must use supported values
+	}
+	if err := config.ValidateRepository(validMixed); err != nil {
+		t.Fatalf("ValidateRepository() error = %v, want valid mixed Codex and Claude configuration to be accepted", err)
+	}
+}

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -101,15 +101,6 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	if err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("ensure agent runtime: %w", err)
 	}
-	// A setting the selected harness cannot honor is refused here, before the
-	// launch creates any directory, worker, credential copy, or surface. The
-	// adapter refuses it again at launch as a fail-closed backstop.
-	if policy.ReasoningEffort != "" && !harnessRuntime.Capabilities().ReasoningEffort {
-		return AgentLaunchResult{}, &PolicyRejection{
-			Code:    PolicyRejectionReasoningEffortUnsupported,
-			Problem: fmt.Sprintf("harness %q cannot honor a reasoning-effort selection for role %q", policy.Harness, request.Role),
-		}
-	}
 	runID, err := s.deps.NewRunID()
 	if err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("generate invocation identifier: %w", err)

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -1043,7 +1043,7 @@ type agentHarness struct {
 
 // Capabilities reports the harness identity this fake stands in for.
 func (*agentHarness) Capabilities() harness.Capabilities {
-	return harness.Capabilities{Name: harness.NameCodex, ReasoningEffort: true}
+	return harness.Capabilities{Name: harness.NameCodex}
 }
 
 // Start records the coordinator-owned prompt request.

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -59,9 +59,6 @@ const (
 	// PolicyRejectionReasoningEffortOverride means the requested reasoning
 	// effort is outside the role's repository-declared options.
 	PolicyRejectionReasoningEffortOverride PolicyRejectionCode = "reasoning_effort_override"
-	// PolicyRejectionReasoningEffortUnsupported means the selected harness
-	// cannot honor a reasoning-effort selection at all.
-	PolicyRejectionReasoningEffortUnsupported PolicyRejectionCode = "reasoning_effort_unsupported"
 	// PolicyRejectionCancelState means cancellation is not legal for the run.
 	PolicyRejectionCancelState PolicyRejectionCode = "cancel_state"
 	// PolicyRejectionAnswerState means the run is not waiting for clarification.

--- a/internal/factory/harness_selection_test.go
+++ b/internal/factory/harness_selection_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/factory"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
-	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
@@ -117,13 +116,38 @@ func TestStartAgentAcceptsAnIssueHarnessOverridePermittedByPolicy(t *testing.T) 
 	}
 }
 
-// TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonor verifies a
-// validated repository setting is refused as a typed policy rejection rather
-// than silently dropped, and that the refusal happens before the launch
-// creates a worker, a credential copy, or a visible surface.
-func TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonor(t *testing.T) {
+// TestStartAgentPassesTheDeclaredReasoningEffortToClaude verifies reasoning
+// effort is selected per role from the repository-declared options and reaches
+// the Claude adapter, which is what constrains the value: Claude Code warns
+// about an unrecognized level and then silently uses its default.
+func TestStartAgentPassesTheDeclaredReasoningEffortToClaude(t *testing.T) {
 	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
 	policy := validRepositoryConfig()
+	policy.RoleHarnessDefaults["implementation"] = config.HarnessClaude
+	policy.ModelOptions["implementation"] = []string{"claude-opus-5"}
+	policy.ReasoningEffortOptions = map[string][]string{"implementation": {"high", "max"}}
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{})
+
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	if launch.Invocation.ReasoningEffort != "high" {
+		t.Fatalf("invocation reasoning effort = %q, want the role's first declared option", launch.Invocation.ReasoningEffort)
+	}
+	command := runtime.interactive[0].Command
+	if !containsAdjacentArguments(command, "--effort", "high") {
+		t.Fatalf("Claude command = %#v, want the declared effort level", command)
+	}
+}
+
+// TestStartAgentRefusesAnUndeclaredReasoningEffort verifies an effort outside
+// the role's declared options is refused as a typed policy rejection before
+// the launch creates a worker, a credential copy, or a visible surface.
+func TestStartAgentRefusesAnUndeclaredReasoningEffort(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
+	policy := validRepositoryConfig()
+	policy.AllowedOverrides = nil
 	policy.RoleHarnessDefaults["implementation"] = config.HarnessClaude
 	policy.ModelOptions["implementation"] = []string{"claude-opus-5"}
 	policy.ReasoningEffortOptions = map[string][]string{"implementation": {"high"}}
@@ -131,10 +155,10 @@ func TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonor(t *testing.T) {
 		ClaudeAuthPath: filepath.Join(t.TempDir(), ".credentials.json"),
 	})
 
-	_, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	_, err := service.StartAgent(context.Background(), factory.AgentRequest{ReasoningEffort: "bogus"})
 	var rejection *factory.PolicyRejection
-	if !errors.As(err, &rejection) || rejection.Code != factory.PolicyRejectionReasoningEffortUnsupported {
-		t.Fatalf("StartAgent() error = %v, want a typed unsupported-setting rejection", err)
+	if !errors.As(err, &rejection) || rejection.Code != factory.PolicyRejectionReasoningEffortOverride {
+		t.Fatalf("StartAgent() error = %v, want a typed reasoning-effort rejection", err)
 	}
 	if len(runtime.starts) != 0 || len(runtime.claudeSeeds) != 0 || len(runtime.interactive) != 0 {
 		t.Fatal("a refused setting started a worker, seeded a credential, or launched a harness")
@@ -144,22 +168,15 @@ func TestStartAgentRefusesAReasoningEffortTheHarnessCannotHonor(t *testing.T) {
 	}
 }
 
-// TestClaudeAdapterRefusesAnUnsupportedSettingAsABackstop verifies the adapter
-// itself still fails closed if a caller reaches it with a setting the harness
-// cannot honor.
-func TestClaudeAdapterRefusesAnUnsupportedSettingAsABackstop(t *testing.T) {
-	_, err := harness.NewClaude(&agentWorker{}, &agentTerminal{}).Start(context.Background(), harness.StartRequest{
-		InvocationID:    "inv-backstop",
-		RunID:           "run-backstop",
-		Role:            "implementation",
-		Stage:           "implementation",
-		WorkspaceID:     "workspace-run",
-		Prompt:          "Implement the frozen specification.",
-		ReasoningEffort: "high",
-	})
-	if !errors.Is(err, harness.ErrUnsupportedSetting) {
-		t.Fatalf("Start() error = %v, want the unsupported-setting sentinel", err)
+// containsAdjacentArguments reports whether a flag is immediately followed by
+// its expected value.
+func containsAdjacentArguments(arguments []string, flag, value string) bool {
+	for index := 0; index+1 < len(arguments); index++ {
+		if arguments[index] == flag && arguments[index+1] == value {
+			return true
+		}
 	}
+	return false
 }
 
 // newDispatchingAgentService recreates the coordinator around a persisted claim

--- a/internal/factory/repair_test.go
+++ b/internal/factory/repair_test.go
@@ -600,7 +600,7 @@ type repairLaunchHarness struct {
 
 // Capabilities satisfies the harness runtime seam.
 func (*repairLaunchHarness) Capabilities() harness.Capabilities {
-	return harness.Capabilities{Name: string(config.HarnessCodex), ReasoningEffort: true}
+	return harness.Capabilities{Name: string(config.HarnessCodex)}
 }
 
 // Start satisfies the harness runtime seam.

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -34,10 +34,9 @@ func NewClaude(runtime worker.WorkerRuntime, terminalRuntime terminal.TerminalRu
 	return &Claude{Worker: runtime, Terminal: terminalRuntime, NewSessionID: newSessionID}
 }
 
-// Capabilities reports the Claude adapter identity. Claude Code exposes no
-// reasoning-effort process argument, so it reports that setting unsupported.
+// Capabilities reports the Claude adapter identity.
 func (*Claude) Capabilities() Capabilities {
-	return Capabilities{Name: NameClaude, ReasoningEffort: false}
+	return Capabilities{Name: NameClaude}
 }
 
 // Start launches a fresh Claude Code TUI with an adapter-assigned native
@@ -79,12 +78,6 @@ func (c *Claude) launch(ctx context.Context, request StartRequest, sessionID str
 	if err := validateStartRequest(NameClaude, request); err != nil {
 		return Session{}, err
 	}
-	if request.ReasoningEffort != "" {
-		// Claude Code exposes no reasoning-effort process argument. Dropping a
-		// validated repository selection would run the role at an effort the
-		// policy never authorized, so the launch is refused instead.
-		return Session{}, fmt.Errorf("%w: Claude reasoning effort", ErrUnsupportedSetting)
-	}
 	if !validSessionID(sessionID) {
 		return Session{}, errors.New("Claude native session id must be a version-four UUID")
 	}
@@ -108,8 +101,17 @@ func (c *Claude) launch(ctx context.Context, request StartRequest, sessionID str
 	if request.Model != "" {
 		command = append(command, "--model", request.Model)
 	}
+	// Claude Code warns about an unrecognized effort level and then silently
+	// uses its default, so the coordinator's repository-declared options are
+	// what actually constrain this value.
+	if request.ReasoningEffort != "" {
+		command = append(command, "--effort", request.ReasoningEffort)
+	}
 	command = append(command, strings.TrimSpace(request.Prompt))
 	environment := invocationEnvironment(NameClaude, request)
+	if request.ReasoningEffort != "" {
+		environment["FACTORY_REASONING_EFFORT"] = request.ReasoningEffort
+	}
 	// The harness version is pinned by the worker image. Claude Code otherwise
 	// attempts a self-update at startup, which must never change the tool
 	// halfway through a run.

--- a/internal/harness/claude_test.go
+++ b/internal/harness/claude_test.go
@@ -84,25 +84,42 @@ func TestClaudeStartRefusesAResumeSessionIdentifier(t *testing.T) {
 	}
 }
 
-// TestClaudeRefusesAReasoningEffortSelection verifies a validated repository
-// setting is refused rather than silently dropped, because Claude Code exposes
-// no reasoning-effort process argument.
-func TestClaudeRefusesAReasoningEffortSelection(t *testing.T) {
+// TestClaudePassesAValidatedReasoningEffort verifies the repository-declared
+// effort reaches the harness. Claude Code warns about an unrecognized level
+// and then silently uses its default, so the coordinator's declared options
+// are what constrain the value.
+func TestClaudePassesAValidatedReasoningEffort(t *testing.T) {
 	workerRuntime := &fakeWorker{}
-	_, err := harness.NewClaude(workerRuntime, &fakeTerminal{surface: claudeSurface()}).Start(context.Background(), harness.StartRequest{
+	terminalRuntime := &fakeTerminal{surface: claudeSurface()}
+	runtime := harness.NewClaude(workerRuntime, terminalRuntime)
+	runtime.NewSessionID = func() (string, error) { return "3f2504e0-4f89-41d3-9a0c-0305e82c3301", nil }
+	if _, err := runtime.Start(context.Background(), harness.StartRequest{
 		InvocationID:    "inv-1",
 		RunID:           "run-1",
 		Role:            "implementation",
 		Stage:           "implementation",
 		WorkspaceID:     "workspace-run",
+		Surface:         terminalRuntime.surface,
 		Prompt:          "Implement the frozen specification.",
+		Model:           "claude-opus-5",
 		ReasoningEffort: "high",
-	})
-	if !errors.Is(err, harness.ErrUnsupportedSetting) {
-		t.Fatalf("Start() error = %v, want the unsupported-setting sentinel", err)
+	}); err != nil {
+		t.Fatalf("Start() error = %v", err)
 	}
-	if len(workerRuntime.requests) != 0 {
-		t.Fatalf("interactive worker requests = %#v, want no launch after a refused setting", workerRuntime.requests)
+	request := workerRuntime.requests[0]
+	wantCommand := []string{
+		"claude", "--dangerously-skip-permissions",
+		"--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
+		"--session-id", "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		"--model", "claude-opus-5",
+		"--effort", "high",
+		"Implement the frozen specification.",
+	}
+	if strings.Join(request.Command, "\x00") != strings.Join(wantCommand, "\x00") {
+		t.Fatalf("Claude command = %#v, want the validated effort level", request.Command)
+	}
+	if request.Environment["FACTORY_REASONING_EFFORT"] != "high" {
+		t.Fatalf("Claude environment = %#v, want the reasoning-effort identity", request.Environment)
 	}
 }
 

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -26,7 +26,7 @@ func NewCodex(runtime worker.WorkerRuntime, terminalRuntime terminal.TerminalRun
 
 // Capabilities reports the Codex adapter identity and native resume support.
 func (*Codex) Capabilities() Capabilities {
-	return Capabilities{Name: NameCodex, ReasoningEffort: true}
+	return Capabilities{Name: NameCodex}
 }
 
 // Start launches a fresh Codex TUI in a worker-backed terminal surface.

--- a/internal/harness/contract_test.go
+++ b/internal/harness/contract_test.go
@@ -33,11 +33,8 @@ func TestHarnessAdaptersSatisfyTheSameContract(t *testing.T) {
 		wantLaunchFlag string
 		wantResumeFlag string
 		wantAssignedID bool
-		// wantReasoningEffort records the one capability the two adapters do
-		// not share.
-		wantReasoningEffort bool
 	}{
-		{name: "codex", harness: harness.NameCodex, wantExecutable: "codex", wantLaunchFlag: "-s", wantResumeFlag: "resume", wantReasoningEffort: true},
+		{name: "codex", harness: harness.NameCodex, wantExecutable: "codex", wantLaunchFlag: "-s", wantResumeFlag: "resume"},
 		{name: "claude", harness: harness.NameClaude, wantExecutable: "claude", wantLaunchFlag: "--session-id", wantResumeFlag: "--resume", wantAssignedID: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -51,9 +48,6 @@ func TestHarnessAdaptersSatisfyTheSameContract(t *testing.T) {
 			capabilities := runtime.Capabilities()
 			if capabilities.Name != test.harness {
 				t.Fatalf("Capabilities() = %#v, want harness %q", capabilities, test.harness)
-			}
-			if capabilities.ReasoningEffort != test.wantReasoningEffort {
-				t.Fatalf("Capabilities() = %#v, want reasoning-effort support %t", capabilities, test.wantReasoningEffort)
 			}
 
 			// Launch.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -70,10 +70,6 @@ type Capabilities struct {
 	// session belongs to the harness that created it, so the coordinator
 	// compares this name before it resumes one.
 	Name string
-	// ReasoningEffort reports whether the harness can honor a reasoning-effort
-	// selection. The coordinator refuses a selection the harness cannot honor
-	// before it creates any invocation side effect.
-	ReasoningEffort bool
 }
 
 // Runtime is the portable harness lifecycle seam used by the coordinator.
@@ -87,11 +83,6 @@ type Runtime interface {
 	// Finish detaches the visible surface after accepted completion.
 	Finish(context.Context, Session) error
 }
-
-// ErrUnsupportedSetting reports that a validated repository setting has no
-// native representation in the selected harness. The adapter refuses the
-// launch rather than silently dropping a policy selection.
-var ErrUnsupportedSetting = errors.New("harness does not support the requested setting")
 
 // ErrUnknownHarness reports that no adapter implements the requested harness.
 var ErrUnknownHarness = errors.New("no adapter implements the requested harness")


### PR DESCRIPTION
Follow-up to #14. Corrects a defect merged in #49.

## The defect

#49 shipped on the claim that Claude Code has no reasoning-effort process argument. That is wrong. Verified against the CLI at the version `worker/base.Dockerfile` pins (2.1.232):

```
--effort <level>    Effort level for the current session
                    (low, medium, high, xhigh, max)
```

There is no `--print`-only restriction, so it applies to the interactive TUI the factory launches.

Built on that false premise, #49 refused a supported setting at three layers and forced every Claude role to declare no reasoning-effort options at all. This removes all of it and passes the setting through.

## What changed

- `Claude.launch` appends `--effort <level>` and exports `FACTORY_REASONING_EFFORT`, matching what the Codex adapter already did with `-c model_reasoning_effort=`.
- Removed `ErrUnsupportedSetting`, `Capabilities.ReasoningEffort`, the coordinator's pre-launch capability check, the `reasoning_effort_unsupported` rejection code, and the config rule forbidding `reasoning_effort_options` on a Claude role.
- ADR-0002 rewritten: its central premise was the false claim.

Net −150 lines. The design is simpler than before: both adapters now just translate a validated selection into their own arguments.

## Why the declared-options check still matters

Worth stating, because it is the reason this is not merely a flag addition. Claude Code does not reject a bad effort level:

```
$ claude --effort bogus -p 'hi'
Warning: Unknown --effort value 'bogus' — ignoring it and using the default
effort. Valid values: low, medium, high, xhigh, max.
```

Exit 0. It warns and runs at the default. An invalid value therefore produces a run at an effort nobody authorized, with no error anywhere and a warning that scrolls past in a TUI.

That makes `reasoning_effort_options` the only check that binds, rather than a redundant convenience. The coordinator still refuses an undeclared value as a typed `reasoning_effort_override` rejection before the launch creates a directory, a worker, a credential copy, or a surface — covered by `TestStartAgentRefusesAnUndeclaredReasoningEffort`, which asserts no side effect survives. Adding `reasoning_effort` to `allowed_overrides` deliberately removes that protection; `configuration.md` and ADR-0002 both say so.

Note also that effort names do not transfer between harnesses — Codex has its own set — which is a further argument for the per-role declaration issue #14 asked for.

## Testing

`gofmt`, `go vet`, `go test ./...` (434 passing), `go build` — the four gates `factory.yaml` declares.

New coverage: `TestClaudePassesAValidatedReasoningEffort` pins the exact argv including `--effort high`; `TestStartAgentPassesTheDeclaredReasoningEffortToClaude` checks the role's first declared option reaches the adapter through the coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrDRfPTNz7htCGCEbaFmdr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring reasoning effort with Claude Code.
  * Reasoning-effort settings are now passed using each harness’s supported format.
  * Per-role harness, model, and reasoning-effort declarations provide more flexible configuration.
  * Validated overrides can customize reasoning effort when explicitly permitted.

* **Bug Fixes**
  * Removed incorrect rejection of valid reasoning-effort settings for Claude Code.

* **Documentation**
  * Updated configuration and runtime guidance for harness-specific options and session compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->