### PR TITLE
feat: add comprehensive startup doctor

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,10 @@ _Avoid_: Reconciliation, recovery
 A typed fail-closed refusal that reports the agreement state and discovered discrepancies without claiming that the run was recovered; issue #21 supersedes it with complete reconciliation.
 _Avoid_: Recovered run, automatic continuation
 
+**Startup diagnosis**:
+A complete pre-claim report of host configuration, external access, repository, terminal, worker, harness, authentication, and operational-store readiness. Every subsystem contributes its own bounded check, and the doctor reports all failures before a run can start.
+_Avoid_: First failure, mid-run diagnosis
+
 **Gate**:
 A repository-declared deterministic command whose result is tied to an exact checkpoint and does not depend on model judgment.
 _Avoid_: Agent check, review

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -332,9 +332,9 @@ Answer commands normally use `/factory answer <question-id> <answer>`; the
 identifier may also be written as `question=`, `question-id=`, or `id=` for
 automation clients, and an answer may begin with `answer=`.
 
-The command grammar also names `claude` for forward-compatible parsing, but the
-current implementation role has only the Codex adapter; selecting Claude is a
-typed `harness_unavailable` rejection until its later adapter is delivered.
+The command grammar and current implementation support both the Codex and Claude
+adapters. A selected harness is still validated against the frozen role policy
+and the startup capability check before an issue can be claimed.
 
 Each comment is processed at most once. The operational store persists a
 monotonic run revision, the processed comment ID watermark, and the revision at

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,8 @@ capabilities, harness authentication sources, and SQLite. It runs every
 contributor even after a failure and returns a nonzero exit status when any
 blocking prerequisite remains. Each failure includes a bounded problem and a
 corrective action; command output and credential contents are never rendered.
+The SQLite check opens the existing store read-only; it does not create,
+migrate, back up, chmod, or initialize store state.
 Missing optional host credential files are warnings because a harness may be
 authenticated during its first visible worker session.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,22 @@ factory status --config /Users/me/.config/factory/config.yaml
 
 `factory register` creates the SQLite store before it writes the registration. It does not contact GitHub, create labels, or write into the registered repository.
 
+Before claiming an issue, run the complete startup diagnosis:
+
+```sh
+factory doctor --config /Users/me/.config/factory/config.yaml
+```
+
+The doctor reports configuration, GitHub authentication and permissions, the
+factory labels, the checkout's remote/hooks/worktree support, cmux, Docker,
+the pinned worker image, both supported harness executables, interactive-resume
+capabilities, harness authentication sources, and SQLite. It runs every
+contributor even after a failure and returns a nonzero exit status when any
+blocking prerequisite remains. Each failure includes a bounded problem and a
+corrective action; command output and credential contents are never rendered.
+Missing optional host credential files are warnings because a harness may be
+authenticated during its first visible worker session.
+
 ## Host configuration
 
 The generated host file contains the repository path, GitHub identity, authorized maintainers, polling settings, cmux settings, the checked-in repository configuration path, and the operational-data path.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
 	"github.com/Stevie1704/sw-factory/internal/factory"
 	"github.com/Stevie1704/sw-factory/internal/store"
 )
@@ -30,6 +31,7 @@ var commandTable = []commandDefinition{
 	{name: "init", handler: runInit},
 	{name: "register", handler: runRegister},
 	{name: "bootstrap-labels", handler: runBootstrapLabels},
+	{name: "doctor", handler: runDoctor},
 	{name: "issue", handler: runIssue},
 	{name: "agent", handler: runAgent},
 	{name: "agent-report", handler: runAgentReport},
@@ -103,6 +105,47 @@ func runBootstrapLabels(ctx context.Context, args []string, defaultConfigPath st
 		return 1
 	}
 	return 0
+}
+
+// runDoctor renders every startup diagnosis and returns a nonzero status when
+// any blocking prerequisite remains unresolved.
+func runDoctor(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("doctor does not accept positional arguments"))
+		return 2
+	}
+	result, err := factory.New(*configPath).Doctor(ctx)
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	for _, check := range result.Report.Results {
+		if check.Status == doctor.StatusPassed {
+			if !writeOutput(output, errorsOutput, "doctor: %s: passed\n", check.Name) {
+				return 1
+			}
+			continue
+		}
+		if !writeOutput(output, errorsOutput, "doctor: %s: %s\nproblem: %s\naction: %s\n", check.Name, check.Status, check.Problem, check.Action) {
+			return 1
+		}
+	}
+	if result.Ready() {
+		if !writeOutput(output, errorsOutput, "doctor: ready\n") {
+			return 1
+		}
+		return 0
+	}
+	if !writeOutput(output, errorsOutput, "doctor: blocked\n") {
+		return 1
+	}
+	return 1
 }
 
 // runIssue handles the one-shot issue claim command.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -158,6 +158,22 @@ func TestRunStatusRejectsPositionalArguments(t *testing.T) {
 	}
 }
 
+// TestRunDoctorRejectsPositionalArguments keeps startup diagnosis configuration
+// explicit and avoids treating an accidental path as a second command input.
+func TestRunDoctorRejectsPositionalArguments(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	var output bytes.Buffer
+	code := cli.Run(context.Background(), []string{"doctor", "extra", "--config", configPath}, &output, &output)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2, output = %s", code, output.String())
+	}
+	if !strings.Contains(output.String(), "doctor does not accept positional arguments") {
+		t.Fatalf("output = %q", output.String())
+	}
+}
+
 // TestRunDraftPullRequestRejectsPositionalArguments verifies the draft-PR
 // command keeps run selection explicit and unambiguous.
 func TestRunDraftPullRequestRejectsPositionalArguments(t *testing.T) {

--- a/internal/config/doctor.go
+++ b/internal/config/doctor.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// DoctorState contains the validated configuration projections needed by
+// other startup-check contributors. Invalid projections remain nil so the
+// coordinator can report dependent failures without guessing values.
+type DoctorState struct {
+	// ConfigPath is the host configuration path being diagnosed.
+	ConfigPath string
+	// Host is the validated host configuration when available.
+	Host HostConfig
+	// Registration is the one registered repository when available.
+	Registration *RepositoryRegistration
+	// Repository is the checked-in repository policy when available.
+	Repository *RepositoryConfig
+	problem    string
+	action     string
+}
+
+// StartupCheck loads and validates host-local and repository configuration
+// once, returning the safe state used to compose the remaining checks.
+func StartupCheck(path string) (DoctorState, doctor.Check) {
+	state := inspectDoctorState(path)
+	return state, func(context.Context) doctor.Result {
+		if state.problem != "" {
+			return doctor.Failure("configuration", state.problem, state.action)
+		}
+		return doctor.Success("configuration")
+	}
+}
+
+// inspectDoctorState performs the configuration-owned read-only diagnosis.
+func inspectDoctorState(path string) DoctorState {
+	state := DoctorState{ConfigPath: path}
+	if strings.TrimSpace(path) == "" {
+		state.problem = "host-local configuration path is not configured"
+		state.action = "set FACTORY_CONFIG or pass --config to a readable host configuration"
+		return state
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		state.problem = "host-local configuration cannot be read"
+		state.action = "run factory init for the configured host configuration path"
+		return state
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		state.problem = "host-local configuration is not a regular file"
+		state.action = "replace the host configuration with a regular private file"
+		return state
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		state.problem = "host-local configuration is not private"
+		state.action = "restrict the host configuration to owner read/write permissions"
+		return state
+	}
+	host, err := LoadHost(path)
+	if err != nil {
+		state.problem = "host-local configuration is missing or invalid"
+		state.action = "repair the host configuration schema and registration fields"
+		return state
+	}
+	state.Host = host
+	if len(host.Repositories) == 0 {
+		state.problem = "no repository is registered"
+		state.action = "run factory register for the repository this coordinator should operate"
+		return state
+	}
+	registration := host.Repositories[0]
+	state.Registration = &registration
+	if !pathWithin(registration.Path, registration.RepositoryConfigPath) {
+		state.problem = "repository configuration is outside the registered repository"
+		state.action = "point repository_config_path at the checked-in factory.yaml inside the repository"
+		return state
+	}
+	configInfo, err := os.Lstat(registration.RepositoryConfigPath)
+	if err != nil || configInfo.Mode()&os.ModeSymlink != 0 || !configInfo.Mode().IsRegular() {
+		state.problem = "checked-in repository configuration is not a regular file"
+		state.action = "restore a regular factory.yaml inside the registered repository checkout"
+		return state
+	}
+	repository, err := LoadRepository(registration.RepositoryConfigPath)
+	if err != nil {
+		state.problem = "checked-in repository configuration is missing or invalid"
+		state.action = "repair the repository factory.yaml and its declared workflow policy"
+		return state
+	}
+	state.Repository = &repository
+	return state
+}
+
+// pathWithin reports whether target is equal to or below root after resolving
+// existing symlinks. Registration validation already requires absolute paths;
+// the repeated check protects diagnosis from a hand-edited host file.
+func pathWithin(root, target string) bool {
+	relative, err := filepath.Rel(resolvePath(root), resolvePath(target))
+	if err != nil {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}
+
+// resolvePath resolves existing path components while preserving unresolved
+// trailing components, so a not-yet-created target can still be checked.
+func resolvePath(path string) string {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	suffix := []string{}
+	current := absolute
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for index := len(suffix) - 1; index >= 0; index-- {
+				resolved = filepath.Join(resolved, suffix[index])
+			}
+			return filepath.Clean(resolved)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return absolute
+		}
+		suffix = append(suffix, filepath.Base(current))
+		current = parent
+	}
+}

