### PR TITLE
feat: add polling coordinator and GitHub lease

### DIFF
--- a/cmd/factory/main.go
+++ b/cmd/factory/main.go
@@ -3,10 +3,16 @@ package main
 import (
 	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/Stevie1704/sw-factory/internal/cli"
 )
 
+// main runs the factory CLI with operating-system cancellation wired into the
+// long-lived coordinator command.
 func main() {
-	os.Exit(cli.Run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	os.Exit(cli.Run(ctx, os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,25 @@ migrate, back up, chmod, or initialize store state.
 Missing optional host credential files are warnings because a harness may be
 authenticated during its first visible worker session.
 
+Start the persistent coordinator after diagnosis is ready:
+
+```sh
+factory start --config /Users/me/.config/factory/config.yaml
+factory stop --config /Users/me/.config/factory/config.yaml
+```
+
+`factory start` runs the complete startup diagnosis before taking a private
+host lock. It polls immediately and then at the configured interval, claims
+only the oldest open issue carrying `agent-ready`, and skips queue claims while
+any non-terminal run exists. GitHub transport failures use the configured
+backoff and do not change workflow state or retry budgets. The coordinator
+publishes a renewable `factory/lease` Commit Status on the target branch; its
+description includes the coordinator, active run, heartbeat, and expiry so a
+stale owner remains diagnosable in GitHub. `factory stop` signals the locked
+coordinator and leaves any active run, branch, worktree, worker, and session
+artifacts in place. Polling never creates factory labels; use
+`factory bootstrap-labels` explicitly.
+
 ## Host configuration
 
 The generated host file contains the repository path, GitHub identity, authorized maintainers, polling settings, cmux settings, the checked-in repository configuration path, and the operational-data path.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,6 +32,8 @@ var commandTable = []commandDefinition{
 	{name: "register", handler: runRegister},
 	{name: "bootstrap-labels", handler: runBootstrapLabels},
 	{name: "doctor", handler: runDoctor},
+	{name: "start", handler: runStart},
+	{name: "stop", handler: runStop},
 	{name: "issue", handler: runIssue},
 	{name: "agent", handler: runAgent},
 	{name: "agent-report", handler: runAgentReport},
@@ -146,6 +148,62 @@ func runDoctor(ctx context.Context, args []string, defaultConfigPath string, out
 		return 1
 	}
 	return 1
+}
+
+// runStart starts the persistent polling coordinator and returns when its
+// context is cancelled by factory stop or an operating-system signal.
+func runStart(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("start", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("start does not accept positional arguments"))
+		return 2
+	}
+	if !writeOutput(output, errorsOutput, "factory polling starting\n") {
+		return 1
+	}
+	if err := factory.New(*configPath).Start(ctx); err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "factory polling stopped\n") {
+		return 1
+	}
+	return 0
+}
+
+// runStop signals the persistent polling coordinator without changing any
+// active run state or removing recoverable run artifacts.
+func runStop(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("stop", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("stop does not accept positional arguments"))
+		return 2
+	}
+	result, err := factory.New(*configPath).Stop(ctx)
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if result.Running {
+		if !writeOutput(output, errorsOutput, "factory stop requested (pid=%d)\n", result.PID) {
+			return 1
+		}
+		return 0
+	}
+	if !writeOutput(output, errorsOutput, "factory is not running\n") {
+		return 1
+	}
+	return 0
 }
 
 // runIssue handles the one-shot issue claim command.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -206,6 +206,27 @@ func TestRunPollRejectsPositionalArguments(t *testing.T) {
 	}
 }
 
