### PR TITLE
fix: attach probe stdin when checking harness authentication

### DIFF
--- a/internal/worker/doctor.go
+++ b/internal/worker/doctor.go
@@ -139,7 +139,9 @@ func (r *DockerRuntime) CheckHarness(ctx context.Context, request HarnessCheckRe
 
 // CheckHarnessAuthentication streams one explicit credential file into a
 // disposable, network-isolated worker and runs that harness's local auth
-// status command. Neither credential contents nor process output is returned.
+// status command. The probe keeps container standard input attached so the
+// credential reaches the in-worker file instead of arriving empty. Neither
+// credential contents nor process output is returned.
 func (r *DockerRuntime) CheckHarnessAuthentication(ctx context.Context, request HarnessAuthenticationCheckRequest) error {
 	if err := validateImageReference(request.Image); err != nil {
 		return err
@@ -156,7 +158,7 @@ func (r *DockerRuntime) CheckHarnessAuthentication(ctx context.Context, request 
 	writeCommand := "umask 077; mkdir -p " + roleHome + "; cat > " + authFile + "; chmod 0400 " + authFile
 	probe := writeCommand + " && " + command
 	if _, err := r.runDockerWithInput(ctx, []string{
-		"run", "--rm", "--pull=never", "--network", "none", "--user", WorkerUser,
+		"run", "--rm", "-i", "--pull=never", "--network", "none", "--user", WorkerUser,
 		"--cap-drop", "ALL", "--security-opt", "no-new-privileges",
 		"--entrypoint", "/bin/sh", imageReference(request.Image.Name, request.Image.Digest), "-c", probe,
 	}, data); err != nil {

--- a/internal/worker/doctor_test.go
+++ b/internal/worker/doctor_test.go
@@ -105,6 +105,9 @@ func TestDockerRuntimeChecksHarnessAuthenticationInsideThePinnedWorker(t *testin
 		"--pull=never", "--network none", "--user 10001:10001",
 		"--cap-drop ALL", "--security-opt no-new-privileges", "codex login status",
 		"ghcr.io/example/factory-worker@"+testWorkerDigest,
+		// Without attached standard input the probe writes an empty
+		// credential file and every authenticated harness fails diagnosis.
+		"run --rm -i ",
 	)
 	if strings.Contains(line, secret) || strings.Contains(line, authPath) {
 		t.Fatalf("credential material or host path entered Docker arguments: %q", line)


### PR DESCRIPTION
## Summary

- `factory doctor`'s harness credential probe built its `docker run` command without `-i`, so container standard input was never attached.
- The probe's in-worker `cat > auth.json` consequently read EOF immediately and wrote a zero-byte credential file, so the harness status command failed for every host.
- `codex authentication` and `claude authentication` could therefore never pass, regardless of whether the host credential was valid.
- The real worker path (`seedCredentialFile`) already uses `docker exec -i` for the same credential streaming, so only diagnosis was affected — no runtime behaviour changes.

## Changes

**internal/worker/doctor.go**
- `CheckHarnessAuthentication` now passes `-i` to `docker run` so the streamed credential reaches the in-worker file.
- Extended the doc comment to record why standard input must stay attached.

**internal/worker/doctor_test.go**
- `TestDockerRuntimeChecksHarnessAuthenticationInsideThePinnedWorker` now asserts `run --rm -i ` in the recorded Docker arguments, so the flag cannot be dropped again.

## Contract Impact

None. No configuration schema, store schema, GitHub, or worker runtime contract changes. The probe keeps the same least-privilege boundary: `--rm`, `--pull=never`, `--network none`, `--user 10001:10001`, `--cap-drop ALL`, `--security-opt no-new-privileges`, and the credential still never enters Docker arguments.

## Test Plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 476 tests pass across 18 packages
- [x] Reproduced the defect against the pinned worker image: the same `docker run` without `-i` writes a 0-byte credential and `codex login status` fails with `EOF while parsing a value at line 1 column 0`; with `-i` it reports `Logged in using ChatGPT`.
- [x] `factory doctor` on a registered repository now reports `codex authentication: passed` and an overall `ready` verdict.

## Checklist

- [x] Tests pass
- [x] No breaking changes
- [x] CLAUDE.md updated if architecture changed (not applicable — no architecture change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL8j1hqRL2E3DbRMJtSC9u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication checks so credential data is correctly passed to the isolated environment.
  * Improved reliability of Docker-based authentication probes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->