--- a/internal/config/doctor_test.go
+++ b/internal/config/doctor_test.go
@@ -1,0 +1,190 @@
+package config_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// TestStartupCheckLoadsTheRegisteredRepositoryPolicy verifies a healthy host
+// configuration exposes the registration and repository policy to composition.
+func TestStartupCheckLoadsTheRegisteredRepositoryPolicy(t *testing.T) {
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDoctorRepositoryConfig(t, repositoryPath)
+	hostPath := filepath.Join(root, "config.yaml")
+	host := `schema_version: 1
+repositories:
+  - path: ` + repositoryPath + `
+    github:
+      owner: example
+      repository: project
+    authorized_users: [alice]
+    polling:
+      interval: 30s
+      backoff: 5m
+    operational_data_path: ` + filepath.Join(root, "state", "factory.db") + `
+    repository_config_path: ` + filepath.Join(repositoryPath, "factory.yaml") + `
+`
+	if err := os.WriteFile(hostPath, []byte(host), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, check := config.StartupCheck(hostPath)
+	result := check(context.Background())
+	if result.Status != doctor.StatusPassed {
+		t.Fatalf("startup result = %#v, want passed", result)
+	}
+	if state.Registration == nil || state.Repository == nil {
+		t.Fatalf("startup state = %#v, want registration and repository policy", state)
+	}
+	if state.Registration.GitHub.Repository != "project" || state.Repository.TargetBranch != "main" {
+		t.Fatalf("startup state = %#v, want registered project and main target", state)
+	}
+}
+
+// TestStartupCheckReportsAnInvalidRepositoryPolicyWithoutRawDetails verifies
+// configuration failures stay actionable without printing file contents.
+func TestStartupCheckReportsAnInvalidRepositoryPolicyWithoutRawDetails(t *testing.T) {
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secret := "do-not-print-this-value"
+	if err := os.WriteFile(filepath.Join(repositoryPath, "factory.yaml"), []byte("schema_version: 1\ntarget_branch: \""+secret+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hostPath := filepath.Join(root, "config.yaml")
+	host := `schema_version: 1
+repositories:
+  - path: ` + repositoryPath + `
+    github:
+      owner: example
+      repository: project
+    authorized_users: [alice]
+    polling:
+      interval: 30s
+      backoff: 5m
+    operational_data_path: ` + filepath.Join(root, "state", "factory.db") + `
+    repository_config_path: ` + filepath.Join(repositoryPath, "factory.yaml") + `
+`
+	if err := os.WriteFile(hostPath, []byte(host), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, check := config.StartupCheck(hostPath)
+	result := check(context.Background())
+	if result.Status != doctor.StatusFailed || !strings.Contains(result.Problem, "repository") {
+		t.Fatalf("startup result = %#v, want repository configuration failure", result)
+	}
+	if strings.Contains(result.Problem+result.Action, secret) {
+		t.Fatalf("startup result exposed configuration content: %#v", result)
+	}
+}
+
+// TestStartupCheckRejectsAGroupReadableHostConfiguration verifies the host
+// file containing credential paths remains private to the operator.
+func TestStartupCheckRejectsAGroupReadableHostConfiguration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("schema_version: 1\nrepositories: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, check := config.StartupCheck(path)
+	result := check(context.Background())
+	if result.Status != doctor.StatusFailed || !strings.Contains(result.Problem, "private") {
+		t.Fatalf("startup result = %#v, want private host configuration failure", result)
+	}
+}
+
+// TestStartupCheckRejectsASymlinkedRepositoryConfiguration verifies the
+// repository policy remains checked-in rather than redirecting diagnosis to a
+// host-local file outside the checkout.
+func TestStartupCheckRejectsASymlinkedRepositoryConfiguration(t *testing.T) {
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	externalPath := filepath.Join(root, "external-factory.yaml")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(externalPath, []byte("schema_version: 1\ntarget_branch: main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalPath, filepath.Join(repositoryPath, "factory.yaml")); err != nil {
+		t.Fatal(err)
+	}
+	hostPath := filepath.Join(root, "config.yaml")
+	host := `schema_version: 1
+repositories:
+  - path: ` + repositoryPath + `
+    github:
+      owner: example
+      repository: project
+    authorized_users: [alice]
+    polling:
+      interval: 30s
+      backoff: 5m
+    operational_data_path: ` + filepath.Join(root, "state", "factory.db") + `
+    repository_config_path: ` + filepath.Join(repositoryPath, "factory.yaml") + `
+`
+	if err := os.WriteFile(hostPath, []byte(host), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, check := config.StartupCheck(hostPath)
+	result := check(context.Background())
+	if result.Status != doctor.StatusFailed || (!strings.Contains(result.Problem, "outside") && !strings.Contains(result.Problem, "regular file")) {
+		t.Fatalf("startup result = %#v, want symlink refusal", result)
+	}
+}
+
+// writeDoctorRepositoryConfig writes the smallest valid repository policy for
+// configuration startup tests.
+func writeDoctorRepositoryConfig(t *testing.T, repositoryPath string) {
+	t.Helper()
+	contents := `schema_version: 1
+target_branch: main
+setup: go mod download
+setup_environment_policy: clean
+gates:
+  - name: test
+    command: go test ./...
+    timeout: 5m
+    blocking: true
+    environment_policy: clean
+role_harness_defaults:
+  test: codex
+  implementation: codex
+model_options:
+  test: [gpt-5]
+  implementation: [gpt-5]
+timeouts:
+  setup: 5m
+  agent: 30m
+  gate: 5m
+  review: 10m
+retry_limits:
+  check_repair: 3
+  review_repair: 2
+  test_revision: 2
+test_policy:
+  mode: required
+worker_build:
+  image: ghcr.io/example/factory-worker
+  digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  definition: worker/Dockerfile
+base_synchronization:
+  mode: never
+`
+	if err := os.WriteFile(filepath.Join(repositoryPath, "factory.yaml"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,115 @@
+// Package doctor contains the neutral startup-diagnosis result and composition
+// seam. Subsystem packages contribute checks; this package only runs them and
+// reports whether any check blocks a factory run.
+package doctor
+
+import "context"
+
+// Status is the outcome class of one startup check.
+type Status string
+
+const (
+	// StatusPassed means the check found the subsystem ready.
+	StatusPassed Status = "passed"
+	// StatusWarning means the check found an operator action that is not a
+	// blocking prerequisite for the current configuration.
+	StatusWarning Status = "warning"
+	// StatusFailed means the subsystem is not safe to use for a factory run.
+	StatusFailed Status = "failed"
+)
+
+// Result is one bounded, operator-facing startup diagnosis. Problem and
+// Action are deliberately separate so every failure explains both what is
+// wrong and how to correct it.
+type Result struct {
+	// Name identifies the subsystem and check being diagnosed.
+	Name string
+	// Status is passed, warning, or failed.
+	Status Status
+	// Problem describes the observed issue without command output or secrets.
+	Problem string
+	// Action describes the corrective operator action.
+	Action string
+}
+
+// Check is a subsystem-owned startup check. Checks must return a bounded
+// Result rather than exposing raw process output to the coordinator or CLI.
+type Check func(context.Context) Result
+
+// Report contains every check result in the order supplied to Run.
+type Report struct {
+	// Results contains successful, warning, and failed checks.
+	Results []Result
+}
+
+// Success creates a passing result for one named subsystem check.
+func Success(name string) Result {
+	return Result{Name: name, Status: StatusPassed}
+}
+
+// Warning creates a non-blocking result with an operator-visible action.
+func Warning(name, problem, action string) Result {
+	return Result{Name: name, Status: StatusWarning, Problem: problem, Action: action}
+}
+
+// Failure creates a blocking result with an operator-visible action.
+func Failure(name, problem, action string) Result {
+	return Result{Name: name, Status: StatusFailed, Problem: problem, Action: action}
+}
+
+// Run executes every supplied check, including checks after a failure, and
+// preserves the deterministic contribution order for CLI output.
+func Run(ctx context.Context, checks ...Check) Report {
+	results := make([]Result, 0, len(checks))
+	for _, check := range checks {
+		if check == nil {
+			results = append(results, Failure("diagnosis", "a startup check was not configured", "configure the missing subsystem check"))
+			continue
+		}
+		result := check(ctx)
+		if result.Name == "" {
+			result.Name = "diagnosis"
+		}
+		if result.Status != StatusPassed && result.Status != StatusWarning && result.Status != StatusFailed {
+			result = Failure(result.Name, "the startup check returned an invalid result", "repair the check implementation before starting the factory")
+		} else if result.Status != StatusPassed && (result.Problem == "" || result.Action == "") {
+			result.Problem = "the startup check did not provide a complete diagnosis"
+			result.Action = "repair the check implementation before starting the factory"
+		}
+		results = append(results, result)
+	}
+	return Report{Results: results}
+}
+
+// Ready reports whether no check blocks startup. Warnings are intentionally
+// non-blocking and remain visible in the report.
+func (r Report) Ready() bool {
+	for _, result := range r.Results {
+		if result.Status == StatusFailed {
+			return false
+		}
+	}
+	return true
+}
+
+// Failures returns all blocking results without changing their order.
+func (r Report) Failures() []Result {
+	return resultsWithStatus(r.Results, StatusFailed)
+}
+
+// Warnings returns all non-blocking warning results without changing their
+// order.
+func (r Report) Warnings() []Result {
+	return resultsWithStatus(r.Results, StatusWarning)
+}
+
+// resultsWithStatus selects one result status while preserving report order.
+func resultsWithStatus(results []Result, status Status) []Result {
+	selected := make([]Result, 0)
+	for _, result := range results {
+		if result.Status == status {
+			selected = append(selected, result)
+		}
+	}
+	return selected
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,54 @@
+package doctor_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// TestRunExecutesEveryCheckInDeclaredOrder verifies one failed check does not
+// prevent later subsystem checks from reporting their own result.
+func TestRunExecutesEveryCheckInDeclaredOrder(t *testing.T) {
+	var executed []string
+	report := doctor.Run(context.Background(),
+		func(context.Context) doctor.Result {
+			executed = append(executed, "configuration")
+			return doctor.Failure("configuration", "host configuration is invalid", "repair the host configuration")
+		},
+		func(context.Context) doctor.Result {
+			executed = append(executed, "docker")
+			return doctor.Success("docker")
+		},
+		func(context.Context) doctor.Result {
+			executed = append(executed, "authentication")
+			return doctor.Warning("authentication", "no host credential source is configured", "authenticate the harness interactively")
+		},
+	)
+
+	if want := []string{"configuration", "docker", "authentication"}; !reflect.DeepEqual(executed, want) {
+		t.Fatalf("executed checks = %#v, want %#v", executed, want)
+	}
+	if report.Ready() {
+		t.Fatal("report with a failure is ready")
+	}
+	if got := len(report.Failures()); got != 1 {
+		t.Fatalf("failure count = %d, want one", got)
+	}
+	if got := len(report.Warnings()); got != 1 {
+		t.Fatalf("warning count = %d, want one", got)
+	}
+}
+
+// TestResultConstructorsPreserveActionableFailureDetails verifies a rendered
+// result contains the subsystem, problem, and corrective action fields.
+func TestResultConstructorsPreserveActionableFailureDetails(t *testing.T) {
+	result := doctor.Failure("GitHub permissions", "repository write permission is unavailable", "grant repository issue, contents, pull-request, and status permissions")
+	if result.Name != "GitHub permissions" || result.Status != doctor.StatusFailed {
+		t.Fatalf("result identity = %#v, want failed GitHub permissions", result)
+	}
+	if result.Problem == "" || result.Action == "" {
+		t.Fatalf("result = %#v, want problem and action", result)
+	}
+}

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/store"
 )
 
@@ -142,6 +143,9 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 	repositoryConfig, err := s.deps.LoadRepository(registration.RepositoryConfigPath)
 	if err != nil {
 		return IssueResult{}, fmt.Errorf("load repository configuration: %w", err)
+	}
+	if err := harness.ValidateInteractiveResumeCapabilities(repositoryConfig, s.deps.HarnessCapabilities); err != nil {
+		return IssueResult{}, fmt.Errorf("validate harness capabilities before claim: %w", err)
 	}
 	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
 	if current != nil {

--- a/internal/factory/claim_test.go
+++ b/internal/factory/claim_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/factory"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/store"
 )
 
@@ -345,6 +346,38 @@ func TestBootstrapLabelsIsTheExplicitLabelCreationPath(t *testing.T) {
 	}
 }
 
+// TestClaimIssueRefusesAnAdapterWithoutInteractiveResumeBeforeGitHubEffects
+// verifies the startup capability guard runs before an issue is read or a
+// worktree is created.
+func TestClaimIssueRefusesAnAdapterWithoutInteractiveResumeBeforeGitHubEffects(t *testing.T) {
+	t.Parallel()
+
+	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentReady}}}
+	worktree := &fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed"}}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfig{value: config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+			Path: "/repo", GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+			AuthorizedUsers: []string{"alice"}, Polling: config.PollingConfig{Interval: "30s", Backoff: "5m"},
+			OperationalDataPath: "/outside/factory.db", RepositoryConfigPath: "/repo/factory.yaml",
+		}}}},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return &fakeRunStore{}, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return validRepositoryConfig(), nil },
+		GitHub:         githubAdapter,
+		Worktree:       worktree,
+		HarnessCapabilities: func(string) (harness.Capabilities, error) {
+			return harness.Capabilities{Name: harness.NameCodex}, nil
+		},
+	})
+
+	_, err := service.ClaimIssue(context.Background(), 42)
+	if err == nil || !strings.Contains(err.Error(), "interactive resume") {
+		t.Fatalf("ClaimIssue() error = %v, want interactive-resume refusal", err)
+	}
+	if githubAdapter.issueCalls != 0 || worktree.called {
+		t.Fatalf("claim effects: issue calls=%d worktree=%t, want none", githubAdapter.issueCalls, worktree.called)
+	}
+}
+
 // newClaimService constructs a deterministic service for claim seam tests.
 func newClaimService(githubAdapter *fakeGitHub, worktree *fakeWorktree, runStore *fakeRunStore, repositoryConfig config.RepositoryConfig) *factory.Service {
 	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
@@ -404,6 +437,7 @@ func validRepositoryConfig() config.RepositoryConfig {
 type fakeGitHub struct {
 	issueValue       github.Issue
 	issueErr         error
+	issueCalls       int
 	createdLabels    []github.Label
 	replacedLabels   []string
 	replacedHistory  [][]string
@@ -416,6 +450,7 @@ type fakeGitHub struct {
 
 // Issue returns the configured issue snapshot.
 func (f *fakeGitHub) Issue(context.Context, github.Repository, int) (github.Issue, error) {
+	f.issueCalls++
 	if f.issueErr != nil {
 		return github.Issue{}, f.issueErr
 	}

--- a/internal/factory/doctor.go
+++ b/internal/factory/doctor.go
@@ -1,0 +1,130 @@
+package factory
+
+import (
+	"context"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// DoctorResult contains the complete neutral startup diagnosis for the
+// configured repository. A report is returned even when checks fail so one
+// invocation exposes every corrective action.
+type DoctorResult struct {
+	// Report contains all subsystem contributions in deterministic order.
+	Report doctor.Report
+}
+
+// Ready reports whether the diagnosis contains no blocking check.
+func (r DoctorResult) Ready() bool {
+	return r.Report.Ready()
+}
+
+// Doctor composes subsystem-owned checks without embedding their command or
+// protocol knowledge in the factory coordinator.
+func (s *Service) Doctor(ctx context.Context) (DoctorResult, error) {
+	configuration, configurationCheck := config.StartupCheck(s.configPath)
+	checks := []doctor.Check{configurationCheck}
+
+	registration := config.RepositoryRegistration{}
+	if configuration.Registration != nil {
+		registration = *configuration.Registration
+	}
+	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	repositoryPolicy := configuration.Repository
+	image := worker.ImageReference{}
+	if repositoryPolicy != nil {
+		image = worker.ImageReference{
+			Name:   repositoryPolicy.WorkerBuild.Image,
+			Digest: repositoryPolicy.WorkerBuild.Digest,
+		}
+	}
+
+	checks = append(checks, github.StartupChecks(s.doctorGitHub(), repository)...)
+	checks = append(checks, gitadapter.StartupChecks(s.doctorGitWorkspace(), gitadapter.DoctorRequest{
+		RepositoryPath:     registration.Path,
+		RemoteName:         gitadapter.DefaultRemoteName,
+		ExpectedOwner:      registration.GitHub.Owner,
+		ExpectedRepository: registration.GitHub.Repository,
+		TargetBranch:       targetBranch(repositoryPolicy),
+	})...)
+
+	terminalChecker := s.deps.Terminal
+	if terminalChecker == nil {
+		terminalChecker = terminal.NewCmuxRuntime(nil, registration.Cmux.SocketPath)
+	}
+	checks = append(checks, terminal.StartupChecks(asTerminalDoctorChecker(terminalChecker))...)
+
+	checks = append(checks, worker.StartupChecks(s.doctorWorker(), image)...)
+	checks = append(checks, harness.StartupChecks(harness.StartupRequest{
+		Policy:                repositoryPolicy,
+		Authentication:        registration.Authentication,
+		Image:                 image,
+		Checker:               s.doctorHarnessChecker(),
+		AuthenticationChecker: s.doctorHarnessAuthenticationChecker(),
+		Resolve:               s.deps.HarnessCapabilities,
+	})...)
+	checks = append(checks, store.StartupCheck(registration.OperationalDataPath))
+
+	return DoctorResult{Report: doctor.Run(ctx, checks...)}, nil
+}
+
+// doctorGitHub resolves the read-only GitHub diagnosis seam.
+func (s *Service) doctorGitHub() github.DoctorClient {
+	checker, _ := s.deps.GitHub.(github.DoctorClient)
+	return checker
+}
+
+// doctorGitWorkspace resolves the read-only Git diagnosis seam from the
+// task-oriented workspace first, then the creation-only compatibility seam.
+func (s *Service) doctorGitWorkspace() gitadapter.DoctorChecker {
+	if checker, ok := s.deps.GitWorkspace.(gitadapter.DoctorChecker); ok {
+		return checker
+	}
+	checker, _ := s.deps.Worktree.(gitadapter.DoctorChecker)
+	return checker
+}
+
+// asTerminalDoctorChecker resolves terminal diagnosis without expanding the
+// portable TerminalRuntime interface for callers that provide their own
+// adapter.
+func asTerminalDoctorChecker(runtime terminal.TerminalRuntime) terminal.DoctorChecker {
+	checker, _ := runtime.(terminal.DoctorChecker)
+	return checker
+}
+
+// doctorWorker resolves the worker daemon and image diagnosis seam.
+func (s *Service) doctorWorker() worker.DoctorChecker {
+	checker, _ := s.deps.Worker.(worker.DoctorChecker)
+	return checker
+}
+
+// doctorHarnessChecker resolves the worker-owned executable probe seam.
+func (s *Service) doctorHarnessChecker() worker.HarnessChecker {
+	checker, _ := s.deps.Worker.(worker.HarnessChecker)
+	return checker
+}
+
+// doctorHarnessAuthenticationChecker resolves the worker-owned credential
+// probe seam.
+func (s *Service) doctorHarnessAuthenticationChecker() worker.HarnessAuthenticationChecker {
+	checker, _ := s.deps.Worker.(worker.HarnessAuthenticationChecker)
+	return checker
+}
+
+// targetBranch extracts the checked-in branch while leaving dependent checks
+// empty when repository configuration was unavailable.
+func targetBranch(policy *config.RepositoryConfig) string {
+	if policy == nil {
+		return ""
+	}
+	return policy.TargetBranch
+}
+
+var _ Factory = (*Service)(nil)

--- a/internal/factory/doctor_test.go
+++ b/internal/factory/doctor_test.go
@@ -1,0 +1,233 @@
+package factory_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestDoctorComposesEverySubsystemAndKeepsOptionalAuthNonBlocking verifies
+// the high-level coordinator reports all contributors in one invocation.
+func TestDoctorComposesEverySubsystemAndKeepsOptionalAuthNonBlocking(t *testing.T) {
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRepositoryConfig(t, repositoryPath)
+	configPath := filepath.Join(root, "host", "config.yaml")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	if err := config.SaveHost(configPath, config.HostConfig{
+		SchemaVersion: config.CurrentSchemaVersion,
+		Repositories: []config.RepositoryRegistration{{
+			Path:                 repositoryPath,
+			GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+			AuthorizedUsers:      []string{"alice"},
+			Polling:              config.PollingConfig{Interval: "30s", Backoff: "5m"},
+			OperationalDataPath:  operationalPath,
+			RepositoryConfigPath: filepath.Join(repositoryPath, config.RepositoryConfigFileName),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	gitWorkspace := &factoryDoctorGitWorkspace{}
+	workerRuntime := &factoryDoctorWorker{}
+	terminalRuntime := &factoryDoctorTerminal{}
+	service := factory.NewWithDependencies(configPath, factory.Dependencies{
+		GitHub:       &fakeGitHub{},
+		GitWorkspace: gitWorkspace,
+		Worktree:     gitWorkspace,
+		Worker:       workerRuntime,
+		Terminal:     terminalRuntime,
+	})
+
+	result, err := service.Doctor(context.Background())
+	if err != nil {
+		t.Fatalf("Doctor() error = %v", err)
+	}
+	if !result.Ready() || len(result.Report.Failures()) != 0 || len(result.Report.Warnings()) != 2 {
+		t.Fatalf("Doctor() report = %#v, want ready with two auth warnings", result.Report)
+	}
+	wantNames := []string{
+		"configuration",
+		"github authentication", "github permissions", "github labels",
+		"git remote", "git hooks", "git worktree",
+		"cmux executable", "cmux socket",
+		"docker daemon", "worker image",
+		"harness capability", "claude worker executable", "codex worker executable",
+		"codex authentication", "claude authentication", "SQLite",
+	}
+	if len(result.Report.Results) != len(wantNames) {
+		t.Fatalf("Doctor() check count = %d, want %d (%#v)", len(result.Report.Results), len(wantNames), result.Report.Results)
+	}
+	for index, name := range wantNames {
+		if result.Report.Results[index].Name != name {
+			t.Fatalf("Doctor() result[%d].Name = %q, want %q", index, result.Report.Results[index].Name, name)
+		}
+	}
+	if workerRuntime.harnessCalls != 2 {
+		t.Fatalf("harness probes = %d, want both built-in harnesses", workerRuntime.harnessCalls)
+	}
+}
+
+// CheckAuthentication implements the read-only GitHub diagnosis seam.
+func (*fakeGitHub) CheckAuthentication(context.Context) error { return nil }
+
+// CheckRepositoryAccess implements the read-only GitHub diagnosis seam.
+func (*fakeGitHub) CheckRepositoryAccess(context.Context, github.Repository) error { return nil }
+
+// CheckFactoryLabels implements the read-only GitHub diagnosis seam.
+func (*fakeGitHub) CheckFactoryLabels(context.Context, github.Repository) error { return nil }
+
+// factoryDoctorGitWorkspace implements the task-oriented Git and diagnosis
+// seams without making host Git calls in the composition test.
+type factoryDoctorGitWorkspace struct{}
+
+// Create implements the worktree manager seam.
+func (*factoryDoctorGitWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	return gitadapter.Workspace{}, nil
+}
+
+// Remove implements the worktree manager seam.
+func (*factoryDoctorGitWorkspace) Remove(context.Context, string, gitadapter.Workspace) error {
+	return nil
+}
+
+// Inspect implements the worktree observation seam.
+func (*factoryDoctorGitWorkspace) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	return gitadapter.WorktreeState{}, nil
+}
+
+// CreateCheckpoint implements the checkpoint seam.
+func (*factoryDoctorGitWorkspace) CreateCheckpoint(context.Context, gitadapter.CheckpointRequest) (gitadapter.CheckpointResult, error) {
+	return gitadapter.CheckpointResult{}, nil
+}
+
+// Push implements the host push seam.
+func (*factoryDoctorGitWorkspace) Push(context.Context, gitadapter.PushRequest) error { return nil }
+
+// SynchronizeBase implements the base synchronization seam.
+func (*factoryDoctorGitWorkspace) SynchronizeBase(context.Context, gitadapter.BaseSyncRequest) error {
+	return nil
+}
+
+// CheckRemote implements the read-only Git diagnosis seam.
+func (*factoryDoctorGitWorkspace) CheckRemote(context.Context, gitadapter.DoctorRequest) error {
+	return nil
+}
+
+// CheckHooks implements the read-only Git diagnosis seam.
+func (*factoryDoctorGitWorkspace) CheckHooks(context.Context, gitadapter.DoctorRequest) error {
+	return nil
+}
+
+// CheckWorktree implements the read-only Git diagnosis seam.
+func (*factoryDoctorGitWorkspace) CheckWorktree(context.Context, gitadapter.DoctorRequest) error {
+	return nil
+}
+
+// factoryDoctorWorker implements worker lifecycle and diagnosis seams for the
+// composition test.
+type factoryDoctorWorker struct {
+	harnessCalls int
+}
+
+// Start implements WorkerRuntime.
+func (*factoryDoctorWorker) Start(context.Context, worker.StartRequest) error { return nil }
+
+// Resume implements WorkerRuntime.
+func (*factoryDoctorWorker) Resume(context.Context, worker.ResumeRequest) error { return nil }
+
+// RunCommand implements WorkerRuntime.
+func (*factoryDoctorWorker) RunCommand(context.Context, worker.CommandRequest) (worker.CommandResult, error) {
+	return worker.CommandResult{}, nil
+}
+
+// Stop implements WorkerRuntime.
+func (*factoryDoctorWorker) Stop(context.Context, string) error { return nil }
+
+// Inspect implements WorkerRuntime.
+func (*factoryDoctorWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+	return worker.Inspection{}, nil
+}
+
+// CheckDocker implements the read-only worker diagnosis seam.
+func (*factoryDoctorWorker) CheckDocker(context.Context) error { return nil }
+
+// CheckImage implements the read-only worker diagnosis seam.
+func (*factoryDoctorWorker) CheckImage(context.Context, worker.ImageReference) error { return nil }
+
+// CheckHarness implements the worker-owned harness executable probe seam.
+func (w *factoryDoctorWorker) CheckHarness(context.Context, worker.HarnessCheckRequest) error {
+	w.harnessCalls++
+	return nil
+}
+
+// CheckHarnessAuthentication implements the worker-owned credential probe
+// seam.
+func (*factoryDoctorWorker) CheckHarnessAuthentication(context.Context, worker.HarnessAuthenticationCheckRequest) error {
+	return nil
+}
+
+// factoryDoctorTerminal implements terminal lifecycle and diagnosis seams for
+// the composition test.
+type factoryDoctorTerminal struct{}
+
+// EnsureControlWorkspace implements TerminalRuntime.
+func (*factoryDoctorTerminal) EnsureControlWorkspace(context.Context, terminal.WorkspaceRequest) (terminal.Workspace, error) {
+	return terminal.Workspace{}, nil
+}
+
+// EnsureRunWorkspace implements TerminalRuntime.
+func (*factoryDoctorTerminal) EnsureRunWorkspace(context.Context, terminal.RunWorkspaceRequest) (terminal.RunWorkspace, error) {
+	return terminal.RunWorkspace{}, nil
+}
+
+// CreateSurface implements TerminalRuntime.
+func (*factoryDoctorTerminal) CreateSurface(context.Context, terminal.SurfaceRequest) (terminal.Surface, error) {
+	return terminal.Surface{}, nil
+}
+
+// LaunchSurface implements TerminalRuntime.
+func (*factoryDoctorTerminal) LaunchSurface(context.Context, terminal.SurfaceID, terminal.Command) error {
+	return nil
+}
+
+// SendInput implements TerminalRuntime.
+func (*factoryDoctorTerminal) SendInput(context.Context, terminal.SurfaceID, []byte) error {
+	return nil
+}
+
+// Notify implements TerminalRuntime.
+func (*factoryDoctorTerminal) Notify(context.Context, terminal.Notification) error { return nil }
+
+// CloseSurface implements TerminalRuntime.
+func (*factoryDoctorTerminal) CloseSurface(context.Context, terminal.SurfaceID) error { return nil }
+
+// CloseWorkspace implements TerminalRuntime.
+func (*factoryDoctorTerminal) CloseWorkspace(context.Context, terminal.WorkspaceID) error { return nil }
+
+// CheckExecutable implements the read-only cmux diagnosis seam.
+func (*factoryDoctorTerminal) CheckExecutable(context.Context) error { return nil }
+
+// CheckSocket implements the read-only cmux diagnosis seam.
+func (*factoryDoctorTerminal) CheckSocket(context.Context) error { return nil }
+
+var _ github.DoctorClient = (*fakeGitHub)(nil)
+var _ gitadapter.GitWorkspace = (*factoryDoctorGitWorkspace)(nil)
+var _ gitadapter.DoctorChecker = (*factoryDoctorGitWorkspace)(nil)
+var _ worker.WorkerRuntime = (*factoryDoctorWorker)(nil)
+var _ worker.DoctorChecker = (*factoryDoctorWorker)(nil)
+var _ worker.HarnessChecker = (*factoryDoctorWorker)(nil)
+var _ worker.HarnessAuthenticationChecker = (*factoryDoctorWorker)(nil)
+var _ terminal.TerminalRuntime = (*factoryDoctorTerminal)(nil)
+var _ terminal.DoctorChecker = (*factoryDoctorTerminal)(nil)

--- a/internal/factory/doctor_test.go
+++ b/internal/factory/doctor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/factory"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
@@ -37,6 +38,13 @@ func TestDoctorComposesEverySubsystemAndKeepsOptionalAuthNonBlocking(t *testing.
 		}},
 	}); err != nil {
 		t.Fatal(err)
+	}
+	opened, err := store.Open(context.Background(), operationalPath)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("Open().Close() error = %v", err)
 	}
 
 	gitWorkspace := &factoryDoctorGitWorkspace{}

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -26,6 +26,9 @@ type Factory interface {
 	Init(context.Context) (InitResult, error)
 	Register(context.Context, RegisterRequest) (RegisterResult, error)
 	BootstrapLabels(context.Context) (BootstrapLabelsResult, error)
+	// Doctor runs every configured startup diagnosis and reports whether a run
+	// can be claimed safely.
+	Doctor(context.Context) (DoctorResult, error)
 	RunCoordinator
 	// RunBaseline evaluates the frozen repository gate model before agent edits.
 	RunBaseline(context.Context, BaselineRequest) (BaselineResult, error)
@@ -122,10 +125,13 @@ type Dependencies struct {
 	// Terminal owns visible control and run workspaces.
 	Terminal terminal.TerminalRuntime
 	// Harness owns interactive role lifecycle and native session recovery.
-	Harness     harness.Runtime
-	Now         Clock
-	NewRunID    RunIDGenerator
-	Coordinator string
+	Harness harness.Runtime
+	// HarnessCapabilities resolves static adapter capabilities for startup and
+	// claim checks without launching a worker or terminal surface.
+	HarnessCapabilities harness.CapabilityResolver
+	Now                 Clock
+	NewRunID            RunIDGenerator
+	Coordinator         string
 }
 
 type Service struct {
@@ -244,6 +250,9 @@ func NewWithDependencies(configPath string, dependencies Dependencies) *Service 
 	}
 	if dependencies.Worker == nil {
 		dependencies.Worker = worker.NewDockerRuntime()
+	}
+	if dependencies.HarnessCapabilities == nil {
+		dependencies.HarnessCapabilities = harness.CapabilitiesFor
 	}
 	if dependencies.Now == nil {
 		dependencies.Now = func() time.Time { return time.Now().UTC() }

--- a/internal/git/doctor.go
+++ b/internal/git/doctor.go
@@ -125,7 +125,20 @@ func (m *LocalWorktreeManager) CheckRemote(ctx context.Context, request DoctorRe
 		return remoteFailure(remoteFailureCheckout)
 	}
 	root, err := filepath.Abs(strings.TrimSpace(string(rootOutput)))
-	if err != nil || filepath.Clean(root) != filepath.Clean(request.RepositoryPath) {
+	if err != nil {
+		return remoteFailure(remoteFailureRoot)
+	}
+	// Resolve symlinks for both paths before comparing to handle cases like
+	// macOS /tmp vs /private/tmp where symlink-equivalent paths should match.
+	resolvedRoot := root
+	if evalRoot, err := filepath.EvalSymlinks(root); err == nil {
+		resolvedRoot = evalRoot
+	}
+	resolvedRepoPath := request.RepositoryPath
+	if evalRepoPath, err := filepath.EvalSymlinks(request.RepositoryPath); err == nil {
+		resolvedRepoPath = evalRepoPath
+	}
+	if filepath.Clean(resolvedRoot) != filepath.Clean(resolvedRepoPath) {
 		return remoteFailure(remoteFailureRoot)
 	}
 	remoteOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"remote", "get-url", request.RemoteName})

--- a/internal/git/doctor.go
+++ b/internal/git/doctor.go
@@ -50,7 +50,7 @@ type remoteCheckError struct {
 
 // Error returns a bounded error that never includes Git command output.
 func (e *remoteCheckError) Error() string {
-	return "Git remote diagnosis failed"
+	return "git remote diagnosis failed"
 }
 
 // remoteFailure creates one categorized Git remote diagnosis error.

--- a/internal/git/doctor.go
+++ b/internal/git/doctor.go
@@ -27,6 +27,37 @@ type DoctorRequest struct {
 	TargetBranch string
 }
 
+// remoteFailureKind identifies the bounded failure categories rendered by the
+// Git remote diagnosis without retaining command output.
+type remoteFailureKind string
+
+const (
+	remoteFailureConfiguration  remoteFailureKind = "configuration"
+	remoteFailureCheckout       remoteFailureKind = "checkout"
+	remoteFailureRoot           remoteFailureKind = "root"
+	remoteFailureFetchRead      remoteFailureKind = "fetch-read"
+	remoteFailureFetchIdentity  remoteFailureKind = "fetch-identity"
+	remoteFailurePushRead       remoteFailureKind = "push-read"
+	remoteFailurePushIdentity   remoteFailureKind = "push-identity"
+	remoteFailureBranchRead     remoteFailureKind = "branch-read"
+	remoteFailureBranchNoCommit remoteFailureKind = "branch-no-commit"
+)
+
+// remoteCheckError carries only a safe category from one Git remote probe.
+type remoteCheckError struct {
+	kind remoteFailureKind
+}
+
+// Error returns a bounded error that never includes Git command output.
+func (e *remoteCheckError) Error() string {
+	return "Git remote diagnosis failed"
+}
+
+// remoteFailure creates one categorized Git remote diagnosis error.
+func remoteFailure(kind remoteFailureKind) error {
+	return &remoteCheckError{kind: kind}
+}
+
 // DoctorChecker is the Git-owned startup diagnosis seam.
 type DoctorChecker interface {
 	CheckRemote(context.Context, DoctorRequest) error
@@ -42,7 +73,8 @@ func StartupChecks(checker DoctorChecker, request DoctorRequest) []doctor.Check 
 				return doctor.Failure("git remote", "the Git diagnosis adapter is unavailable", "configure the host Git workspace adapter")
 			}
 			if err := checker.CheckRemote(ctx, request); err != nil {
-				return doctor.Failure("git remote", "the registered checkout cannot reach the configured GitHub target", "repair the origin remote and ensure the configured target branch exists")
+				problem, action := remoteDiagnosis(err)
+				return doctor.Failure("git remote", problem, action)
 			}
 			return doctor.Success("git remote")
 		},
@@ -67,54 +99,88 @@ func StartupChecks(checker DoctorChecker, request DoctorRequest) []doctor.Check 
 	}
 }
 
-// CheckRemote verifies the ordinary checkout, its origin identity, and the
-// configured target branch without changing any Git reference.
+// CheckRemote verifies the ordinary checkout, its configured remote identity,
+// and the target branch without changing any Git reference.
 func (m *LocalWorktreeManager) CheckRemote(ctx context.Context, request DoctorRequest) error {
 	if err := validateDoctorRepository(request.RepositoryPath); err != nil {
-		return err
+		return remoteFailure(remoteFailureCheckout)
 	}
 	if strings.TrimSpace(request.RemoteName) == "" {
-		return errors.New("Git remote name is required")
+		return remoteFailure(remoteFailureConfiguration)
+	}
+	if err := validateRefPart(request.RemoteName); err != nil {
+		return remoteFailure(remoteFailureConfiguration)
 	}
 	if strings.TrimSpace(request.ExpectedOwner) == "" || strings.TrimSpace(request.ExpectedRepository) == "" {
-		return errors.New("expected GitHub repository identity is required")
+		return remoteFailure(remoteFailureConfiguration)
 	}
 	if strings.TrimSpace(request.TargetBranch) == "" {
-		return errors.New("Git target branch is required")
+		return remoteFailure(remoteFailureConfiguration)
 	}
 	if err := validateRefPart(request.TargetBranch); err != nil {
-		return fmt.Errorf("Git target branch: %w", err)
+		return remoteFailure(remoteFailureConfiguration)
 	}
 	rootOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"rev-parse", "--show-toplevel"})
 	if err != nil {
-		return fmt.Errorf("inspect Git checkout: %w", err)
+		return remoteFailure(remoteFailureCheckout)
 	}
 	root, err := filepath.Abs(strings.TrimSpace(string(rootOutput)))
 	if err != nil || filepath.Clean(root) != filepath.Clean(request.RepositoryPath) {
-		return errors.New("Git checkout root does not match the registered repository")
+		return remoteFailure(remoteFailureRoot)
 	}
 	remoteOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"remote", "get-url", request.RemoteName})
 	if err != nil {
-		return fmt.Errorf("read Git remote: %w", err)
+		return remoteFailure(remoteFailureFetchRead)
 	}
 	if !remoteMatches(string(remoteOutput), request.ExpectedOwner, request.ExpectedRepository) {
-		return errors.New("Git remote does not identify the registered GitHub repository")
+		return remoteFailure(remoteFailureFetchIdentity)
 	}
 	pushRemoteOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"remote", "get-url", "--push", request.RemoteName})
 	if err != nil {
-		return fmt.Errorf("read Git push remote: %w", err)
+		return remoteFailure(remoteFailurePushRead)
 	}
 	if !remoteMatches(string(pushRemoteOutput), request.ExpectedOwner, request.ExpectedRepository) {
-		return errors.New("Git push remote does not identify the registered GitHub repository")
+		return remoteFailure(remoteFailurePushIdentity)
 	}
 	branchOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"ls-remote", "--exit-code", request.RemoteName, "refs/heads/" + request.TargetBranch})
 	if err != nil {
-		return fmt.Errorf("probe Git target branch: %w", err)
+		return remoteFailure(remoteFailureBranchRead)
 	}
 	if strings.TrimSpace(string(branchOutput)) == "" {
-		return errors.New("Git target branch returned no commit")
+		return remoteFailure(remoteFailureBranchNoCommit)
 	}
 	return nil