+// TestRunStartAndStopRejectPositionalArguments keeps lifecycle control
+// explicit and prevents accidental arguments from being treated as paths.
+func TestRunStartAndStopRejectPositionalArguments(t *testing.T) {
+	t.Parallel()
+
+	for _, command := range []string{"start", "stop"} {
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			var output bytes.Buffer
+			code := cli.Run(context.Background(), []string{command, "extra", "--config", configPath}, &output, &output)
+			if code != 2 {
+				t.Fatalf("exit code = %d, want 2, output = %s", code, output.String())
+			}
+			if !strings.Contains(output.String(), command+" does not accept positional arguments") {
+				t.Fatalf("output = %q", output.String())
+			}
+		})
+	}
+}
+
 func TestRunInitRejectsAnUnknownFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -29,6 +29,12 @@ type Factory interface {
 	// Doctor runs every configured startup diagnosis and reports whether a run
 	// can be claimed safely.
 	Doctor(context.Context) (DoctorResult, error)
+	// Start runs the supervised polling coordinator until its context is
+	// cancelled or a separate Stop command signals it.
+	Start(context.Context) error
+	// Stop asks a running coordinator to stop polling without changing the
+	// state of its active run.
+	Stop(context.Context) (StopResult, error)
 	RunCoordinator
 	// RunBaseline evaluates the frozen repository gate model before agent edits.
 	RunBaseline(context.Context, BaselineRequest) (BaselineResult, error)
@@ -58,7 +64,7 @@ type Factory interface {
 }
 
 // RunCoordinator is the single claim/state-transition seam used by the
-// one-shot command and the future poller.
+// one-shot command and the persistent polling coordinator.
 type RunCoordinator interface {
 	ClaimIssue(context.Context, int) (IssueResult, error)
 	Transition(context.Context, TransitionRequest) (store.Run, error)
@@ -106,6 +112,9 @@ type Clock func() time.Time
 // RunIDGenerator supplies an immutable identifier for a new run.
 type RunIDGenerator func() (string, error)
 
+// StartupDiagnosis runs the complete pre-poll startup diagnosis.
+type StartupDiagnosis func(context.Context) (DoctorResult, error)
+
 // Dependencies are the adapters at the high-level factory seam.
 type Dependencies struct {
 	Config          ConfigRepository
@@ -113,8 +122,13 @@ type Dependencies struct {
 	CheckRepository RepositoryChecker
 	LoadRepository  RepositoryConfigLoader
 	GitHub          github.Client
-	CommitStatuses  github.CommitStatusPublisher
-	Worktree        gitadapter.WorktreeManager
+	// IssuePoller lists eligible GitHub work without broadening the mutation
+	// authority of the existing issue client seam.
+	IssuePoller github.IssuePoller
+	// Lease publishes the coordinator's visible GitHub heartbeat.
+	Lease          github.LeaseClient
+	CommitStatuses github.CommitStatusPublisher
+	Worktree       gitadapter.WorktreeManager
 	// GitWorkspace owns checkpoint, base-sync, push, and cleanup effects on the host.
 	GitWorkspace gitadapter.GitWorkspace
 	// PullRequests owns idempotent draft pull-request discovery and mutation.
@@ -132,6 +146,9 @@ type Dependencies struct {
 	Now                 Clock
 	NewRunID            RunIDGenerator
 	Coordinator         string
+	// StartupDiagnosis is injectable for embedders and deterministic polling
+	// tests; nil uses the service's full Doctor implementation.
+	StartupDiagnosis StartupDiagnosis
 }
 
 type Service struct {
@@ -145,6 +162,8 @@ type Service struct {
 	startupMu         sync.Mutex
 	startupChecked    bool
 	startupErr        error
+	pollMu            sync.Mutex
+	pollCancel        context.CancelFunc
 }
 
 type InitResult struct {
@@ -224,6 +243,16 @@ func NewWithDependencies(configPath string, dependencies Dependencies) *Service 
 	}
 	if dependencies.GitHub == nil {
 		dependencies.GitHub = github.NewClient()
+	}
+	if dependencies.IssuePoller == nil {
+		if poller, ok := dependencies.GitHub.(github.IssuePoller); ok {
+			dependencies.IssuePoller = poller
+		}
+	}
+	if dependencies.Lease == nil {
+		if lease, ok := dependencies.GitHub.(github.LeaseClient); ok {
+			dependencies.Lease = lease
+		}
 	}
 	if dependencies.CommitStatuses == nil {
 		if publisher, ok := dependencies.GitHub.(github.CommitStatusPublisher); ok {

--- a/internal/factory/lock.go
+++ b/internal/factory/lock.go
@@ -1,0 +1,221 @@
+package factory
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+)
+
+// ErrCoordinatorAlreadyRunning reports that another process owns the
+// repository's host lock.
+var ErrCoordinatorAlreadyRunning = errors.New("factory coordinator is already running")
+
+// ErrCoordinatorNotRunning reports that no process currently owns the host
+// lock targeted by a stop request.
+var ErrCoordinatorNotRunning = errors.New("factory coordinator is not running")
+
+// StopResult reports whether a stop signal was sent to a coordinator.
+type StopResult struct {
+	// Running is true when a live lock owner received the stop signal.
+	Running bool
+	// PID is the signalled process identifier, or zero when no coordinator ran.
+	PID int
+}
+
+// coordinatorLock is a kernel-backed repository ownership lock held for the
+// lifetime of one polling coordinator process.
+type coordinatorLock struct {
+	file *os.File
+}
+
+// coordinatorLockPath returns a stable private lock keyed by the canonical
+// registered checkout path. Keeping the lock outside both the checkout and
+// operational store makes separate host configurations for one repository
+// share ownership without modifying repository contents.
+func coordinatorLockPath(registration config.RepositoryRegistration) string {
+	repositoryPath := filepath.Clean(registration.Path)
+	if absolute, err := filepath.Abs(repositoryPath); err == nil {
+		repositoryPath = absolute
+	}
+	if resolved, err := filepath.EvalSymlinks(repositoryPath); err == nil {
+		repositoryPath = resolved
+	}
+	identity := sha256.Sum256([]byte(repositoryPath))
+	return filepath.Join(os.TempDir(), "sw-factory", "coordinators", fmt.Sprintf("%x.lock", identity))
+}
+
+// acquireCoordinatorLock takes a non-blocking advisory lock and records the
+// owning PID for a separate factory stop command to signal.
+func acquireCoordinatorLock(path string) (*coordinatorLock, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("coordinator lock path is required")
+	}
+	if err := ensurePrivateLockDirectory(filepath.Dir(path)); err != nil {
+		return nil, err
+	}
+	file, err := openPrivateLockFile(path, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = file.Close()
+		if lockWouldBlock(err) {
+			return nil, ErrCoordinatorAlreadyRunning
+		}
+		return nil, fmt.Errorf("acquire coordinator lock: %w", err)
+	}
+	if err := file.Truncate(0); err != nil {
+		_ = releaseCoordinatorFile(file)
+		return nil, fmt.Errorf("clear coordinator lock owner: %w", err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		_ = releaseCoordinatorFile(file)
+		return nil, fmt.Errorf("seek coordinator lock owner: %w", err)
+	}
+	if _, err := io.WriteString(file, strconv.Itoa(os.Getpid())+"\n"); err != nil {
+		_ = releaseCoordinatorFile(file)
+		return nil, fmt.Errorf("write coordinator lock owner: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = releaseCoordinatorFile(file)
+		return nil, fmt.Errorf("sync coordinator lock owner: %w", err)
+	}
+	return &coordinatorLock{file: file}, nil
+}
+
+// release unlocks and closes one coordinator lock, retaining its path as a
+// reusable lock inode for later coordinator starts.
+func (lock *coordinatorLock) release() error {
+	if lock == nil || lock.file == nil {
+		return nil
+	}
+	file := lock.file
+	lock.file = nil
+	return releaseCoordinatorFile(file)
+}
+
+// requestCoordinatorStop signals the current kernel lock owner without
+// deleting the lock file or touching the active run's workflow state.
+func requestCoordinatorStop(path string) (StopResult, error) {
+	if strings.TrimSpace(path) == "" {
+		return StopResult{}, errors.New("coordinator lock path is required")
+	}
+	file, err := openPrivateLockFile(path, false)
+	if errors.Is(err, os.ErrNotExist) {
+		return StopResult{}, ErrCoordinatorNotRunning
+	}
+	if err != nil {
+		return StopResult{}, err
+	}
+	defer func() { _ = file.Close() }()
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err == nil {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		return StopResult{}, ErrCoordinatorNotRunning
+	} else if !lockWouldBlock(err) {
+		return StopResult{}, fmt.Errorf("inspect coordinator lock: %w", err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return StopResult{}, fmt.Errorf("read coordinator lock owner: %w", err)
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return StopResult{}, fmt.Errorf("read coordinator lock owner: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return StopResult{}, errors.New("coordinator lock has no valid owner PID")
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return StopResult{}, fmt.Errorf("find coordinator process: %w", err)
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		return StopResult{}, fmt.Errorf("signal coordinator process %d: %w", pid, err)
+	}
+	return StopResult{Running: true, PID: pid}, nil
+}
+
+// ensurePrivateLockDirectory creates and validates the lock's parent without
+// permitting group or other-user access to the PID marker.
+func ensurePrivateLockDirectory(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return fmt.Errorf("create coordinator lock directory: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect coordinator lock directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("coordinator lock directory %q is not private", path)
+	}
+	return nil
+}
+
+// openPrivateLockFile opens a regular lock inode without following a final
+// symlink, preventing a lock path replacement from redirecting PID writes or
+// stop reads to an unrelated file.
+func openPrivateLockFile(path string, create bool) (*os.File, error) {
+	flags := unix.O_RDWR | unix.O_CLOEXEC | unix.O_NOFOLLOW
+	if create {
+		flags |= unix.O_CREAT
+	}
+	fd, err := unix.Open(path, flags, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open coordinator lock: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, errors.New("open coordinator lock returned an invalid file")
+	}
+	if err := validatePrivateLockFile(file); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+// validatePrivateLockFile verifies that an existing PID marker is a private
+// regular file before its advisory lock is used.
+func validatePrivateLockFile(file *os.File) error {
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect coordinator lock: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return errors.New("coordinator lock is not a private regular file")
+	}
+	return nil
+}
+
+// lockWouldBlock recognizes the platform's non-blocking advisory-lock result.
+func lockWouldBlock(err error) bool {
+	return errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN)
+}
+
+// releaseCoordinatorFile unlocks and closes a lock file while retaining the
+// inode for later starts.
+func releaseCoordinatorFile(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	unlockErr := unix.Flock(int(file.Fd()), unix.LOCK_UN)
+	closeErr := file.Close()
+	if unlockErr != nil && closeErr != nil {
+		return errors.Join(unlockErr, closeErr)
+	}
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}

--- a/internal/factory/lock_test.go
+++ b/internal/factory/lock_test.go
@@ -1,0 +1,96 @@
+package factory
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+)
+
+// TestCoordinatorLockPreventsASecondOwner verifies the host lock is enforced
+// by the kernel and becomes reusable after the first owner releases it.
+func TestCoordinatorLockPreventsASecondOwner(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "state", "factory.lock")
+	first, err := acquireCoordinatorLock(path)
+	if err != nil {
+		t.Fatalf("first acquireCoordinatorLock() error = %v", err)
+	}
+	defer func() { _ = first.release() }()
+	if _, err := acquireCoordinatorLock(path); !errors.Is(err, ErrCoordinatorAlreadyRunning) {
+		t.Fatalf("second acquireCoordinatorLock() error = %v, want ErrCoordinatorAlreadyRunning", err)
+	}
+	if err := first.release(); err != nil {
+		t.Fatalf("release() error = %v", err)
+	}
+	second, err := acquireCoordinatorLock(path)
+	if err != nil {
+		t.Fatalf("reacquireCoordinatorLock() error = %v", err)
+	}
+	if err := second.release(); err != nil {
+		t.Fatalf("second release() error = %v", err)
+	}
+}
+
+// TestRequestCoordinatorStopReportsNoOwner verifies an idle stop is safe and
+// leaves no misleading success result for the CLI.
+func TestRequestCoordinatorStopReportsNoOwner(t *testing.T) {
+	t.Parallel()
+
+	result, err := requestCoordinatorStop(filepath.Join(t.TempDir(), "missing.lock"))
+	if !errors.Is(err, ErrCoordinatorNotRunning) {
+		t.Fatalf("requestCoordinatorStop() error = %v, want ErrCoordinatorNotRunning", err)
+	}
+	if result.Running || result.PID != 0 {
+		t.Fatalf("stop result = %#v, want no running coordinator", result)
+	}
+}
+
+// TestCoordinatorLockPathUsesTheRepositoryIdentity verifies separate host
+// configurations for one checkout cannot bypass the coordinator lock by
+// choosing different operational-store paths.
+func TestCoordinatorLockPathUsesTheRepositoryIdentity(t *testing.T) {
+	t.Parallel()
+
+	first := config.RepositoryRegistration{
+		Path:                filepath.Join(t.TempDir(), "repository"),
+		OperationalDataPath: filepath.Join(t.TempDir(), "first.db"),
+	}
+	second := first
+	second.OperationalDataPath = filepath.Join(t.TempDir(), "second.db")
+	if got, want := coordinatorLockPath(first), coordinatorLockPath(second); got != want {
+		t.Fatalf("lock paths = %q and %q, want shared path for one repository", got, want)
+	}
+}
+
+// TestCoordinatorLockRejectsSymlinkedLockFiles verifies lock ownership and
+// stop inspection cannot follow a path replacement into an unrelated file.
+func TestCoordinatorLockRejectsSymlinkedLockFiles(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	target := filepath.Join(directory, "target")
+	if err := os.WriteFile(target, []byte("123\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(directory, "coordinator.lock")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := acquireCoordinatorLock(link); err == nil {
+		t.Fatal("acquireCoordinatorLock() followed a symlink")
+	}
+	if _, err := requestCoordinatorStop(link); err == nil {
+		t.Fatal("requestCoordinatorStop() followed a symlink")
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "123\n" {
+		t.Fatalf("symlink target content = %q, want unchanged PID marker", content)
+	}
+}

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -26,6 +26,12 @@ const (
 	PollClaimed PollOutcome = "claimed"
 )
 
+const (
+	// maxConsecutiveLeaseFailures limits lease-renewal retry attempts before
+	// returning a persistent error to the caller.
+	maxConsecutiveLeaseFailures = 5
+)
+
 // PollResult reports one deterministic polling observation and any run it
 // found or claimed.
 type PollResult struct {
@@ -109,6 +115,7 @@ func (s *Service) Start(ctx context.Context) error {
 	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
 	leaseRunID := ""
 	delay := time.Duration(0)
+	consecutiveLeaseFailures := 0
 	for {
 		if err := waitPolling(pollContext, delay); err != nil {
 			if pollingContextDone(err) {
@@ -133,9 +140,14 @@ func (s *Service) Start(ctx context.Context) error {
 			if pollingContextDone(err) {
 				return nil
 			}
+			consecutiveLeaseFailures++
+			if consecutiveLeaseFailures > maxConsecutiveLeaseFailures {
+				return fmt.Errorf("lease renewal failed after %d consecutive attempts: %w", maxConsecutiveLeaseFailures, err)
+			}
 			delay = backoff
 			continue
 		}
+		consecutiveLeaseFailures = 0
 
 		result, err := s.pollOnce(pollContext, registration)
 		if err != nil {

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -1,0 +1,342 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// PollOutcome identifies the result of one queue observation.
+type PollOutcome string
+
+const (
+	// PollNoWork means the repository has no eligible issue at this instant.
+	PollNoWork PollOutcome = "no_work"
+	// PollActiveRun means an existing non-terminal run suppressed claiming.
+	PollActiveRun PollOutcome = "active_run"
+	// PollClaimed means the oldest eligible issue was claimed successfully.
+	PollClaimed PollOutcome = "claimed"
+)
+
+// PollResult reports one deterministic polling observation and any run it
+// found or claimed.
+type PollResult struct {
+	// Outcome identifies whether work was claimed or suppressed.
+	Outcome PollOutcome
+	// IssueNumber is the issue claimed during this observation, or zero.
+	IssueNumber int
+	// Run is the active or newly claimed run, when one exists.
+	Run store.Run
+}
+
+// StartupBlockedError reports that a blocking startup diagnosis prevented the
+// coordinator from acquiring its host lock or contacting the issue queue.
+type StartupBlockedError struct {
+	// Diagnosis contains every startup check result, including warnings.
+	Diagnosis DoctorResult
+}
+
+// pollingTransportError marks a read-only queue transport failure that can be
+// retried without entering the claim state machine.
+type pollingTransportError struct {
+	err error
+}
+
+// Error returns the bounded polling transport failure.
+func (e *pollingTransportError) Error() string { return e.err.Error() }
+
+// Unwrap exposes the underlying queue adapter failure to callers and tests.
+func (e *pollingTransportError) Unwrap() error { return e.err }
+
+// Error returns a bounded startup refusal while retaining the full diagnosis
+// for callers that need to render individual corrective actions.
+func (e *StartupBlockedError) Error() string {
+	if e == nil {
+		return "startup diagnosis blocked"
+	}
+	return fmt.Sprintf("startup diagnosis blocked: %d blocking checks", len(e.Diagnosis.Report.Failures()))
+}
+
+// Start runs the supervised polling loop until its context is cancelled. It
+// diagnoses the full host before taking the lock, renews a visible GitHub
+// lease, and backs off read-only queue or lease transport failures without
+// changing run state or retry budgets. Claim failures are returned because the
+// claim state machine may already have performed compensating effects.
+func (s *Service) Start(ctx context.Context) error {
+	diagnosis, err := s.startupDiagnosis(ctx)
+	if err != nil {
+		return fmt.Errorf("run startup diagnosis: %w", err)
+	}
+	if !diagnosis.Ready() {
+		return &StartupBlockedError{Diagnosis: diagnosis}
+	}
+	registration, repositoryConfig, err := s.pollConfiguration()
+	if err != nil {
+		return err
+	}
+	if s.issuePoller() == nil {
+		return errors.New("GitHub issue poller is required to start the coordinator")
+	}
+	if s.deps.Lease == nil {
+		return errors.New("GitHub lease client is required to start the coordinator")
+	}
+	interval, backoff, err := pollingDurations(registration.Polling)
+	if err != nil {
+		return err
+	}
+	lock, err := acquireCoordinatorLock(coordinatorLockPath(registration))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lock.release() }()
+
+	pollContext, cancel := context.WithCancel(ctx)
+	if !s.setPollCancel(cancel) {
+		cancel()
+		return ErrCoordinatorAlreadyRunning
+	}
+	defer s.clearPollCancel()
+	defer cancel()
+
+	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
+	leaseRunID := ""
+	delay := time.Duration(0)
+	for {
+		if err := waitPolling(pollContext, delay); err != nil {
+			if pollingContextDone(err) {
+				return nil
+			}
+			return err
+		}
+		if err := pollContext.Err(); err != nil {
+			if pollingContextDone(err) {
+				return nil
+			}
+			return err
+		}
+		now := s.deps.Now().UTC()
+		if err := s.deps.Lease.RenewLease(pollContext, repository, github.Lease{
+			TargetBranch: repositoryConfig.TargetBranch,
+			Coordinator:  s.deps.Coordinator,
+			RunID:        leaseRunID,
+			RenewedAt:    now,
+			ExpiresAt:    now.Add(interval + backoff),
+		}); err != nil {
+			if pollingContextDone(err) {
+				return nil
+			}
+			delay = backoff
+			continue
+		}
+
+		result, err := s.pollOnce(pollContext, registration)
+		if err != nil {
+			if pollingContextDone(err) {
+				return nil
+			}
+			var transportErr *pollingTransportError
+			if errors.As(err, &transportErr) {
+				delay = backoff
+				continue
+			}
+			return err
+		}
+		leaseRunID = result.Run.ID
+		delay = interval
+	}
+}
+
+// Stop asks the current coordinator process to stop polling. A same-process
+// stop cancels the loop directly; a separate CLI process signals the PID
+// recorded by the kernel-backed host lock. Neither path changes an active
+// run's workflow status or removes its artifacts.
+func (s *Service) Stop(ctx context.Context) (StopResult, error) {
+	if err := ctx.Err(); err != nil {
+		return StopResult{}, err
+	}
+	s.pollMu.Lock()
+	cancel := s.pollCancel
+	s.pollMu.Unlock()
+	if cancel != nil {
+		cancel()
+		return StopResult{Running: true, PID: os.Getpid()}, nil
+	}
+	registration, err := s.registration()
+	if err != nil {
+		return StopResult{}, err
+	}
+	result, err := requestCoordinatorStop(coordinatorLockPath(registration))
+	if errors.Is(err, ErrCoordinatorNotRunning) {
+		return StopResult{}, nil
+	}
+	return result, err
+}
+
+// PollOnce performs one queue observation using the same active-run check and
+// claim path as Start. It is useful for a supervised one-shot poll and for
+// testing the high-level coordinator seam without waiting on a timer.
+func (s *Service) PollOnce(ctx context.Context) (PollResult, error) {
+	registration, _, err := s.pollConfiguration()
+	if err != nil {
+		return PollResult{}, err
+	}
+	return s.pollOnce(ctx, registration)
+}
+
+// pollOnce checks the operational store before reading GitHub, ensuring an
+// active run suppresses queue work and that the oldest eligible issue wins.
+func (s *Service) pollOnce(ctx context.Context, registration config.RepositoryRegistration) (PollResult, error) {
+	if err := ctx.Err(); err != nil {
+		return PollResult{}, err
+	}
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return PollResult{}, fmt.Errorf("open operational store for polling: %w", err)
+	}
+	run, currentErr := opened.CurrentRun(ctx)
+	closeErr := opened.Close()
+	if currentErr != nil {
+		return PollResult{}, fmt.Errorf("read active run for polling: %w", currentErr)
+	}
+	if closeErr != nil {
+		return PollResult{}, fmt.Errorf("close operational store after polling: %w", closeErr)
+	}
+	if run != nil {
+		return PollResult{Outcome: PollActiveRun, Run: *run}, nil
+	}
+
+	poller := s.issuePoller()
+	if poller == nil {
+		return PollResult{}, errors.New("GitHub issue poller is required for polling")
+	}
+	issues, err := poller.ListEligibleIssues(ctx, github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository})
+	if err != nil {
+		return PollResult{}, &pollingTransportError{err: fmt.Errorf("poll eligible issues: %w", err)}
+	}
+	issues = eligibleIssueQueue(issues)
+	if len(issues) == 0 {
+		return PollResult{Outcome: PollNoWork}, nil
+	}
+	claimed, err := s.ClaimIssue(ctx, issues[0].Number)
+	if err != nil {
+		return PollResult{}, fmt.Errorf("claim oldest eligible issue #%d: %w", issues[0].Number, err)
+	}
+	return PollResult{Outcome: PollClaimed, IssueNumber: claimed.Run.IssueNumber, Run: claimed.Run}, nil
+}
+
+// pollConfiguration loads the one registered repository and its checked-in
+// policy after startup diagnosis has confirmed both are readable.
+func (s *Service) pollConfiguration() (config.RepositoryRegistration, config.RepositoryConfig, error) {
+	registration, err := s.registration()
+	if err != nil {
+		return config.RepositoryRegistration{}, config.RepositoryConfig{}, err
+	}
+	repositoryConfig, err := s.deps.LoadRepository(registration.RepositoryConfigPath)
+	if err != nil {
+		return config.RepositoryRegistration{}, config.RepositoryConfig{}, fmt.Errorf("load repository configuration for polling: %w", err)
+	}
+	return registration, repositoryConfig, nil
+}
+
+// startupDiagnosis resolves the injected diagnosis seam or the complete
+// service-owned Doctor implementation.
+func (s *Service) startupDiagnosis(ctx context.Context) (DoctorResult, error) {
+	if s.deps.StartupDiagnosis != nil {
+		return s.deps.StartupDiagnosis(ctx)
+	}
+	return s.Doctor(ctx)
+}
+
+// issuePoller resolves the configured queue adapter without broadening the
+// existing GitHub mutation client seam.
+func (s *Service) issuePoller() github.IssuePoller {
+	if s.deps.IssuePoller != nil {
+		return s.deps.IssuePoller
+	}
+	if poller, ok := s.deps.GitHub.(github.IssuePoller); ok {
+		return poller
+	}
+	return nil
+}
+
+// eligibleIssueQueue defensively applies the queue contract even when a test
+// or alternate GitHub adapter does not filter its endpoint response.
+func eligibleIssueQueue(issues []github.Issue) []github.Issue {
+	eligible := make([]github.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.Number <= 0 || issue.IsPullRequest || !strings.EqualFold(strings.TrimSpace(issue.State), "open") || !hasLabel(issue.Labels, github.LabelAgentReady) {
+			continue
+		}
+		eligible = append(eligible, issue)
+	}
+	sort.SliceStable(eligible, func(left, right int) bool {
+		return eligible[left].Number < eligible[right].Number
+	})
+	return eligible
+}
+
+// pollingDurations parses the configured normal interval and transport
+// backoff, preserving the configuration validator's positive-duration rule at
+// the runtime boundary as well.
+func pollingDurations(polling config.PollingConfig) (time.Duration, time.Duration, error) {
+	interval, err := time.ParseDuration(strings.TrimSpace(polling.Interval))
+	if err != nil || interval <= 0 {
+		return 0, 0, fmt.Errorf("invalid polling interval %q", polling.Interval)
+	}
+	backoff, err := time.ParseDuration(strings.TrimSpace(polling.Backoff))
+	if err != nil || backoff <= 0 {
+		return 0, 0, fmt.Errorf("invalid polling backoff %q", polling.Backoff)
+	}
+	return interval, backoff, nil
+}
+
+// waitPolling waits for one configured delay without making context
+// cancellation depend on a wall-clock sleep.
+func waitPolling(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// pollingContextDone reports the two context endings that are normal for a
+// long-running coordinator controlled by start/stop.
+func pollingContextDone(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// setPollCancel records a same-process stop handle while rejecting duplicate
+// loops before they can poll the same repository.
+func (s *Service) setPollCancel(cancel context.CancelFunc) bool {
+	s.pollMu.Lock()
+	defer s.pollMu.Unlock()
+	if s.pollCancel != nil {
+		return false
+	}
+	s.pollCancel = cancel
+	return true
+}
+
+// clearPollCancel removes the stop handle when the polling loop completes.
+func (s *Service) clearPollCancel() {
+	s.pollMu.Lock()
+	defer s.pollMu.Unlock()
+	if s.pollCancel != nil {
+		s.pollCancel = nil
+	}
+}

--- a/internal/factory/polling_test.go
+++ b/internal/factory/polling_test.go
@@ -1,0 +1,270 @@
+package factory_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestPollOnceClaimsTheOldestEligibleIssue verifies deterministic queue
+// ordering, eligibility filtering, and reuse of the existing claim seam.
+func TestPollOnceClaimsTheOldestEligibleIssue(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	issues := []github.Issue{
+		{Number: 12, Title: "newer", State: "open", Labels: []string{github.LabelAgentReady}},
+		{Number: 9, Title: "pull request", State: "open", Labels: []string{github.LabelAgentReady}, IsPullRequest: true},
+		{Number: 5, Title: "oldest", State: "open", Labels: []string{github.LabelAgentReady}},
+		{Number: 2, Title: "closed", State: "closed", Labels: []string{github.LabelAgentReady}},
+	}
+	githubAdapter := &pollingGitHub{fakeGitHub: &fakeGitHub{}, issues: issues}
+	runStore := &fakeRunStore{}
+	service := newPollingService(root, githubAdapter, githubAdapter, nil, runStore, &fakeWorktree{workspace: gitadapter.Workspace{
+		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
+	}})
+
+	result, err := service.PollOnce(context.Background())
+	if err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+	if result.Outcome != factory.PollClaimed || result.IssueNumber != 5 || result.Run.ID != "run-fixed" {
+		t.Fatalf("PollOnce() result = %#v, want claimed issue 5/run-fixed", result)
+	}
+	if githubAdapter.claimedIssue != 5 {
+		t.Fatalf("claimed issue = %d, want oldest eligible issue 5", githubAdapter.claimedIssue)
+	}
+	if len(githubAdapter.createdLabels) != 0 {
+		t.Fatalf("polling created labels = %#v, want none", githubAdapter.createdLabels)
+	}
+}
+
+// TestPollOnceDoesNotClaimWhileARunIsActive verifies a persisted active run
+// suppresses issue listing and all claim effects.
+func TestPollOnceDoesNotClaimWhileARunIsActive(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	active := store.Run{ID: "run-active", RepositoryPath: "/repo", IssueNumber: 42, Stage: store.StageImplementation, Status: store.StatusActive}
+	runStore := &fakeRunStore{saved: []store.Run{active}}
+	issues := []github.Issue{{Number: 7, State: "open", Labels: []string{github.LabelAgentReady}}}
+	githubAdapter := &pollingGitHub{fakeGitHub: &fakeGitHub{}, issues: issues}
+	service := newPollingService(root, githubAdapter, githubAdapter, nil, runStore, &fakeWorktree{})
+
+	result, err := service.PollOnce(context.Background())
+	if err != nil {
+		t.Fatalf("PollOnce() error = %v", err)
+	}
+	if result.Outcome != factory.PollActiveRun || result.Run.ID != active.ID {
+		t.Fatalf("PollOnce() result = %#v, want active run %q", result, active.ID)
+	}
+	if githubAdapter.listCalls != 0 || githubAdapter.claimedIssue != 0 {
+		t.Fatalf("polling effects = list=%d claim=%d, want no issue poll or claim", githubAdapter.listCalls, githubAdapter.claimedIssue)
+	}
+}
+
+// TestStartRefusesToPollWhenStartupDiagnosisIsBlocked verifies startup
+// diagnosis is completed before host-lock, lease, or issue-poll effects.
+func TestStartRefusesToPollWhenStartupDiagnosisIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	reader := &pollingIssueReader{}
+	service := factory.NewWithDependencies(filepath.Join(t.TempDir(), "config.yaml"), factory.Dependencies{
+		StartupDiagnosis: func(context.Context) (factory.DoctorResult, error) {
+			return factory.DoctorResult{Report: doctor.Report{Results: []doctor.Result{
+				doctor.Failure("GitHub", "transport unavailable", "restore GitHub access"),
+			}}}, nil
+		},
+		IssuePoller: reader,
+	})
+
+	err := service.Start(context.Background())
+	var blocked *factory.StartupBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("Start() error = %v, want StartupBlockedError", err)
+	}
+	if reader.calls != 0 {
+		t.Fatalf("issue list calls = %d, want zero when startup is blocked", reader.calls)
+	}
+}
+
+// TestStartPollsThenStopsWithoutCancellingTheActiveRun verifies the normal
+// immediate poll, the one-run claim limit, lease renewal, and context stop.
+func TestStartPollsThenStopsWithoutCancellingTheActiveRun(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	issues := []github.Issue{{Number: 7, Title: "claim me", State: "open", Labels: []string{github.LabelAgentReady}}}
+	githubAdapter := &pollingGitHub{fakeGitHub: &fakeGitHub{}, issues: issues}
+	runStore := &fakeRunStore{}
+	var cancel context.CancelFunc
+	lease := &pollingLease{onRenew: func(value github.Lease) {
+		if value.RunID == "run-fixed" && cancel != nil {
+			cancel()
+		}
+	}}
+	service := newPollingService(root, githubAdapter, githubAdapter, lease, runStore, &fakeWorktree{workspace: gitadapter.Workspace{
+		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
+	}})
+	ctx, stop := context.WithCancel(context.Background())
+	cancel = stop
+
+	if err := service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if githubAdapter.listCalls != 1 || githubAdapter.claimedIssue != 7 {
+		t.Fatalf("polling calls = list=%d claim=%d, want one claim poll for issue 7", githubAdapter.listCalls, githubAdapter.claimedIssue)
+	}
+	if len(runStore.saved) == 0 || runStore.saved[len(runStore.saved)-1].Status != store.StatusActive {
+		t.Fatalf("saved runs = %#v, want the claimed run to remain active", runStore.saved)
+	}
+	if len(lease.calls) < 2 || lease.calls[0].RunID != "" || lease.calls[1].RunID != "run-fixed" {
+		t.Fatalf("lease renewals = %#v, want initial and claimed-run renewals", lease.calls)
+	}
+	if strings.Contains(githubAdapter.lastLabelMutation, github.LabelAgentCancelled) {
+		t.Fatal("stopping polling cancelled the active run")
+	}
+}
+
+// TestStartUsesTransportBackoffWithoutChangingRunState verifies a GitHub
+// listing failure delays the next poll and consumes no run or repair budget.
+func TestStartUsesTransportBackoffWithoutChangingRunState(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	var cancel context.CancelFunc
+	reader := &pollingIssueReader{onList: func(call int) ([]github.Issue, error) {
+		if call == 1 {
+			return nil, errors.New("GitHub transport unavailable")
+		}
+		cancel()
+		return nil, nil
+	}}
+	lease := &pollingLease{}
+	runStore := &fakeRunStore{}
+	service := newPollingService(root, &fakeGitHub{}, reader, lease, runStore, &fakeWorktree{})
+	ctx, stop := context.WithCancel(context.Background())
+	cancel = stop
+	started := time.Now()
+
+	if err := service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if reader.calls != 2 {
+		t.Fatalf("issue list calls = %d, want one retry after transport backoff", reader.calls)
+	}
+	if elapsed := time.Since(started); elapsed < 20*time.Millisecond {
+		t.Fatalf("retry elapsed = %s, want configured backoff before the second poll", elapsed)
+	}
+	if len(runStore.saved) != 0 {
+		t.Fatalf("runs saved after queue transport failures = %#v, want none", runStore.saved)
+	}
+}
+
+// pollingGitHub combines the existing claim fake with a deterministic issue
+// listing adapter for coordinator polling tests.
+type pollingGitHub struct {
+	*fakeGitHub
+	issues            []github.Issue
+	listCalls         int
+	claimedIssue      int
+	lastLabelMutation string
+}
+
+// ListEligibleIssues returns the configured issue queue in its source order.
+func (f *pollingGitHub) ListEligibleIssues(context.Context, github.Repository) ([]github.Issue, error) {
+	f.listCalls++
+	return append([]github.Issue(nil), f.issues...), nil
+}
+
+// Issue returns the requested issue so the claim path observes the selected
+// queue candidate rather than a shared fixture value.
+func (f *pollingGitHub) Issue(ctx context.Context, repository github.Repository, number int) (github.Issue, error) {
+	for _, issue := range f.issues {
+		if issue.Number == number {
+			f.claimedIssue = number
+			f.fakeGitHub.issueValue = issue
+			return f.fakeGitHub.Issue(ctx, repository, number)
+		}
+	}
+	return github.Issue{}, errors.New("issue not found")
+}
+
+// ReplaceIssueLabels records label mutations without changing the polling
+// assertions' access to the embedded claim fake.
+func (f *pollingGitHub) ReplaceIssueLabels(ctx context.Context, repository github.Repository, number int, labels []string) error {
+	f.lastLabelMutation = strings.Join(labels, ",")
+	return f.fakeGitHub.ReplaceIssueLabels(ctx, repository, number, labels)
+}
+
+// pollingIssueReader is a small issue-listing seam with controllable retries.
+type pollingIssueReader struct {
+	calls  int
+	onList func(int) ([]github.Issue, error)
+}
+
+// ListEligibleIssues invokes the configured polling response.
+func (f *pollingIssueReader) ListEligibleIssues(_ context.Context, _ github.Repository) ([]github.Issue, error) {
+	f.calls++
+	if f.onList == nil {
+		return nil, nil
+	}
+	return f.onList(f.calls)
+}
+
+// pollingLease records visible lease renewals for start-loop assertions.
+type pollingLease struct {
+	calls   []github.Lease
+	onRenew func(github.Lease)
+}
+
+// RenewLease records the lease and invokes its optional test hook.
+func (f *pollingLease) RenewLease(_ context.Context, _ github.Repository, lease github.Lease) error {
+	f.calls = append(f.calls, lease)
+	if f.onRenew != nil {
+		f.onRenew(lease)
+	}
+	return nil
+}
+
+// newPollingService constructs a service with real queue/claim behavior and
+// isolated fakes for the external polling and lease adapters.
+func newPollingService(root string, githubAdapter github.Client, issuePoller github.IssuePoller, lease github.LeaseClient, runStore *fakeRunStore, worktree gitadapter.WorktreeManager) *factory.Service {
+	registration := config.RepositoryRegistration{
+		Path:                 filepath.Join(root, "repository"),
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		AuthorizedUsers:      []string{"alice"},
+		Polling:              config.PollingConfig{Interval: "1ms", Backoff: "20ms"},
+		OperationalDataPath:  filepath.Join(root, "state", "factory.db"),
+		RepositoryConfigPath: filepath.Join(root, "repository", "factory.yaml"),
+	}
+	return factory.NewWithDependencies(filepath.Join(root, "config.yaml"), factory.Dependencies{
+		Config: &fakeConfig{value: config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{registration}}},
+		OpenStore: func(context.Context, string) (factory.OperationalStore, error) {
+			return runStore, nil
+		},
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return validRepositoryConfig(), nil },
+		GitHub:         githubAdapter,
+		IssuePoller:    issuePoller,
+		Lease:          lease,
+		Worktree:       worktree,
+		Now: func() time.Time {
+			return time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+		},
+		NewRunID:    func() (string, error) { return "run-fixed", nil },
+		Coordinator: "coordinator-test",
+		StartupDiagnosis: func(context.Context) (factory.DoctorResult, error) {
+			return factory.DoctorResult{Report: doctor.Report{Results: []doctor.Result{doctor.Success("startup")}}}, nil
+		},
+	})
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/ref"
 )
 
 // DefaultRemoteName is the repository remote used by factory Git operations.
@@ -477,10 +479,7 @@ func porcelainPaths(output string) []string {
 // validateRefPart prevents user-controlled ref fragments from becoming
 // ambiguous Git command arguments.
 func validateRefPart(value string) error {
-	if strings.ContainsAny(value, "\r\n") || strings.HasPrefix(value, "-") || strings.Contains(value, "..") || strings.ContainsAny(value, " ~^:?*[\\") {
-		return fmt.Errorf("contains characters that cannot be used safely: %q", value)
-	}
-	return nil
+	return ref.ValidatePart(value)
 }
 
 // validCommitSHA reports whether value is a full SHA-1 or SHA-256 identity.

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -8,8 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/ref"
 )
 
 const (
@@ -59,6 +62,24 @@ type Issue struct {
 	UpdatedAt     time.Time
 }
 
+// LeaseStatusContext is the stable Commit Status context used to expose the
+// coordinator's renewable GitHub lease on the configured target branch.
+const LeaseStatusContext = "factory/lease"
+
+// Lease describes one visible coordinator ownership heartbeat.
+type Lease struct {
+	// TargetBranch is the branch whose current commit receives the status.
+	TargetBranch string
+	// Coordinator identifies the host holding the lease.
+	Coordinator string
+	// RunID identifies the active run, when one has been claimed.
+	RunID string
+	// RenewedAt is the coordinator's latest heartbeat time.
+	RenewedAt time.Time
+	// ExpiresAt is the time after which the GitHub projection is stale.
+	ExpiresAt time.Time
+}
+
 // Label describes a factory-owned GitHub label.
 type Label struct {
 	Name        string
@@ -83,6 +104,16 @@ type Comment struct {
 // shared GitHub issue-comments endpoint.
 type CommentReader interface {
 	IssueComments(context.Context, Repository, int) ([]Comment, error)
+}
+
+// IssuePoller lists the repository's open, agent-authorized issue queue.
+type IssuePoller interface {
+	ListEligibleIssues(context.Context, Repository) ([]Issue, error)
+}
+
+// LeaseClient publishes a renewable, operator-visible coordinator lease.
+type LeaseClient interface {
+	RenewLease(context.Context, Repository, Lease) error
 }
 
 // PullRequest is the pull-request identity and body returned to the
@@ -214,6 +245,8 @@ type GhClient struct {
 }
 
 var _ CommentReader = (*GhClient)(nil)
+var _ IssuePoller = (*GhClient)(nil)
+var _ LeaseClient = (*GhClient)(nil)
 
 // NewClient returns a GitHub CLI-backed client.
 func NewClient() *GhClient { return &GhClient{Runner: commandRunner{}} }
@@ -235,19 +268,74 @@ func (c *GhClient) Issue(ctx context.Context, repository Repository, number int)
 	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/issues/%d", repository.String(), number)}, nil, &response); err != nil {
 		return Issue{}, fmt.Errorf("fetch issue #%d: %w", number, err)
 	}
-	labels := make([]string, 0, len(response.Labels))
-	for _, label := range response.Labels {
-		labels = append(labels, label.Name)
+	return response.issue(), nil
+}
+
+// ListEligibleIssues reads open issues labeled agent-ready and returns them in
+// ascending issue-number order. GitHub's issues endpoint also returns pull
+// requests, so those are filtered before the result crosses the adapter seam.
+func (c *GhClient) ListEligibleIssues(ctx context.Context, repository Repository) ([]Issue, error) {
+	args := []string{
+		"api", fmt.Sprintf("repos/%s/issues", repository.String()),
+		"--paginate", "--slurp", "--method", "GET",
+		"-f", "state=open", "-f", "labels=" + LabelAgentReady,
 	}
-	return Issue{
-		Number:        response.Number,
-		Title:         response.Title,
-		Body:          response.Body,
-		State:         response.State,
-		Labels:        labels,
-		IsPullRequest: response.PullRequest != nil,
-		UpdatedAt:     response.UpdatedAt,
-	}, nil
+	output, err := c.callBytes(ctx, args, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list eligible issues: %w", err)
+	}
+	responses, err := decodeIssueList(output)
+	if err != nil {
+		return nil, fmt.Errorf("decode eligible issues: %w", err)
+	}
+	issues := make([]Issue, 0, len(responses))
+	for _, response := range responses {
+		issue := response.issue()
+		if issue.Number <= 0 || issue.IsPullRequest || !strings.EqualFold(strings.TrimSpace(issue.State), "open") || !containsLabel(issue.Labels, LabelAgentReady) {
+			continue
+		}
+		issues = append(issues, issue)
+	}
+	sort.SliceStable(issues, func(left, right int) bool {
+		return issues[left].Number < issues[right].Number
+	})
+	return issues, nil
+}
+
+// RenewLease publishes the coordinator heartbeat as a pending Commit Status
+// on the current target-branch commit. A stale heartbeat remains visible in
+// GitHub with its expiry timestamp after a host process disappears.
+func (c *GhClient) RenewLease(ctx context.Context, repository Repository, lease Lease) error {
+	if strings.TrimSpace(lease.TargetBranch) == "" {
+		return errors.New("lease target branch is required and must be safe")
+	}
+	if err := ref.ValidatePart(lease.TargetBranch); err != nil {
+		return fmt.Errorf("lease target branch: %w", err)
+	}
+	if strings.TrimSpace(lease.Coordinator) == "" || strings.ContainsAny(lease.Coordinator, "\x00\r\n") {
+		return errors.New("lease coordinator is required and must be a single line")
+	}
+	if lease.RenewedAt.IsZero() || lease.ExpiresAt.IsZero() || !lease.ExpiresAt.After(lease.RenewedAt) {
+		return errors.New("lease heartbeat and expiry must be valid")
+	}
+	var response commitResponse
+	if err := c.callJSON(ctx, []string{"api", fmt.Sprintf("repos/%s/commits/%s", repository.String(), lease.TargetBranch), "--method", "GET"}, nil, &response); err != nil {
+		return fmt.Errorf("read target branch for coordinator lease: %w", err)
+	}
+	if !ValidCommitSHA(response.SHA) {
+		return errors.New("target branch response did not contain a valid commit SHA")
+	}
+	description := fmt.Sprintf("coordinator=%s run=%s renewed=%s expires=%s", safeStatusValue(lease.Coordinator), safeStatusValue(lease.RunID), lease.RenewedAt.UTC().Format(time.RFC3339), lease.ExpiresAt.UTC().Format(time.RFC3339))
+	description = truncateStatusDescription(description, 140)
+	if err := c.CreateCommitStatus(ctx, repository, CommitStatus{
+		SHA:         response.SHA,
+		State:       CommitStatusPending,
+		Context:     LeaseStatusContext,
+		Description: description,
+	}); err != nil {
+		return fmt.Errorf("publish coordinator lease: %w", err)
+	}
+	return nil
 }
 
 // CreateLabel creates or updates one factory label through gh.
@@ -524,6 +612,74 @@ type issueResponse struct {
 		Name string `json:"name"`
 	} `json:"labels"`
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// issue converts the GitHub issue response into the adapter-neutral model.
+func (r issueResponse) issue() Issue {
+	labels := make([]string, 0, len(r.Labels))
+	for _, label := range r.Labels {
+		labels = append(labels, label.Name)
+	}
+	return Issue{
+		Number:        r.Number,
+		Title:         r.Title,
+		Body:          r.Body,
+		State:         r.State,
+		Labels:        labels,
+		IsPullRequest: r.PullRequest != nil,
+		UpdatedAt:     r.UpdatedAt,
+	}
+}
+
+// decodeIssueList accepts both gh's slurped pagination array and one page of
+// issue responses, keeping the adapter tolerant of test and CLI modes.
+func decodeIssueList(output []byte) ([]issueResponse, error) {
+	var pages [][]issueResponse
+	if err := json.Unmarshal(output, &pages); err == nil {
+		issues := make([]issueResponse, 0)
+		for _, page := range pages {
+			issues = append(issues, page...)
+		}
+		return issues, nil
+	}
+	var singlePage []issueResponse
+	if err := json.Unmarshal(output, &singlePage); err != nil {
+		return nil, err
+	}
+	return singlePage, nil
+}
+
+// containsLabel reports whether one issue projection contains a named label.
+func containsLabel(labels []string, wanted string) bool {
+	for _, label := range labels {
+		if label == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+// safeStatusValue bounds untrusted lease values to one status-comment line.
+func safeStatusValue(value string) string {
+	return strings.TrimSpace(strings.NewReplacer("\r", " ", "\n", " ", "\x00", " ").Replace(value))
+}
+
+// truncateStatusDescription limits a status description by Unicode code
+// points so an unusually long coordinator identity cannot create invalid UTF-8.
+func truncateStatusDescription(value string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit])
+}
+
+// commitResponse is the branch-head projection needed by lease publishing.
+type commitResponse struct {
+	SHA string `json:"sha"`
 }
 
 // commentResponse is the subset of a GitHub comment response needed to retain

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/github"
 )
@@ -84,6 +85,82 @@ func TestGhClientUsesTheLocalCLIForIssueAndClaimMutations(t *testing.T) {
 	for _, index := range []int{0, 2, 3, 4, 5, 6} {
 		if hasArgs(runner.calls[index].args, "--repo") {
 			t.Errorf("gh api call %d still uses unsupported --repo: %#v", index, runner.calls[index].args)
+		}
+	}
+}
+
+// TestGhClientListsEligibleIssuesInDeterministicOrder verifies the polling
+// adapter asks GitHub for open agent-ready issues and filters the mixed issue
+// endpoint response before returning queue candidates.
+func TestGhClientListsEligibleIssuesInDeterministicOrder(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeCommandRunner{outputs: [][]byte{[]byte(`[[
+		{"number":12,"title":"newer","state":"open","labels":[{"name":"agent-ready"}]},
+		{"number":4,"title":"pull request","state":"open","labels":[{"name":"agent-ready"}],"pull_request":{"url":"https://api.github.com/pulls/4"}},
+		{"number":2,"title":"older","state":"open","labels":[{"name":"agent-ready"},{"name":"bug"}]},
+		{"number":1,"title":"closed","state":"closed","labels":[{"name":"agent-ready"}]},
+		{"number":8,"title":"unlabeled","state":"open","labels":[{"name":"bug"}]}
+	]]`)}}
+	client := &github.GhClient{Runner: runner}
+
+	issues, err := client.ListEligibleIssues(context.Background(), github.Repository{Owner: "example", Name: "project"})
+	if err != nil {
+		t.Fatalf("ListEligibleIssues() error = %v", err)
+	}
+	if len(issues) != 2 || issues[0].Number != 2 || issues[1].Number != 12 {
+		t.Fatalf("eligible issues = %#v, want issue numbers [2 12]", issues)
+	}
+	if len(runner.calls) != 1 || !containsArgs(runner.calls[0].args, "repos/example/project/issues", "--paginate", "--slurp", "--method", "GET") {
+		t.Fatalf("GitHub call = %#v, want paginated GET issue listing", runner.calls)
+	}
+	if !hasArgs(runner.calls[0].args, "-f", "state=open", "-f", "labels=agent-ready") {
+		t.Fatalf("GitHub call args = %#v, want open agent-ready filters", runner.calls[0].args)
+	}
+}
+
+// TestGhClientPublishesAVisibleRenewableLease verifies the lease adapter
+// records coordinator ownership as an exact target-branch Commit Status.
+func TestGhClientPublishesAVisibleRenewableLease(t *testing.T) {
+	t.Parallel()
+
+	sha := "0123456789abcdef0123456789abcdef01234567"
+	runner := &fakeCommandRunner{outputs: [][]byte{
+		[]byte(`{"sha":"` + sha + `"}`),
+		[]byte(""),
+	}}
+	client := &github.GhClient{Runner: runner}
+	renewed := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	expires := renewed.Add(5 * time.Minute)
+	err := client.RenewLease(context.Background(), github.Repository{Owner: "example", Name: "project"}, github.Lease{
+		TargetBranch: "main",
+		Coordinator:  "coordinator-test",
+		RunID:        "run-42",
+		RenewedAt:    renewed,
+		ExpiresAt:    expires,
+	})
+	if err != nil {
+		t.Fatalf("RenewLease() error = %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("GitHub calls = %d, want branch lookup plus status write", len(runner.calls))
+	}
+	if !containsArgs(runner.calls[0].args, "repos/example/project/commits/main", "--method", "GET") {
+		t.Fatalf("branch lookup args = %#v", runner.calls[0].args)
+	}
+	if !containsArgs(runner.calls[1].args, "repos/example/project/statuses/"+sha, "--method", "POST", "--input", "-") {
+		t.Fatalf("lease status args = %#v", runner.calls[1].args)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(runner.calls[1].input, &payload); err != nil {
+		t.Fatalf("decode lease status payload: %v", err)
+	}
+	if payload["state"] != string(github.CommitStatusPending) || payload["context"] != github.LeaseStatusContext {
+		t.Fatalf("lease status payload = %#v, want pending %q", payload, github.LeaseStatusContext)
+	}
+	for _, expected := range []string{"coordinator-test", "run-42", "expires=2026-08-26T12:05:00Z"} {
+		if !strings.Contains(payload["description"], expected) {
+			t.Errorf("lease description %q does not contain %q", payload["description"], expected)
 		}
 	}
 }

--- a/internal/ref/ref.go
+++ b/internal/ref/ref.go
@@ -1,0 +1,17 @@
+// Package ref contains validation shared by host adapters that pass Git refs
+// to external commands or APIs.
+package ref
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidatePart rejects ref fragments that are ambiguous or unsafe when they
+// become arguments or path fragments in a Git operation.
+func ValidatePart(value string) error {
+	if strings.ContainsAny(value, "\r\n") || strings.HasPrefix(value, "-") || strings.Contains(value, "..") || strings.ContainsAny(value, " ~^:?*[\\") {
+		return fmt.Errorf("contains characters that cannot be used safely: %q", value)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add startup-gated polling for the oldest open `agent-ready` issue
- add a repository-keyed kernel host lock with `factory start` and `factory stop`
- publish a renewable `factory/lease` GitHub Commit Status and back off read-only transport failures
- add shared Git ref validation, documentation, and focused coordinator/adapter tests

## Validation

- `GOCACHE=/private/tmp/sw-factory-go-cache make check`

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `factory start` and `factory stop` commands for managing coordinator polling.
  * Added automatic discovery and selection of eligible issues in a predictable order.
  * Added coordinator ownership protection to prevent multiple active processes.
  * Added visible, renewable lease status updates during active polling.
  * Added graceful shutdown handling for interrupts and termination signals.

* **Bug Fixes**
  * Improved handling of active runs and temporary transport failures.
  * Added validation to reject unsafe Git references and lock-file symlinks.

* **Documentation**
  * Documented startup, shutdown, polling, locking, leasing, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->