+}
+
+// remoteDiagnosis translates one safe Git remote category into the specific
+// problem and corrective action shown by the startup report.
+func remoteDiagnosis(err error) (string, string) {
+	var failure *remoteCheckError
+	if !errors.As(err, &failure) {
+		return "the Git remote diagnosis could not be classified", "repair the registered checkout and configured Git remote, then retry the diagnosis"
+	}
+	switch failure.kind {
+	case remoteFailureConfiguration:
+		return "the Git remote diagnosis request is incomplete or unsafe", "repair the registered repository identity, remote name, and target branch"
+	case remoteFailureCheckout:
+		return "the registered checkout cannot be inspected as a Git repository", "repair the registered checkout path and initialize or restore its Git metadata"
+	case remoteFailureRoot:
+		return "Git resolved a checkout root different from the registered repository", "register the checkout's actual Git root or correct the repository path"
+	case remoteFailureFetchRead:
+		return "the configured Git fetch remote is missing or unreadable", "configure the factory remote and verify the checkout can read it"
+	case remoteFailureFetchIdentity:
+		return "the Git fetch remote does not identify the registered GitHub repository", "set the configured remote's fetch URL to the registered GitHub repository"
+	case remoteFailurePushRead:
+		return "the configured Git push remote is missing or unreadable", "configure a push URL for the factory remote and verify the checkout can read it"
+	case remoteFailurePushIdentity:
+		return "the Git push remote does not identify the registered GitHub repository", "set the configured remote's push URL to the registered GitHub repository"
+	case remoteFailureBranchRead:
+		return "the configured Git target branch cannot be read from the remote", "fetch the target branch and verify network and remote permissions"
+	case remoteFailureBranchNoCommit:
+		return "the configured Git target branch has no commit on the remote", "choose an existing target branch or publish the branch before starting the factory"
+	default:
+		return "the Git remote diagnosis returned an unknown failure", "repair the registered checkout and configured Git remote, then retry the diagnosis"
+	}
 }
 
 // CheckHooks verifies the configured Git hooks path is present and readable.

--- a/internal/git/doctor.go
+++ b/internal/git/doctor.go
@@ -1,0 +1,208 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// DoctorRequest identifies the registered checkout and the GitHub branch it
+// must be able to operate on during a factory run.
+type DoctorRequest struct {
+	// RepositoryPath is the ordinary host checkout.
+	RepositoryPath string
+	// RemoteName is the Git remote used by factory operations.
+	RemoteName string
+	// ExpectedOwner is the registered GitHub owner.
+	ExpectedOwner string
+	// ExpectedRepository is the registered GitHub repository name.
+	ExpectedRepository string
+	// TargetBranch is the branch fetched to begin a run.
+	TargetBranch string
+}
+
+// DoctorChecker is the Git-owned startup diagnosis seam.
+type DoctorChecker interface {
+	CheckRemote(context.Context, DoctorRequest) error
+	CheckHooks(context.Context, DoctorRequest) error
+	CheckWorktree(context.Context, DoctorRequest) error
+}
+
+// StartupChecks returns independent Git remote, hooks, and worktree checks.
+func StartupChecks(checker DoctorChecker, request DoctorRequest) []doctor.Check {
+	return []doctor.Check{
+		func(ctx context.Context) doctor.Result {
+			if checker == nil {
+				return doctor.Failure("git remote", "the Git diagnosis adapter is unavailable", "configure the host Git workspace adapter")
+			}
+			if err := checker.CheckRemote(ctx, request); err != nil {
+				return doctor.Failure("git remote", "the registered checkout cannot reach the configured GitHub target", "repair the origin remote and ensure the configured target branch exists")
+			}
+			return doctor.Success("git remote")
+		},
+		func(ctx context.Context) doctor.Result {
+			if checker == nil {
+				return doctor.Failure("git hooks", "the Git diagnosis adapter is unavailable", "configure the host Git workspace adapter")
+			}
+			if err := checker.CheckHooks(ctx, request); err != nil {
+				return doctor.Failure("git hooks", "the checkout's Git hooks directory cannot be inspected", "restore a readable Git hooks directory or correct core.hooksPath")
+			}
+			return doctor.Success("git hooks")
+		},
+		func(ctx context.Context) doctor.Result {
+			if checker == nil {
+				return doctor.Failure("git worktree", "the Git diagnosis adapter is unavailable", "configure the host Git workspace adapter")
+			}
+			if err := checker.CheckWorktree(ctx, request); err != nil {
+				return doctor.Failure("git worktree", "the registered checkout cannot provide the worktree support required by a run", "repair the checkout and enable the Git worktree command")
+			}
+			return doctor.Success("git worktree")
+		},
+	}
+}
+
+// CheckRemote verifies the ordinary checkout, its origin identity, and the
+// configured target branch without changing any Git reference.
+func (m *LocalWorktreeManager) CheckRemote(ctx context.Context, request DoctorRequest) error {
+	if err := validateDoctorRepository(request.RepositoryPath); err != nil {
+		return err
+	}
+	if strings.TrimSpace(request.RemoteName) == "" {
+		return errors.New("Git remote name is required")
+	}
+	if strings.TrimSpace(request.ExpectedOwner) == "" || strings.TrimSpace(request.ExpectedRepository) == "" {
+		return errors.New("expected GitHub repository identity is required")
+	}
+	if strings.TrimSpace(request.TargetBranch) == "" {
+		return errors.New("Git target branch is required")
+	}
+	if err := validateRefPart(request.TargetBranch); err != nil {
+		return fmt.Errorf("Git target branch: %w", err)
+	}
+	rootOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"rev-parse", "--show-toplevel"})
+	if err != nil {
+		return fmt.Errorf("inspect Git checkout: %w", err)
+	}
+	root, err := filepath.Abs(strings.TrimSpace(string(rootOutput)))
+	if err != nil || filepath.Clean(root) != filepath.Clean(request.RepositoryPath) {
+		return errors.New("Git checkout root does not match the registered repository")
+	}
+	remoteOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"remote", "get-url", request.RemoteName})
+	if err != nil {
+		return fmt.Errorf("read Git remote: %w", err)
+	}
+	if !remoteMatches(string(remoteOutput), request.ExpectedOwner, request.ExpectedRepository) {
+		return errors.New("Git remote does not identify the registered GitHub repository")
+	}
+	pushRemoteOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"remote", "get-url", "--push", request.RemoteName})
+	if err != nil {
+		return fmt.Errorf("read Git push remote: %w", err)
+	}
+	if !remoteMatches(string(pushRemoteOutput), request.ExpectedOwner, request.ExpectedRepository) {
+		return errors.New("Git push remote does not identify the registered GitHub repository")
+	}
+	branchOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"ls-remote", "--exit-code", request.RemoteName, "refs/heads/" + request.TargetBranch})
+	if err != nil {
+		return fmt.Errorf("probe Git target branch: %w", err)
+	}
+	if strings.TrimSpace(string(branchOutput)) == "" {
+		return errors.New("Git target branch returned no commit")
+	}
+	return nil
+}
+
+// CheckHooks verifies the configured Git hooks path is present and readable.
+// Hooks are never executed by diagnosis.
+func (m *LocalWorktreeManager) CheckHooks(ctx context.Context, request DoctorRequest) error {
+	if err := validateDoctorRepository(request.RepositoryPath); err != nil {
+		return err
+	}
+	output, err := m.runner().Run(ctx, request.RepositoryPath, []string{"rev-parse", "--git-path", "hooks"})
+	if err != nil {
+		return fmt.Errorf("resolve Git hooks path: %w", err)
+	}
+	hooksPath := strings.TrimSpace(string(output))
+	if hooksPath == "" {
+		return errors.New("Git returned an empty hooks path")
+	}
+	if !filepath.IsAbs(hooksPath) {
+		hooksPath = filepath.Join(request.RepositoryPath, hooksPath)
+	}
+	info, err := os.Stat(hooksPath)
+	if err != nil {
+		return fmt.Errorf("inspect Git hooks directory: %w", err)
+	}
+	if !info.IsDir() {
+		return errors.New("Git hooks path is not a directory")
+	}
+	return nil
+}
+
+// CheckWorktree verifies the checkout is a worktree and can enumerate its
+// current worktree metadata without creating or removing a user worktree.
+func (m *LocalWorktreeManager) CheckWorktree(ctx context.Context, request DoctorRequest) error {
+	if err := validateDoctorRepository(request.RepositoryPath); err != nil {
+		return err
+	}
+	insideOutput, err := m.runner().Run(ctx, request.RepositoryPath, []string{"rev-parse", "--is-inside-work-tree"})
+	if err != nil {
+		return fmt.Errorf("probe Git worktree support: %w", err)
+	}
+	if strings.TrimSpace(string(insideOutput)) != "true" {
+		return errors.New("Git did not report a worktree checkout")
+	}
+	if _, err := m.runner().Run(ctx, request.RepositoryPath, []string{"worktree", "list", "--porcelain"}); err != nil {
+		return fmt.Errorf("list Git worktrees: %w", err)
+	}
+	return nil
+}
+
+// validateDoctorRepository verifies a repository path before invoking Git.
+func validateDoctorRepository(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("Git repository path is required")
+	}
+	if !filepath.IsAbs(path) {
+		return errors.New("Git repository path must be absolute")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("inspect Git repository path: %w", err)
+	}
+	if !info.IsDir() {
+		return errors.New("Git repository path is not a directory")
+	}
+	return nil
+}
+
+// remoteMatches compares a GitHub owner/repository identity while accepting
+// the HTTPS and scp-like SSH URL forms emitted by Git.
+func remoteMatches(value, owner, repository string) bool {
+	remote := strings.TrimSpace(value)
+	if remote == "" || strings.ContainsAny(remote, "\x00\r\n") {
+		return false
+	}
+	if !strings.Contains(remote, "://") {
+		at := strings.LastIndex(remote, "@")
+		colon := strings.Index(remote, ":")
+		if colon <= at {
+			return false
+		}
+		remote = "ssh://" + remote[:colon] + "/" + remote[colon+1:]
+	}
+	parsed, err := url.Parse(remote)
+	if err != nil || !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return false
+	}
+	path := strings.Trim(strings.TrimSuffix(parsed.Path, ".git"), "/")
+	wanted := strings.Trim(strings.TrimSuffix(owner+"/"+repository, ".git"), "/")
+	return strings.EqualFold(path, wanted)
+}
+
+var _ DoctorChecker = (*LocalWorktreeManager)(nil)

--- a/internal/git/doctor_internal_test.go
+++ b/internal/git/doctor_internal_test.go
@@ -1,0 +1,53 @@
+package git
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// TestRemoteDiagnosisPreservesTheSpecificFailureCategory verifies the Git
+// contributor does not collapse independent remote failures into one action.
+func TestRemoteDiagnosisPreservesTheSpecificFailureCategory(t *testing.T) {
+	for _, test := range []struct {
+		kind    remoteFailureKind
+		problem string
+	}{
+		{kind: remoteFailureFetchIdentity, problem: "fetch remote"},
+		{kind: remoteFailurePushIdentity, problem: "push remote"},
+		{kind: remoteFailureBranchNoCommit, problem: "has no commit"},
+	} {
+		t.Run(string(test.kind), func(t *testing.T) {
+			report := doctor.Run(context.Background(), StartupChecks(&remoteFailureChecker{err: remoteFailure(test.kind)}, DoctorRequest{})[0])
+			result := report.Results[0]
+			if result.Status != doctor.StatusFailed || !strings.Contains(result.Problem, test.problem) || result.Action == "" {
+				t.Fatalf("remote result = %#v, want specific problem/action", result)
+			}
+		})
+	}
+}
+
+// remoteFailureChecker supplies a categorized remote result without invoking
+// the host Git executable.
+type remoteFailureChecker struct {
+	err error
+}
+
+// CheckRemote implements the Git remote diagnosis seam for category tests.
+func (c *remoteFailureChecker) CheckRemote(context.Context, DoctorRequest) error {
+	return c.err
+}
+
+// CheckHooks implements the required Git diagnosis seam for category tests.
+func (*remoteFailureChecker) CheckHooks(context.Context, DoctorRequest) error {
+	return nil
+}
+
+// CheckWorktree implements the required Git diagnosis seam for category tests.
+func (*remoteFailureChecker) CheckWorktree(context.Context, DoctorRequest) error {
+	return nil
+}
+
+var _ DoctorChecker = (*remoteFailureChecker)(nil)

--- a/internal/git/doctor_test.go
+++ b/internal/git/doctor_test.go
@@ -1,0 +1,128 @@
+package git_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+)
+
+// TestLocalWorktreeManagerChecksTheConfiguredRemoteAndTargetBranch verifies
+// diagnosis checks the checkout identity before probing the remote branch.
+func TestLocalWorktreeManagerChecksTheConfiguredRemoteAndTargetBranch(t *testing.T) {
+	repositoryPath := t.TempDir()
+	runner := &gitDoctorRunner{repositoryPath: repositoryPath}
+	manager := &gitadapter.LocalWorktreeManager{Runner: runner}
+	err := manager.CheckRemote(context.Background(), gitadapter.DoctorRequest{
+		RepositoryPath:     repositoryPath,
+		RemoteName:         "origin",
+		ExpectedOwner:      "example",
+		ExpectedRepository: "project",
+		TargetBranch:       "main",
+	})
+	if err != nil {
+		t.Fatalf("CheckRemote() error = %v", err)
+	}
+	joined := strings.Join(runner.commands, "\n")
+	for _, want := range []string{"rev-parse --show-toplevel", "remote get-url origin", "remote get-url --push origin", "ls-remote --exit-code origin refs/heads/main"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("Git commands = %q, want %q", joined, want)
+		}
+	}
+}
+
+// TestLocalWorktreeManagerChecksHooksAndWorktreeSupport verifies the two
+// repository-local capability checks use read-only Git observations.
+func TestLocalWorktreeManagerChecksHooksAndWorktreeSupport(t *testing.T) {
+	repositoryPath := t.TempDir()
+	hooksPath := filepath.Join(repositoryPath, ".git", "hooks")
+	if err := os.MkdirAll(hooksPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := &gitDoctorRunner{repositoryPath: repositoryPath, hooksPath: hooksPath}
+	manager := &gitadapter.LocalWorktreeManager{Runner: runner}
+	request := gitadapter.DoctorRequest{RepositoryPath: repositoryPath}
+	if err := manager.CheckHooks(context.Background(), request); err != nil {
+		t.Fatalf("CheckHooks() error = %v", err)
+	}
+	if err := manager.CheckWorktree(context.Background(), request); err != nil {
+		t.Fatalf("CheckWorktree() error = %v", err)
+	}
+	joined := strings.Join(runner.commands, "\n")
+	if !strings.Contains(joined, "rev-parse --git-path hooks") || !strings.Contains(joined, "worktree list --porcelain") {
+		t.Fatalf("Git commands = %q, want hooks and worktree checks", joined)
+	}
+}
+
+// TestStartupChecksKeepGitFailuresIndependent verifies one failed Git check
+// does not suppress the other Git-owned diagnostics.
+func TestStartupChecksKeepGitFailuresIndependent(t *testing.T) {
+	checker := &fakeGitDoctorChecker{remoteErr: errors.New("remote unavailable")}
+	report := doctor.Run(context.Background(), gitadapter.StartupChecks(checker, gitadapter.DoctorRequest{})...)
+	if report.Ready() || len(report.Failures()) != 1 {
+		t.Fatalf("Git report = %#v, want one failure", report)
+	}
+	if len(report.Results) != 3 || checker.calls != 3 {
+		t.Fatalf("Git results/calls = %d/%d, want three", len(report.Results), checker.calls)
+	}
+}
+
+// gitDoctorRunner returns deterministic observations for Git diagnosis.
+type gitDoctorRunner struct {
+	repositoryPath string
+	hooksPath      string
+	commands       []string
+}
+
+// Run records one host-side Git command and returns its safe fixture output.
+func (r *gitDoctorRunner) Run(_ context.Context, _ string, args []string) ([]byte, error) {
+	r.commands = append(r.commands, strings.Join(args, " "))
+	switch {
+	case len(args) == 2 && args[0] == "rev-parse" && args[1] == "--show-toplevel":
+		return []byte(r.repositoryPath + "\n"), nil
+	case len(args) == 2 && args[0] == "rev-parse" && args[1] == "--is-inside-work-tree":
+		return []byte("true\n"), nil
+	case len(args) == 3 && args[0] == "remote":
+		return []byte("git@github.com:example/project.git\n"), nil
+	case len(args) == 4 && args[0] == "remote" && args[2] == "--push":
+		return []byte("git@github.com:example/project.git\n"), nil
+	case len(args) > 0 && args[0] == "ls-remote":
+		return []byte("0123456789abcdef0123456789abcdef01234567\trefs/heads/main\n"), nil
+	case len(args) == 3 && args[0] == "rev-parse" && args[1] == "--git-path":
+		return []byte(r.hooksPath + "\n"), nil
+	default:
+		return []byte("worktree\n"), nil
+	}
+}
+
+// fakeGitDoctorChecker records the three Git-owned diagnosis calls.
+type fakeGitDoctorChecker struct {
+	remoteErr error
+	calls     int
+}
+
+// CheckRemote implements the Git diagnosis seam for composition tests.
+func (f *fakeGitDoctorChecker) CheckRemote(context.Context, gitadapter.DoctorRequest) error {
+	f.calls++
+	return f.remoteErr
+}
+
+// CheckHooks implements the Git diagnosis seam for composition tests.
+func (f *fakeGitDoctorChecker) CheckHooks(context.Context, gitadapter.DoctorRequest) error {
+	f.calls++
+	return nil
+}
+
+// CheckWorktree implements the Git diagnosis seam for composition tests.
+func (f *fakeGitDoctorChecker) CheckWorktree(context.Context, gitadapter.DoctorRequest) error {
+	f.calls++
+	return nil
+}
+
+var _ gitadapter.CommandRunner = (*gitDoctorRunner)(nil)
+var _ gitadapter.DoctorChecker = (*fakeGitDoctorChecker)(nil)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 )
 
+// DefaultRemoteName is the repository remote used by factory Git operations.
+const DefaultRemoteName = "origin"
+
 // Workspace identifies the fetched base commit and isolated checkout created
 // for one run.
 type Workspace struct {
@@ -228,7 +231,7 @@ func (m *LocalWorktreeManager) Create(ctx context.Context, repositoryPath, targe
 		return Workspace{}, fmt.Errorf("run id: %w", err)
 	}
 
-	if _, err := m.runner().Run(ctx, repositoryPath, []string{"fetch", "--no-tags", "origin", "refs/heads/" + targetBranch}); err != nil {
+	if _, err := m.runner().Run(ctx, repositoryPath, []string{"fetch", "--no-tags", DefaultRemoteName, "refs/heads/" + targetBranch}); err != nil {
 		return Workspace{}, fmt.Errorf("fetch target branch %q: %w", targetBranch, err)
 	}
 	baseOutput, err := m.runner().Run(ctx, repositoryPath, []string{"rev-parse", "FETCH_HEAD"})
@@ -370,7 +373,7 @@ func (m *LocalWorktreeManager) Push(ctx context.Context, request PushRequest) er
 	if err := validateRefPart(request.Branch); err != nil {
 		return fmt.Errorf("push branch: %w", err)
 	}
-	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"push", "--set-upstream", "origin", "HEAD:refs/heads/" + request.Branch}); err != nil {
+	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"push", "--set-upstream", DefaultRemoteName, "HEAD:refs/heads/" + request.Branch}); err != nil {
 		return fmt.Errorf("push run branch %q: %w", request.Branch, err)
 	}
 	return nil
@@ -391,7 +394,7 @@ func (m *LocalWorktreeManager) SynchronizeBase(ctx context.Context, request Base
 	if err := validateRefPart(request.TargetBranch); err != nil {
 		return fmt.Errorf("base synchronization target branch: %w", err)
 	}
-	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"fetch", "--no-tags", "origin", "refs/heads/" + request.TargetBranch}); err != nil {
+	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"fetch", "--no-tags", DefaultRemoteName, "refs/heads/" + request.TargetBranch}); err != nil {
 		return fmt.Errorf("fetch base branch %q: %w", request.TargetBranch, err)
 	}
 	if _, err := m.runner().Run(ctx, request.WorktreePath, []string{"merge", "--ff-only", "FETCH_HEAD"}); err != nil {

--- a/internal/github/doctor.go
+++ b/internal/github/doctor.go
@@ -26,6 +26,7 @@ var (
 	errRepositoryUnreadable     = errors.New("registered GitHub repository is not readable")
 	errRepositoryContentsWrite  = errors.New("registered GitHub repository does not permit contents writes")
 	errRepositoryIssueSupervise = errors.New("registered GitHub repository does not permit issue and pull-request supervision")
+	errRepositoryTokenAccess    = errors.New("GitHub token permissions are not sufficient for factory operations")
 	errFactoryLabelsUnavailable = errors.New("factory labels are unavailable")
 	errFactoryLabelsMalformed   = errors.New("factory labels response is malformed")
 )
@@ -106,7 +107,48 @@ func (c *GhClient) CheckRepositoryAccess(ctx context.Context, repository Reposit
 	if !response.Permissions.Triage && !response.Permissions.Maintain && !response.Permissions.Admin {
 		return errRepositoryIssueSupervise
 	}
+	if err := c.checkTokenPermissions(ctx, response.Private); err != nil {
+		return err
+	}
 	return nil
+}
+
+// checkTokenPermissions verifies the scope metadata exposed by gh without
+// requesting or printing the token. Fine-grained tokens that expose no
+// inspectable scope metadata fail closed because repository role data alone
+// cannot establish their write categories.
+func (c *GhClient) checkTokenPermissions(ctx context.Context, private bool) error {
+	output, err := c.runner().Run(ctx, []string{"auth", "status", "--hostname", "github.com", "--json", "hosts"}, nil)
+	if err != nil {
+		return errRepositoryTokenAccess
+	}
+	var response doctorAuthStatusResponse
+	if err := json.Unmarshal(output, &response); err != nil {
+		return errRepositoryTokenAccess
+	}
+	for _, host := range response.Hosts["github.com"] {
+		if !host.Active || host.State != "success" {
+			continue
+		}
+		scopes := make(map[string]struct{})
+		for _, scope := range strings.Split(host.Scopes, ",") {
+			scope = strings.TrimSpace(scope)
+			if scope != "" {
+				scopes[scope] = struct{}{}
+			}
+		}
+		if _, ok := scopes["repo"]; ok {
+			return nil
+		}
+		if !private {
+			_, publicRepo := scopes["public_repo"]
+			_, repoStatus := scopes["repo:status"]
+			if publicRepo && repoStatus {
+				return nil
+			}
+		}
+	}
+	return errRepositoryTokenAccess
 }
 
 // repositoryAccessDiagnosis translates a read-only repository permission
@@ -121,6 +163,8 @@ func repositoryAccessDiagnosis(err error) (string, string) {
 		return "the authenticated account cannot write repository contents", "grant contents write access so the factory can publish its run branch"
 	case errors.Is(err, errRepositoryIssueSupervise):
 		return "the authenticated account cannot supervise issues and pull requests", "grant triage, maintain, or administrator repository access for labels, comments, and pull requests"
+	case errors.Is(err, errRepositoryTokenAccess):
+		return "the GitHub token does not expose the scopes required by factory operations", "authenticate gh with repo access, or with public_repo plus repo:status for a public repository"
 	default:
 		return "the registered GitHub repository permissions could not be validated", "verify repository access and retry the diagnosis"
 	}
@@ -183,6 +227,7 @@ func validateDoctorRepository(repository Repository) error {
 // doctorRepositoryResponse is the small repository API projection needed for
 // permission diagnosis.
 type doctorRepositoryResponse struct {
+	Private     bool `json:"private"`
 	Permissions struct {
 		Pull     bool `json:"pull"`
 		Push     bool `json:"push"`
@@ -190,6 +235,16 @@ type doctorRepositoryResponse struct {
 		Maintain bool `json:"maintain"`
 		Admin    bool `json:"admin"`
 	} `json:"permissions"`
+}
+
+// doctorAuthStatusResponse is the credential-free gh auth status projection
+// used to establish classic-token scope coverage.
+type doctorAuthStatusResponse struct {
+	Hosts map[string][]struct {
+		Active bool   `json:"active"`
+		State  string `json:"state"`
+		Scopes string `json:"scopes"`
+	} `json:"hosts"`
 }
 
 // doctorLabelResponse is the small label API projection needed by diagnosis.

--- a/internal/github/doctor.go
+++ b/internal/github/doctor.go
@@ -26,7 +26,7 @@ var (
 	errRepositoryUnreadable     = errors.New("registered GitHub repository is not readable")
 	errRepositoryContentsWrite  = errors.New("registered GitHub repository does not permit contents writes")
 	errRepositoryIssueSupervise = errors.New("registered GitHub repository does not permit issue and pull-request supervision")
-	errRepositoryTokenAccess    = errors.New("GitHub token permissions are not sufficient for factory operations")
+	errRepositoryTokenAccess    = errors.New("github token permissions are not sufficient for factory operations")
 	errFactoryLabelsUnavailable = errors.New("factory labels are unavailable")
 	errFactoryLabelsMalformed   = errors.New("factory labels response is malformed")
 )
@@ -142,8 +142,7 @@ func (c *GhClient) checkTokenPermissions(ctx context.Context, private bool) erro
 		}
 		if !private {
 			_, publicRepo := scopes["public_repo"]
-			_, repoStatus := scopes["repo:status"]
-			if publicRepo && repoStatus {
+			if publicRepo {
 				return nil
 			}
 		}
@@ -164,7 +163,7 @@ func repositoryAccessDiagnosis(err error) (string, string) {
 	case errors.Is(err, errRepositoryIssueSupervise):
 		return "the authenticated account cannot supervise issues and pull requests", "grant triage, maintain, or administrator repository access for labels, comments, and pull requests"
 	case errors.Is(err, errRepositoryTokenAccess):
-		return "the GitHub token does not expose the scopes required by factory operations", "authenticate gh with repo access, or with public_repo plus repo:status for a public repository"
+		return "the GitHub token does not expose the scopes required by factory operations", "authenticate gh with repo access, or with public_repo for a public repository"
 	default:
 		return "the registered GitHub repository permissions could not be validated", "verify repository access and retry the diagnosis"
 	}

--- a/internal/github/doctor.go
+++ b/internal/github/doctor.go
@@ -1,0 +1,161 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// DoctorClient is the read-only GitHub health seam used by startup diagnosis.
+// It is separate from Client so diagnosing a repository cannot accidentally
+// gain mutation authority.
+type DoctorClient interface {
+	CheckAuthentication(context.Context) error
+	CheckRepositoryAccess(context.Context, Repository) error
+	CheckFactoryLabels(context.Context, Repository) error
+}
+
+// StartupChecks returns the GitHub-owned authentication, permission, and
+// factory-label checks in deterministic order.
+func StartupChecks(client DoctorClient, repository Repository) []doctor.Check {
+	return []doctor.Check{
+		func(ctx context.Context) doctor.Result {
+			if client == nil {
+				return doctor.Failure("github authentication", "the GitHub diagnosis adapter is unavailable", "configure the authenticated gh client")
+			}
+			if err := client.CheckAuthentication(ctx); err != nil {
+				return doctor.Failure("github authentication", "the GitHub CLI is not authenticated", "run gh auth login for the GitHub account that owns the registered repository")
+			}
+			return doctor.Success("github authentication")
+		},
+		func(ctx context.Context) doctor.Result {
+			if client == nil {
+				return doctor.Failure("github permissions", "the GitHub diagnosis adapter is unavailable", "configure the authenticated gh client")
+			}
+			if err := client.CheckRepositoryAccess(ctx, repository); err != nil {
+				return doctor.Failure("github permissions", "the authenticated account cannot perform the factory's repository operations", "grant repository read, issue-label, issue-comment, contents, pull-request, and commit-status permissions")
+			}
+			return doctor.Success("github permissions")
+		},
+		func(ctx context.Context) doctor.Result {
+			if client == nil {
+				return doctor.Failure("github labels", "the GitHub diagnosis adapter is unavailable", "configure the authenticated gh client")
+			}
+			if err := client.CheckFactoryLabels(ctx, repository); err != nil {
+				return doctor.Failure("github labels", "one or more factory state labels are missing", "run factory bootstrap-labels after granting label-management permission")
+			}
+			return doctor.Success("github labels")
+		},
+	}
+}
+
+// CheckAuthentication verifies that the local gh process has a usable
+// GitHub authentication without reading or printing its credential.
+func (c *GhClient) CheckAuthentication(ctx context.Context) error {
+	if _, err := c.runner().Run(ctx, []string{"auth", "status", "--hostname", "github.com"}, nil); err != nil {
+		return errors.New("gh authentication status failed")
+	}
+	return nil
+}
+
+// CheckRepositoryAccess verifies the registered repository exists and exposes
+// the write permissions required for labels, comments, commits, and pull
+// requests. The API response is discarded after this bounded validation.
+func (c *GhClient) CheckRepositoryAccess(ctx context.Context, repository Repository) error {
+	if err := validateDoctorRepository(repository); err != nil {
+		return err
+	}
+	var response doctorRepositoryResponse
+	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s", repository.String())}, nil, &response); err != nil {
+		return errors.New("registered GitHub repository is not readable")
+	}
+	if !response.Permissions.Pull {
+		return errors.New("registered GitHub repository is not readable")
+	}
+	if !response.Permissions.Push {
+		return errors.New("registered GitHub repository does not permit contents writes")
+	}
+	if !response.Permissions.Triage && !response.Permissions.Maintain && !response.Permissions.Admin {
+		return errors.New("registered GitHub repository does not permit issue and pull-request supervision")
+	}
+	return nil
+}
+
+// CheckFactoryLabels verifies all factory-owned labels exist without creating
+// or changing any label.
+func (c *GhClient) CheckFactoryLabels(ctx context.Context, repository Repository) error {
+	if err := validateDoctorRepository(repository); err != nil {
+		return err
+	}
+	output, err := c.callBytes(ctx, []string{"api", fmt.Sprintf("repos/%s/labels", repository.String()), "--paginate", "--slurp"}, nil)
+	if err != nil {
+		return errors.New("factory labels are not readable")
+	}
+	labels, err := decodeDoctorLabels(output)
+	if err != nil {
+		return errors.New("factory labels response is malformed")
+	}
+	seen := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		seen[label.Name] = struct{}{}
+	}
+	for _, required := range FactoryStateLabels {
+		if _, ok := seen[required]; !ok {
+			return fmt.Errorf("factory label %q is missing", required)
+		}
+	}
+	return nil
+}
+
+// validateDoctorRepository rejects values that could alter a read-only API
+// endpoint assembled by the GitHub adapter.
+func validateDoctorRepository(repository Repository) error {
+	if strings.TrimSpace(repository.Owner) == "" || strings.TrimSpace(repository.Name) == "" {
+		return errors.New("GitHub repository owner and name are required")
+	}
+	if strings.ContainsAny(repository.Owner+repository.Name, "\x00\r\n") || strings.Contains(repository.Owner, "/") || strings.Contains(repository.Name, "/") {
+		return errors.New("GitHub repository owner and name are unsafe")
+	}
+	return nil
+}
+
+// doctorRepositoryResponse is the small repository API projection needed for
+// permission diagnosis.
+type doctorRepositoryResponse struct {
+	Permissions struct {
+		Pull     bool `json:"pull"`
+		Push     bool `json:"push"`
+		Triage   bool `json:"triage"`
+		Maintain bool `json:"maintain"`
+		Admin    bool `json:"admin"`
+	} `json:"permissions"`
+}
+
+// doctorLabelResponse is the small label API projection needed by diagnosis.
+type doctorLabelResponse struct {
+	Name string `json:"name"`
+}
+
+// decodeDoctorLabels accepts gh's paginated slurp shape and a plain page for
+// compatibility with controlled command-runner tests.
+func decodeDoctorLabels(output []byte) ([]doctorLabelResponse, error) {
+	var pages [][]doctorLabelResponse
+	if err := json.Unmarshal(output, &pages); err == nil {
+		labels := make([]doctorLabelResponse, 0)
+		for _, page := range pages {
+			labels = append(labels, page...)
+		}
+		return labels, nil
+	}
+	var page []doctorLabelResponse
+	if err := json.Unmarshal(output, &page); err != nil {
+		return nil, err
+	}
+	return page, nil
+}
+
+var _ DoctorClient = (*GhClient)(nil)

--- a/internal/github/doctor.go
+++ b/internal/github/doctor.go
@@ -27,6 +27,7 @@ var (
 	errRepositoryContentsWrite  = errors.New("registered GitHub repository does not permit contents writes")
 	errRepositoryIssueSupervise = errors.New("registered GitHub repository does not permit issue and pull-request supervision")
 	errRepositoryTokenAccess    = errors.New("github token permissions are not sufficient for factory operations")
+	errGhVersionUnsupported     = errors.New("github CLI version does not support required features")
 	errFactoryLabelsUnavailable = errors.New("factory labels are unavailable")
 	errFactoryLabelsMalformed   = errors.New("factory labels response is malformed")
 )
@@ -120,6 +121,10 @@ func (c *GhClient) CheckRepositoryAccess(ctx context.Context, repository Reposit
 func (c *GhClient) checkTokenPermissions(ctx context.Context, private bool) error {
 	output, err := c.runner().Run(ctx, []string{"auth", "status", "--hostname", "github.com", "--json", "hosts"}, nil)
 	if err != nil {
+		// Distinguish unsupported gh CLI version from actual token permission issues
+		if strings.Contains(err.Error(), "unknown flag") || strings.Contains(err.Error(), "unknown command") {
+			return errGhVersionUnsupported
+		}
 		return errRepositoryTokenAccess
 	}
 	var response doctorAuthStatusResponse
@@ -162,6 +167,8 @@ func repositoryAccessDiagnosis(err error) (string, string) {
 		return "the authenticated account cannot write repository contents", "grant contents write access so the factory can publish its run branch"
 	case errors.Is(err, errRepositoryIssueSupervise):
 		return "the authenticated account cannot supervise issues and pull requests", "grant triage, maintain, or administrator repository access for labels, comments, and pull requests"
+	case errors.Is(err, errGhVersionUnsupported):
+		return "the GitHub CLI version does not support token scope inspection", "upgrade gh to version 2.81.0 or newer to enable factory permission diagnosis"
 	case errors.Is(err, errRepositoryTokenAccess):
 		return "the GitHub token does not expose the scopes required by factory operations", "authenticate gh with repo access, or with public_repo for a public repository"
 	default:

--- a/internal/github/doctor.go
+++ b/internal/github/doctor.go
@@ -19,6 +19,28 @@ type DoctorClient interface {
 	CheckFactoryLabels(context.Context, Repository) error
 }
 
+// Sentinel errors preserve safe repository and label diagnosis categories
+// without retaining GitHub CLI output.
+var (
+	errRepositoryUnavailable    = errors.New("registered GitHub repository is unavailable")
+	errRepositoryUnreadable     = errors.New("registered GitHub repository is not readable")
+	errRepositoryContentsWrite  = errors.New("registered GitHub repository does not permit contents writes")
+	errRepositoryIssueSupervise = errors.New("registered GitHub repository does not permit issue and pull-request supervision")
+	errFactoryLabelsUnavailable = errors.New("factory labels are unavailable")
+	errFactoryLabelsMalformed   = errors.New("factory labels response is malformed")
+)
+
+// missingFactoryLabelError identifies one required factory label that the
+// read-only label listing did not contain.
+type missingFactoryLabelError struct {
+	name string
+}
+
+// Error returns a bounded label diagnosis without including API output.
+func (e *missingFactoryLabelError) Error() string {
+	return fmt.Sprintf("factory label %q is missing", e.name)
+}
+
 // StartupChecks returns the GitHub-owned authentication, permission, and
 // factory-label checks in deterministic order.
 func StartupChecks(client DoctorClient, repository Repository) []doctor.Check {
@@ -37,7 +59,8 @@ func StartupChecks(client DoctorClient, repository Repository) []doctor.Check {
 				return doctor.Failure("github permissions", "the GitHub diagnosis adapter is unavailable", "configure the authenticated gh client")
 			}
 			if err := client.CheckRepositoryAccess(ctx, repository); err != nil {
-				return doctor.Failure("github permissions", "the authenticated account cannot perform the factory's repository operations", "grant repository read, issue-label, issue-comment, contents, pull-request, and commit-status permissions")
+				problem, action := repositoryAccessDiagnosis(err)
+				return doctor.Failure("github permissions", problem, action)
 			}
 			return doctor.Success("github permissions")
 		},
@@ -46,7 +69,8 @@ func StartupChecks(client DoctorClient, repository Repository) []doctor.Check {
 				return doctor.Failure("github labels", "the GitHub diagnosis adapter is unavailable", "configure the authenticated gh client")
 			}
 			if err := client.CheckFactoryLabels(ctx, repository); err != nil {
-				return doctor.Failure("github labels", "one or more factory state labels are missing", "run factory bootstrap-labels after granting label-management permission")
+				problem, action := factoryLabelsDiagnosis(err)
+				return doctor.Failure("github labels", problem, action)
 			}
 			return doctor.Success("github labels")
 		},
@@ -71,18 +95,35 @@ func (c *GhClient) CheckRepositoryAccess(ctx context.Context, repository Reposit
 	}
 	var response doctorRepositoryResponse
 	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s", repository.String())}, nil, &response); err != nil {
-		return errors.New("registered GitHub repository is not readable")
+		return errRepositoryUnavailable
 	}
 	if !response.Permissions.Pull {
-		return errors.New("registered GitHub repository is not readable")
+		return errRepositoryUnreadable
 	}
 	if !response.Permissions.Push {
-		return errors.New("registered GitHub repository does not permit contents writes")
+		return errRepositoryContentsWrite
 	}
 	if !response.Permissions.Triage && !response.Permissions.Maintain && !response.Permissions.Admin {
-		return errors.New("registered GitHub repository does not permit issue and pull-request supervision")
+		return errRepositoryIssueSupervise
 	}
 	return nil
+}
+
+// repositoryAccessDiagnosis translates a read-only repository permission
+// result into the specific problem and corrective action shown by the report.
+func repositoryAccessDiagnosis(err error) (string, string) {
+	switch {
+	case errors.Is(err, errRepositoryUnavailable):
+		return "the registered GitHub repository could not be read", "verify the repository owner/name, network access, and GitHub authentication"
+	case errors.Is(err, errRepositoryUnreadable):
+		return "the authenticated account cannot read the registered GitHub repository", "grant repository read access to the authenticated account"
+	case errors.Is(err, errRepositoryContentsWrite):
+		return "the authenticated account cannot write repository contents", "grant contents write access so the factory can publish its run branch"
+	case errors.Is(err, errRepositoryIssueSupervise):
+		return "the authenticated account cannot supervise issues and pull requests", "grant triage, maintain, or administrator repository access for labels, comments, and pull requests"
+	default:
+		return "the registered GitHub repository permissions could not be validated", "verify repository access and retry the diagnosis"
+	}
 }
 
 // CheckFactoryLabels verifies all factory-owned labels exist without creating
@@ -93,11 +134,11 @@ func (c *GhClient) CheckFactoryLabels(ctx context.Context, repository Repository
 	}
 	output, err := c.callBytes(ctx, []string{"api", fmt.Sprintf("repos/%s/labels", repository.String()), "--paginate", "--slurp"}, nil)
 	if err != nil {
-		return errors.New("factory labels are not readable")
+		return errFactoryLabelsUnavailable
 	}
 	labels, err := decodeDoctorLabels(output)
 	if err != nil {
-		return errors.New("factory labels response is malformed")
+		return errFactoryLabelsMalformed
 	}
 	seen := make(map[string]struct{}, len(labels))
 	for _, label := range labels {
@@ -105,10 +146,26 @@ func (c *GhClient) CheckFactoryLabels(ctx context.Context, repository Repository
 	}
 	for _, required := range FactoryStateLabels {
 		if _, ok := seen[required]; !ok {
-			return fmt.Errorf("factory label %q is missing", required)
+			return &missingFactoryLabelError{name: required}
 		}
 	}
 	return nil
+}
+
+// factoryLabelsDiagnosis translates a read-only GitHub label error into the
+// specific problem and corrective action shown by the startup report.
+func factoryLabelsDiagnosis(err error) (string, string) {
+	if errors.Is(err, errFactoryLabelsUnavailable) {
+		return "the factory state labels could not be read from GitHub", "verify GitHub authentication and repository label-read access, then retry"
+	}
+	if errors.Is(err, errFactoryLabelsMalformed) {
+		return "GitHub returned an invalid factory-label response", "verify gh and GitHub API compatibility, then retry the diagnosis"
+	}
+	var missing *missingFactoryLabelError
+	if errors.As(err, &missing) {
+		return fmt.Sprintf("required factory label %q is missing", missing.name), "run factory bootstrap-labels after granting label-management permission"
+	}
+	return "the registered factory labels could not be validated", "verify the registered repository and GitHub label access, then retry"
 }
 
 // validateDoctorRepository rejects values that could alter a read-only API

--- a/internal/github/doctor_test.go
+++ b/internal/github/doctor_test.go
@@ -16,6 +16,7 @@ func TestStartupChecksReportMissingFactoryLabelsAlongsideSuccessfulAccessChecks(
 	runner := &doctorRunner{responses: []doctorResponse{
 		{output: []byte("authenticated\n")},
 		{output: []byte(`{"permissions":{"pull":true,"push":true,"triage":true}}`)},
+		{output: []byte(`{"hosts":{"github.com":[{"state":"success","active":true,"scopes":"repo"}]}}`)},
 		{output: []byte(`[[{"name":"agent-ready"}]]`)},
 	}}
 	client := &github.GhClient{Runner: runner}
@@ -49,6 +50,7 @@ func TestStartupChecksDistinguishLabelReadFailuresFromMissingLabels(t *testing.T
 			runner := &doctorRunner{responses: []doctorResponse{
 				{output: []byte("authenticated\n")},
 				{output: []byte(`{"permissions":{"pull":true,"push":true,"triage":true}}`)},
+				{output: []byte(`{"hosts":{"github.com":[{"state":"success","active":true,"scopes":"repo"}]}}`)},
 				{output: test.output, err: test.err},
 			}}
 			client := &github.GhClient{Runner: runner}
@@ -78,12 +80,29 @@ func TestStartupChecksNeverRenderAnAuthenticationError(t *testing.T) {
 	}
 }
 
+// TestStartupChecksRejectMissingTokenScopes verifies repository role data does
+// not overstate the effective classic-token permissions needed by the factory.
+func TestStartupChecksRejectMissingTokenScopes(t *testing.T) {
+	runner := &doctorRunner{responses: []doctorResponse{
+		{output: []byte("authenticated\n")},
+		{output: []byte(`{"private":true,"permissions":{"pull":true,"push":true,"triage":true}}`)},
+		{output: []byte(`{"hosts":{"github.com":[{"state":"success","active":true,"scopes":"public_repo"}]}}`)},
+	}}
+	client := &github.GhClient{Runner: runner}
+	report := doctor.Run(context.Background(), github.StartupChecks(client, github.Repository{Owner: "example", Name: "project"})...)
+	result := report.Results[1]
+	if result.Status != doctor.StatusFailed || !strings.Contains(result.Problem, "token") || result.Action == "" {
+		t.Fatalf("permission result = %#v, want missing-token-scope diagnosis", result)
+	}
+}
+
 // TestGhClientDoctorUsesReadOnlyGitHubOperations verifies diagnosis does not
 // create labels or mutate repository state.
 func TestGhClientDoctorUsesReadOnlyGitHubOperations(t *testing.T) {
 	runner := &doctorRunner{responses: []doctorResponse{
 		{output: []byte("authenticated\n")},
 		{output: []byte(`{"permissions":{"pull":true,"push":true,"triage":true}}`)},
+		{output: []byte(`{"hosts":{"github.com":[{"state":"success","active":true,"scopes":"repo"}]}}`)},
 		{output: []byte(`[[{"name":"agent-ready"},{"name":"agent-running"},{"name":"agent-needs-input"},{"name":"agent-failed"},{"name":"agent-cancelled"},{"name":"agent-complete"}]]`)},
 	}}
 	client := &github.GhClient{Runner: runner}

--- a/internal/github/doctor_test.go
+++ b/internal/github/doctor_test.go
@@ -96,6 +96,26 @@ func TestStartupChecksRejectMissingTokenScopes(t *testing.T) {
 	}
 }
 
+// TestStartupChecksAcceptPublicRepoScopeForPublicRepository verifies that a
+// classic token with only public_repo scope is accepted for public repositories.
+func TestStartupChecksAcceptPublicRepoScopeForPublicRepository(t *testing.T) {
+	runner := &doctorRunner{responses: []doctorResponse{
+		{output: []byte("authenticated\n")},
+		{output: []byte(`{"private":false,"permissions":{"pull":true,"push":true,"triage":true}}`)},
+		{output: []byte(`{"hosts":{"github.com":[{"state":"success","active":true,"scopes":"public_repo"}]}}`)},
+		{output: []byte(`[[{"name":"agent-ready"},{"name":"agent-running"},{"name":"agent-needs-input"},{"name":"agent-failed"},{"name":"agent-cancelled"},{"name":"agent-complete"}]]`)},
+	}}
+	client := &github.GhClient{Runner: runner}
+	report := doctor.Run(context.Background(), github.StartupChecks(client, github.Repository{Owner: "example", Name: "project"})...)
+	if !report.Ready() {
+		t.Fatalf("GitHub report failed with public_repo scope on public repository: %+v", report.Results)
+	}
+	result := report.Results[1]
+	if result.Status != doctor.StatusPassed {
+		t.Fatalf("permission result = %#v, want success with public_repo scope", result)
+	}
+}
+
 // TestGhClientDoctorUsesReadOnlyGitHubOperations verifies diagnosis does not
 // create labels or mutate repository state.
 func TestGhClientDoctorUsesReadOnlyGitHubOperations(t *testing.T) {

--- a/internal/github/doctor_test.go
+++ b/internal/github/doctor_test.go
@@ -32,6 +32,38 @@ func TestStartupChecksReportMissingFactoryLabelsAlongsideSuccessfulAccessChecks(
 	}
 }
 
+// TestStartupChecksDistinguishLabelReadFailuresFromMissingLabels verifies the
+// report preserves the operator-relevant cause of a label diagnosis failure.
+func TestStartupChecksDistinguishLabelReadFailuresFromMissingLabels(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		output  []byte
+		err     error
+		problem string
+	}{
+		{name: "api failure", err: errors.New("network secret"), problem: "could not be read"},
+		{name: "malformed response", output: []byte(`{"labels":`), problem: "invalid factory-label response"},
+		{name: "missing label", output: []byte(`[[{"name":"agent-ready"}]]`), problem: `required factory label "agent-running" is missing`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runner := &doctorRunner{responses: []doctorResponse{
+				{output: []byte("authenticated\n")},
+				{output: []byte(`{"permissions":{"pull":true,"push":true,"triage":true}}`)},
+				{output: test.output, err: test.err},
+			}}
+			client := &github.GhClient{Runner: runner}
+			report := doctor.Run(context.Background(), github.StartupChecks(client, github.Repository{Owner: "example", Name: "project"})...)
+			result := report.Results[2]
+			if !strings.Contains(result.Problem, test.problem) {
+				t.Fatalf("label problem = %q, want substring %q", result.Problem, test.problem)
+			}
+			if result.Action == "" {
+				t.Fatal("label action is empty")
+			}
+		})
+	}
+}
+
 // TestStartupChecksNeverRenderAnAuthenticationError verifies diagnosis output
 // remains content-free even when the command runner reports a sensitive error.
 func TestStartupChecksNeverRenderAnAuthenticationError(t *testing.T) {

--- a/internal/github/doctor_test.go
+++ b/internal/github/doctor_test.go
@@ -1,0 +1,99 @@
+package github_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/github"
+)
+
+// TestStartupChecksReportMissingFactoryLabelsAlongsideSuccessfulAccessChecks
+// verifies the GitHub contributor checks every required read-only prerequisite.
+func TestStartupChecksReportMissingFactoryLabelsAlongsideSuccessfulAccessChecks(t *testing.T) {
+	runner := &doctorRunner{responses: []doctorResponse{
+		{output: []byte("authenticated\n")},
+		{output: []byte(`{"permissions":{"pull":true,"push":true,"triage":true}}`)},
+		{output: []byte(`[[{"name":"agent-ready"}]]`)},
+	}}
+	client := &github.GhClient{Runner: runner}
+	report := doctor.Run(context.Background(), github.StartupChecks(client, github.Repository{Owner: "example", Name: "project"})...)
+
+	if report.Ready() {
+		t.Fatal("GitHub report is ready despite missing factory labels")
+	}
+	if got := len(report.Results); got != 3 {
+		t.Fatalf("GitHub check count = %d, want authentication, permissions, and labels", got)
+	}
+	if got := report.Results[2]; got.Status != doctor.StatusFailed || !strings.Contains(got.Name, "labels") || got.Problem == "" || got.Action == "" {
+		t.Fatalf("label result = %#v, want actionable failure", got)
+	}
+}
+
+// TestStartupChecksNeverRenderAnAuthenticationError verifies diagnosis output
+// remains content-free even when the command runner reports a sensitive error.
+func TestStartupChecksNeverRenderAnAuthenticationError(t *testing.T) {
+	secret := "credential-value-must-not-appear"
+	runner := &doctorRunner{responses: []doctorResponse{{err: errors.New(secret)}}}
+	client := &github.GhClient{Runner: runner}
+	report := doctor.Run(context.Background(), github.StartupChecks(client, github.Repository{Owner: "example", Name: "project"})...)
+	for _, result := range report.Results {
+		if strings.Contains(result.Problem+result.Action, secret) {
+			t.Fatalf("diagnosis result exposed authentication error: %#v", result)
+		}
+	}
+}
+
+// TestGhClientDoctorUsesReadOnlyGitHubOperations verifies diagnosis does not
+// create labels or mutate repository state.
+func TestGhClientDoctorUsesReadOnlyGitHubOperations(t *testing.T) {
+	runner := &doctorRunner{responses: []doctorResponse{
+		{output: []byte("authenticated\n")},
+		{output: []byte(`{"permissions":{"pull":true,"push":true,"triage":true}}`)},
+		{output: []byte(`[[{"name":"agent-ready"},{"name":"agent-running"},{"name":"agent-needs-input"},{"name":"agent-failed"},{"name":"agent-cancelled"},{"name":"agent-complete"}]]`)},
+	}}
+	client := &github.GhClient{Runner: runner}
+	if err := client.CheckAuthentication(context.Background()); err != nil {
+		t.Fatalf("CheckAuthentication() error = %v", err)
+	}
+	if err := client.CheckRepositoryAccess(context.Background(), github.Repository{Owner: "example", Name: "project"}); err != nil {
+		t.Fatalf("CheckRepositoryAccess() error = %v", err)
+	}
+	if err := client.CheckFactoryLabels(context.Background(), github.Repository{Owner: "example", Name: "project"}); err != nil {
+		t.Fatalf("CheckFactoryLabels() error = %v", err)
+	}
+	joined := ""
+	for _, call := range runner.calls {
+		joined += strings.Join(call, " ") + "\n"
+	}
+	if strings.Contains(joined, "label create") || strings.Contains(joined, "--method POST") || strings.Contains(joined, "--method PUT") {
+		t.Fatalf("doctor used a mutating GitHub operation: %q", joined)
+	}
+}
+
+// doctorResponse is one deterministic GitHub command result.
+type doctorResponse struct {
+	output []byte
+	err    error
+}
+
+// doctorRunner records GitHub diagnosis calls and returns queued responses.
+type doctorRunner struct {
+	responses []doctorResponse
+	calls     [][]string
+}
+
+// Run implements the GitHub command runner for diagnosis tests.
+func (r *doctorRunner) Run(_ context.Context, args []string, _ []byte) ([]byte, error) {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	if len(r.responses) == 0 {
+		return nil, errors.New("unexpected GitHub command")
+	}
+	response := r.responses[0]
+	r.responses = r.responses[1:]
+	return response.output, response.err
+}
+
+var _ github.CommandRunner = (*doctorRunner)(nil)

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -36,7 +36,7 @@ func NewClaude(runtime worker.WorkerRuntime, terminalRuntime terminal.TerminalRu
 
 // Capabilities reports the Claude adapter identity.
 func (*Claude) Capabilities() Capabilities {
-	return Capabilities{Name: NameClaude}
+	return Capabilities{Name: NameClaude, InteractiveResume: true}
 }
 
 // Start launches a fresh Claude Code TUI with an adapter-assigned native

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -26,7 +26,7 @@ func NewCodex(runtime worker.WorkerRuntime, terminalRuntime terminal.TerminalRun
 
 // Capabilities reports the Codex adapter identity and native resume support.
 func (*Codex) Capabilities() Capabilities {
-	return Capabilities{Name: NameCodex}
+	return Capabilities{Name: NameCodex, InteractiveResume: true}
 }
 
 // Start launches a fresh Codex TUI in a worker-backed terminal surface.

--- a/internal/harness/doctor.go
+++ b/internal/harness/doctor.go
@@ -1,0 +1,185 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// CapabilityResolver returns the static capabilities for one configured
+// harness. It performs no worker or terminal side effect.
+type CapabilityResolver func(string) (Capabilities, error)
+
+// CapabilityError identifies a role-to-harness capability refusal without
+// retaining an adapter's underlying error text, which may contain sensitive
+// environment details.
+type CapabilityError struct {
+	// Role is the repository-declared role that cannot be resumed safely.
+	Role string
+	// Harness is the repository-declared harness selected for Role.
+	Harness string
+	// Reason is a fixed safe explanation of the capability mismatch.
+	Reason string
+}
+
+// Error returns the bounded capability refusal shown to a coordinator caller.
+func (e *CapabilityError) Error() string {
+	return fmt.Sprintf("role %q selected harness %q %s", e.Role, e.Harness, e.Reason)
+}
+
+// CapabilitiesFor returns the built-in adapter capabilities for a harness
+// name. Unknown names fail closed before an issue can be claimed.
+func CapabilitiesFor(name string) (Capabilities, error) {
+	switch strings.TrimSpace(name) {
+	case NameCodex:
+		return (&Codex{}).Capabilities(), nil
+	case NameClaude:
+		return (&Claude{}).Capabilities(), nil
+	default:
+		return Capabilities{}, fmt.Errorf("%w: %q", ErrUnknownHarness, name)
+	}
+}
+
+// ValidateInteractiveResumeCapabilities verifies every role-selected
+// harness can resume an interrupted interactive session before claim effects
+// begin.
+func ValidateInteractiveResumeCapabilities(policy config.RepositoryConfig, resolve CapabilityResolver) error {
+	if len(policy.RoleHarnessDefaults) == 0 {
+		return errors.New("no role harnesses are configured")
+	}
+	if resolve == nil {
+		resolve = CapabilitiesFor
+	}
+	roles := make([]string, 0, len(policy.RoleHarnessDefaults))
+	for role := range policy.RoleHarnessDefaults {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	for _, role := range roles {
+		selected := string(policy.RoleHarnessDefaults[role])
+		capabilities, err := resolve(selected)
+		if err != nil {
+			return &CapabilityError{Role: role, Harness: selected, Reason: "has no usable adapter"}
+		}
+		if capabilities.Name != selected {
+			return &CapabilityError{Role: role, Harness: selected, Reason: "resolved to a different adapter"}
+		}
+		if !capabilities.InteractiveResume {
+			return &CapabilityError{Role: role, Harness: selected, Reason: "does not support interactive resume"}
+		}
+	}
+	return nil
+}
+
+// StartupRequest contains the configuration and worker seam needed by the
+// harness-owned startup checks.
+type StartupRequest struct {
+	// Policy is the checked-in role-to-harness selection.
+	Policy *config.RepositoryConfig
+	// Authentication contains optional host credential-file paths.
+	Authentication config.AuthenticationConfig
+	// Image is the immutable worker image used for executable probes.
+	Image worker.ImageReference
+	// Checker probes harness executables inside the worker image.
+	Checker worker.HarnessChecker
+	// AuthenticationChecker verifies configured credentials inside the worker
+	// image without returning credential contents.
+	AuthenticationChecker worker.HarnessAuthenticationChecker
+	// Resolve supplies adapter capabilities; nil selects built-ins.
+	Resolve CapabilityResolver
+}
+
+// StartupChecks returns independent capability, executable, and authentication
+// checks. Every selected harness contributes a check before the run begins.
+func StartupChecks(request StartupRequest) []doctor.Check {
+	checks := []doctor.Check{interactiveResumeCheck(request.Policy, request.Resolve)}
+	selected := selectedHarnesses(request.Policy)
+	for _, name := range selected {
+		harnessName := name
+		checks = append(checks, executableCheck(request.Checker, request.Image, harnessName))
+	}
+	checks = append(checks,
+		credentialCheck(NameCodex, request.Authentication.CodexAuthPath, request.Image, request.AuthenticationChecker),
+		credentialCheck(NameClaude, request.Authentication.ClaudeAuthPath, request.Image, request.AuthenticationChecker),
+	)
+	return checks
+}
+
+// selectedHarnesses returns both built-in harnesses plus any extra name in the
+// policy, in deterministic order. The worker image is therefore checked for
+// both supported adapters even when a repository currently selects only one.
+func selectedHarnesses(policy *config.RepositoryConfig) []string {
+	seen := map[string]struct{}{NameClaude: {}, NameCodex: {}}
+	if policy == nil {
+		return []string{NameClaude, NameCodex}
+	}
+	for _, selected := range policy.RoleHarnessDefaults {
+		name := strings.TrimSpace(string(selected))
+		if name != "" {
+			seen[name] = struct{}{}
+		}
+	}
+	selected := make([]string, 0, len(seen))
+	for name := range seen {
+		selected = append(selected, name)
+	}
+	sort.Strings(selected)
+	return selected
+}
+
+// interactiveResumeCheck adapts the capability validation error to a bounded
+// operator-facing diagnosis without exposing implementation error details.
+func interactiveResumeCheck(policy *config.RepositoryConfig, resolve CapabilityResolver) doctor.Check {
+	return func(context.Context) doctor.Result {
+		if policy == nil {
+			return doctor.Failure("harness capability", "repository harness policy is unavailable", "repair the checked-in role_harness_defaults configuration")
+		}
+		if err := ValidateInteractiveResumeCapabilities(*policy, resolve); err != nil {
+			return doctor.Failure("harness capability", err.Error(), "select an adapter with interactive resume support for every declared role")
+		}
+		return doctor.Success("harness capability")
+	}
+}
+
+// executableCheck probes one selected harness in the exact pinned image.
+func executableCheck(checker worker.HarnessChecker, image worker.ImageReference, name string) doctor.Check {
+	return func(ctx context.Context) doctor.Result {
+		if checker == nil {
+			return doctor.Failure(name+" worker executable", "the worker harness diagnosis adapter is unavailable", "configure the Docker worker runtime")
+		}
+		if err := checker.CheckHarness(ctx, worker.HarnessCheckRequest{Image: image, Name: name}); err != nil {
+			return doctor.Failure(name+" worker executable", "the configured "+name+" executable is not usable in the worker image", "rebuild or load the pinned worker image with the configured "+name+" harness")
+		}
+		return doctor.Success(name + " worker executable")
+	}
+}
+
+// credentialCheck validates an optional source and, when configured, asks the
+// worker adapter to verify it with the harness's local auth command. It never
+// opens or reports credential contents in a diagnosis result.
+func credentialCheck(name, path string, image worker.ImageReference, checker worker.HarnessAuthenticationChecker) doctor.Check {
+	return func(ctx context.Context) doctor.Result {
+		if strings.TrimSpace(path) == "" {
+			return doctor.Warning(name+" authentication", "no host credential file is configured", "authenticate during the first visible worker session or configure a private credential file")
+		}
+		info, err := os.Lstat(path)
+		if !filepath.IsAbs(path) || strings.ContainsAny(path, "\x00\r\n") || err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 || info.Mode().Perm()&0o400 == 0 || info.Size() == 0 {
+			return doctor.Failure(name+" authentication", "the configured host credential source is unavailable or unsafe", "provide a non-empty regular credential file readable only by its owner")
+		}
+		if checker == nil {
+			return doctor.Failure(name+" authentication", "the worker authentication diagnosis adapter is unavailable", "configure the Docker worker runtime to verify the credential inside the pinned image")
+		}
+		if err := checker.CheckHarnessAuthentication(ctx, worker.HarnessAuthenticationCheckRequest{Image: image, Name: name, AuthPath: path}); err != nil {
+			return doctor.Failure(name+" authentication", "the configured credential is not usable by the worker harness", "authenticate the "+name+" harness and provide a valid private credential source")
+		}
+		return doctor.Success(name + " authentication")
+	}
+}

--- a/internal/harness/doctor_test.go
+++ b/internal/harness/doctor_test.go
@@ -1,0 +1,143 @@
+package harness_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestValidateInteractiveResumeCapabilitiesRefusesAMissingCapability verifies
+// a role cannot select an adapter that cannot recover an interactive session.
+func TestValidateInteractiveResumeCapabilitiesRefusesAMissingCapability(t *testing.T) {
+	policy := config.RepositoryConfig{RoleHarnessDefaults: map[string]config.Harness{"implementation": config.HarnessCodex}}
+	err := harness.ValidateInteractiveResumeCapabilities(policy, func(string) (harness.Capabilities, error) {
+		return harness.Capabilities{Name: harness.NameCodex}, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "interactive resume") {
+		t.Fatalf("ValidateInteractiveResumeCapabilities() error = %v, want missing capability", err)
+	}
+}
+
+// TestStartupChecksProbeBothHarnessesAndConfiguredCredentials verifies the
+// harness contributor checks both adapters and never reads credential content
+// into a diagnosis result.
+func TestStartupChecksProbeBothHarnessesAndConfiguredCredentials(t *testing.T) {
+	root := t.TempDir()
+	codexPath := filepath.Join(root, "auth.json")
+	claudePath := filepath.Join(root, ".credentials.json")
+	for _, path := range []string{codexPath, claudePath} {
+		if err := os.WriteFile(path, []byte("credential contents"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	checker := &harnessDoctorChecker{}
+	report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
+		Policy: &config.RepositoryConfig{RoleHarnessDefaults: map[string]config.Harness{
+			"test": config.HarnessCodex, "implementation": config.HarnessClaude,
+		}},
+		Authentication: config.AuthenticationConfig{CodexAuthPath: codexPath, ClaudeAuthPath: claudePath},
+		Image: worker.ImageReference{
+			Name:   "ghcr.io/example/factory-worker",
+			Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+		Checker:               checker,
+		AuthenticationChecker: checker,
+	})...)
+	if !report.Ready() {
+		t.Fatalf("harness report = %#v, want ready", report)
+	}
+	if checker.calls != 2 {
+		t.Fatalf("harness executable checks = %d, want Codex and Claude", checker.calls)
+	}
+	if checker.authCalls != 2 {
+		t.Fatalf("harness authentication checks = %d, want Codex and Claude", checker.authCalls)
+	}
+}
+
+// TestStartupChecksKeepMissingOptionalCredentialsNonBlocking verifies a host
+// may defer authentication to an interactive worker session.
+func TestStartupChecksKeepMissingOptionalCredentialsNonBlocking(t *testing.T) {
+	report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
+		Policy: &config.RepositoryConfig{RoleHarnessDefaults: map[string]config.Harness{"test": config.HarnessCodex}},
+		Image: worker.ImageReference{
+			Name:   "ghcr.io/example/factory-worker",
+			Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+		Checker: &harnessDoctorChecker{},
+	})...)
+	if !report.Ready() || len(report.Warnings()) != 2 {
+		t.Fatalf("harness report = %#v, want two non-blocking auth warnings", report)
+	}
+}
+
+// TestStartupChecksDoNotRenderCredentialErrors verifies configured credential
+// failures never include a path's contents or the underlying error string.
+func TestStartupChecksDoNotRenderCredentialErrors(t *testing.T) {
+	secret := "credential-secret"
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
+		Authentication: config.AuthenticationConfig{CodexAuthPath: path},
+	})...)
+	for _, result := range report.Results {
+		if strings.Contains(result.Problem+result.Action, secret) {
+			t.Fatalf("harness result exposed credential contents: %#v", result)
+		}
+	}
+}
+
+// TestStartupChecksDoNotRenderWorkerAuthenticationErrors verifies an auth
+// command's private diagnostic output is also reduced to a safe result.
+func TestStartupChecksDoNotRenderWorkerAuthenticationErrors(t *testing.T) {
+	secret := "worker-auth-secret"
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(path, []byte("credential contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checker := &harnessDoctorChecker{authError: errors.New(secret)}
+	report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
+		Authentication:        config.AuthenticationConfig{CodexAuthPath: path},
+		AuthenticationChecker: checker,
+	})...)
+	for _, result := range report.Results {
+		if strings.Contains(result.Problem+result.Action, secret) {
+			t.Fatalf("harness result exposed worker authentication error: %#v", result)
+		}
+	}
+}
+
+// harnessDoctorChecker records worker-image harness probes.
+type harnessDoctorChecker struct {
+	err       error
+	calls     int
+	authCalls int
+	authError error
+}
+
+// CheckHarness implements the worker harness diagnosis seam.
+func (c *harnessDoctorChecker) CheckHarness(context.Context, worker.HarnessCheckRequest) error {
+	c.calls++
+	return c.err
+}
+
+// CheckHarnessAuthentication implements the worker credential diagnosis seam.
+func (c *harnessDoctorChecker) CheckHarnessAuthentication(context.Context, worker.HarnessAuthenticationCheckRequest) error {
+	c.authCalls++
+	return c.authError
+}
+
+var _ worker.HarnessChecker = (*harnessDoctorChecker)(nil)
+var _ worker.HarnessAuthenticationChecker = (*harnessDoctorChecker)(nil)

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -70,6 +70,9 @@ type Capabilities struct {
 	// session belongs to the harness that created it, so the coordinator
 	// compares this name before it resumes one.
 	Name string
+	// InteractiveResume reports whether interrupted sessions can be resumed
+	// through the adapter's native lifecycle.
+	InteractiveResume bool
 }
 
 // Runtime is the portable harness lifecycle seam used by the coordinator.

--- a/internal/store/doctor.go
+++ b/internal/store/doctor.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// StartupCheck returns the SQLite readiness check for one host-local
+// operational-store path. The normal store opener remains the single owner of
+// directory, schema, migration, and permission validation.
+func StartupCheck(path string) doctor.Check {
+	return func(ctx context.Context) doctor.Result {
+		if strings.TrimSpace(path) == "" {
+			return doctor.Failure("SQLite", "the operational store path is not configured", "register the repository with a private operational_data_path")
+		}
+		opened, err := Open(ctx, path)
+		if err != nil {
+			return doctor.Failure("SQLite", "the operational store cannot be opened with its supported schema", "repair the operational store path, permissions, or schema before starting the factory")
+		}
+		if err := opened.Close(); err != nil {
+			return doctor.Failure("SQLite", "the operational store could not be closed after diagnosis", "repair the local SQLite store or its filesystem permissions")
+		}
+		return doctor.Success("SQLite")
+	}
+}

--- a/internal/store/doctor.go
+++ b/internal/store/doctor.go
@@ -7,17 +7,17 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/doctor"
 )
 
-// StartupCheck returns the SQLite readiness check for one host-local
-// operational-store path. The normal store opener remains the single owner of
-// directory, schema, migration, and permission validation.
+// StartupCheck returns the SQLite readiness check for one existing host-local
+// operational-store path. Diagnosis uses the read-only opener so it never
+// creates, migrates, backs up, chmods, or initializes the operational store.
 func StartupCheck(path string) doctor.Check {
 	return func(ctx context.Context) doctor.Result {
 		if strings.TrimSpace(path) == "" {
 			return doctor.Failure("SQLite", "the operational store path is not configured", "register the repository with a private operational_data_path")
 		}
-		opened, err := Open(ctx, path)
+		opened, err := OpenReadOnly(ctx, path)
 		if err != nil {
-			return doctor.Failure("SQLite", "the operational store cannot be opened with its supported schema", "repair the operational store path, permissions, or schema before starting the factory")
+			return doctor.Failure("SQLite", "the existing operational store cannot be opened read-only with its current schema", "run the normal store initialization or migration, then retry the diagnosis")
 		}
 		if err := opened.Close(); err != nil {
 			return doctor.Failure("SQLite", "the operational store could not be closed after diagnosis", "repair the local SQLite store or its filesystem permissions")

--- a/internal/store/doctor_test.go
+++ b/internal/store/doctor_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,18 +10,75 @@ import (
 
 	"github.com/Stevie1704/sw-factory/internal/doctor"
 	"github.com/Stevie1704/sw-factory/internal/store"
+	_ "modernc.org/sqlite"
 )
 
-// TestStartupCheckOpensTheVersionedOperationalStore verifies SQLite diagnosis
-// delegates schema and permission ownership to the operational store.
-func TestStartupCheckOpensTheVersionedOperationalStore(t *testing.T) {
+// TestStartupCheckReadsTheVersionedOperationalStore verifies SQLite diagnosis
+// delegates schema and permission ownership to the read-only store opener.
+func TestStartupCheckReadsTheVersionedOperationalStore(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("Open().Close() error = %v", err)
+	}
 	result := doctor.Run(context.Background(), store.StartupCheck(path)).Results[0]
 	if result.Status != doctor.StatusPassed {
 		t.Fatalf("SQLite result = %#v, want passed", result)
 	}
 	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("diagnosed store was not created by the store opener: %v", err)
+		t.Fatalf("diagnosed store disappeared: %v", err)
+	}
+}
+
+// TestStartupCheckDoesNotCreateOrMigrateTheOperationalStore verifies diagnosis
+// remains observational and leaves missing store state for normal startup.
+func TestStartupCheckDoesNotCreateOrMigrateTheOperationalStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "factory.db")
+	result := doctor.Run(context.Background(), store.StartupCheck(path)).Results[0]
+	if result.Status != doctor.StatusFailed {
+		t.Fatalf("SQLite result = %#v, want failed for a missing store", result)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("diagnosis created an operational store; stat error = %v", err)
+	}
+}
+
+// TestStartupCheckDoesNotCreateAMigrationBackup verifies an older store is
+// reported for normal migration without being changed by diagnosis.
+func TestStartupCheckDoesNotCreateAMigrationBackup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("Open().Close() error = %v", err)
+	}
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(context.Background(), "UPDATE schema_metadata SET version = 0 WHERE singleton = 1"); err != nil {
+		_ = database.Close()
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	result := doctor.Run(context.Background(), store.StartupCheck(path)).Results[0]
+	if result.Status != doctor.StatusFailed {
+		t.Fatalf("SQLite result = %#v, want migration failure", result)
+	}
+	backups, err := filepath.Glob(path + ".bak-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("diagnosis created migration backups: %v", backups)
 	}
 }
 

--- a/internal/store/doctor_test.go
+++ b/internal/store/doctor_test.go
@@ -1,0 +1,44 @@
+package store_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestStartupCheckOpensTheVersionedOperationalStore verifies SQLite diagnosis
+// delegates schema and permission ownership to the operational store.
+func TestStartupCheckOpensTheVersionedOperationalStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "factory.db")
+	result := doctor.Run(context.Background(), store.StartupCheck(path)).Results[0]
+	if result.Status != doctor.StatusPassed {
+		t.Fatalf("SQLite result = %#v, want passed", result)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("diagnosed store was not created by the store opener: %v", err)
+	}
+}
+
+// TestStartupCheckDoesNotExposeSQLiteErrors verifies the CLI-facing result is
+// bounded even when the underlying store reports a path-specific failure.
+func TestStartupCheckDoesNotExposeSQLiteErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "factory.db")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result := doctor.Run(context.Background(), store.StartupCheck(path)).Results[0]
+	if result.Status != doctor.StatusFailed {
+		t.Fatalf("SQLite result = %#v, want failed", result)
+	}
+	if strings.Contains(result.Problem+result.Action, "factory.db") {
+		t.Fatalf("SQLite result exposed a path: %#v", result)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -481,6 +482,62 @@ func Open(ctx context.Context, path string) (*Store, error) {
 			return nil, err
 		}
 		version = CurrentSchemaVersion
+	}
+	closeOnError = false
+	return &Store{db: database, path: absolutePath, schemaVersion: version}, nil
+}
+
+// OpenReadOnly opens an existing, current operational store without creating
+// directories, changing permissions, initializing metadata, migrating schema,
+// or creating a backup. It is the only store entry point used by diagnosis.
+func OpenReadOnly(ctx context.Context, path string) (*Store, error) {
+	if path == "" {
+		return nil, errors.New("operational store path is required")
+	}
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve operational store path: %w", err)
+	}
+	storeDirectory := filepath.Dir(absolutePath)
+	if info, err := os.Stat(storeDirectory); err != nil {
+		return nil, fmt.Errorf("inspect operational store directory: %w", err)
+	} else if !info.IsDir() {
+		return nil, errors.New("operational store parent is not a directory")
+	} else if info.Mode().Perm()&0o077 != 0 {
+		return nil, errors.New("operational store directory is not private")
+	}
+	info, err := os.Lstat(absolutePath)
+	if err != nil {
+		return nil, fmt.Errorf("inspect operational store: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, errors.New("operational store is not a regular file")
+	}
+	if info.Mode().Perm()&0o077 != 0 || info.Mode().Perm()&0o400 == 0 {
+		return nil, errors.New("operational store file is not private and owner-readable")
+	}
+	if info.Size() == 0 {
+		return nil, &UnversionedDatabaseError{Path: absolutePath, Err: errors.New("database file is empty")}
+	}
+	database, err := openReadOnlyDatabase(ctx, absolutePath)
+	if err != nil {
+		return nil, err
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = database.Close()
+		}
+	}()
+	version, err := readSchemaVersion(ctx, database, absolutePath)
+	if err != nil {
+		return nil, err
+	}
+	if version > CurrentSchemaVersion {
+		return nil, &UnknownSchemaVersionError{Version: version, Supported: CurrentSchemaVersion}
+	}
+	if version < CurrentSchemaVersion {
+		return nil, errors.New("operational store schema requires migration")
 	}
 	closeOnError = false
 	return &Store{db: database, path: absolutePath, schemaVersion: version}, nil
@@ -1688,6 +1745,23 @@ func openConfiguredDatabase(ctx context.Context, path string) (*sql.DB, error) {
 		_ = database.Close()
 		return nil, err
 	}
+	return database, nil
+}
+
+// openReadOnlyDatabase opens a SQLite URI in read-only mode and applies only
+// connection-pool settings, never database-changing pragmas.
+func openReadOnlyDatabase(ctx context.Context, path string) (*sql.DB, error) {
+	dsn := (&url.URL{Scheme: "file", Path: path, RawQuery: "mode=ro"}).String()
+	database, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open operational store read-only: %w", err)
+	}
+	if err := database.PingContext(ctx); err != nil {
+		_ = database.Close()
+		return nil, fmt.Errorf("open operational store read-only: %w", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
 	return database, nil
 }
 

--- a/internal/terminal/doctor.go
+++ b/internal/terminal/doctor.go
@@ -1,0 +1,68 @@
+package terminal
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// DoctorChecker is the cmux-owned startup diagnosis seam.
+type DoctorChecker interface {
+	CheckExecutable(context.Context) error
+	CheckSocket(context.Context) error
+}
+
+// StartupChecks returns independent cmux executable and socket-reachability
+// checks so a broken terminal setup is fully reported in one run.
+func StartupChecks(checker DoctorChecker) []doctor.Check {
+	return []doctor.Check{
+		func(ctx context.Context) doctor.Result {
+			if checker == nil {
+				return doctor.Failure("cmux executable", "the cmux diagnosis adapter is unavailable", "configure the macOS cmux terminal adapter")
+			}
+			if err := checker.CheckExecutable(ctx); err != nil {
+				return doctor.Failure("cmux executable", "cmux is not available on the coordinator PATH", "install cmux and make its command available to the factory process")
+			}
+			return doctor.Success("cmux executable")
+		},
+		func(ctx context.Context) doctor.Result {
+			if checker == nil {
+				return doctor.Failure("cmux socket", "the cmux diagnosis adapter is unavailable", "configure the macOS cmux terminal adapter")
+			}
+			if err := checker.CheckSocket(ctx); err != nil {
+				return doctor.Failure("cmux socket", "the coordinator cannot reach the configured cmux control socket", "start cmux from the coordinator's permitted environment and verify the configured socket path")
+			}
+			return doctor.Success("cmux socket")
+		},
+	}
+}
+
+// CheckExecutable verifies the cmux binary exists when the production command
+// runner is in use. Injected runners represent an already controlled adapter.
+func (r *CmuxRuntime) CheckExecutable(context.Context) error {
+	if r.Runner != nil {
+		return nil
+	}
+	binary := strings.TrimSpace(r.Binary)
+	if binary == "" {
+		binary = "cmux"
+	}
+	if _, err := exec.LookPath(binary); err != nil {
+		return errors.New("cmux executable is unavailable")
+	}
+	return nil
+}
+
+// CheckSocket performs a read-only cmux topology query through the same
+// configured socket and process boundary used by terminal operations.
+func (r *CmuxRuntime) CheckSocket(ctx context.Context) error {
+	if _, err := r.topology(ctx, []string{"tree", "--json", "--id-format", "uuids"}); err != nil {
+		return errors.New("cmux topology query failed")
+	}
+	return nil
+}
+
+var _ DoctorChecker = (*CmuxRuntime)(nil)

--- a/internal/terminal/doctor_test.go
+++ b/internal/terminal/doctor_test.go
@@ -1,0 +1,58 @@
+package terminal_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+)
+
+// TestStartupChecksVerifyCmuxAvailabilityAndReachability verifies diagnosis
+// reports both terminal prerequisites independently.
+func TestStartupChecksVerifyCmuxAvailabilityAndReachability(t *testing.T) {
+	runner := &cmuxDoctorRunner{tree: `{"windows":[]}`}
+	runtime := terminal.NewCmuxRuntime(runner)
+	report := doctor.Run(context.Background(), terminal.StartupChecks(runtime)...)
+	if !report.Ready() || len(report.Results) != 2 {
+		t.Fatalf("cmux report = %#v, want two passing checks", report)
+	}
+	if runner.calls != 1 || !strings.Contains(runner.lastArgs, "tree --json --id-format uuids") {
+		t.Fatalf("cmux calls = %d/%q, want one topology probe", runner.calls, runner.lastArgs)
+	}
+}
+
+// TestStartupChecksReportAnUnavailableCmuxSocket verifies a socket failure is
+// actionable and does not expose the command runner's error text.
+func TestStartupChecksReportAnUnavailableCmuxSocket(t *testing.T) {
+	secret := "socket-secret"
+	runner := &cmuxDoctorRunner{err: errors.New(secret)}
+	report := doctor.Run(context.Background(), terminal.StartupChecks(terminal.NewCmuxRuntime(runner))...)
+	if report.Ready() {
+		t.Fatal("cmux report is ready despite an unavailable socket")
+	}
+	for _, result := range report.Results {
+		if strings.Contains(result.Problem+result.Action, secret) {
+			t.Fatalf("cmux result exposed command error: %#v", result)
+		}
+	}
+}
+
+// cmuxDoctorRunner records one topology probe.
+type cmuxDoctorRunner struct {
+	tree     string
+	err      error
+	calls    int
+	lastArgs string
+}
+
+// Run implements the terminal command runner for diagnosis tests.
+func (r *cmuxDoctorRunner) Run(_ context.Context, args []string, _ []byte) ([]byte, error) {
+	r.calls++
+	r.lastArgs = strings.Join(args, " ")
+	return []byte(r.tree), r.err
+}
+
+var _ terminal.CommandRunner = (*cmuxDoctorRunner)(nil)

--- a/internal/worker/doctor.go
+++ b/internal/worker/doctor.go
@@ -1,0 +1,208 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+)
+
+// ImageReference identifies the immutable worker image required by a run.
+type ImageReference struct {
+	// Name is the repository image name without a mutable tag.
+	Name string
+	// Digest is the full sha256 image digest.
+	Digest string
+}
+
+// HarnessCheckRequest identifies one harness executable that must be present
+// in the immutable worker image.
+type HarnessCheckRequest struct {
+	// Image is the worker image to inspect.
+	Image ImageReference
+	// Name is the safe executable name to probe.
+	Name string
+}
+
+// HarnessAuthenticationCheckRequest identifies one harness auth source to
+// validate inside a disposable pinned worker image.
+type HarnessAuthenticationCheckRequest struct {
+	// Image is the worker image to inspect.
+	Image ImageReference
+	// Name is the built-in harness executable to authenticate.
+	Name string
+	// AuthPath is the one explicit host credential file streamed to the probe.
+	AuthPath string
+}
+
+// DoctorChecker is the worker-owned Docker and image diagnosis seam.
+type DoctorChecker interface {
+	CheckDocker(context.Context) error
+	CheckImage(context.Context, ImageReference) error
+}
+
+// HarnessChecker is the worker execution seam used by the harness module to
+// probe each pinned harness executable inside the worker image.
+type HarnessChecker interface {
+	CheckHarness(context.Context, HarnessCheckRequest) error
+}
+
+// HarnessAuthenticationChecker is the worker execution seam for checking a
+// configured harness credential without exposing it to the coordinator.
+type HarnessAuthenticationChecker interface {
+	CheckHarnessAuthentication(context.Context, HarnessAuthenticationCheckRequest) error
+}
+
+// StartupChecks returns independent Docker daemon and worker-image checks.
+func StartupChecks(checker DoctorChecker, image ImageReference) []doctor.Check {
+	return []doctor.Check{
+		func(ctx context.Context) doctor.Result {
+			if checker == nil {
+				return doctor.Failure("docker daemon", "the Docker diagnosis adapter is unavailable", "configure the Docker worker runtime")
+			}
+			if err := checker.CheckDocker(ctx); err != nil {
+				return doctor.Failure("docker daemon", "the coordinator cannot reach a usable Docker daemon", "start Docker and verify the coordinator account can access it")
+			}
+			return doctor.Success("docker daemon")
+		},
+		func(ctx context.Context) doctor.Result {
+			if checker == nil {
+				return doctor.Failure("worker image", "the Docker diagnosis adapter is unavailable", "configure the Docker worker runtime")
+			}
+			if err := checker.CheckImage(ctx, image); err != nil {
+				return doctor.Failure("worker image", "the configured worker image@sha256 digest is not available locally", "build or load the configured worker image at the exact digest; doctor never pulls images")
+			}
+			return doctor.Success("worker image")
+		},
+	}
+}
+
+// CheckDocker verifies the Docker executable and daemon without displaying
+// Docker's version or diagnostic output.
+func (r *DockerRuntime) CheckDocker(ctx context.Context) error {
+	binary := strings.TrimSpace(r.DockerBinary)
+	if binary == "" {
+		binary = "docker"
+	}
+	if _, err := exec.LookPath(binary); err != nil {
+		return errors.New("Docker executable is unavailable")
+	}
+	if _, err := r.runDocker(ctx, []string{"version", "--format", "{{.Server.Version}}"}); err != nil {
+		return errors.New("Docker daemon is unavailable")
+	}
+	return nil
+}
+
+// CheckImage verifies the exact digest-qualified worker image exists without
+// pulling or changing any local image.
+func (r *DockerRuntime) CheckImage(ctx context.Context, image ImageReference) error {
+	if err := validateImageReference(image); err != nil {
+		return err
+	}
+	result, err := r.runDocker(ctx, []string{"image", "inspect", "--format", "{{json .}}", imageReference(image.Name, image.Digest)})
+	if err != nil {
+		return errors.New("worker image inspection failed")
+	}
+	if strings.TrimSpace(result.Stdout) == "" {
+		return errors.New("worker image inspection returned no image")
+	}
+	return nil
+}
+
+// CheckHarness verifies one harness executable and its version command inside
+// the exact worker image, using a disposable no-pull container.
+func (r *DockerRuntime) CheckHarness(ctx context.Context, request HarnessCheckRequest) error {
+	if err := validateImageReference(request.Image); err != nil {
+		return err
+	}
+	if !validName(request.Name) {
+		return errors.New("harness executable name is unsafe")
+	}
+	command := "command -v " + request.Name + " >/dev/null 2>&1 && " + request.Name + " --version >/dev/null 2>&1"
+	if _, err := r.runDocker(ctx, []string{
+		"run", "--rm", "--pull=never", "--entrypoint", "/bin/sh",
+		imageReference(request.Image.Name, request.Image.Digest), "-c", command,
+	}); err != nil {
+		return errors.New("harness executable is not usable in the worker image")
+	}
+	return nil
+}
+
+// CheckHarnessAuthentication streams one explicit credential file into a
+// disposable, network-isolated worker and runs that harness's local auth
+// status command. Neither credential contents nor process output is returned.
+func (r *DockerRuntime) CheckHarnessAuthentication(ctx context.Context, request HarnessAuthenticationCheckRequest) error {
+	if err := validateImageReference(request.Image); err != nil {
+		return err
+	}
+	roleHome, credentialFile, command, err := harnessAuthenticationCommand(request.Name)
+	if err != nil {
+		return err
+	}
+	data, err := readAuthenticationSource(request.AuthPath)
+	if err != nil {
+		return err
+	}
+	authFile := roleHome + "/" + credentialFile
+	writeCommand := "umask 077; mkdir -p " + roleHome + "; cat > " + authFile + "; chmod 0400 " + authFile
+	probe := writeCommand + " && " + command
+	if _, err := r.runDockerWithInput(ctx, []string{
+		"run", "--rm", "--pull=never", "--network", "none", "--user", WorkerUser,
+		"--entrypoint", "/bin/sh", imageReference(request.Image.Name, request.Image.Digest), "-c", probe,
+	}, data); err != nil {
+		return errors.New("harness authentication is not usable in the worker image")
+	}
+	return nil
+}
+
+// harnessAuthenticationCommand returns the fixed in-worker auth file location
+// and status command for a supported harness. It never incorporates user text
+// into a shell command.
+func harnessAuthenticationCommand(name string) (string, string, string, error) {
+	switch name {
+	case "codex":
+		return "/home/factory/.codex", "auth.json", "codex login status >/dev/null 2>&1", nil
+	case "claude":
+		return "/home/factory/.claude", ".credentials.json", "claude auth status >/dev/null 2>&1", nil
+	default:
+		return "", "", "", fmt.Errorf("unsupported harness authentication probe %q", name)
+	}
+}
+
+// readAuthenticationSource validates and reads one private credential file for
+// a worker-side probe without returning its bytes in an error or result.
+func readAuthenticationSource(path string) ([]byte, error) {
+	if !filepath.IsAbs(path) || strings.ContainsAny(path, "\x00\r\n") {
+		return nil, errors.New("harness authentication path must be absolute and safe")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 || info.Mode().Perm()&0o400 == 0 || info.Size() == 0 {
+		return nil, errors.New("harness authentication source is unavailable or unsafe")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return nil, errors.New("harness authentication source cannot be read")
+	}
+	return data, nil
+}
+
+// validateImageReference validates the image name and immutable digest before
+// either value crosses into a Docker command.
+func validateImageReference(image ImageReference) error {
+	if err := validateImageName(image.Name); err != nil {
+		return err
+	}
+	if !validDigest(image.Digest) {
+		return errors.New("worker image digest must be a sha256 digest with 64 lowercase hexadecimal characters")
+	}
+	return nil
+}
+
+var _ DoctorChecker = (*DockerRuntime)(nil)
+var _ HarnessChecker = (*DockerRuntime)(nil)
+var _ HarnessAuthenticationChecker = (*DockerRuntime)(nil)

--- a/internal/worker/doctor.go
+++ b/internal/worker/doctor.go
@@ -125,7 +125,9 @@ func (r *DockerRuntime) CheckHarness(ctx context.Context, request HarnessCheckRe
 	}
 	command := "command -v " + request.Name + " >/dev/null 2>&1 && " + request.Name + " --version >/dev/null 2>&1"
 	if _, err := r.runDocker(ctx, []string{
-		"run", "--rm", "--pull=never", "--entrypoint", "/bin/sh",
+		"run", "--rm", "--pull=never", "--user", WorkerUser,
+		"--cap-drop", "ALL", "--security-opt", "no-new-privileges", "--network", "none",
+		"--entrypoint", "/bin/sh",
 		imageReference(request.Image.Name, request.Image.Digest), "-c", command,
 	}); err != nil {
 		return errors.New("harness executable is not usable in the worker image")
@@ -153,6 +155,7 @@ func (r *DockerRuntime) CheckHarnessAuthentication(ctx context.Context, request 
 	probe := writeCommand + " && " + command
 	if _, err := r.runDockerWithInput(ctx, []string{
 		"run", "--rm", "--pull=never", "--network", "none", "--user", WorkerUser,
+		"--cap-drop", "ALL", "--security-opt", "no-new-privileges",
 		"--entrypoint", "/bin/sh", imageReference(request.Image.Name, request.Image.Digest), "-c", probe,
 	}, data); err != nil {
 		return errors.New("harness authentication is not usable in the worker image")

--- a/internal/worker/doctor.go
+++ b/internal/worker/doctor.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"golang.org/x/sys/unix"
 )
 
 // ImageReference identifies the immutable worker image required by a run.
@@ -183,11 +185,16 @@ func readAuthenticationSource(path string) ([]byte, error) {
 	if !filepath.IsAbs(path) || strings.ContainsAny(path, "\x00\r\n") {
 		return nil, errors.New("harness authentication path must be absolute and safe")
 	}
-	info, err := os.Lstat(path)
+	file, err := os.OpenFile(path, os.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, errors.New("harness authentication source is unavailable or unsafe")
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
 	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 || info.Mode().Perm()&0o400 == 0 || info.Size() == 0 {
 		return nil, errors.New("harness authentication source is unavailable or unsafe")
 	}
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(file)
 	if err != nil || len(data) == 0 {
 		return nil, errors.New("harness authentication source cannot be read")
 	}

--- a/internal/worker/doctor_test.go
+++ b/internal/worker/doctor_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Stevie1704/sw-factory/internal/doctor"
@@ -106,5 +108,113 @@ func TestDockerRuntimeChecksHarnessAuthenticationInsideThePinnedWorker(t *testin
 	)
 	if strings.Contains(line, secret) || strings.Contains(line, authPath) {
 		t.Fatalf("credential material or host path entered Docker arguments: %q", line)
+	}
+}
+
+// TestDockerRuntimeDoesNotSendContentsFromReplacedAuthenticationPath verifies
+// replacing the validated path cannot redirect the credential sent to Docker.
+func TestDockerRuntimeDoesNotSendContentsFromReplacedAuthenticationPath(t *testing.T) {
+	stub, _, _ := writeDockerStub(t)
+	inputDirectory := filepath.Join(t.TempDir(), "docker-input")
+	if err := os.Mkdir(inputDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WORKER_DOCKER_INPUT_DIR", inputDirectory)
+
+	root := t.TempDir()
+	safeSourcePath := filepath.Join(root, "safe-auth.json")
+	authPath := filepath.Join(root, "auth.json")
+	replacementPath := filepath.Join(root, "replacement")
+	restorePath := filepath.Join(root, "restore")
+	arbitraryHostFilePath := filepath.Join(root, "host-file")
+	safeContents := []byte("expected-credential")
+	arbitraryHostContents := []byte("arbitrary-host-file-contents")
+	if err := os.WriteFile(safeSourcePath, safeContents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(arbitraryHostFilePath, arbitraryHostContents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(safeSourcePath, authPath); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &worker.DockerRuntime{DockerBinary: stub}
+	request := worker.HarnessAuthenticationCheckRequest{
+		Image:    worker.ImageReference{Name: "ghcr.io/example/factory-worker", Digest: testWorkerDigest},
+		Name:     "codex",
+		AuthPath: authPath,
+	}
+	if err := runtime.CheckHarnessAuthentication(context.Background(), request); err != nil {
+		t.Fatalf("baseline CheckHarnessAuthentication() error = %v", err)
+	}
+
+	stopReplacement := make(chan struct{})
+	replacementDone := make(chan struct{})
+	replacementReady := make(chan struct{})
+	var replacementCount atomic.Int64
+	var replacementReadyOnce sync.Once
+	go func() {
+		defer close(replacementDone)
+		for {
+			select {
+			case <-stopReplacement:
+				return
+			default:
+			}
+
+			_ = os.Remove(replacementPath)
+			if err := os.Symlink(arbitraryHostFilePath, replacementPath); err != nil {
+				continue
+			}
+			if err := os.Rename(replacementPath, authPath); err != nil {
+				_ = os.Remove(replacementPath)
+				continue
+			}
+			replacementCount.Add(1)
+			replacementReadyOnce.Do(func() { close(replacementReady) })
+
+			_ = os.Remove(restorePath)
+			if err := os.Link(safeSourcePath, restorePath); err != nil {
+				continue
+			}
+			_ = os.Rename(restorePath, authPath)
+		}
+	}()
+	<-replacementReady
+
+	const attempts = 512
+	const workers = 8
+	var checks sync.WaitGroup
+	checks.Add(workers)
+	for range workers {
+		go func() {
+			defer checks.Done()
+			for range attempts / workers {
+				_ = runtime.CheckHarnessAuthentication(context.Background(), request)
+			}
+		}()
+	}
+	checks.Wait()
+	close(stopReplacement)
+	<-replacementDone
+	if replacementCount.Load() == 0 {
+		t.Fatal("authentication path was not replaced during the check")
+	}
+
+	entries, err := os.ReadDir(inputDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("Docker received no authentication input")
+	}
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(inputDirectory, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != string(safeContents) {
+			t.Fatalf("Docker received unexpected authentication input: %q", data)
+		}
 	}
 }

--- a/internal/worker/doctor_test.go
+++ b/internal/worker/doctor_test.go
@@ -1,0 +1,87 @@
+package worker_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestStartupChecksReportDockerAndWorkerImageIndependently verifies the
+// worker contributor reports every prerequisite even when Docker is unavailable.
+func TestStartupChecksReportDockerAndWorkerImageIndependently(t *testing.T) {
+	checker := &fakeWorkerDoctorChecker{dockerErr: errors.New("docker unavailable")}
+	report := doctor.Run(context.Background(), worker.StartupChecks(checker, worker.ImageReference{
+		Name:   "ghcr.io/example/factory-worker",
+		Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	})...)
+	if report.Ready() || len(report.Failures()) != 1 {
+		t.Fatalf("worker report = %#v, want one Docker failure", report)
+	}
+	if len(report.Results) != 2 || checker.calls != 2 {
+		t.Fatalf("worker results/calls = %d/%d, want daemon and image checks", len(report.Results), checker.calls)
+	}
+}
+
+// TestStartupChecksDoNotRenderWorkerCommandErrors verifies worker diagnosis
+// keeps process output, which may contain repository data, out of the report.
+func TestStartupChecksDoNotRenderWorkerCommandErrors(t *testing.T) {
+	secret := "worker-command-secret"
+	checker := &fakeWorkerDoctorChecker{dockerErr: errors.New(secret), imageErr: errors.New(secret)}
+	report := doctor.Run(context.Background(), worker.StartupChecks(checker, worker.ImageReference{})...)
+	for _, result := range report.Results {
+		if strings.Contains(result.Problem+result.Action, secret) {
+			t.Fatalf("worker result exposed command error: %#v", result)
+		}
+	}
+}
+
+// fakeWorkerDoctorChecker records worker diagnosis calls.
+type fakeWorkerDoctorChecker struct {
+	dockerErr error
+	imageErr  error
+	calls     int
+}
+
+// CheckDocker implements the worker daemon diagnosis seam.
+func (f *fakeWorkerDoctorChecker) CheckDocker(context.Context) error {
+	f.calls++
+	return f.dockerErr
+}
+
+// CheckImage implements the worker image diagnosis seam.
+func (f *fakeWorkerDoctorChecker) CheckImage(context.Context, worker.ImageReference) error {
+	f.calls++
+	return f.imageErr
+}
+
+var _ worker.DoctorChecker = (*fakeWorkerDoctorChecker)(nil)
+
+// TestDockerRuntimeChecksHarnessAuthenticationInsideThePinnedWorker verifies
+// credential input is streamed to a disposable network-isolated probe rather
+// than passed as a command argument or rendered in output.
+func TestDockerRuntimeChecksHarnessAuthenticationInsideThePinnedWorker(t *testing.T) {
+	stub, logPath, _ := writeDockerStub(t)
+	secret := "credential-value-must-not-enter-docker-args"
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authPath, []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &worker.DockerRuntime{DockerBinary: stub}
+	if err := runtime.CheckHarnessAuthentication(context.Background(), worker.HarnessAuthenticationCheckRequest{
+		Image: worker.ImageReference{Name: "ghcr.io/example/factory-worker", Digest: testWorkerDigest},
+		Name:  "codex", AuthPath: authPath,
+	}); err != nil {
+		t.Fatalf("CheckHarnessAuthentication() error = %v", err)
+	}
+	line := findLogLine(t, readStubLog(t, logPath), " run ")
+	assertContainsAll(t, line, "--pull=never", "--network none", "--user 10001:10001", "codex login status", "ghcr.io/example/factory-worker@"+testWorkerDigest)
+	if strings.Contains(line, secret) || strings.Contains(line, authPath) {
+		t.Fatalf("credential material or host path entered Docker arguments: %q", line)
+	}
+}

--- a/internal/worker/doctor_test.go
+++ b/internal/worker/doctor_test.go
@@ -62,6 +62,25 @@ func (f *fakeWorkerDoctorChecker) CheckImage(context.Context, worker.ImageRefere
 
 var _ worker.DoctorChecker = (*fakeWorkerDoctorChecker)(nil)
 
+// TestDockerRuntimeChecksHarnessInsideTheHardenedProbe verifies executable
+// diagnosis uses the same least-privilege boundary as a real worker.
+func TestDockerRuntimeChecksHarnessInsideTheHardenedProbe(t *testing.T) {
+	stub, logPath, _ := writeDockerStub(t)
+	runtime := &worker.DockerRuntime{DockerBinary: stub}
+	if err := runtime.CheckHarness(context.Background(), worker.HarnessCheckRequest{
+		Image: worker.ImageReference{Name: "ghcr.io/example/factory-worker", Digest: testWorkerDigest},
+		Name:  "codex",
+	}); err != nil {
+		t.Fatalf("CheckHarness() error = %v", err)
+	}
+	line := findLogLine(t, readStubLog(t, logPath), " run ")
+	assertContainsAll(t, line,
+		"--pull=never", "--user 10001:10001", "--cap-drop ALL",
+		"--security-opt no-new-privileges", "--network none",
+		"codex --version", "ghcr.io/example/factory-worker@"+testWorkerDigest,
+	)
+}
+
 // TestDockerRuntimeChecksHarnessAuthenticationInsideThePinnedWorker verifies
 // credential input is streamed to a disposable network-isolated probe rather
 // than passed as a command argument or rendered in output.
@@ -80,7 +99,11 @@ func TestDockerRuntimeChecksHarnessAuthenticationInsideThePinnedWorker(t *testin
 		t.Fatalf("CheckHarnessAuthentication() error = %v", err)
 	}
 	line := findLogLine(t, readStubLog(t, logPath), " run ")
-	assertContainsAll(t, line, "--pull=never", "--network none", "--user 10001:10001", "codex login status", "ghcr.io/example/factory-worker@"+testWorkerDigest)
+	assertContainsAll(t, line,
+		"--pull=never", "--network none", "--user 10001:10001",
+		"--cap-drop ALL", "--security-opt no-new-privileges", "codex login status",
+		"ghcr.io/example/factory-worker@"+testWorkerDigest,
+	)
 	if strings.Contains(line, secret) || strings.Contains(line, authPath) {
 		t.Fatalf("credential material or host path entered Docker arguments: %q", line)
 	}

--- a/internal/worker/runtime_contract_test.go
+++ b/internal/worker/runtime_contract_test.go
@@ -344,6 +344,9 @@ case "$command_name" in
     printf '\n'
     ;;
   run)
+    if [ -n "${WORKER_DOCKER_INPUT_DIR:-}" ]; then
+      cat > "$WORKER_DOCKER_INPUT_DIR/input.$$"
+    fi
     printf 'running\n' > "$WORKER_DOCKER_STATE"
     # Extract and record mount information from run command
     printf '' > "$WORKER_DOCKER_MOUNTS"


### PR DESCRIPTION
Closes #19. Adds the composed factory doctor with subsystem-owned checks for configuration, GitHub access and labels, Git remotes/hooks/worktrees, cmux, Docker and the pinned worker image, both harnesses and auth sources, interactive-resume capability validation, and SQLite. Adds the pre-claim capability guard, CLI rendering, safe actionable failures, and tests/docs. Verification: make fmt-check; GOCACHE=/tmp/sw-factory-go-cache make vet; GOCACHE=/tmp/sw-factory-go-cache go test ./...; GOPROXY=off GOSUMDB=off GOCACHE=/tmp/sw-factory-go-cache make build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `factory doctor` command for comprehensive startup readiness checks.
  - Checks configuration, GitHub access, repository state, terminal tools, workers, harnesses, authentication, and operational storage.
  - Reports failures with actionable remediation details before a run begins.
  - Added support and validation for Codex and Claude interactive session resumption.
  - Performs storage checks without creating or modifying the operational database.

- **Bug Fixes**
  - Prevents claims from starting when configured harness capabilities are unsupported.
  - Redacts credentials and sensitive diagnostic details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->