### PR TITLE
Implement restart reconciliation and idempotent effect recovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,8 +41,14 @@ _Avoid_: Dependency cache key, mutable latest state
 A read-only comparison of one persisted non-terminal run with its registered repository, worktree, Git projection, and GitHub projections.
 _Avoid_: Reconciliation, recovery
 
+**Reconciliation**:
+The coordinator's restart pass that consumes one durable pending effect when
+safe, repairs the projections that effect owns, and otherwise pauses the run
+with a typed discrepancy.
+_Avoid_: Diagnosis, automatic retry
+
 **Recovery-required result**:
-A typed fail-closed refusal that reports the agreement state and discovered discrepancies without claiming that the run was recovered; issue #21 supersedes it with complete reconciliation.
+A typed discrepancy result that reports the agreement state and discovered discrepancies; journaled runs reconcile safe effects automatically and pause unresolved disagreements for a human, while legacy stores retain the fail-closed refusal.
 _Avoid_: Recovered run, automatic continuation
 
 **Startup diagnosis**:

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -80,12 +80,14 @@ read-only recovery diagnosis finds that every checked projection agrees and
 the operational store contains no invocation history. This is a completed
 claim or test handoff awaiting its first invocation, not an interrupted run.
 
-The exception applies only to first-agent startup. Any persisted invocation,
-including a terminal one, or any recovery discrepancy returns the typed
-`recovery-required` result without starting a worker, terminal surface, or
-harness. Gates, reports, transitions, draft pull requests, and other
-progression paths retain the fail-closed boundary until issue #21 provides
-complete reconciliation.
+The exception applies only to first-agent startup. A persisted active invocation
+with a complete native-session identity is resumed once against its persisted
+worker and terminal handles; a missing identity or any other recovery
+discrepancy pauses the run for a human. Terminal report acceptance is replayed
+from its durable effect record without finalizing the same invocation twice.
+Gates, reports, transitions, draft pull requests, and other progression paths
+reconcile the durable effect journal and external identities before they resume
+an interrupted run.
 
 The `TerminalRuntime` seam owns workspace, surface, input, notification, and
 lifecycle behavior. The macOS adapter invokes cmux; workflow code never sees

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -306,17 +306,19 @@ The coordinator then fetches `origin/<target_branch>`, records that fetched comm
 The GitHub adapter invokes the locally authenticated `gh` CLI. The coordinator receives issue and mutation results in memory; GitHub credentials are not read into or persisted by the factory. `factory status` reports the active run's stage, status, branch, and worktree, or the latest terminal run when no run is active.
 
 Before any later coordinator command can progress a persisted non-terminal run,
-the new process performs a read-only recovery diagnosis. It compares the run
+the new process reconciles the durable effect journal and compares the run
 identifier, registered repository, worktree, branch, checkpoint SHA, issue
 number and factory state label, marked status-comment identity, and persisted
 pull-request identity when present. A missing or mismatched projection is
-reported alongside every other discovered discrepancy. Even when all sources
-agree, the command returns the typed `recovery-required` result and refuses to
-resume: this version performs no Git, GitHub, worker, terminal, harness, or
-workflow-state mutation and consumes no workflow budget. `factory status`
-remains available and prints the run, agreement state, discrepancies, and safe
-operator actions. Issue #21 explicitly supersedes this boundary with complete
-reconciliation and idempotent effect recovery.
+reported alongside every other discovered discrepancy and pauses the run for
+human disposition. A journaled effect is replayed only when its exact intent
+can be recognized or completed idempotently; otherwise the run remains waiting
+with the pending effect visible to `factory status`. `factory status` reports
+the run, agreement state, pending effect, discrepancies, and safe operator
+actions. After inspecting an ambiguous mutation, an operator can explicitly
+discard it with `factory reconcile --abandon-effect <effect-id> --reason <reason>`;
+the run remains paused. Legacy stores without the journal retain the typed
+`recovery-required` refusal.
 
 ## Authorized GitHub commands
 
@@ -392,7 +394,7 @@ prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use
 `factory agent-report --invocation-id <id>` to ask the coordinator to validate
 and accept the structured report. Terminal output is never treated as a stage
-result. The operational store schema is version 18 and persists invocation
+result. The operational store schema is version 22 and persists invocation
 identity, opaque surface handles, prompt version, result directory, native
 session identifier, and permitted handoff paths in addition to run state. It
 also persists the draft pull-request number and URL so a restarted command can

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -311,9 +311,15 @@ identifier, registered repository, worktree, branch, checkpoint SHA, issue
 number and factory state label, marked status-comment identity, and persisted
 pull-request identity when present. A missing or mismatched projection is
 reported alongside every other discovered discrepancy and pauses the run for
-human disposition. A journaled effect is replayed only when its exact intent
-can be recognized or completed idempotently; otherwise the run remains waiting
-with the pending effect visible to `factory status`. `factory status` reports
+human disposition. A remote run branch whose head is an ancestor of the
+persisted checkpoint is not a discrepancy: a checkpoint is committed before the
+gate suite runs and pushed only afterwards, so an unpushed commit is an
+ordinary in-flight state rather than a diverged branch. A journaled effect is
+replayed only when its exact intent can be recognized or completed
+idempotently; otherwise the run remains waiting with the pending effect visible
+to `factory status`. A retried attempt refreshes the payload of its own
+reservation, because the effect identity rather than the payload is the
+reservation. `factory status` reports
 the run, agreement state, pending effect, discrepancies, and safe operator
 actions. After inspecting an ambiguous mutation, an operator can explicitly
 discard it with `factory reconcile --abandon-effect <effect-id> --reason <reason>`;
@@ -372,7 +378,10 @@ without duplicating polling or replay logic.
 When an implementation report requests clarification, the coordinator pauses
 the run with `agent-needs-input`, renders pending question IDs and prompts in
 the editable status comment, posts the questions on the issue (or tracked pull
-request), and notifies cmux. A command such as
+request), and notifies cmux. The question comment carries a marker scoped to
+the run and its specification packet version, so an interrupted publication
+repairs that round's comment while an answered round's questions remain
+readable. A command such as
 `/factory answer clarification-1 use the existing JSON format` records the
 authorized answer in a new specification-packet version and resumes a fresh
 implementation invocation with that packet. Clarification pauses do not

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,7 +313,7 @@ pull-request identity when present. A missing or mismatched projection is
 reported alongside every other discovered discrepancy and pauses the run for
 human disposition. A remote run branch whose head is an ancestor of the
 persisted checkpoint is not a discrepancy: a checkpoint is committed before the
-gate suite runs and pushed only afterwards, so an unpushed commit is an
+gate suite runs and pushed only afterward, so an unpushed commit is an
 ordinary in-flight state rather than a diverged branch. A journaled effect is
 replayed only when its exact intent can be recognized or completed
 idempotently; otherwise the run remains waiting with the pending effect visible

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -558,6 +558,11 @@ func runStatus(ctx context.Context, args []string, defaultConfigPath string, out
 		if !writeOutput(output, errorsOutput, "recovery: %s (run=%s sources=%s)\n", result.Recovery.Code, result.Recovery.RunID, agreement) {
 			return 1
 		}
+		if pending := result.Recovery.PendingEffect; pending != nil {
+			if !writeOutput(output, errorsOutput, "recovery pending effect: id=%s kind=%s\n", pending.ID, pending.Kind) {
+				return 1
+			}
+		}
 		for _, discrepancy := range result.Recovery.Discrepancies {
 			if !writeOutput(output, errorsOutput, "recovery discrepancy: %s.%s expected=%q observed=%q\n", discrepancy.Source, discrepancy.Field, discrepancy.Expected, discrepancy.Observed) {
 				return 1
@@ -590,6 +595,10 @@ func runReconcile(ctx context.Context, args []string, defaultConfigPath string, 
 	}
 	if *effectID == "" && *reason != "" {
 		writeError(errorsOutput, errors.New("--reason applies only to --abandon-effect"))
+		return 2
+	}
+	if *effectID == "" && *runID != "" {
+		writeError(errorsOutput, errors.New("--run-id applies only to --abandon-effect"))
 		return 2
 	}
 	service := factory.New(*configPath)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -39,6 +39,7 @@ var commandTable = []commandDefinition{
 	{name: "agent-report", handler: runAgentReport},
 	{name: "draft-pr", handler: runDraftPullRequest},
 	{name: "poll", handler: runPollCommands},
+	{name: "reconcile", handler: runReconcile},
 	{name: "status", handler: runStatus},
 	{name: "evaluation", handler: runEvaluation},
 	{name: "evaluation-delete", handler: runEvaluationDelete},
@@ -566,6 +567,53 @@ func runStatus(ctx context.Context, args []string, defaultConfigPath string, out
 			if !writeOutput(output, errorsOutput, "recovery safe action: %s\n", action) {
 				return 1
 			}
+		}
+	}
+	return 0
+}
+
+// runReconcile executes one restart reconciliation or explicitly abandons the
+// effect named by --abandon-effect after a human has inspected it.
+func runReconcile(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("reconcile", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "optional run identifier")
+	effectID := flags.String("abandon-effect", "", "effect identity to abandon after human review")
+	reason := flags.String("reason", "", "reason for abandoning the pending effect")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("reconcile does not accept positional arguments"))
+		return 2
+	}
+	service := factory.New(*configPath)
+	var (
+		result factory.RecoveryResult
+		err    error
+	)
+	if *effectID != "" {
+		result, err = service.AbandonPendingEffect(ctx, factory.AbandonPendingEffectRequest{RunID: *runID, EffectID: *effectID, Reason: *reason})
+	} else {
+		result, err = service.Reconcile(ctx)
+	}
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if result.Run == nil {
+		if !writeOutput(output, errorsOutput, "reconciliation: no persisted run\n") {
+			return 1
+		}
+		return 0
+	}
+	if !writeOutput(output, errorsOutput, "reconciliation: outcome=%s run=%s status=%s stage=%s\n", result.Outcome, result.Run.ID, result.Run.Status, result.Run.Stage) {
+		return 1
+	}
+	for _, discrepancy := range result.Diagnosis.Discrepancies {
+		if !writeOutput(output, errorsOutput, "reconciliation discrepancy: %s.%s expected=%q observed=%q\n", discrepancy.Source, discrepancy.Field, discrepancy.Expected, discrepancy.Observed) {
+			return 1
 		}
 	}
 	return 0

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -588,6 +588,10 @@ func runReconcile(ctx context.Context, args []string, defaultConfigPath string, 
 		writeError(errorsOutput, errors.New("reconcile does not accept positional arguments"))
 		return 2
 	}
+	if *effectID == "" && *reason != "" {
+		writeError(errorsOutput, errors.New("--reason applies only to --abandon-effect"))
+		return 2
+	}
 	service := factory.New(*configPath)
 	var (
 		result factory.RecoveryResult
@@ -598,11 +602,15 @@ func runReconcile(ctx context.Context, args []string, defaultConfigPath string, 
 	} else {
 		result, err = service.Reconcile(ctx)
 	}
-	if err != nil {
-		writeError(errorsOutput, err)
-		return 1
-	}
+	// A paused run is a reported outcome, not a failed command: reconciliation
+	// returns a typed discrepancy error alongside the diagnosis it just wrote.
+	// Print the structured result first so the operator sees the run, the
+	// pending effect, and every discrepancy, then surface the typed error.
 	if result.Run == nil {
+		if err != nil {
+			writeError(errorsOutput, err)
+			return 1
+		}
 		if !writeOutput(output, errorsOutput, "reconciliation: no persisted run\n") {
 			return 1
 		}
@@ -611,10 +619,24 @@ func runReconcile(ctx context.Context, args []string, defaultConfigPath string, 
 	if !writeOutput(output, errorsOutput, "reconciliation: outcome=%s run=%s status=%s stage=%s\n", result.Outcome, result.Run.ID, result.Run.Status, result.Run.Stage) {
 		return 1
 	}
+	if pending := result.Diagnosis.PendingEffect; pending != nil {
+		if !writeOutput(output, errorsOutput, "reconciliation pending effect: id=%s kind=%s\n", pending.ID, pending.Kind) {
+			return 1
+		}
+	}
 	for _, discrepancy := range result.Diagnosis.Discrepancies {
 		if !writeOutput(output, errorsOutput, "reconciliation discrepancy: %s.%s expected=%q observed=%q\n", discrepancy.Source, discrepancy.Field, discrepancy.Expected, discrepancy.Observed) {
 			return 1
 		}
+	}
+	for _, action := range result.Diagnosis.SafeActions {
+		if !writeOutput(output, errorsOutput, "reconciliation safe action: %s\n", action) {
+			return 1
+		}
+	}
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
 	}
 	return 0
 }

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -185,6 +185,15 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 			if pendingErr != nil {
 				return AgentResult{}, fmt.Errorf("read pending effect for repeated report acceptance: %w", pendingErr)
 			}
+			// Capture the accepted report from the pending effect before replay clears it
+			var acceptedReport report.Report
+			var haveAcceptedReport bool
+			if pending != nil && pending.Kind == store.PendingEffectKindResultAcceptance {
+				if extractedReport, extractErr := readAcceptedReportFromEffect(*pending); extractErr == nil {
+					acceptedReport = extractedReport
+					haveAcceptedReport = true
+				}
+			}
 			if pending != nil {
 				updatedRun, replayErr := s.replayPendingEffect(ctx, runStore, *pending)
 				if replayErr != nil {
@@ -199,8 +208,14 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 			if refreshed != nil {
 				invocation = refreshed
 			}
-			value, readErr := readAcceptedAgentReport(*invocation)
-			if readErr == nil {
+			// Use the accepted report from the pending effect if available, otherwise
+			// fall back to reading from the filesystem for backward compatibility
+			value := acceptedReport
+			var readErr error
+			if !haveAcceptedReport {
+				value, readErr = readAcceptedAgentReport(*invocation)
+			}
+			if haveAcceptedReport || readErr == nil {
 				resumed, projected, projectionErr := s.resumeAcceptedStageProjection(ctx, registration, runStore, run, invocation, value)
 				if projected {
 					return resumed, projectionErr
@@ -373,7 +388,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 				WorkspaceID: terminal.WorkspaceID(acceptedInvocation.WorkspaceID),
 				Name:        acceptedInvocation.Role,
 			},
-		}, acceptedInvocation, previousRun, nextRun, value.Outcome == report.OutcomeNeedsClarification)
+		}, acceptedInvocation, previousRun, nextRun, value.Outcome == report.OutcomeNeedsClarification, value)
 		if err != nil {
 			return AgentResult{}, err
 		}
@@ -499,13 +514,38 @@ func agentReportRunProjection(previous store.Run, value report.Report) store.Run
 
 // readAcceptedAgentReport returns the immutable report belonging to a terminal
 // invocation. It makes repeated acceptance a read-only idempotent operation for
-// the durable journal store without re-finishing its harness session.
+// the durable journal store without re-finishing its harness session. This
+// function reads from the filesystem and should only be used as a fallback when
+// the pending effect payload is unavailable.
 func readAcceptedAgentReport(invocation store.Invocation) (report.Report, error) {
 	path := filepath.Join(invocation.ResultDirectory, report.ReportFileName)
 	if invocation.Stage == store.StageTest {
 		return report.ReadEnvelope(path)
 	}
 	return report.Read(path)
+}
+
+// readAcceptedReportFromEffect extracts the accepted report from a result
+// acceptance pending effect payload. This provides the immutable snapshot that
+// was validated during acceptance, avoiding re-reading mutable report.json.
+func readAcceptedReportFromEffect(pending store.PendingEffect) (report.Report, error) {
+	if pending.Kind != store.PendingEffectKindResultAcceptance {
+		return report.Report{}, fmt.Errorf("expected result_acceptance effect, got %s", pending.Kind)
+	}
+	var payload struct {
+		AcceptedReport string `json:"accepted_report"`
+	}
+	if err := json.Unmarshal([]byte(pending.Payload), &payload); err != nil {
+		return report.Report{}, fmt.Errorf("decode result acceptance payload: %w", err)
+	}
+	if strings.TrimSpace(payload.AcceptedReport) == "" {
+		return report.Report{}, errors.New("result acceptance payload has no accepted report")
+	}
+	var value report.Report
+	if err := json.Unmarshal([]byte(payload.AcceptedReport), &value); err != nil {
+		return report.Report{}, fmt.Errorf("decode accepted report from effect: %w", err)
+	}
+	return value, nil
 }
 
 // RunAgent launches the visible agent and accepts a report when one is already

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -369,7 +369,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 				WorkspaceID: terminal.WorkspaceID(acceptedInvocation.WorkspaceID),
 				Name:        acceptedInvocation.Role,
 			},
-		}, acceptedInvocation, previousRun, nextRun, !isTestReport && !isReviewReport && value.Outcome == report.OutcomeNeedsClarification)
+		}, acceptedInvocation, previousRun, nextRun, value.Outcome == report.OutcomeNeedsClarification)
 		if err != nil {
 			return AgentResult{}, err
 		}

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -154,7 +154,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	if strings.TrimSpace(request.InvocationID) == "" {
 		return AgentResult{}, errors.New("invocation id is required")
 	}
-	registration, runStore, run, err := s.openActiveRunStore(ctx)
+	registration, runStore, run, err := s.openReportRunStore(ctx)
 	if err != nil {
 		return AgentResult{}, err
 	}
@@ -180,6 +180,30 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		return AgentResult{}, fmt.Errorf("invocation %q does not belong to run %q", request.InvocationID, run.ID)
 	}
 	if invocation.Status != store.InvocationStatusActive {
+		if journal, journaled := runStore.(PendingEffectStore); journaled {
+			pending, pendingErr := journal.PendingEffect(ctx, run.ID)
+			if pendingErr != nil {
+				return AgentResult{}, fmt.Errorf("read pending effect for repeated report acceptance: %w", pendingErr)
+			}
+			if pending != nil {
+				updatedRun, replayErr := s.replayPendingEffect(ctx, runStore, *pending)
+				if replayErr != nil {
+					return AgentResult{}, fmt.Errorf("replay pending effect before repeated report acceptance: %w", replayErr)
+				}
+				*run = updatedRun
+			}
+			refreshed, refreshErr := invocationStore.Invocation(ctx, run.ID, request.InvocationID)
+			if refreshErr != nil {
+				return AgentResult{}, fmt.Errorf("refresh repeated report invocation: %w", refreshErr)
+			}
+			if refreshed != nil {
+				invocation = refreshed
+			}
+			value, readErr := readAcceptedAgentReport(*invocation)
+			if readErr == nil {
+				return AgentResult{Invocation: *invocation, Report: value}, nil
+			}
+		}
 		return AgentResult{}, fmt.Errorf("invocation %q is already %s", invocation.ID, invocation.Status)
 	}
 	if err := validateAgentRunState(*run); err != nil {
@@ -320,6 +344,52 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	if nativeSessionID == "" {
 		return AgentResult{}, errors.New("accepted agent report must retain a native session identifier")
 	}
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		acceptedInvocation := *invocation
+		acceptedInvocation.NativeSessionID = nativeSessionID
+		acceptedInvocation.Status = acceptedInvocationStatus(value.Outcome)
+		acceptedInvocation.UpdatedAt = s.deps.Now().UTC()
+		previousRun := *run
+		nextRun := previousRun
+		isTestReport := invocation.Stage == store.StageTest
+		isReviewReport := invocation.Role == "spec_review" && invocation.Stage == store.StageReview
+		if !isTestReport && !isReviewReport {
+			nextRun = agentReportRunProjection(previousRun, value)
+		}
+		nextRun.Revision = previousRun.Revision + 1
+		if isTestReport || isReviewReport {
+			nextRun.Revision = previousRun.Revision
+		}
+		nextRun.UpdatedAt = s.deps.Now().UTC()
+		acceptedInvocation, nextRun, err = s.acceptResultWithEffect(ctx, runStore, invocationStore, registration, harnessRuntime, harness.Session{
+			InvocationID:    acceptedInvocation.ID,
+			NativeSessionID: nativeSessionID,
+			Surface: terminal.Surface{
+				ID:          terminal.SurfaceID(acceptedInvocation.ImplementationSurfaceID),
+				WorkspaceID: terminal.WorkspaceID(acceptedInvocation.WorkspaceID),
+				Name:        acceptedInvocation.Role,
+			},
+		}, acceptedInvocation, previousRun, nextRun, !isTestReport && !isReviewReport && value.Outcome == report.OutcomeNeedsClarification)
+		if err != nil {
+			return AgentResult{}, err
+		}
+		*invocation = acceptedInvocation
+		*run = nextRun
+		if isTestReport {
+			return s.acceptTestStageReport(ctx, registration, runStore, run, invocation, value, state)
+		}
+		if isReviewReport {
+			return s.acceptSpecificationReviewReport(ctx, registration, runStore, run, invocation, value)
+		}
+		if value.Outcome == report.OutcomeNeedsClarification {
+			published, publicationErr := s.ensureClarificationPublication(ctx, registration, runStore, *run)
+			if publicationErr != nil {
+				return AgentResult{}, publicationErr
+			}
+			*run = published
+		}
+		return AgentResult{Invocation: *invocation, Report: value}, nil
+	}
 	if err := harnessRuntime.Finish(ctx, harness.Session{InvocationID: invocation.ID, NativeSessionID: nativeSessionID, Surface: terminal.Surface{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID), Name: invocation.Role}}); err != nil {
 		return AgentResult{}, fmt.Errorf("finish accepted harness session: %w", err)
 	}
@@ -329,14 +399,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		}
 	}
 	invocation.NativeSessionID = nativeSessionID
-	switch value.Outcome {
-	case report.OutcomeCompleted:
-		invocation.Status = store.InvocationStatusCompleted
-	case report.OutcomeNeedsClarification:
-		invocation.Status = store.InvocationStatusWaitingForHuman
-	case report.OutcomeCannotProceed:
-		invocation.Status = store.InvocationStatusCannotProceed
-	}
+	invocation.Status = acceptedInvocationStatus(value.Outcome)
 	invocation.UpdatedAt = s.deps.Now().UTC()
 	if err := invocationStore.SaveInvocation(ctx, *invocation); err != nil {
 		return AgentResult{}, fmt.Errorf("persist accepted invocation: %w", err)
@@ -348,27 +411,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	if invocation.Role == "spec_review" && invocation.Stage == store.StageReview {
 		return s.acceptSpecificationReviewReport(ctx, registration, runStore, run, invocation, value)
 	}
-	run.Stage = store.StageImplementation
-	switch value.Outcome {
-	case report.OutcomeNeedsClarification:
-		run.Status = store.StatusWaitingForHuman
-		run.PendingQuestions = pendingQuestionsFromReport(value.Questions)
-		run.ClarificationCommentID = ""
-		run.ClarificationNotificationSent = false
-	case report.OutcomeCannotProceed:
-		run.Status = store.StatusFailed
-		run.PendingQuestions = nil
-		run.ClarificationCommentID = ""
-		run.ClarificationNotificationSent = false
-	default:
-		run.Status = store.StatusActive
-		if value.Handoff != nil {
-			run.ImplementationHandoff = implementationHandoffFromReport(*value.Handoff)
-		}
-		run.PendingQuestions = nil
-		run.ClarificationCommentID = ""
-		run.ClarificationNotificationSent = false
-	}
+	*run = agentReportRunProjection(previousRun, value)
 	run.UpdatedAt = s.deps.Now().UTC()
 	if err := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); err != nil {
 		return AgentResult{}, fmt.Errorf("persist accepted agent state: %w", err)
@@ -381,6 +424,57 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		*run = published
 	}
 	return AgentResult{Invocation: *invocation, Report: value}, nil
+}
+
+// acceptedInvocationStatus maps a validated report outcome to its durable
+// invocation lifecycle state, keeping result acceptance consistent across all
+// visible roles.
+func acceptedInvocationStatus(outcome report.Outcome) store.InvocationStatus {
+	switch outcome {
+	case report.OutcomeCompleted:
+		return store.InvocationStatusCompleted
+	case report.OutcomeNeedsClarification:
+		return store.InvocationStatusWaitingForHuman
+	case report.OutcomeCannotProceed:
+		return store.InvocationStatusCannotProceed
+	default:
+		return store.InvocationStatusCannotProceed
+	}
+}
+
+// agentReportRunProjection applies the shared workflow projection for a
+// validated non-test, non-review report in both journaled and legacy paths.
+func agentReportRunProjection(previous store.Run, value report.Report) store.Run {
+	next := previous
+	next.Stage = store.StageImplementation
+	switch value.Outcome {
+	case report.OutcomeNeedsClarification:
+		next.Status = store.StatusWaitingForHuman
+		next.PendingQuestions = pendingQuestionsFromReport(value.Questions)
+	case report.OutcomeCannotProceed:
+		next.Status = store.StatusFailed
+		next.PendingQuestions = nil
+	default:
+		next.Status = store.StatusActive
+		if value.Handoff != nil {
+			next.ImplementationHandoff = implementationHandoffFromReport(*value.Handoff)
+		}
+		next.PendingQuestions = nil
+	}
+	next.ClarificationCommentID = ""
+	next.ClarificationNotificationSent = false
+	return next
+}
+
+// readAcceptedAgentReport returns the immutable report belonging to a terminal
+// invocation. It makes repeated acceptance a read-only idempotent operation for
+// the durable journal store without re-finishing its harness session.
+func readAcceptedAgentReport(invocation store.Invocation) (report.Report, error) {
+	path := filepath.Join(invocation.ResultDirectory, report.ReportFileName)
+	if invocation.Stage == store.StageTest {
+		return report.ReadEnvelope(path)
+	}
+	return report.Read(path)
 }
 
 // RunAgent launches the visible agent and accepts a report when one is already

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -201,6 +201,10 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 			}
 			value, readErr := readAcceptedAgentReport(*invocation)
 			if readErr == nil {
+				resumed, projected, projectionErr := s.resumeAcceptedStageProjection(ctx, registration, runStore, run, invocation, value)
+				if projected {
+					return resumed, projectionErr
+				}
 				return AgentResult{Invocation: *invocation, Report: value}, nil
 			}
 		}
@@ -424,6 +428,33 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		*run = published
 	}
 	return AgentResult{Invocation: *invocation, Report: value}, nil
+}
+
+// resumeAcceptedStageProjection completes the test- or review-specific run
+// transition when result acceptance made the invocation terminal but a crash
+// left the durable run active at the same stage. A run that already moved away
+// from the invocation stage is the durable proof that no continuation remains.
+func (s *Service) resumeAcceptedStageProjection(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, invocation *store.Invocation, value report.Report) (AgentResult, bool, error) {
+	if run == nil || run.Status != store.StatusActive || run.Stage != invocation.Stage {
+		return AgentResult{}, false, nil
+	}
+	if invocation.Stage == store.StageTest {
+		inspector := s.worktreeInspector()
+		if inspector == nil {
+			return AgentResult{}, true, errors.New("worktree inspector is required to resume accepted test projection")
+		}
+		state, err := inspector.Inspect(ctx, run.Worktree)
+		if err != nil {
+			return AgentResult{}, true, fmt.Errorf("inspect worktree to resume accepted test projection: %w", err)
+		}
+		result, err := s.acceptTestStageReport(ctx, registration, runStore, run, invocation, value, state)
+		return result, true, err
+	}
+	if invocation.Role == "spec_review" && invocation.Stage == store.StageReview {
+		result, err := s.acceptSpecificationReviewReport(ctx, registration, runStore, run, invocation, value)
+		return result, true, err
+	}
+	return AgentResult{}, false, nil
 }
 
 // acceptedInvocationStatus maps a validated report outcome to its durable

--- a/internal/factory/agent_internal_test.go
+++ b/internal/factory/agent_internal_test.go
@@ -1,0 +1,40 @@
+package factory
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestPromptForPersistedInvocationRejectsUnsupportedSchemaVersion verifies
+// recovery refuses invocation packets it cannot interpret without building a
+// degraded role prompt.
+func TestPromptForPersistedInvocationRejectsUnsupportedSchemaVersion(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		version int
+	}{
+		{name: "legacy", version: invocationPacketVersion - 1},
+		{name: "future", version: invocationPacketVersion + 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			run := store.Run{ID: "run-prompt", SpecificationPacket: "{}"}
+			invocation := store.Invocation{
+				ID: "inv-prompt", RunID: run.ID, Role: "implementation", Stage: store.StageImplementation,
+				InvocationDirectory: directory,
+			}
+			if err := writeInvocationPacket(directory, InvocationPacket{
+				SchemaVersion: test.version,
+				InvocationID:  invocation.ID,
+				RunID:         run.ID,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := promptForPersistedInvocation(run, invocation, SpecificationPacket{}); err == nil || !strings.Contains(err.Error(), "unsupported persisted invocation packet schema version") {
+				t.Fatalf("promptForPersistedInvocation() error = %v, want schema-version refusal", err)
+			}
+		})
+	}
+}

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -403,6 +403,15 @@ func (s *Service) resumePersistedInvocation(ctx context.Context, registration co
 		if !workerImageMatches(inspection.Image, workerRequest.Image, workerRequest.ImageDigest) {
 			return invocation, fmt.Errorf("persisted worker image %q does not match frozen image %q@%s", inspection.Image, workerRequest.Image, workerRequest.ImageDigest)
 		}
+		if inspection.Running {
+			known, matches := inspection.MountContractStatus(workerRequest)
+			if !known {
+				return invocation, errors.New("persisted running worker does not expose mount contract identity")
+			}
+			if !matches {
+				return invocation, errors.New("persisted running worker mount contract does not match the invocation")
+			}
+		}
 	}
 	if !inspection.Exists || !inspection.Running {
 		if err := s.startWorkerWithEffect(ctx, runStore, workerRequest); err != nil {

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -2,10 +2,12 @@ package factory
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
@@ -47,6 +49,10 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 			return AgentLaunchResult{}, fmt.Errorf("look up active visible invocation: %w", lookupErr)
 		}
 		if active != nil {
+			if !s.invocationStartedHere(active.ID) && active.RecoveryResumeCount > 0 {
+				s.markInvocationStarted(active.ID)
+				return AgentLaunchResult{Invocation: *active}, nil
+			}
 			return AgentLaunchResult{}, fmt.Errorf("run %q already has active invocation %q", run.ID, active.ID)
 		}
 	}
@@ -67,6 +73,15 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	if err := validateAgentRequest(request); err != nil {
 		return AgentLaunchResult{}, err
 	}
+	if latestStore, ok := runStore.(LatestInvocationStore); ok {
+		latest, latestErr := latestStore.LatestInvocation(ctx, run.ID)
+		if latestErr != nil {
+			return AgentLaunchResult{}, fmt.Errorf("look up latest invocation before launch: %w", latestErr)
+		}
+		if latest != nil && latest.Status != store.InvocationStatusSuperseded && latest.Role == request.Role && latest.Stage == request.Stage {
+			return AgentLaunchResult{}, fmt.Errorf("run %q already has invocation history for %s/%s", run.ID, request.Role, request.Stage)
+		}
+	}
 	isReview := request.Role == "spec_review" && request.Stage == store.StageReview
 	var reviewContext *prompt.ReviewContext
 	if isReview {
@@ -82,7 +97,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		return AgentLaunchResult{}, err
 	}
 	if isReview {
-		if err := s.publishSpecificationReviewStatus(ctx, registration, *run, github.CommitStatusPending, "specification review in progress"); err != nil {
+		if err := s.publishSpecificationReviewStatus(ctx, registration, runStore, *run, github.CommitStatusPending, "specification review in progress"); err != nil {
 			return AgentLaunchResult{}, fmt.Errorf("publish pending specification review status: %w", err)
 		}
 	}
@@ -177,6 +192,15 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		if returnErr == nil || !invocationPersisted {
 			return
 		}
+		if journal, journaled := runStore.(PendingEffectStore); journaled {
+			pending, pendingErr := journal.PendingEffect(context.WithoutCancel(ctx), run.ID)
+			if pendingErr == nil && pending != nil {
+				// Leave the active invocation and its reserved effect intact. A
+				// restart must replay the exact worker boundary before deciding
+				// whether the native session can be resumed or needs human review.
+				return
+			}
+		}
 		rollbackContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		invocation.Status = store.InvocationStatusCannotProceed
@@ -205,7 +229,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	if err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("prepare worker Git metadata: %w", err)
 	}
-	if err := s.deps.Worker.Start(ctx, worker.StartRequest{
+	workerRequest := worker.StartRequest{
 		RunID:             run.ID,
 		WorktreePath:      run.Worktree,
 		GitMetadataPath:   gitMetadataPath,
@@ -216,7 +240,8 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		ResultPath:        resultDirectory,
 		CredentialStoreID: credentialStoreID,
 		Role:              role,
-	}); err != nil {
+	}
+	if err := s.startWorkerWithEffect(ctx, runStore, workerRequest); err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("start worker for visible agent: %w", err)
 	}
 	workerStarted = true
@@ -310,11 +335,193 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		return AgentLaunchResult{}, fmt.Errorf("persist %s stage: %w", role, err)
 	}
 	if isReview {
-		if err := s.refreshSpecificationReviewPullRequest(ctx, registration, *run); err != nil {
+		if err := s.refreshSpecificationReviewPullRequest(ctx, registration, runStore, *run); err != nil {
 			return AgentLaunchResult{}, err
 		}
 	}
+	s.markInvocationStarted(invocation.ID)
 	return AgentLaunchResult{Invocation: invocation, Prompt: promptText}, nil
+}
+
+// resumePersistedInvocation restores one active invocation after a coordinator
+// restart. It reuses the persisted worker, workspace, surface, harness, and
+// native session identity; it never creates a second invocation for the run.
+func (s *Service) resumePersistedInvocation(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, invocation store.Invocation) (store.Invocation, error) {
+	if invocation.RecoveryResumeCount > 0 {
+		return invocation, nil
+	}
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return invocation, errors.New("operational store does not support invocation recovery")
+	}
+	if strings.TrimSpace(invocation.NativeSessionID) == "" {
+		return invocation, errors.New("active invocation has no persisted native session identifier")
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return invocation, fmt.Errorf("decode specification packet for invocation recovery: %w", err)
+	}
+	terminalRuntime, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, config.Harness(invocation.Harness))
+	if err != nil {
+		return invocation, err
+	}
+	capabilities := harnessRuntime.Capabilities()
+	if capabilities.Name != invocation.Harness {
+		return invocation, fmt.Errorf("harness %q cannot resume persisted %q session", capabilities.Name, invocation.Harness)
+	}
+	if !capabilities.InteractiveResume {
+		return invocation, fmt.Errorf("harness %q does not support native session resume", invocation.Harness)
+	}
+	promptText, err := promptForPersistedInvocation(run, invocation, packet)
+	if err != nil {
+		return invocation, err
+	}
+	gitMetadataPath, err := prepareGitMetadataProjection(run.ID, registration.Path, run.Worktree)
+	if err != nil {
+		return invocation, fmt.Errorf("prepare recovery Git metadata: %w", err)
+	}
+	workerRequest := worker.StartRequest{
+		RunID:             run.ID,
+		WorktreePath:      run.Worktree,
+		GitMetadataPath:   gitMetadataPath,
+		Image:             packet.RepositoryConfig.WorkerBuild.Image,
+		ImageDigest:       run.ImageDigest,
+		Caches:            workerCaches(packet.RepositoryConfig.Caches),
+		InvocationPath:    invocation.InvocationDirectory,
+		ResultPath:        invocation.ResultDirectory,
+		CredentialStoreID: invocation.CredentialStoreID,
+		Role:              invocation.Role,
+	}
+	if s.deps.Worker == nil {
+		return invocation, errors.New("worker runtime is required for invocation recovery")
+	}
+	inspection, err := s.deps.Worker.Inspect(ctx, run.ID)
+	if err != nil {
+		return invocation, fmt.Errorf("inspect worker for invocation recovery: %w", err)
+	}
+	if inspection.Exists {
+		if !workerImageMatches(inspection.Image, workerRequest.Image, workerRequest.ImageDigest) {
+			return invocation, fmt.Errorf("persisted worker image %q does not match frozen image %q@%s", inspection.Image, workerRequest.Image, workerRequest.ImageDigest)
+		}
+	}
+	if !inspection.Exists || !inspection.Running {
+		if err := s.startWorkerWithEffect(ctx, runStore, workerRequest); err != nil {
+			return invocation, fmt.Errorf("start missing worker during invocation recovery: %w", err)
+		}
+	}
+	workspaceID := terminal.WorkspaceID(invocation.WorkspaceID)
+	implementationSurface := terminal.Surface{
+		ID:          terminal.SurfaceID(invocation.ImplementationSurfaceID),
+		WorkspaceID: workspaceID,
+		Name:        invocation.Role,
+	}
+	if workspaceID == "" || implementationSurface.ID == "" {
+		runWorkspace, workspaceErr := terminalRuntime.EnsureRunWorkspace(ctx, terminal.RunWorkspaceRequest{
+			RunID:            run.ID,
+			Name:             "factory-" + run.ID,
+			Description:      fmt.Sprintf("factory run for issue #%d", run.IssueNumber),
+			WorkingDirectory: run.Worktree,
+		})
+		if workspaceErr != nil {
+			return invocation, fmt.Errorf("restore run terminal workspace: %w", workspaceErr)
+		}
+		workspaceID = runWorkspace.ID
+		implementationSurface = runWorkspace.Implementation
+		if invocation.Role == "test" {
+			implementationSurface = runWorkspace.Checks
+		} else if invocation.Role == "spec_review" {
+			implementationSurface = terminal.Surface{WorkspaceID: runWorkspace.ID, Name: "spec-review"}
+		}
+		invocation.WorkspaceID = string(runWorkspace.ID)
+		invocation.StatusSurfaceID = string(runWorkspace.Status.ID)
+		invocation.ImplementationSurfaceID = string(implementationSurface.ID)
+		invocation.ChecksSurfaceID = string(runWorkspace.Checks.ID)
+		if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
+			return invocation, fmt.Errorf("persist restored terminal handles: %w", err)
+		}
+	}
+	resumeRequest := harness.StartRequest{
+		InvocationID:    invocation.ID,
+		RunID:           run.ID,
+		Role:            invocation.Role,
+		Stage:           string(invocation.Stage),
+		CheckpointSHA:   reviewCheckpointSHA(invocation.Stage == store.StageReview, run.CheckpointSHA),
+		WorkspaceID:     workspaceID,
+		Surface:         implementationSurface,
+		Prompt:          promptText,
+		Model:           invocation.Model,
+		ReasoningEffort: invocation.ReasoningEffort,
+		ResumeSessionID: invocation.NativeSessionID,
+	}
+	updated, err := s.resumeHarnessWithEffect(ctx, runStore, invocationStore, registration.Cmux.SocketPath, harnessRuntime, invocation, resumeRequest)
+	if err != nil {
+		return updated, err
+	}
+	return updated, nil
+}
+
+// promptForPersistedInvocation rebuilds the same role prompt from the frozen
+// packet and invocation packet after a process restart.
+func promptForPersistedInvocation(run store.Run, invocation store.Invocation, packet SpecificationPacket) (string, error) {
+	var persisted InvocationPacket
+	data, err := os.ReadFile(filepath.Join(invocation.InvocationDirectory, invocationPacketFileName))
+	if err != nil {
+		return "", fmt.Errorf("read persisted invocation packet: %w", err)
+	}
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		return "", fmt.Errorf("decode persisted invocation packet: %w", err)
+	}
+	if persisted.InvocationID != invocation.ID || persisted.RunID != run.ID {
+		return "", errors.New("persisted invocation packet identity does not match the run")
+	}
+	return prompt.Build(prompt.Request{
+		InvocationID:            invocation.ID,
+		RunID:                   run.ID,
+		Role:                    invocation.Role,
+		Stage:                   string(invocation.Stage),
+		SpecificationPacket:     run.SpecificationPacket,
+		RepositoryGuidance:      packet.Issue.Body,
+		TestHandoff:             persisted.TestHandoff,
+		ProtectedTestPaths:      persisted.ProtectedTestPaths,
+		TestExemption:           persisted.TestExemption,
+		TestPaths:               packet.RepositoryConfig.TestPolicy.TestPaths,
+		TestInfrastructurePaths: packet.RepositoryConfig.TestPolicy.InfrastructurePaths,
+		CheckRepairAttempt:      checkRepairAttempt(persisted.CheckRepair),
+		CheckRepairBudget:       checkRepairBudget(persisted.CheckRepair),
+		ReviewContext:           persisted.ReviewContext,
+	})
+}
+
+// checkRepairAttempt extracts the bounded repair attempt from a persisted
+// invocation packet while keeping the prompt package independent of factory
+// packet types.
+func checkRepairAttempt(packet *CheckRepairPacket) int {
+	if packet == nil {
+		return 0
+	}
+	return packet.Attempt
+}
+
+// checkRepairBudget extracts the configured repair ceiling from a persisted
+// invocation packet.
+func checkRepairBudget(packet *CheckRepairPacket) int {
+	if packet == nil {
+		return 0
+	}
+	return packet.Budget
+}
+
+// workerImageMatches accepts Docker's image@digest formatting while requiring
+// the frozen digest whenever the runtime exposes an image identity.
+func workerImageMatches(observed, image, digest string) bool {
+	observed = strings.TrimSpace(observed)
+	if observed == "" {
+		return true
+	}
+	if strings.TrimSpace(digest) == "" {
+		return observed == image
+	}
+	return observed == image+"@"+digest || strings.HasSuffix(observed, "@"+digest)
 }
 
 // reviewCheckpointSHA supplies an exact checkpoint only to the review harness.

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -480,6 +480,9 @@ func promptForPersistedInvocation(run store.Run, invocation store.Invocation, pa
 	if err := json.Unmarshal(data, &persisted); err != nil {
 		return "", fmt.Errorf("decode persisted invocation packet: %w", err)
 	}
+	if persisted.SchemaVersion != invocationPacketVersion {
+		return "", fmt.Errorf("unsupported persisted invocation packet schema version %d", persisted.SchemaVersion)
+	}
 	if persisted.InvocationID != invocation.ID || persisted.RunID != run.ID {
 		return "", errors.New("persisted invocation packet identity does not match the run")
 	}

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -741,7 +741,7 @@ func newFreshAgentService(t *testing.T, runStore *agentRunStore, worktree *inspe
 	}}}
 	githubRuntime := &fakeGitHub{
 		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
-		statusComment: github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: " + run.ID + " -->"},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)},
 	}
 	return factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config:         &fakeConfig{value: host},

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -103,9 +103,15 @@ type stateTransition struct {
 	Previous      store.Run
 	Next          store.Run
 	CreateComment bool
+	// StopWorker makes terminal transitions keep worker shutdown inside the
+	// same durable effect as the GitHub and run projections.
+	StopWorker bool
 	// PersistBeforeEffects is used by replay-sensitive commands so the
 	// processed-comment watermark is durable before GitHub mutation.
 	PersistBeforeEffects bool
+	// InvalidateResults makes a packet revision boundary invalidate prior
+	// invocation and gate projections atomically with the run update.
+	InvalidateResults bool
 }
 
 // BootstrapLabels explicitly creates or updates the factory-owned labels for
@@ -323,6 +329,88 @@ func (s *Service) applyStateTransition(ctx context.Context, runStore RunStore, t
 	if next.Revision <= transition.Previous.Revision {
 		next.Revision = transition.Previous.Revision + 1
 	}
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		return s.applyJournaledStateTransition(ctx, runStore, transition, next)
+	}
+	return s.applyLegacyStateTransition(ctx, runStore, transition, next)
+}
+
+// applyJournaledStateTransition reserves the complete label/comment transition
+// before crossing GitHub's mutation boundary. The reservation remains until
+// both the projection and durable run state are complete.
+func (s *Service) applyJournaledStateTransition(ctx context.Context, runStore RunStore, transition stateTransition, next store.Run) (store.Run, error) {
+	payload := stateTransitionEffectPayload{
+		Repository:        transition.Repository,
+		Issue:             transition.Issue,
+		Previous:          transition.Previous,
+		Next:              next,
+		CreateComment:     transition.CreateComment,
+		StopWorker:        transition.StopWorker,
+		InvalidateResults: transition.InvalidateResults,
+	}
+	effect, err := s.newPendingEffect(next.ID, store.PendingEffectKindStateTransition, fmt.Sprintf("revision=%d", next.Revision), payload)
+	if err != nil {
+		return next, err
+	}
+	apply := func() error {
+		if transition.StopWorker {
+			if err := s.stopRunWorker(ctx, transition.Previous.ID); err != nil {
+				return err
+			}
+		}
+		if transition.PersistBeforeEffects {
+			next.UpdatedAt = s.deps.Now().UTC()
+			if transition.CreateComment {
+				return errors.New("cannot persist a command before creating its status comment")
+			}
+			if err := saveCommandRun(ctx, runStore, transition.Previous.Revision, next); err != nil {
+				return fmt.Errorf("persist state transition before GitHub effects: %w", err)
+			}
+			if recorder, ok := runStore.(evaluationRecorder); ok {
+				if err := recordEvaluationTransition(ctx, recorder, transition.Previous, next, next.UpdatedAt); err != nil {
+					return fmt.Errorf("record evaluation state transition: %w", err)
+				}
+			}
+		}
+		if err := s.applyStateTransitionEffects(ctx, &next, transition); err != nil {
+			return err
+		}
+		next.UpdatedAt = s.deps.Now().UTC()
+		if !transition.PersistBeforeEffects {
+			if transition.InvalidateResults {
+				if atomicStore, ok := runStore.(atomicPacketTransitionStore); ok {
+					if err := atomicStore.SaveRunAndInvalidateResults(ctx, transition.Previous.Revision, next); err != nil {
+						return fmt.Errorf("persist state transition and invalidate results: %w", err)
+					}
+				} else {
+					if err := saveCommandRun(ctx, runStore, transition.Previous.Revision, next); err != nil {
+						return fmt.Errorf("persist state transition: %w", err)
+					}
+					if err := invalidateRunResults(ctx, runStore, next.ID); err != nil {
+						return err
+					}
+				}
+			} else if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+				return fmt.Errorf("persist state transition: %w", err)
+			}
+			if recorder, ok := runStore.(evaluationRecorder); ok {
+				if err := recordEvaluationTransition(ctx, recorder, transition.Previous, next, next.UpdatedAt); err != nil {
+					return fmt.Errorf("record evaluation state transition: %w", err)
+				}
+			}
+		}
+		return nil
+	}
+	if err := s.withPendingEffect(ctx, runStore, effect, apply); err != nil {
+		return next, err
+	}
+	return next, nil
+}
+
+// applyLegacyStateTransition retains the pre-journal behavior for embedders
+// that supply an older RunStore implementation. The production SQLite store
+// implements PendingEffectStore and always uses the restart-safe path.
+func (s *Service) applyLegacyStateTransition(ctx context.Context, runStore RunStore, transition stateTransition, next store.Run) (store.Run, error) {
 	if transition.PersistBeforeEffects {
 		next.UpdatedAt = s.deps.Now().UTC()
 		if transition.CreateComment {
@@ -451,9 +539,31 @@ func (s *Service) openActiveRunStore(ctx context.Context) (config.RepositoryRegi
 		_ = runStore.Close()
 		return config.RepositoryRegistration{}, nil, nil, err
 	}
-	if err := s.ensureProgressionStartup(ctx, registration, run); err != nil {
+	if err := s.ensureProgressionStartup(ctx, registration, runStore, run); err != nil {
 		_ = runStore.Close()
 		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	return registration, runStore, run, nil
+}
+
+// openReportRunStore opens the active run for report acceptance and also
+// exposes the latest terminal run so a retried report can be recognized as an
+// already-completed idempotent operation.
+func (s *Service) openReportRunStore(ctx context.Context) (config.RepositoryRegistration, RunStore, *store.Run, error) {
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	if run != nil {
+		if err := s.ensureProgressionStartup(ctx, registration, runStore, run); err != nil {
+			_ = runStore.Close()
+			return config.RepositoryRegistration{}, nil, nil, err
+		}
 	}
 	return registration, runStore, run, nil
 }
@@ -477,30 +587,42 @@ func (s *Service) openAgentStartRunStore(ctx context.Context, request AgentReque
 	return registration, runStore, run, nil
 }
 
-// ensureProgressionStartup performs the read-only startup guard shared by all
-// progression seams except the dedicated first-agent handoff. A service that
-// found no interrupted run may continue a run it claims during that same
-// process; a fresh service refuses every persisted non-terminal run until issue
-// #21 supplies reconciliation.
-func (s *Service) ensureProgressionStartup(ctx context.Context, registration config.RepositoryRegistration, run *store.Run) error {
+// ensureProgressionStartup performs the restart reconciliation shared by all
+// progression seams. A production store consumes one pending effect, verifies
+// the external projections, and permits continuation only after they agree.
+func (s *Service) ensureProgressionStartup(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run) error {
 	s.startupMu.Lock()
 	defer s.startupMu.Unlock()
 	if s.startupChecked {
 		return s.startupErr
 	}
 	s.startupChecked = true
-	if run == nil || store.IsTerminalStatus(run.Status) {
+	if run == nil {
+		latest, err := readReconciliationRun(ctx, runStore)
+		if err != nil {
+			s.startupErr = fmt.Errorf("read latest run for startup reconciliation: %w", err)
+			return s.startupErr
+		}
+		run = latest
+	}
+	if run == nil {
 		return nil
 	}
-	diagnosis := s.diagnoseInterruptedRun(ctx, registration, *run)
-	s.startupErr = recoveryRequiredError(diagnosis)
+	updated, _, _, err := s.reconcileInterruptedRun(ctx, registration, runStore, *run)
+	if err != nil {
+		*run = updated
+		s.startupErr = err
+		return s.startupErr
+	}
+	*run = updated
 	return s.startupErr
 }
 
 // ensureAgentStartup permits only clean claim/test or explicitly skipped-test
 // states to cross into their first visible invocation. A clean draft checkpoint
-// may also cross into its independent immutable review. Every other later or
-// interrupted state retains the typed #24 refusal until reconciliation exists.
+// may also cross into its independent immutable review. Journaled interrupted
+// runs have already passed reconciliation before this seam is reached; legacy
+// stores retain the typed #24 refusal.
 func (s *Service) ensureAgentStartup(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, request AgentRequest) error {
 	s.startupMu.Lock()
 	defer s.startupMu.Unlock()
@@ -511,9 +633,191 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 	if run == nil || store.IsTerminalStatus(run.Status) {
 		return nil
 	}
+	if _, journaled := runStore.(PendingEffectStore); !journaled {
+		return s.ensureLegacyAgentStartup(ctx, registration, runStore, run, request)
+	}
+	updated, diagnosis, _, err := s.reconcileInterruptedRun(ctx, registration, runStore, *run)
+	*run = updated
+	if err != nil {
+		s.startupErr = err
+		return s.startupErr
+	}
+	if activeStore, ok := runStore.(ActiveInvocationStore); ok {
+		active, lookupErr := activeStore.ActiveInvocation(ctx, run.ID)
+		if lookupErr != nil {
+			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "operational store",
+				Field:    "active invocation",
+				Expected: "read active invocation",
+				Observed: lookupErr.Error(),
+			})
+			diagnosis.SourcesAgree = false
+			return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
+		}
+		if active != nil && !s.invocationStartedHere(active.ID) && active.RecoveryResumeCount == 0 {
+			if strings.TrimSpace(active.NativeSessionID) == "" {
+				addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyInfrastructure,
+					Source:   "harness",
+					Field:    "native session identity",
+					Expected: "persisted native session identifier",
+					Observed: "empty; launch may still be in progress",
+				})
+				diagnosis.SourcesAgree = false
+				return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
+			}
+			if _, resumeErr := s.resumePersistedInvocation(ctx, registration, runStore, *run, *active); resumeErr != nil {
+				addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyInfrastructure,
+					Source:   "harness",
+					Field:    "native session resume",
+					Expected: "resume persisted session exactly once",
+					Observed: resumeErr.Error(),
+				})
+				diagnosis.SourcesAgree = false
+				return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
+			}
+		}
+	}
+	if run.CheckRepairPendingAttempt != 0 {
+		updated, completionErr := s.completePendingCheckRepair(ctx, registration, runStore, *run)
+		if completionErr != nil {
+			diagnosis.SourcesAgree = false
+			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "check-repair",
+				Field:    "attempt reservation",
+				Expected: "completed resumed invocation",
+				Observed: completionErr.Error(),
+			})
+			s.startupErr = &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+			return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
+		}
+		*run = updated
+	}
+	if run.Status == store.StatusActive && run.Stage == store.StageImplementation &&
+		(run.LastCommandName == "answer" || run.LastCommandName == "refresh") &&
+		run.LastCommandOutcome == string(CommandAccepted) {
+		return nil
+	}
+	reviewStart := request.Role == "spec_review" || (request.Role == "" && run.Stage == store.StageDraftPR)
+	cleanStart := run.Stage == store.StageClaim || run.Stage == store.StageTest || (run.Stage == store.StageImplementation && run.TestStageSkipped)
+	if reviewStart && run.Stage == store.StageDraftPR {
+		return nil
+	}
+	if !cleanStart || run.Status != store.StatusActive {
+		return nil
+	}
+	if latestStore, ok := runStore.(LatestInvocationStore); ok {
+		latest, latestErr := latestStore.LatestInvocation(ctx, run.ID)
+		if latestErr != nil {
+			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "operational store",
+				Field:    "latest invocation",
+				Expected: "read latest invocation",
+				Observed: latestErr.Error(),
+			})
+			diagnosis.SourcesAgree = false
+			return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
+		}
+		resumedActiveInvocation := latest != nil && latest.Status == store.InvocationStatusActive && latest.RecoveryResumeCount > 0
+		if latest != nil && latest.Status != store.InvocationStatusSuperseded && !resumedActiveInvocation && invocationBlocksCleanStart(*run, *latest) {
+			diagnosis.InvocationExists = true
+			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyWorkflow,
+				Source:   "run",
+				Field:    "invocation history",
+				Expected: "no unfinished invocation for the clean stage boundary",
+				Observed: fmt.Sprintf("invocation %q is %s", latest.ID, latest.Status),
+			})
+			diagnosis.SourcesAgree = false
+			return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
+		}
+	} else if run.Stage == store.StageClaim {
+		if historyStore, ok := runStore.(InvocationHistoryStore); ok {
+			hasInvocation, historyErr := historyStore.HasInvocation(ctx, run.ID)
+			if historyErr != nil {
+				addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyInfrastructure,
+					Source:   "operational store",
+					Field:    "invocation history",
+					Expected: "read invocation history",
+					Observed: historyErr.Error(),
+				})
+				diagnosis.SourcesAgree = false
+				return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
+			}
+			if hasInvocation {
+				diagnosis.InvocationExists = true
+				addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyWorkflow,
+					Source:   "run",
+					Field:    "invocation history",
+					Expected: "no invocation history for a clean claim stage",
+					Observed: "persisted invocation exists",
+				})
+				diagnosis.SourcesAgree = false
+				return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
+			}
+		}
+	}
+	return nil
+}
+
+// invocationBlocksCleanStart identifies terminal invocation history that means
+// a clean-stage launch may be the second attempt at an already accepted report.
+func invocationBlocksCleanStart(run store.Run, invocation store.Invocation) bool {
+	switch run.Stage {
+	case store.StageClaim:
+		return true
+	case store.StageTest:
+		return invocation.Stage == store.StageTest
+	case store.StageImplementation:
+		return invocation.Stage == store.StageImplementation
+	case store.StageDraftPR:
+		return invocation.Stage == store.StageReview
+	default:
+		return false
+	}
+}
+
+// pauseAgentStartup records a startup disagreement before returning its typed
+// category. Journaled stores use the ordinary waiting transition when the
+// external surface is available and fall back to a local waiting projection
+// while preserving any pending effect that still needs operator resolution.
+func (s *Service) pauseAgentStartup(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, diagnosis RecoveryDiagnosis) error {
+	paused, pauseErr := s.pauseForRecovery(ctx, registration, runStore, *run, diagnosis)
+	*run = paused
+	if pauseErr != nil {
+		local, localErr := s.pauseRunLocally(ctx, runStore, *run, diagnosis)
+		*run = local
+		if localErr != nil {
+			pauseErr = errors.Join(pauseErr, localErr)
+		}
+	}
+	if hasWorkflowDiscrepancy(diagnosis) {
+		// Keep the legacy RecoveryRequiredError discoverable for callers that
+		// used it as the broad startup refusal while exposing workflow failure
+		// as the primary category for new callers.
+		s.startupErr = &WorkflowFailureError{RunID: run.ID, Cause: recoveryRequiredError(diagnosis)}
+	} else {
+		s.startupErr = &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+	}
+	if pauseErr != nil {
+		s.startupErr = errors.Join(s.startupErr, pauseErr)
+	}
+	return s.startupErr
+}
+
+// ensureLegacyAgentStartup preserves the first-invocation compatibility seam
+// for embedders that have not upgraded their operational store to the durable
+// pending-effect journal.
+func (s *Service) ensureLegacyAgentStartup(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, request AgentRequest) error {
 	diagnosis := s.diagnoseInterruptedRun(ctx, registration, *run)
 	if !diagnosis.SourcesAgree {
-		s.startupErr = recoveryRequiredError(diagnosis)
+		s.startupErr = recoveryDiscrepancyError(diagnosis)
 		return s.startupErr
 	}
 	if run.Status == store.StatusActive && run.Stage == store.StageImplementation &&
@@ -527,7 +831,7 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 		return nil
 	}
 	if !cleanStart || run.Status != store.StatusActive {
-		s.startupErr = recoveryRequiredError(diagnosis)
+		s.startupErr = recoveryDiscrepancyError(diagnosis)
 		return s.startupErr
 	}
 	historyStore, ok := runStore.(InvocationHistoryStore)
@@ -539,7 +843,7 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 			Observed: "store does not support invocation history",
 		})
 		diagnosis.SourcesAgree = false
-		s.startupErr = recoveryRequiredError(diagnosis)
+		s.startupErr = recoveryDiscrepancyError(diagnosis)
 		return s.startupErr
 	}
 	hasInvocation, err := historyStore.HasInvocation(ctx, run.ID)
@@ -551,12 +855,12 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 			Observed: err.Error(),
 		})
 		diagnosis.SourcesAgree = false
-		s.startupErr = recoveryRequiredError(diagnosis)
+		s.startupErr = recoveryDiscrepancyError(diagnosis)
 		return s.startupErr
 	}
 	if hasInvocation {
 		diagnosis.InvocationExists = true
-		s.startupErr = recoveryRequiredError(diagnosis)
+		s.startupErr = recoveryDiscrepancyError(diagnosis)
 		return s.startupErr
 	}
 	return nil
@@ -565,6 +869,50 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 // failClaim records a terminal failure and best-effort moves the issue label
 // away from running so a partial claim is visible and retryable.
 func (s *Service) failClaim(ctx context.Context, runStore RunStore, run store.Run, repository github.Repository, issue github.Issue, cause error) (IssueResult, error) {
+	if journal, journaled := runStore.(PendingEffectStore); journaled {
+		// Claim failure owns the partially created run. Abandon the in-flight
+		// success transition before recording failure, otherwise a restart
+		// could replay an obsolete agent-running projection over the failed run.
+		if pending, err := journal.PendingEffect(ctx, run.ID); err != nil {
+			cause = errors.Join(cause, fmt.Errorf("inspect failed-claim pending effect: %w", err))
+		} else if pending != nil {
+			if err := journal.ClearPendingEffect(ctx, run.ID, pending.ID); err != nil {
+				cause = errors.Join(cause, fmt.Errorf("abandon failed-claim pending effect: %w", err))
+			}
+		}
+		previous := run
+		next := run
+		next.Status = store.StatusFailed
+		next.Revision = previous.Revision + 1
+		next.UpdatedAt = s.deps.Now().UTC()
+		updated, transitionErr := s.applyStateTransition(ctx, runStore, stateTransition{
+			Repository:    repository,
+			Issue:         issue,
+			Previous:      previous,
+			Next:          next,
+			CreateComment: strings.TrimSpace(previous.StatusCommentID) == "",
+		})
+		if transitionErr != nil {
+			cause = errors.Join(cause, fmt.Errorf("persist failed claim transition: %w", transitionErr))
+			if pending, pendingErr := journal.PendingEffect(ctx, run.ID); pendingErr == nil && pending != nil {
+				_ = journal.ClearPendingEffect(ctx, run.ID, pending.ID)
+			}
+			if saveErr := runStore.SaveRun(ctx, next); saveErr != nil {
+				cause = errors.Join(cause, fmt.Errorf("persist failed claim fallback: %w", saveErr))
+			}
+			run = next
+		} else {
+			run = updated
+		}
+		if recorder, ok := runStore.(evaluationRecorder); ok {
+			if err := recorder.EnsureEvaluationSummary(ctx, run); err != nil {
+				cause = errors.Join(cause, fmt.Errorf("ensure failed-claim evaluation summary: %w", err))
+			} else if err := recorder.FinalizeEvaluation(ctx, run.ID, store.EvaluationOutcomeFailed, run.UpdatedAt); err != nil {
+				cause = errors.Join(cause, fmt.Errorf("finalize failed-claim evaluation summary: %w", err))
+			}
+		}
+		return IssueResult{}, cause
+	}
 	run.Status = store.StatusFailed
 	run.UpdatedAt = s.deps.Now().UTC()
 	compensationErrors := []error{
@@ -631,6 +979,11 @@ func statusCommentBody(run store.Run) string {
 	review := specificationReviewStatusComment(run)
 	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, checkRepair, pullRequest, lifecycle, harness, review, questions, commandFeedback)
 }
+
+// StatusCommentBody renders the coordinator-owned status projection for one
+// run. It is exported for adapters and integration tests that need to compare
+// a recovered GitHub comment without treating its marker alone as agreement.
+func StatusCommentBody(run store.Run) string { return statusCommentBody(run) }
 
 // specificationReviewStatusComment renders the complete accepted review
 // finding contract in the single editable issue supervision comment.

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -543,6 +543,10 @@ func (s *Service) openActiveRunStore(ctx context.Context) (config.RepositoryRegi
 		_ = runStore.Close()
 		return config.RepositoryRegistration{}, nil, nil, err
 	}
+	if err := s.drainPendingEffect(ctx, registration, runStore, run); err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
 	return registration, runStore, run, nil
 }
 
@@ -561,6 +565,10 @@ func (s *Service) openReportRunStore(ctx context.Context) (config.RepositoryRegi
 	}
 	if run != nil {
 		if err := s.ensureProgressionStartup(ctx, registration, runStore, run); err != nil {
+			_ = runStore.Close()
+			return config.RepositoryRegistration{}, nil, nil, err
+		}
+		if err := s.drainPendingEffect(ctx, registration, runStore, run); err != nil {
 			_ = runStore.Close()
 			return config.RepositoryRegistration{}, nil, nil, err
 		}
@@ -585,6 +593,31 @@ func (s *Service) openAgentStartRunStore(ctx context.Context, request AgentReque
 		return config.RepositoryRegistration{}, nil, nil, err
 	}
 	return registration, runStore, run, nil
+}
+
+// drainPendingEffect consumes a durable effect left behind by an earlier
+// failed attempt in this same process. The one-time startup reconciliation
+// cannot cover it, because a reservation may outlive any operation that failed
+// after startup. Without this drain the next reservation would collide with the
+// stale one and block every later progression until the process restarts.
+func (s *Service) drainPendingEffect(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run) error {
+	if run == nil {
+		return nil
+	}
+	journal, journaled := runStore.(PendingEffectStore)
+	if !journaled {
+		return nil
+	}
+	pending, err := journal.PendingEffect(ctx, run.ID)
+	if err != nil {
+		return fmt.Errorf("read pending effect before progression: %w", err)
+	}
+	if pending == nil {
+		return nil
+	}
+	updated, _, _, reconcileErr := s.reconcileInterruptedRun(ctx, registration, runStore, *run)
+	*run = updated
+	return reconcileErr
 }
 
 // ensureProgressionStartup performs the restart reconciliation shared by all

--- a/internal/factory/clarification.go
+++ b/internal/factory/clarification.go
@@ -78,29 +78,11 @@ func pendingQuestionsFromReport(questions []report.Question) []store.PendingQues
 	return pending
 }
 
-// postClarification publishes the current questions on the active supervision
-// target, using the pull request once a run has one and the issue beforehand.
-func (s *Service) postClarification(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packetVersion int, questions []store.PendingQuestion) (github.Comment, error) {
-	target := run.IssueNumber
-	if run.PullRequestNumber > 0 {
-		target = run.PullRequestNumber
-	}
-	body := clarificationCommentBody(run, packetVersion, questions)
-	comment, err := s.deps.GitHub.CreateIssueComment(ctx, commandRepository(registration), target, body)
-	if err != nil {
-		return github.Comment{}, fmt.Errorf("post clarification questions on #%d: %w", target, err)
-	}
-	if strings.TrimSpace(comment.ID) == "" {
-		return github.Comment{}, fmt.Errorf("post clarification questions on #%d returned an empty comment id", target)
-	}
-	return comment, nil
-}
-
 // clarificationCommentBody renders a bounded, machine-visible question list
 // without making ordinary prose an executable command.
 func clarificationCommentBody(run store.Run, packetVersion int, questions []store.PendingQuestion) string {
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "<!-- factory-clarification: %s -->\n", run.ID)
+	builder.WriteString(clarificationCommentMarker(run.ID, packetVersion) + "\n")
 	builder.WriteString("## Factory clarification requested\n\n")
 	fmt.Fprintf(&builder, "This run is waiting for human input for specification packet version `%d`.\n\n", packetVersion)
 	builder.WriteString("Questions:\n")
@@ -137,13 +119,14 @@ func (s *Service) ensureClarificationPublication(ctx context.Context, registrati
 		body := clarificationCommentBody(run, packet.Version, run.PendingQuestions)
 		payload := clarificationCommentEffectPayload{
 			Repository: commandRepository(registration), Target: target, Body: body,
+			PacketVersion: packet.Version,
 		}
-		effect, effectErr := s.newPendingEffect(run.ID, store.PendingEffectKindClarificationComment, fmt.Sprintf("target=%d\x00body=%s", target, body), payload)
+		effect, effectErr := s.newPendingEffect(run.ID, store.PendingEffectKindClarificationComment, fmt.Sprintf("target=%d\x00version=%d", target, packet.Version), payload)
 		if effectErr != nil {
 			return run, effectErr
 		}
 		if effectErr := s.withPendingEffect(ctx, runStore, effect, func() error {
-			comment, findErr := s.findOrCreateClarificationComment(ctx, payload.Repository, target, run.ID, body)
+			comment, findErr := s.findOrCreateClarificationComment(ctx, payload.Repository, target, run.ID, packet.Version, body)
 			if findErr != nil {
 				return findErr
 			}
@@ -173,11 +156,11 @@ func (s *Service) ensureClarificationPublication(ctx context.Context, registrati
 // findOrCreateClarificationComment observes the coordinator-owned marker and
 // repairs its body before creating a question comment, making publication
 // safe across response loss and stale question edits.
-func (s *Service) findOrCreateClarificationComment(ctx context.Context, repository github.Repository, target int, runID, body string) (github.Comment, error) {
+func (s *Service) findOrCreateClarificationComment(ctx context.Context, repository github.Repository, target int, runID string, packetVersion int, body string) (github.Comment, error) {
 	if s.deps.GitHub == nil {
 		return github.Comment{}, errors.New("GitHub client is required for clarification publication")
 	}
-	comment, err := s.deps.GitHub.FindStatusComment(ctx, repository, target, clarificationCommentMarker(runID))
+	comment, err := s.deps.GitHub.FindStatusComment(ctx, repository, target, clarificationCommentMarker(runID, packetVersion))
 	if err != nil {
 		return github.Comment{}, fmt.Errorf("find existing clarification questions on #%d: %w", target, err)
 	}
@@ -202,8 +185,11 @@ func (s *Service) findOrCreateClarificationComment(ctx context.Context, reposito
 
 // clarificationCommentMarker identifies the coordinator-authored clarification
 // comment so a response-loss restart can recover it before creating another.
-func clarificationCommentMarker(runID string) string {
-	return fmt.Sprintf("<!-- factory-clarification: %s -->", runID)
+// The marker carries the specification packet version because each answered
+// round advances that version: scoping it this way keeps replay idempotent
+// within a round while leaving an earlier round's questions on the issue.
+func clarificationCommentMarker(runID string, packetVersion int) string {
+	return fmt.Sprintf("<!-- factory-clarification: %s v%d -->", runID, packetVersion)
 }
 
 // pendingQuestion returns one run question by its stable identifier.

--- a/internal/factory/clarification.go
+++ b/internal/factory/clarification.go
@@ -130,14 +130,31 @@ func (s *Service) ensureClarificationPublication(ctx context.Context, registrati
 		return run, fmt.Errorf("decode specification packet for clarification publication: %w", err)
 	}
 	if run.ClarificationCommentID == "" {
-		comment, postErr := s.postClarification(ctx, registration, run, packet.Version, run.PendingQuestions)
-		if postErr != nil {
-			return run, postErr
+		target := run.IssueNumber
+		if run.PullRequestNumber > 0 {
+			target = run.PullRequestNumber
 		}
-		run.ClarificationCommentID = comment.ID
-		run.UpdatedAt = s.deps.Now().UTC()
-		if err := saveRunWithRetry(ctx, runStore, run); err != nil {
-			return run, fmt.Errorf("persist clarification comment identity: %w", err)
+		body := clarificationCommentBody(run, packet.Version, run.PendingQuestions)
+		payload := clarificationCommentEffectPayload{
+			Repository: commandRepository(registration), Target: target, Body: body,
+		}
+		effect, effectErr := s.newPendingEffect(run.ID, store.PendingEffectKindClarificationComment, fmt.Sprintf("target=%d\x00body=%s", target, body), payload)
+		if effectErr != nil {
+			return run, effectErr
+		}
+		if effectErr := s.withPendingEffect(ctx, runStore, effect, func() error {
+			comment, findErr := s.findOrCreateClarificationComment(ctx, payload.Repository, target, run.ID, body)
+			if findErr != nil {
+				return findErr
+			}
+			run.ClarificationCommentID = comment.ID
+			run.UpdatedAt = s.deps.Now().UTC()
+			if err := saveRunWithRetry(ctx, runStore, run); err != nil {
+				return fmt.Errorf("persist clarification comment identity: %w", err)
+			}
+			return nil
+		}); effectErr != nil {
+			return run, effectErr
 		}
 	}
 	if !run.ClarificationNotificationSent {
@@ -151,6 +168,42 @@ func (s *Service) ensureClarificationPublication(ctx context.Context, registrati
 		}
 	}
 	return run, nil
+}
+
+// findOrCreateClarificationComment observes the coordinator-owned marker and
+// repairs its body before creating a question comment, making publication
+// safe across response loss and stale question edits.
+func (s *Service) findOrCreateClarificationComment(ctx context.Context, repository github.Repository, target int, runID, body string) (github.Comment, error) {
+	if s.deps.GitHub == nil {
+		return github.Comment{}, errors.New("GitHub client is required for clarification publication")
+	}
+	comment, err := s.deps.GitHub.FindStatusComment(ctx, repository, target, clarificationCommentMarker(runID))
+	if err != nil {
+		return github.Comment{}, fmt.Errorf("find existing clarification questions on #%d: %w", target, err)
+	}
+	if strings.TrimSpace(comment.ID) != "" {
+		if comment.Body != body {
+			if err := s.deps.GitHub.EditIssueComment(ctx, repository, comment.ID, body); err != nil {
+				return github.Comment{}, fmt.Errorf("repair clarification questions on #%d: %w", target, err)
+			}
+			comment.Body = body
+		}
+		return comment, nil
+	}
+	created, err := s.deps.GitHub.CreateIssueComment(ctx, repository, target, body)
+	if err != nil {
+		return github.Comment{}, fmt.Errorf("post clarification questions on #%d: %w", target, err)
+	}
+	if strings.TrimSpace(created.ID) == "" {
+		return github.Comment{}, fmt.Errorf("post clarification questions on #%d returned an empty comment id", target)
+	}
+	return created, nil
+}
+
+// clarificationCommentMarker identifies the coordinator-authored clarification
+// comment so a response-loss restart can recover it before creating another.
+func clarificationCommentMarker(runID string) string {
+	return fmt.Sprintf("<!-- factory-clarification: %s -->", runID)
 }
 
 // pendingQuestion returns one run question by its stable identifier.

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -431,13 +431,21 @@ func (s *Service) stopRunWorkerIfActive(ctx context.Context, runStore RunStore, 
 // invalidation commit or roll back together. The command watermark (ProcessedCommentID)
 // is intentionally not set here; it is deferred until after successful resumption
 // to keep packet-change resumption retryable when startAgentWithStore fails.
-func (s *Service) applyPacketChangeTransition(ctx context.Context, runStore RunStore, registration config.RepositoryRegistration, issue github.Issue, previous, next store.Run, commandName string) (store.Run, error) {
+func (s *Service) applyPacketChangeTransition(ctx context.Context, runStore RunStore, registration config.RepositoryRegistration, issue github.Issue, previous, next store.Run, _ string) (store.Run, error) {
 	repository := commandRepository(registration)
 	next.UpdatedAt = s.deps.Now().UTC()
 	if next.Revision <= previous.Revision {
 		next.Revision = previous.Revision + 1
 	}
-	next.LastCommandName = commandName
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		return s.applyStateTransition(ctx, runStore, stateTransition{
+			Repository:        repository,
+			Issue:             issue,
+			Previous:          previous,
+			Next:              next,
+			InvalidateResults: true,
+		})
+	}
 
 	// Apply GitHub effects first (labels and status comment update)
 	oldLabels := append([]string(nil), issue.Labels...)
@@ -735,6 +743,9 @@ func (s *Service) persistCommandProjectionWithRun(ctx context.Context, registrat
 		}
 		next.StatusCommentID = recovered.StatusCommentID
 	}
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		return s.persistCommandProjectionWithEffect(ctx, runStore, commandRepository(registration), previous, next)
+	}
 	if err := saveCommandRun(ctx, runStore, previous.Revision, next); err != nil {
 		return next, fmt.Errorf("persist command watermark: %w", err)
 	}
@@ -794,9 +805,9 @@ func commandResultName(parsed commandlanguage.Request) string {
 	return string(parsed.Kind)
 }
 
-// openCommandRunStore opens a store without invoking the progression startup
-// guard, because status, refresh, and policy rejection are read-only workflow
-// operations even when a run needs recovery diagnosis.
+// openCommandRunStore opens a command-capable store and consumes any pending
+// effect before command watermark checks. Legacy stores retain their historical
+// command-only behavior because they do not expose a replay journal.
 func (s *Service) openCommandRunStore(ctx context.Context) (config.RepositoryRegistration, RunStore, *store.Run, error) {
 	registration, runStore, err := s.openRunStore(ctx)
 	if err != nil {
@@ -811,6 +822,26 @@ func (s *Service) openCommandRunStore(ctx context.Context) (config.RepositoryReg
 	if err != nil {
 		_ = runStore.Close()
 		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	if _, journaled := runStore.(PendingEffectStore); journaled && run != nil {
+		if err := s.ensureProgressionStartup(ctx, registration, runStore, run); err != nil {
+			_ = runStore.Close()
+			return config.RepositoryRegistration{}, nil, nil, err
+		}
+		// The process may have created a pending effect after its one-time
+		// startup check. Commands must still drain that effect before checking
+		// the processed-comment watermark.
+		if pending, pendingErr := runStore.(PendingEffectStore).PendingEffect(ctx, run.ID); pendingErr != nil {
+			_ = runStore.Close()
+			return config.RepositoryRegistration{}, nil, nil, pendingErr
+		} else if pending != nil {
+			updated, _, _, reconcileErr := s.reconcileInterruptedRun(ctx, registration, runStore, *run)
+			*run = updated
+			if reconcileErr != nil {
+				_ = runStore.Close()
+				return config.RepositoryRegistration{}, nil, nil, reconcileErr
+			}
+		}
 	}
 	return registration, runStore, run, nil
 }

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -251,7 +251,7 @@ func (s *Service) handleAnswerCommand(ctx context.Context, registration config.R
 	if err != nil {
 		return CommandResult{}, fmt.Errorf("read issue for answer: %w", err)
 	}
-	updated, err := s.applyPacketChangeTransition(ctx, runStore, registration, issue, run, next, processedCommentID)
+	updated, err := s.applyPacketChangeTransition(ctx, runStore, registration, issue, run, next)
 	if err != nil {
 		return CommandResult{}, err
 	}
@@ -319,7 +319,7 @@ func (s *Service) handleRefreshCommand(ctx context.Context, registration config.
 	// Clear ProcessedCommentID temporarily to defer watermark until after resumption
 	processedCommentID := next.ProcessedCommentID
 	next.ProcessedCommentID = run.ProcessedCommentID
-	updated, err := s.applyPacketChangeTransition(ctx, runStore, registration, issue, run, next, processedCommentID)
+	updated, err := s.applyPacketChangeTransition(ctx, runStore, registration, issue, run, next)
 	if err != nil {
 		return CommandResult{}, err
 	}
@@ -431,7 +431,7 @@ func (s *Service) stopRunWorkerIfActive(ctx context.Context, runStore RunStore, 
 // invalidation commit or roll back together. The command watermark (ProcessedCommentID)
 // is intentionally not set here; it is deferred until after successful resumption
 // to keep packet-change resumption retryable when startAgentWithStore fails.
-func (s *Service) applyPacketChangeTransition(ctx context.Context, runStore RunStore, registration config.RepositoryRegistration, issue github.Issue, previous, next store.Run, _ string) (store.Run, error) {
+func (s *Service) applyPacketChangeTransition(ctx context.Context, runStore RunStore, registration config.RepositoryRegistration, issue github.Issue, previous, next store.Run) (store.Run, error) {
 	repository := commandRepository(registration)
 	next.UpdatedAt = s.deps.Now().UTC()
 	if next.Revision <= previous.Revision {
@@ -831,16 +831,9 @@ func (s *Service) openCommandRunStore(ctx context.Context) (config.RepositoryReg
 		// The process may have created a pending effect after its one-time
 		// startup check. Commands must still drain that effect before checking
 		// the processed-comment watermark.
-		if pending, pendingErr := runStore.(PendingEffectStore).PendingEffect(ctx, run.ID); pendingErr != nil {
+		if err := s.drainPendingEffect(ctx, registration, runStore, run); err != nil {
 			_ = runStore.Close()
-			return config.RepositoryRegistration{}, nil, nil, pendingErr
-		} else if pending != nil {
-			updated, _, _, reconcileErr := s.reconcileInterruptedRun(ctx, registration, runStore, *run)
-			*run = updated
-			if reconcileErr != nil {
-				_ = runStore.Close()
-				return config.RepositoryRegistration{}, nil, nil, reconcileErr
-			}
+			return config.RepositoryRegistration{}, nil, nil, err
 		}
 	}
 	return registration, runStore, run, nil

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -71,7 +71,7 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 		return DraftPullRequestResult{}, err
 	}
 	if run.Stage == store.StageDraftPR {
-		pullRequest, err := s.regenerateDraftPullRequest(ctx, registration, *run, packet, request.Intervention)
+		pullRequest, err := s.regenerateDraftPullRequest(ctx, registration, runStore, *run, packet, request.Intervention)
 		if err != nil {
 			return DraftPullRequestResult{Run: *run}, err
 		}
@@ -132,12 +132,25 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 			}
 		}
 	} else {
-		checkpoint, checkpointErr := workspace.CreateCheckpoint(ctx, gitadapter.CheckpointRequest{
+		checkpointRequest := gitadapter.CheckpointRequest{
 			RunID:        run.ID,
 			WorktreePath: run.Worktree,
 			ParentSHA:    run.CheckpointSHA,
 			Message:      checkpointMessage(*run),
-		})
+		}
+		checkpoint := gitadapter.CheckpointResult{}
+		checkpointErr := error(nil)
+		next.SpecificationReview = nil
+		next.Stage = store.StageCheck
+		next.Status = store.StatusActive
+		next.LifecycleReason = "evaluating implementation checkpoint"
+		next.Revision = run.Revision + 1
+		next.UpdatedAt = s.deps.Now().UTC()
+		if _, journaled := runStore.(PendingEffectStore); journaled {
+			checkpoint, next, checkpointErr = s.checkpointAndPersistWithEffect(ctx, runStore, workspace, checkpointRequest, repository, issue, *run, next)
+		} else {
+			checkpoint, checkpointErr = workspace.CreateCheckpoint(ctx, checkpointRequest)
+		}
 		if checkpointErr != nil {
 			return DraftPullRequestResult{}, checkpointErr
 		}
@@ -147,17 +160,14 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 		if run.CheckRepairAttempts > 0 && checkpoint.SHA == run.CheckpointSHA {
 			return DraftPullRequestResult{}, fmt.Errorf("check-repair attempt %d did not produce a new checkpoint SHA", run.CheckRepairAttempts)
 		}
-		next.CheckpointSHA = checkpoint.SHA
-		next.SpecificationReview = nil
-		next.Stage = store.StageCheck
-		next.Status = store.StatusActive
-		next.LifecycleReason = "evaluating implementation checkpoint"
-		next.UpdatedAt = s.deps.Now().UTC()
-		next, err = s.applyStateTransition(ctx, runStore, stateTransition{
-			Repository: repository, Issue: issue, Previous: *run, Next: next,
-		})
-		if err != nil {
-			return DraftPullRequestResult{}, err
+		if _, journaled := runStore.(PendingEffectStore); !journaled {
+			next.CheckpointSHA = checkpoint.SHA
+			next, err = s.applyStateTransition(ctx, runStore, stateTransition{
+				Repository: repository, Issue: issue, Previous: *run, Next: next,
+			})
+			if err != nil {
+				return DraftPullRequestResult{}, err
+			}
 		}
 	}
 
@@ -179,26 +189,46 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 	if len(state.ChangedPaths) != 0 {
 		return result, errors.New("worktree has uncommitted changes after deterministic gates")
 	}
-	if err := workspace.Push(ctx, gitadapter.PushRequest{WorktreePath: next.Worktree, Branch: next.Branch}); err != nil {
-		return result, err
+	pushRequest := gitadapter.PushRequest{WorktreePath: next.Worktree, Branch: next.Branch}
+	var pushErr error
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		pushErr = s.pushWithEffect(ctx, runStore, next.ID, workspace, pushRequest, next.CheckpointSHA)
+	} else {
+		pushErr = workspace.Push(ctx, pushRequest)
+	}
+	if pushErr != nil {
+		return result, pushErr
 	}
 
 	pullRequests := s.pullRequestClient()
 	if pullRequests == nil {
 		return result, errors.New("GitHub client does not support pull-request operations")
 	}
-	pullRequest, err := s.upsertDraftPullRequest(ctx, pullRequests, repository, next, packet, gates, request.Intervention)
-	if err != nil {
-		return result, err
+	pullRequest := github.PullRequest{}
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		plannedRequest, expectedNumber, planErr := s.planDraftPullRequest(ctx, pullRequests, repository, next, packet, gates, request.Intervention)
+		if planErr != nil {
+			return result, planErr
+		}
+		next.Stage = store.StageDraftPR
+		next.Status = store.StatusActive
+		next.Revision = result.Run.Revision + 1
+		next.UpdatedAt = s.deps.Now().UTC()
+		pullRequest, next, err = s.upsertPullRequestAndPersistWithEffect(ctx, runStore, pullRequests, repository, issue, result.Run, next, plannedRequest, expectedNumber)
+	} else {
+		pullRequest, err = s.upsertDraftPullRequest(ctx, pullRequests, repository, next, packet, gates, request.Intervention)
+		if err != nil {
+			return result, err
+		}
+		next.PullRequestNumber = pullRequest.Number
+		next.PullRequestURL = pullRequest.URL
+		next.Stage = store.StageDraftPR
+		next.Status = store.StatusActive
+		next.UpdatedAt = s.deps.Now().UTC()
+		next, err = s.applyStateTransition(ctx, runStore, stateTransition{
+			Repository: repository, Issue: issue, Previous: result.Run, Next: next,
+		})
 	}
-	next.PullRequestNumber = pullRequest.Number
-	next.PullRequestURL = pullRequest.URL
-	next.Stage = store.StageDraftPR
-	next.Status = store.StatusActive
-	next.UpdatedAt = s.deps.Now().UTC()
-	next, err = s.applyStateTransition(ctx, runStore, stateTransition{
-		Repository: repository, Issue: issue, Previous: result.Run, Next: next,
-	})
 	if err != nil {
 		return DraftPullRequestResult{Run: next, Gates: gates, PullRequest: pullRequest}, err
 	}
@@ -221,9 +251,19 @@ func (s *Service) runConfiguredGates(ctx context.Context, registration config.Re
 // upsertDraftPullRequest finds a prior branch pull request before creating one
 // and merges the generated section into its existing body when present.
 func (s *Service) upsertDraftPullRequest(ctx context.Context, client github.PullRequestClient, repository github.Repository, run store.Run, packet SpecificationPacket, gates []gate.Result, intervention string) (github.PullRequest, error) {
-	existing, err := client.FindPullRequest(ctx, repository, run.Branch, packet.RepositoryConfig.TargetBranch)
+	request, expectedNumber, err := s.planDraftPullRequest(ctx, client, repository, run, packet, gates, intervention)
 	if err != nil {
 		return github.PullRequest{}, err
+	}
+	return s.upsertPullRequestRequest(ctx, client, repository, expectedNumber, request)
+}
+
+// planDraftPullRequest reads the current branch PR once and freezes the exact
+// request used by both the first mutation and a restart replay.
+func (s *Service) planDraftPullRequest(ctx context.Context, client github.PullRequestClient, repository github.Repository, run store.Run, packet SpecificationPacket, gates []gate.Result, intervention string) (github.PullRequestRequest, int, error) {
+	existing, err := client.FindPullRequest(ctx, repository, run.Branch, packet.RepositoryConfig.TargetBranch)
+	if err != nil {
+		return github.PullRequestRequest{}, 0, err
 	}
 	body := generatedPullRequestBody(run, packet, gates, intervention)
 	request := github.PullRequestRequest{
@@ -235,29 +275,14 @@ func (s *Service) upsertDraftPullRequest(ctx context.Context, client github.Pull
 	}
 	if existing.Number > 0 {
 		request.Body = mergeGeneratedPullRequestBody(existing.Body, body)
-		updated, err := client.UpdatePullRequest(ctx, repository, existing.Number, request)
-		if err != nil {
-			return github.PullRequest{}, err
-		}
-		if updated.Number <= 0 {
-			return github.PullRequest{}, errors.New("pull-request update returned no pull-request identity")
-		}
-		return updated, nil
 	}
-	created, err := client.CreatePullRequest(ctx, repository, request)
-	if err != nil {
-		return github.PullRequest{}, err
-	}
-	if created.Number <= 0 {
-		return github.PullRequest{}, errors.New("pull-request creation returned no pull-request identity")
-	}
-	return created, nil
+	return request, existing.Number, nil
 }
 
 // regenerateDraftPullRequest refreshes a previously created PR without
 // rerunning gates or pushing again. The branch lookup supplies the current
 // human-authored body for preservation.
-func (s *Service) regenerateDraftPullRequest(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packet SpecificationPacket, intervention string) (github.PullRequest, error) {
+func (s *Service) regenerateDraftPullRequest(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, packet SpecificationPacket, intervention string) (github.PullRequest, error) {
 	client := s.pullRequestClient()
 	if client == nil {
 		return github.PullRequest{}, errors.New("GitHub client does not support pull-request operations")
@@ -271,13 +296,22 @@ func (s *Service) regenerateDraftPullRequest(ctx context.Context, registration c
 		return github.PullRequest{}, fmt.Errorf("draft pull request for branch %q was not found", run.Branch)
 	}
 	body := mergeGeneratedPullRequestBody(existing.Body, generatedPullRequestBody(run, packet, nil, intervention))
-	updated, err := client.UpdatePullRequest(ctx, repository, existing.Number, github.PullRequestRequest{
+	updateRequest := github.PullRequestRequest{
 		Title: defaultString(packet.Issue.Title, fmt.Sprintf("Issue #%d", packet.Issue.Number)), Body: body,
 		HeadBranch: run.Branch, BaseBranch: packet.RepositoryConfig.TargetBranch, Draft: true,
-	})
+	}
+	updated := existing
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		err = s.updatePullRequestWithEffect(ctx, runStore, run.ID, client, repository, existing.Number, updateRequest)
+	} else {
+		updated, err = client.UpdatePullRequest(ctx, repository, existing.Number, updateRequest)
+	}
 	if err != nil {
 		return github.PullRequest{}, err
 	}
+	updated.Body = updateRequest.Body
+	updated.Title = updateRequest.Title
+	updated.Draft = updateRequest.Draft
 	if updated.Number <= 0 {
 		return github.PullRequest{}, errors.New("pull-request regeneration returned no pull-request identity")
 	}

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -1,0 +1,1392 @@
+package factory
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// PendingEffectStore is the optional durable journal used to make external
+// mutations recoverable across a coordinator process boundary.
+type PendingEffectStore interface {
+	PendingEffect(context.Context, string) (*store.PendingEffect, error)
+	SavePendingEffect(context.Context, store.PendingEffect) error
+	ClearPendingEffect(context.Context, string, string) error
+}
+
+// PendingEffectAbandoner is the explicit operator seam for discarding one
+// ambiguous effect after human review. It is separate from PendingEffectStore
+// so older in-memory embedders can retain the journal read/replay contract.
+type PendingEffectAbandoner interface {
+	AbandonPendingEffect(context.Context, string, string, string) error
+}
+
+var _ PendingEffectStore = (*store.Store)(nil)
+
+// stateTransitionEffectPayload is the serialized intent for one paired issue
+// label and status-comment projection.
+type stateTransitionEffectPayload struct {
+	Repository        github.Repository
+	Issue             github.Issue
+	Previous          store.Run
+	Next              store.Run
+	CreateComment     bool
+	StopWorker        bool
+	InvalidateResults bool
+}
+
+// statusCommentEffectPayload is the serialized intent for a command
+// watermark and its corresponding status-comment edit.
+type statusCommentEffectPayload struct {
+	Repository github.Repository
+	Previous   store.Run
+	Next       store.Run
+}
+
+// clarificationCommentEffectPayload is the serialized intent for one
+// coordinator-authored clarification comment and its run identity projection.
+type clarificationCommentEffectPayload struct {
+	Repository github.Repository
+	Target     int
+	Body       string
+}
+
+// labelTransitionEffectPayload is the serialized intent for a standalone
+// complete issue-label replacement.
+type labelTransitionEffectPayload struct {
+	Repository  github.Repository
+	IssueNumber int
+	Labels      []string
+}
+
+// commitStatusEffectPayload is the serialized intent for one exact-SHA status.
+type commitStatusEffectPayload struct {
+	Repository github.Repository
+	Status     github.CommitStatus
+}
+
+// checkpointRequestJSON keeps the git adapter request independent from the
+// unexported effect implementation while retaining every replay input.
+type checkpointRequestJSON struct {
+	RunID        string
+	WorktreePath string
+	ParentSHA    string
+	Kind         string
+	Paths        []string
+	Message      string
+}
+
+// pushEffectPayload is the serialized intent for one branch push.
+type pushEffectPayload struct {
+	Request     pushRequestJSON
+	ExpectedSHA string
+}
+
+// pushRequestJSON keeps the git adapter request independent from the effect
+// journal package boundary.
+type pushRequestJSON struct {
+	WorktreePath string
+	Branch       string
+}
+
+// pullRequestEffectPayload is the serialized intent for one draft PR mutation.
+type pullRequestEffectPayload struct {
+	Repository github.Repository
+	Number     int
+	Request    github.PullRequestRequest
+	PersistRun bool
+	Issue      github.Issue
+	Previous   store.Run
+	Next       store.Run
+}
+
+// workerLaunchEffectPayload is the serialized intent for one worker launch or
+// reuse. The request type itself is already a portable worker seam.
+type workerLaunchEffectPayload struct {
+	Request worker.StartRequest
+}
+
+// harnessResumeEffectPayload is the durable intent for one native-session
+// continuation. The target resume count lets recovery recognize a reservation
+// that crossed the harness boundary before the invocation row was finalized.
+type harnessResumeEffectPayload struct {
+	SocketPath        string
+	Request           harness.StartRequest
+	Invocation        store.Invocation
+	TargetResumeCount int
+}
+
+// resultAcceptanceEffectPayload is the complete durable intent for accepting
+// a validated visible report.
+type resultAcceptanceEffectPayload struct {
+	Repository github.Repository
+	SocketPath string
+	Issue      github.Issue
+	Session    harness.Session
+	Invocation store.Invocation
+	Previous   store.Run
+	Next       store.Run
+	StopWorker bool
+}
+
+// pendingEffectID derives a stable, bounded identity from the semantic effect
+// rather than from a process-generated UUID. The same operation can therefore
+// be recognized after a restart.
+func pendingEffectID(runID string, kind store.PendingEffectKind, identity string) string {
+	digest := sha256.Sum256([]byte(runID + "\x00" + string(kind) + "\x00" + identity))
+	return string(kind) + ":" + hex.EncodeToString(digest[:])
+}
+
+// withPendingEffect journals one external mutation before running it and
+// acknowledges the journal only after the mutation succeeds. When an older
+// operational-store adapter has no journal seam, it retains the historical
+// direct execution behavior.
+func (s *Service) withPendingEffect(ctx context.Context, runStore RunStore, effect store.PendingEffect, action func() error) error {
+	journal, ok := runStore.(PendingEffectStore)
+	if !ok {
+		return action()
+	}
+	if err := journal.SavePendingEffect(ctx, effect); err != nil {
+		return fmt.Errorf("reserve %s effect: %w", effect.Kind, err)
+	}
+	if err := action(); err != nil {
+		return err
+	}
+	if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+		return fmt.Errorf("complete %s effect: %w", effect.Kind, err)
+	}
+	return nil
+}
+
+// newPendingEffect encodes a replay intent and applies the coordinator clock
+// so all journal records share the run's operational time source.
+func (s *Service) newPendingEffect(runID string, kind store.PendingEffectKind, identity string, payload any) (store.PendingEffect, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return store.PendingEffect{}, fmt.Errorf("encode %s effect: %w", kind, err)
+	}
+	if len(data) == 0 || !json.Valid(data) {
+		return store.PendingEffect{}, errors.New("pending effect payload is not valid JSON")
+	}
+	now := s.deps.Now().UTC()
+	return store.PendingEffect{
+		RunID:     runID,
+		ID:        pendingEffectID(runID, kind, identity),
+		Kind:      kind,
+		Payload:   string(data),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, nil
+}
+
+// decodePendingEffect decodes one bounded replay payload and reports malformed
+// journal data as an infrastructure discrepancy rather than a workflow result.
+func decodePendingEffect(effect store.PendingEffect, destination any) error {
+	if strings.TrimSpace(effect.Payload) == "" {
+		return errors.New("pending effect payload is empty")
+	}
+	if err := json.Unmarshal([]byte(effect.Payload), destination); err != nil {
+		return fmt.Errorf("decode %s effect: %w", effect.Kind, err)
+	}
+	return nil
+}
+
+// commitStatusPublisher wraps the gate status seam with durable idempotency.
+type commitStatusPublisher struct {
+	service  *Service
+	runStore RunStore
+	runID    string
+	delegate github.CommitStatusPublisher
+}
+
+// CreateCommitStatus publishes or recognizes one exact-SHA status without
+// creating a second semantic status after a process interruption.
+func (p commitStatusPublisher) CreateCommitStatus(ctx context.Context, repository github.Repository, status github.CommitStatus) error {
+	payload := commitStatusEffectPayload{Repository: repository, Status: status}
+	effect, err := p.service.newPendingEffect(p.runID, store.PendingEffectKindCommitStatus, status.SHA+"\x00"+status.Context+"\x00"+string(status.State)+"\x00"+status.Description, payload)
+	if err != nil {
+		return err
+	}
+	return p.service.withPendingEffect(ctx, p.runStore, effect, func() error {
+		if reader, ok := p.delegate.(github.CommitStatusReader); ok {
+			statuses, err := reader.ListCommitStatuses(ctx, repository, status.SHA)
+			if err != nil {
+				return fmt.Errorf("inspect existing commit status: %w", err)
+			}
+			for _, existing := range statuses {
+				if sameCommitStatus(existing, status) {
+					return nil
+				}
+			}
+		}
+		return p.delegate.CreateCommitStatus(ctx, repository, status)
+	})
+}
+
+// sameCommitStatus compares every semantic field that makes a status replay
+// safe; GitHub may assign its own numeric status identity.
+func sameCommitStatus(left, right github.CommitStatus) bool {
+	return left.SHA == right.SHA && left.State == right.State && left.Context == right.Context && left.Description == right.Description && left.TargetURL == right.TargetURL
+}
+
+// applyStateTransitionEffects makes the two GitHub projections converge on a
+// persisted run revision. Reads before each mutation recognize an effect that
+// completed just before a process interruption.
+func (s *Service) applyStateTransitionEffects(ctx context.Context, next *store.Run, transition stateTransition) error {
+	if next == nil {
+		return errors.New("state transition run is required")
+	}
+	issue := transition.Issue
+	if s.deps.GitHub == nil {
+		return errors.New("GitHub client is required for state transition")
+	}
+	observed, err := s.deps.GitHub.Issue(ctx, transition.Repository, next.IssueNumber)
+	if err != nil {
+		return fmt.Errorf("read issue before state transition: %w", err)
+	}
+	if observed.Number != 0 {
+		issue = observed
+	}
+	desiredLabels := replaceFactoryState(issue.Labels, factoryLabelForStatus(next.Status))
+	if !sameStringSlice(issue.Labels, desiredLabels) {
+		if err := s.deps.GitHub.ReplaceIssueLabels(ctx, transition.Repository, next.IssueNumber, desiredLabels); err != nil {
+			return fmt.Errorf("set issue #%d state: %w", next.IssueNumber, err)
+		}
+	}
+
+	marker := statusCommentMarker(next.ID)
+	comment, err := s.deps.GitHub.FindStatusComment(ctx, transition.Repository, next.IssueNumber, marker)
+	if err != nil {
+		return fmt.Errorf("find status comment during state transition: %w", err)
+	}
+	if transition.CreateComment {
+		if strings.TrimSpace(comment.ID) != "" {
+			next.StatusCommentID = comment.ID
+			if comment.Body != statusCommentBody(*next) {
+				if err := s.deps.GitHub.EditIssueComment(ctx, transition.Repository, comment.ID, statusCommentBody(*next)); err != nil {
+					return fmt.Errorf("repair existing status comment: %w", err)
+				}
+			}
+			return nil
+		}
+		created, err := s.deps.GitHub.CreateIssueComment(ctx, transition.Repository, next.IssueNumber, statusCommentBody(*next))
+		if err != nil {
+			return fmt.Errorf("create status comment: %w", err)
+		}
+		if strings.TrimSpace(created.ID) == "" {
+			return errors.New("create status comment returned an empty comment id")
+		}
+		next.StatusCommentID = created.ID
+		return nil
+	}
+	if strings.TrimSpace(next.StatusCommentID) == "" {
+		if strings.TrimSpace(comment.ID) == "" {
+			return errors.New("active run has no recoverable status comment")
+		}
+		next.StatusCommentID = comment.ID
+	}
+	if comment.ID == next.StatusCommentID && comment.Body == statusCommentBody(*next) {
+		return nil
+	}
+	if err := s.deps.GitHub.EditIssueComment(ctx, transition.Repository, next.StatusCommentID, statusCommentBody(*next)); err != nil {
+		return fmt.Errorf("edit status comment: %w", err)
+	}
+	return nil
+}
+
+// applyStatusCommentEffect observes the marker-owned status comment before
+// editing it. A matching body is already complete, so a replay after an
+// ambiguous GitHub response performs no second mutation.
+func (s *Service) applyStatusCommentEffect(ctx context.Context, payload statusCommentEffectPayload) error {
+	if s.deps.GitHub == nil {
+		return errors.New("GitHub client is required for status comment effect")
+	}
+	if strings.TrimSpace(payload.Next.StatusCommentID) == "" {
+		return errors.New("status comment effect has no comment identity")
+	}
+	comment, err := s.deps.GitHub.FindStatusComment(ctx, payload.Repository, payload.Next.IssueNumber, statusCommentMarker(payload.Next.ID))
+	if err != nil {
+		return fmt.Errorf("find status comment for replay: %w", err)
+	}
+	body := statusCommentBody(payload.Next)
+	if comment.ID == payload.Next.StatusCommentID && comment.Body == body {
+		return nil
+	}
+	if comment.ID != "" && comment.ID != payload.Next.StatusCommentID {
+		if comment.Body == body {
+			return nil
+		}
+		return fmt.Errorf("status comment identity changed from %q to %q", payload.Next.StatusCommentID, comment.ID)
+	}
+	if err := s.deps.GitHub.EditIssueComment(ctx, payload.Repository, payload.Next.StatusCommentID, body); err != nil {
+		return fmt.Errorf("edit status comment for replay: %w", err)
+	}
+	return nil
+}
+
+// sameStringSlice compares complete ordered projections for idempotent PUT
+// suppression while preserving ordinary labels exactly as returned by GitHub.
+func sameStringSlice(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// replayPendingEffect completes a journaled effect whose process boundary was
+// crossed before the journal could be cleared. Each handler first observes the
+// external projection where the adapter supports observation, then performs at
+// most the missing part of the original intent.
+func (s *Service) replayPendingEffect(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	switch effect.Kind {
+	case store.PendingEffectKindStateTransition:
+		return s.replayPendingStateTransition(ctx, runStore, effect)
+	case store.PendingEffectKindLabelTransition:
+		return s.replayPendingLabelTransition(ctx, runStore, effect)
+	case store.PendingEffectKindWorkerLaunch:
+		return s.replayPendingWorkerLaunch(ctx, runStore, effect)
+	case store.PendingEffectKindCheckpoint:
+		return s.replayPendingCheckpoint(ctx, runStore, effect)
+	case store.PendingEffectKindPush:
+		return s.replayPendingPush(ctx, runStore, effect)
+	case store.PendingEffectKindPullRequest:
+		return s.replayPendingPullRequest(ctx, runStore, effect)
+	case store.PendingEffectKindCommitStatus:
+		return s.replayPendingCommitStatus(ctx, runStore, effect)
+	case store.PendingEffectKindStatusComment:
+		return s.replayPendingStatusComment(ctx, runStore, effect)
+	case store.PendingEffectKindClarificationComment:
+		return s.replayPendingClarificationComment(ctx, runStore, effect)
+	case store.PendingEffectKindResultAcceptance:
+		return s.replayPendingResultAcceptance(ctx, runStore, effect)
+	case store.PendingEffectKindHarnessResume:
+		return s.replayPendingHarnessResume(ctx, runStore, effect)
+	default:
+		return store.Run{}, fmt.Errorf("unsupported pending effect kind %q", effect.Kind)
+	}
+}
+
+// replayPendingClarificationComment completes a question publication after a
+// response-loss boundary by finding the marker before creating anything.
+func (s *Service) replayPendingClarificationComment(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload clarificationCommentEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	current, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run during clarification replay: %w", err)
+	}
+	if current == nil {
+		return store.Run{}, fmt.Errorf("run %q disappeared during clarification replay", effect.RunID)
+	}
+	comment, err := s.findOrCreateClarificationComment(ctx, payload.Repository, payload.Target, effect.RunID, payload.Body)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("replay clarification comment: %w", err)
+	}
+	current.ClarificationCommentID = comment.ID
+	current.UpdatedAt = s.deps.Now().UTC()
+	if err := saveRunWithRetry(ctx, runStore, *current); err != nil {
+		return store.Run{}, fmt.Errorf("persist replayed clarification comment identity: %w", err)
+	}
+	journal, ok := runStore.(PendingEffectStore)
+	if !ok {
+		return *current, nil
+	}
+	if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+		return store.Run{}, fmt.Errorf("clear replayed clarification comment: %w", err)
+	}
+	return *current, nil
+}
+
+// persistCommandProjectionWithEffect journals a command's local watermark
+// together with its status-comment mutation. The local projection is part of
+// the action so a process stop between the two writes leaves a replayable
+// intent instead of an apparently processed but stale command.
+func (s *Service) persistCommandProjectionWithEffect(ctx context.Context, runStore RunStore, repository github.Repository, previous, next store.Run) (store.Run, error) {
+	payload := statusCommentEffectPayload{Repository: repository, Previous: previous, Next: next}
+	effect, err := s.newPendingEffect(next.ID, store.PendingEffectKindStatusComment, fmt.Sprintf("revision=%d\x00comment=%s", next.Revision, next.ProcessedCommentID), payload)
+	if err != nil {
+		return next, err
+	}
+	action := func() error {
+		current, err := readReconciliationRun(ctx, runStore)
+		if err != nil {
+			return fmt.Errorf("read run before command projection: %w", err)
+		}
+		if current == nil {
+			return fmt.Errorf("run %q disappeared before command projection", next.ID)
+		}
+		switch {
+		case current.Revision < next.Revision:
+			if current.Revision != previous.Revision {
+				return fmt.Errorf("command projection expected revision %d, found %d", previous.Revision, current.Revision)
+			}
+			if err := saveCommandRun(ctx, runStore, previous.Revision, next); err != nil {
+				return fmt.Errorf("persist command watermark: %w", err)
+			}
+		case current.Revision == next.Revision:
+			if current.ProcessedCommentID != next.ProcessedCommentID || current.LastCommandName != next.LastCommandName {
+				return fmt.Errorf("command projection revision %d belongs to another command", current.Revision)
+			}
+		default:
+			if current.ProcessedCommentID != next.ProcessedCommentID {
+				return fmt.Errorf("command projection was superseded at revision %d", current.Revision)
+			}
+		}
+		return s.applyStatusCommentEffect(ctx, payload)
+	}
+	if err := s.withPendingEffect(ctx, runStore, effect, action); err != nil {
+		return next, err
+	}
+	return next, nil
+}
+
+// replayPendingStatusComment finishes a command projection after a process
+// boundary. It persists the watermark only when it is still missing, then
+// recognizes or applies the exact status-comment body before clearing intent.
+func (s *Service) replayPendingStatusComment(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload statusCommentEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	current, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run during status-comment replay: %w", err)
+	}
+	if current == nil {
+		return store.Run{}, fmt.Errorf("run %q disappeared during status-comment replay", effect.RunID)
+	}
+	next := payload.Next
+	if current.Revision < next.Revision {
+		if current.Revision != payload.Previous.Revision {
+			return store.Run{}, fmt.Errorf("status-comment replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+		}
+		if err := saveCommandRun(ctx, runStore, payload.Previous.Revision, next); err != nil {
+			return store.Run{}, fmt.Errorf("persist replayed command watermark: %w", err)
+		}
+	} else if current.Revision == next.Revision {
+		if current.ProcessedCommentID != next.ProcessedCommentID || current.LastCommandName != next.LastCommandName {
+			return store.Run{}, fmt.Errorf("status-comment replay revision %d belongs to another command", current.Revision)
+		}
+	} else if current.ProcessedCommentID != next.ProcessedCommentID {
+		return store.Run{}, fmt.Errorf("status-comment replay was superseded at revision %d", current.Revision)
+	}
+	if err := s.applyStatusCommentEffect(ctx, payload); err != nil {
+		return store.Run{}, fmt.Errorf("replay status comment: %w", err)
+	}
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+			return store.Run{}, fmt.Errorf("clear replayed status comment: %w", err)
+		}
+	}
+	if current.Revision < next.Revision {
+		return next, nil
+	}
+	return *current, nil
+}
+
+// applyLabelTransitionEffect observes the complete factory-owned label set
+// before replacing it, making a successful mutation reported as an error safe
+// to recognize on replay.
+func (s *Service) applyLabelTransitionEffect(ctx context.Context, payload labelTransitionEffectPayload) error {
+	if s.deps.GitHub == nil {
+		return errors.New("GitHub client is required for label effect")
+	}
+	issue, err := s.deps.GitHub.Issue(ctx, payload.Repository, payload.IssueNumber)
+	if err != nil {
+		return fmt.Errorf("read issue for label replay: %w", err)
+	}
+	if sameStringSlice(issue.Labels, payload.Labels) {
+		return nil
+	}
+	if err := s.deps.GitHub.ReplaceIssueLabels(ctx, payload.Repository, payload.IssueNumber, append([]string(nil), payload.Labels...)); err != nil {
+		return fmt.Errorf("replace labels for replay: %w", err)
+	}
+	return nil
+}
+
+// replayPendingLabelTransition completes a standalone label reservation and
+// leaves workflow state untouched.
+func (s *Service) replayPendingLabelTransition(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload labelTransitionEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	if err := s.applyLabelTransitionEffect(ctx, payload); err != nil {
+		return store.Run{}, err
+	}
+	journal, ok := runStore.(PendingEffectStore)
+	if !ok {
+		return store.Run{}, errors.New("operational store does not support label replay")
+	}
+	if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+		return store.Run{}, fmt.Errorf("clear replayed labels: %w", err)
+	}
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run after label replay: %w", err)
+	}
+	if run == nil {
+		return store.Run{}, fmt.Errorf("run %q disappeared during label replay", effect.RunID)
+	}
+	return *run, nil
+}
+
+// startWorkerWithEffect reserves a worker launch before crossing into Docker.
+// DockerRuntime makes Start itself idempotent for an exact run/image/mount
+// identity, so replaying a completed launch is safe.
+func (s *Service) startWorkerWithEffect(ctx context.Context, runStore RunStore, request worker.StartRequest) error {
+	payload := workerLaunchEffectPayload{Request: request}
+	effect, err := s.newPendingEffect(request.RunID, store.PendingEffectKindWorkerLaunch, request.Role+"\x00"+request.InvocationPath+"\x00"+request.ResultPath, payload)
+	if err != nil {
+		return err
+	}
+	return s.withPendingEffect(ctx, runStore, effect, func() error {
+		if s.deps.Worker == nil {
+			return errors.New("worker runtime is required")
+		}
+		return s.deps.Worker.Start(ctx, request)
+	})
+}
+
+// replayPendingWorkerLaunch completes a worker reservation from its portable
+// start request and leaves the durable run projection unchanged.
+func (s *Service) replayPendingWorkerLaunch(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload workerLaunchEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	if s.deps.Worker == nil {
+		return store.Run{}, errors.New("worker runtime is required to replay worker launch")
+	}
+	if err := s.deps.Worker.Start(ctx, payload.Request); err != nil {
+		return store.Run{}, fmt.Errorf("replay worker launch: %w", err)
+	}
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+			return store.Run{}, fmt.Errorf("clear replayed worker launch: %w", err)
+		}
+	}
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run after worker launch replay: %w", err)
+	}
+	if run == nil {
+		return store.Run{}, fmt.Errorf("run %q disappeared during worker launch replay", effect.RunID)
+	}
+	return *run, nil
+}
+
+// resumeHarnessWithEffect journals a native-session continuation before the
+// harness command crosses into a visible terminal. The invocation counter is
+// reserved before the native command, so an ambiguous post-launch failure is
+// never replayed as a second visible session.
+func (s *Service) resumeHarnessWithEffect(ctx context.Context, runStore RunStore, invocationStore InvocationStore, socketPath string, runtime harness.Runtime, invocation store.Invocation, request harness.StartRequest) (store.Invocation, error) {
+	if runtime == nil {
+		return invocation, errors.New("harness runtime is required for native resume")
+	}
+	targetCount := invocation.RecoveryResumeCount + 1
+	reserved := invocation
+	reserved.RecoveryResumeCount = targetCount
+	reserved.UpdatedAt = s.deps.Now().UTC()
+	if _, journaled := runStore.(PendingEffectStore); !journaled {
+		// Keep the compatibility behavior of older embedding stores: they do
+		// not expose a restart journal, so their historical resume boundary is
+		// the native command followed by invocation persistence.
+		session, err := runtime.Resume(ctx, request)
+		if err != nil {
+			return invocation, fmt.Errorf("resume native harness session: %w", err)
+		}
+		updated := reserved
+		if session.NativeSessionID != "" {
+			updated.NativeSessionID = session.NativeSessionID
+		}
+		updated.UpdatedAt = s.deps.Now().UTC()
+		if err := invocationStore.SaveInvocation(ctx, updated); err != nil {
+			return updated, fmt.Errorf("persist resumed native session: %w", err)
+		}
+		return updated, nil
+	}
+	payload := harnessResumeEffectPayload{
+		SocketPath: socketPath, Request: request, Invocation: invocation,
+		TargetResumeCount: targetCount,
+	}
+	effect, err := s.newPendingEffect(invocation.RunID, store.PendingEffectKindHarnessResume, invocation.ID+"\x00"+fmt.Sprint(targetCount), payload)
+	if err != nil {
+		return invocation, err
+	}
+	updated := invocation
+	apply := func() error {
+		if err := invocationStore.SaveInvocation(ctx, reserved); err != nil {
+			return fmt.Errorf("reserve native session resume: %w", err)
+		}
+		updated = reserved
+		session, err := runtime.Resume(ctx, request)
+		if err != nil {
+			return fmt.Errorf("resume native harness session: %w", err)
+		}
+		updated = reserved
+		if session.NativeSessionID != "" {
+			updated.NativeSessionID = session.NativeSessionID
+		}
+		updated.UpdatedAt = s.deps.Now().UTC()
+		if err := invocationStore.SaveInvocation(ctx, updated); err != nil {
+			return fmt.Errorf("persist resumed native session: %w", err)
+		}
+		return nil
+	}
+	if err := s.withPendingEffect(ctx, runStore, effect, apply); err != nil {
+		// A journaled resume is never rolled back after reservation is
+		// attempted. Returning the reserved projection makes callers retain
+		// the one-resume ceiling even when the journal or native adapter fails.
+		return reserved, err
+	}
+	return updated, nil
+}
+
+// replayPendingHarnessResume completes a native-resume reservation. A durable
+// reservation is treated as an already-crossed boundary; a missing
+// reservation is recorded before replay so a second restart cannot launch a
+// duplicate session after an ambiguous native command.
+func (s *Service) replayPendingHarnessResume(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload harnessResumeEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return store.Run{}, errors.New("operational store does not support harness resume replay")
+	}
+	invocation, err := invocationStore.Invocation(ctx, effect.RunID, payload.Invocation.ID)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read invocation during harness resume replay: %w", err)
+	}
+	if invocation == nil {
+		return store.Run{}, fmt.Errorf("invocation %q disappeared during harness resume replay", payload.Invocation.ID)
+	}
+	if invocation.RecoveryResumeCount < payload.TargetResumeCount {
+		reserved := *invocation
+		reserved.RecoveryResumeCount = payload.TargetResumeCount
+		reserved.UpdatedAt = s.deps.Now().UTC()
+		if err := invocationStore.SaveInvocation(ctx, reserved); err != nil {
+			return store.Run{}, fmt.Errorf("reserve replayed native session resume: %w", err)
+		}
+		_, harnessRuntime, runtimeErr := s.ensureAgentRuntime(payload.SocketPath, config.Harness(payload.Invocation.Harness))
+		if runtimeErr != nil {
+			return store.Run{}, fmt.Errorf("ensure harness for native resume replay: %w", runtimeErr)
+		}
+		session, resumeErr := harnessRuntime.Resume(ctx, payload.Request)
+		if resumeErr != nil {
+			return store.Run{}, fmt.Errorf("resume native harness session during replay: %w", resumeErr)
+		}
+		if session.NativeSessionID != "" {
+			reserved.NativeSessionID = session.NativeSessionID
+		}
+		reserved.UpdatedAt = s.deps.Now().UTC()
+		if err := invocationStore.SaveInvocation(ctx, reserved); err != nil {
+			return store.Run{}, fmt.Errorf("persist replayed native session: %w", err)
+		}
+	}
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+			return store.Run{}, fmt.Errorf("clear replayed harness resume: %w", err)
+		}
+	}
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run after harness resume replay: %w", err)
+	}
+	if run == nil {
+		return store.Run{}, fmt.Errorf("run %q disappeared during harness resume replay", effect.RunID)
+	}
+	return *run, nil
+}
+
+// pushWithEffect publishes one run branch while recognizing an already
+// matching remote head. A repeated Git push is transport-safe, but the remote
+// head read makes the semantic effect exactly-once at the coordinator seam.
+func (s *Service) pushWithEffect(ctx context.Context, runStore RunStore, runID string, workspace gitadapter.GitWorkspace, request gitadapter.PushRequest, expectedSHA string) error {
+	payload := pushEffectPayload{
+		Request:     pushRequestJSON{WorktreePath: request.WorktreePath, Branch: request.Branch},
+		ExpectedSHA: expectedSHA,
+	}
+	effect, err := s.newPendingEffect(runID, store.PendingEffectKindPush, request.WorktreePath+"\x00"+request.Branch+"\x00"+expectedSHA, payload)
+	if err != nil {
+		return err
+	}
+	return s.withPendingEffect(ctx, runStore, effect, func() error {
+		return s.pushOnce(ctx, workspace, request, expectedSHA)
+	})
+}
+
+// pushOnce observes the remote branch when the adapter supports it and only
+// invokes the mutating push when the expected checkpoint is not already there.
+func (s *Service) pushOnce(ctx context.Context, workspace gitadapter.GitWorkspace, request gitadapter.PushRequest, expectedSHA string) error {
+	if workspace == nil {
+		return errors.New("GitWorkspace is required for push")
+	}
+	if inspector, ok := workspace.(gitadapter.RemoteBranchInspector); ok {
+		head, err := inspector.RemoteBranchHead(ctx, request)
+		if err != nil {
+			return fmt.Errorf("inspect remote branch before push: %w", err)
+		}
+		if strings.TrimSpace(expectedSHA) != "" && head == expectedSHA {
+			return nil
+		}
+	}
+	if err := workspace.Push(ctx, request); err != nil {
+		return err
+	}
+	return nil
+}
+
+// replayPendingPush completes or recognizes a branch push recorded before a
+// process interruption.
+func (s *Service) replayPendingPush(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload pushEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	workspace := s.gitWorkspace()
+	if workspace == nil {
+		return store.Run{}, errors.New("GitWorkspace is required to replay push")
+	}
+	request := gitadapter.PushRequest{WorktreePath: payload.Request.WorktreePath, Branch: payload.Request.Branch}
+	if err := s.pushOnce(ctx, workspace, request, payload.ExpectedSHA); err != nil {
+		return store.Run{}, fmt.Errorf("replay push: %w", err)
+	}
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+			return store.Run{}, fmt.Errorf("clear replayed push: %w", err)
+		}
+	}
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run after push replay: %w", err)
+	}
+	if run == nil {
+		return store.Run{}, fmt.Errorf("run %q disappeared during push replay", effect.RunID)
+	}
+	return *run, nil
+}
+
+// replayPendingCommitStatus recognizes or republishes one exact-SHA status and
+// then clears its durable reservation. A reader is required during recovery so
+// an adapter cannot blindly create a duplicate after an ambiguous response.
+func (s *Service) replayPendingCommitStatus(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload commitStatusEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	if s.deps.CommitStatuses == nil {
+		return store.Run{}, errors.New("commit-status publisher is required to replay status")
+	}
+	reader, ok := s.deps.CommitStatuses.(github.CommitStatusReader)
+	if !ok {
+		return store.Run{}, errors.New("commit-status reader is required to replay status safely")
+	}
+	statuses, err := reader.ListCommitStatuses(ctx, payload.Repository, payload.Status.SHA)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("inspect commit status during replay: %w", err)
+	}
+	found := false
+	for _, status := range statuses {
+		if sameCommitStatus(status, payload.Status) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		if err := s.deps.CommitStatuses.CreateCommitStatus(ctx, payload.Repository, payload.Status); err != nil {
+			return store.Run{}, fmt.Errorf("replay commit status: %w", err)
+		}
+	}
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+			return store.Run{}, fmt.Errorf("clear replayed commit status: %w", err)
+		}
+	}
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run after commit status replay: %w", err)
+	}
+	if run == nil {
+		return store.Run{}, fmt.Errorf("run %q disappeared during commit status replay", effect.RunID)
+	}
+	return *run, nil
+}
+
+// acceptResultWithEffect journals harness finalization, invocation state, and
+// the resulting workflow projection as one replayable acceptance operation.
+func (s *Service) acceptResultWithEffect(ctx context.Context, runStore RunStore, invocationStore InvocationStore, registration config.RepositoryRegistration, harnessRuntime harness.Runtime, session harness.Session, invocation store.Invocation, previous, next store.Run, stopWorker bool) (store.Invocation, store.Run, error) {
+	payload := resultAcceptanceEffectPayload{
+		Repository: github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository},
+		SocketPath: registration.Cmux.SocketPath,
+		Issue:      github.Issue{Number: next.IssueNumber},
+		Session:    session,
+		Invocation: invocation,
+		Previous:   previous,
+		Next:       next,
+		StopWorker: stopWorker,
+	}
+	// Keep the issue snapshot in the payload so replay does not have to infer
+	// it from the mutable repository configuration.
+	if s.deps.GitHub != nil {
+		if issue, err := s.deps.GitHub.Issue(ctx, payload.Repository, next.IssueNumber); err == nil {
+			payload.Issue = issue
+		}
+	}
+	effect, err := s.newPendingEffect(next.ID, store.PendingEffectKindResultAcceptance, invocation.ID+"\x00"+string(invocation.Status)+"\x00"+fmt.Sprint(next.Revision), payload)
+	if err != nil {
+		return invocation, next, err
+	}
+	apply := func() error {
+		currentInvocation, err := invocationStore.Invocation(ctx, invocation.RunID, invocation.ID)
+		if err != nil {
+			return fmt.Errorf("read invocation before accepting result: %w", err)
+		}
+		if currentInvocation == nil {
+			return fmt.Errorf("invocation %q disappeared before accepting result", invocation.ID)
+		}
+		if currentInvocation.Status == store.InvocationStatusActive {
+			// Mark the invocation terminal before Finish crosses the external
+			// boundary. A restart after this reservation can safely replay the
+			// idempotent Finish operation when its response was lost.
+			if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
+				return fmt.Errorf("reserve accepted invocation: %w", err)
+			}
+		} else if currentInvocation.Status != invocation.Status || currentInvocation.NativeSessionID != invocation.NativeSessionID {
+			return fmt.Errorf("invocation %q changed while accepting result", invocation.ID)
+		}
+		if harnessRuntime == nil {
+			return errors.New("harness runtime is required to accept result")
+		}
+		if err := harnessRuntime.Finish(ctx, session); err != nil {
+			return fmt.Errorf("finish accepted harness session: %w", err)
+		}
+		if stopWorker {
+			if err := s.stopRunWorker(ctx, previous.ID); err != nil {
+				return err
+			}
+		}
+		if err := s.applyStateTransitionEffects(ctx, &next, stateTransition{
+			Repository: payload.Repository,
+			Issue:      payload.Issue,
+			Previous:   previous,
+			Next:       next,
+		}); err != nil {
+			return err
+		}
+		next.UpdatedAt = s.deps.Now().UTC()
+		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return fmt.Errorf("persist accepted result state: %w", err)
+		}
+		if recorder, ok := runStore.(evaluationRecorder); ok {
+			if err := recordEvaluationTransition(ctx, recorder, previous, next, next.UpdatedAt); err != nil {
+				return fmt.Errorf("record accepted result transition: %w", err)
+			}
+		}
+		return nil
+	}
+	if err := s.withPendingEffect(ctx, runStore, effect, apply); err != nil {
+		return invocation, next, err
+	}
+	return invocation, next, nil
+}
+
+// replayPendingResultAcceptance completes a report acceptance and retries the
+// idempotent harness finalization when the prior process stopped before its
+// response was observed.
+func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload resultAcceptanceEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return store.Run{}, errors.New("operational store does not support result acceptance replay")
+	}
+	currentInvocation, err := invocationStore.Invocation(ctx, effect.RunID, payload.Invocation.ID)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read invocation during result acceptance replay: %w", err)
+	}
+	if currentInvocation == nil {
+		return store.Run{}, fmt.Errorf("invocation %q disappeared during result acceptance replay", payload.Invocation.ID)
+	}
+	if currentInvocation.Status == store.InvocationStatusActive {
+		// Reserve the terminal invocation projection before replaying Finish.
+		if err := invocationStore.SaveInvocation(ctx, payload.Invocation); err != nil {
+			return store.Run{}, fmt.Errorf("reserve replayed accepted invocation: %w", err)
+		}
+	} else if currentInvocation.Status != payload.Invocation.Status || currentInvocation.NativeSessionID != payload.Invocation.NativeSessionID {
+		return store.Run{}, fmt.Errorf("invocation %q changed during result acceptance replay", payload.Invocation.ID)
+	}
+	_, harnessRuntime, runtimeErr := s.ensureAgentRuntime(payload.SocketPath, config.Harness(payload.Invocation.Harness))
+	if runtimeErr != nil {
+		return store.Run{}, fmt.Errorf("ensure harness for result acceptance replay: %w", runtimeErr)
+	}
+	if err := harnessRuntime.Finish(ctx, payload.Session); err != nil {
+		return store.Run{}, fmt.Errorf("finish replayed harness session: %w", err)
+	}
+	if payload.StopWorker {
+		// Stopping is idempotent for the run-scoped worker. Repeat it even when
+		// the invocation was already marked terminal before an earlier process
+		// crossed this boundary; that state is the durable evidence that the
+		// acceptance reservation was already in flight.
+		if err := s.stopRunWorker(ctx, effect.RunID); err != nil {
+			return store.Run{}, err
+		}
+	}
+	currentRun, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run during result acceptance replay: %w", err)
+	}
+	next := payload.Next
+	if currentRun != nil && currentRun.ID != effect.RunID {
+		return store.Run{}, fmt.Errorf("result acceptance replay belongs to run %q, current run is %q", effect.RunID, currentRun.ID)
+	}
+	if currentRun != nil && currentRun.Revision > next.Revision {
+		return store.Run{}, fmt.Errorf("result acceptance revision %d is older than current revision %d", next.Revision, currentRun.Revision)
+	}
+	if currentRun != nil && currentRun.Revision < next.Revision && currentRun.Revision != payload.Previous.Revision {
+		return store.Run{}, fmt.Errorf("result acceptance replay expected revision %d, found %d", payload.Previous.Revision, currentRun.Revision)
+	}
+	if currentRun != nil && currentRun.Revision == next.Revision && currentRun.StatusCommentID != "" {
+		next.StatusCommentID = currentRun.StatusCommentID
+	}
+	if err := s.applyStateTransitionEffects(ctx, &next, stateTransition{
+		Repository: payload.Repository,
+		Issue:      payload.Issue,
+		Previous:   payload.Previous,
+		Next:       next,
+	}); err != nil {
+		return store.Run{}, fmt.Errorf("replay accepted result projection: %w", err)
+	}
+	next.UpdatedAt = s.deps.Now().UTC()
+	if currentRun == nil || currentRun.Revision < next.Revision {
+		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return store.Run{}, fmt.Errorf("persist replayed accepted result: %w", err)
+		}
+	}
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+			return store.Run{}, fmt.Errorf("clear replayed result acceptance: %w", err)
+		}
+	}
+	return next, nil
+}
+
+// upsertPullRequestRequest performs a branch-scoped, idempotent PR mutation.
+// The expected number prevents a replay from silently attaching to another PR.
+func (s *Service) upsertPullRequestRequest(ctx context.Context, client github.PullRequestClient, repository github.Repository, expectedNumber int, request github.PullRequestRequest) (github.PullRequest, error) {
+	if client == nil {
+		return github.PullRequest{}, errors.New("pull-request client is required")
+	}
+	existing, err := client.FindPullRequest(ctx, repository, request.HeadBranch, request.BaseBranch)
+	if err != nil {
+		return github.PullRequest{}, err
+	}
+	if existing.Number > 0 {
+		if expectedNumber > 0 && existing.Number != expectedNumber {
+			return github.PullRequest{}, fmt.Errorf("pull request changed from #%d to #%d during replay", expectedNumber, existing.Number)
+		}
+		if samePullRequestRequest(existing, request) {
+			return existing, nil
+		}
+		updated, err := client.UpdatePullRequest(ctx, repository, existing.Number, request)
+		if err != nil {
+			return github.PullRequest{}, err
+		}
+		if updated.Number <= 0 {
+			return github.PullRequest{}, errors.New("pull-request update returned no pull-request identity")
+		}
+		return updated, nil
+	}
+	if expectedNumber > 0 {
+		return github.PullRequest{}, fmt.Errorf("pull request #%d disappeared before replay", expectedNumber)
+	}
+	created, err := client.CreatePullRequest(ctx, repository, request)
+	if err != nil {
+		return github.PullRequest{}, err
+	}
+	if created.Number <= 0 {
+		return github.PullRequest{}, errors.New("pull-request creation returned no pull-request identity")
+	}
+	return created, nil
+}
+
+// samePullRequestRequest suppresses a redundant update after an interrupted
+// create or update has already reached GitHub.
+func samePullRequestRequest(existing github.PullRequest, request github.PullRequestRequest) bool {
+	return existing.Title == request.Title && existing.Body == request.Body && existing.Draft == request.Draft &&
+		existing.HeadBranch == request.HeadBranch && existing.BaseBranch == request.BaseBranch
+}
+
+// upsertPullRequestAndPersistWithEffect journals a draft PR mutation together
+// with the run projection that records its identity. Recovery can therefore
+// discover a created PR and finish the missing durable state without creating a
+// second PR.
+func (s *Service) upsertPullRequestAndPersistWithEffect(ctx context.Context, runStore RunStore, client github.PullRequestClient, repository github.Repository, issue github.Issue, previous, next store.Run, request github.PullRequestRequest, expectedNumber int) (github.PullRequest, store.Run, error) {
+	payload := pullRequestEffectPayload{Repository: repository, Number: expectedNumber, Request: request, PersistRun: true, Issue: issue, Previous: previous, Next: next}
+	effect, err := s.newPendingEffect(next.ID, store.PendingEffectKindPullRequest, request.HeadBranch+"\x00"+request.BaseBranch+"\x00"+request.Body, payload)
+	if err != nil {
+		return github.PullRequest{}, next, err
+	}
+	var pullRequest github.PullRequest
+	apply := func() error {
+		pullRequest, err = s.upsertPullRequestRequest(ctx, client, repository, expectedNumber, request)
+		if err != nil {
+			return fmt.Errorf("upsert draft pull request: %w", err)
+		}
+		next.PullRequestNumber = pullRequest.Number
+		next.PullRequestURL = pullRequest.URL
+		if err := s.applyStateTransitionEffects(ctx, &next, stateTransition{
+			Repository: repository,
+			Issue:      issue,
+			Previous:   previous,
+			Next:       next,
+		}); err != nil {
+			return err
+		}
+		next.UpdatedAt = s.deps.Now().UTC()
+		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return fmt.Errorf("persist draft pull-request projection: %w", err)
+		}
+		if recorder, ok := runStore.(evaluationRecorder); ok {
+			if err := recordEvaluationTransition(ctx, recorder, previous, next, next.UpdatedAt); err != nil {
+				return fmt.Errorf("record draft pull-request transition: %w", err)
+			}
+		}
+		return nil
+	}
+	if err := s.withPendingEffect(ctx, runStore, effect, apply); err != nil {
+		return pullRequest, next, err
+	}
+	return pullRequest, next, nil
+}
+
+// updatePullRequestWithEffect journals a standalone generated-body update,
+// such as review regeneration, when no run-state change accompanies it.
+func (s *Service) updatePullRequestWithEffect(ctx context.Context, runStore RunStore, runID string, client github.PullRequestClient, repository github.Repository, number int, request github.PullRequestRequest) error {
+	payload := pullRequestEffectPayload{Repository: repository, Number: number, Request: request}
+	effect, err := s.newPendingEffect(runID, store.PendingEffectKindPullRequest, fmt.Sprintf("update=%d\x00%s", number, request.Body), payload)
+	if err != nil {
+		return err
+	}
+	return s.withPendingEffect(ctx, runStore, effect, func() error {
+		_, err := s.upsertPullRequestRequest(ctx, client, repository, number, request)
+		return err
+	})
+}
+
+// replayPendingPullRequest finishes a PR mutation and its run projection from
+// the persisted request, recognizing an already-created PR by branch identity.
+func (s *Service) replayPendingPullRequest(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload pullRequestEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	client := s.pullRequestClient()
+	if client == nil {
+		return store.Run{}, errors.New("pull-request client is required to replay draft pull request")
+	}
+	pullRequest, err := s.upsertPullRequestRequest(ctx, client, payload.Repository, payload.Number, payload.Request)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("replay draft pull request: %w", err)
+	}
+	if !payload.PersistRun {
+		if journal, ok := runStore.(PendingEffectStore); ok {
+			if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+				return store.Run{}, fmt.Errorf("clear replayed draft pull-request update: %w", err)
+			}
+		}
+		run, err := readReconciliationRun(ctx, runStore)
+		if err != nil {
+			return store.Run{}, fmt.Errorf("read run after draft pull-request update replay: %w", err)
+		}
+		if run == nil {
+			return store.Run{}, fmt.Errorf("run %q disappeared during draft pull-request update replay", effect.RunID)
+		}
+		return *run, nil
+	}
+	current, currentErr := readReconciliationRun(ctx, runStore)
+	if currentErr != nil {
+		return store.Run{}, fmt.Errorf("read run during pull-request replay: %w", currentErr)
+	}
+	if current != nil {
+		if current.ID != effect.RunID {
+			return store.Run{}, fmt.Errorf("pull-request replay belongs to run %q, current run is %q", effect.RunID, current.ID)
+		}
+		if current.Revision > payload.Next.Revision {
+			return store.Run{}, fmt.Errorf("pull-request replay revision %d is older than current revision %d", payload.Next.Revision, current.Revision)
+		}
+		if current.Revision < payload.Next.Revision && current.Revision != payload.Previous.Revision {
+			return store.Run{}, fmt.Errorf("pull-request replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+		}
+	}
+	next := payload.Next
+	next.PullRequestNumber = pullRequest.Number
+	next.PullRequestURL = pullRequest.URL
+	if err := s.applyStateTransitionEffects(ctx, &next, stateTransition{
+		Repository: payload.Repository,
+		Issue:      payload.Issue,
+		Previous:   payload.Previous,
+		Next:       next,
+	}); err != nil {
+		return store.Run{}, fmt.Errorf("replay draft pull-request state projection: %w", err)
+	}
+	next.UpdatedAt = s.deps.Now().UTC()
+	if current == nil || current.Revision < next.Revision {
+		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return store.Run{}, fmt.Errorf("persist replayed draft pull request: %w", err)
+		}
+	}
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+			return store.Run{}, fmt.Errorf("clear replayed draft pull request: %w", err)
+		}
+	}
+	return next, nil
+}
+
+// checkpointEffectPayload is the complete restart intent for a checkpoint and
+// its immediately following run projection.
+type checkpointEffectPayload struct {
+	Request    checkpointRequestJSON
+	Repository github.Repository
+	Issue      github.Issue
+	Previous   store.Run
+	Next       store.Run
+}
+
+// checkpointRequest converts a serialized checkpoint request back to the Git
+// adapter's portable input type.
+func checkpointRequest(value checkpointRequestJSON) gitadapter.CheckpointRequest {
+	return gitadapter.CheckpointRequest{
+		RunID:        value.RunID,
+		WorktreePath: value.WorktreePath,
+		ParentSHA:    value.ParentSHA,
+		Kind:         gitadapter.CheckpointKind(value.Kind),
+		Paths:        append([]string(nil), value.Paths...),
+		Message:      value.Message,
+	}
+}
+
+// checkpointAndPersistWithEffect makes a checkpoint commit and the immediate
+// run projection one restart-safe operation. The marker in the Git adapter
+// handles a commit that was created just before the process stopped.
+func (s *Service) checkpointAndPersistWithEffect(ctx context.Context, runStore RunStore, workspace gitadapter.GitWorkspace, request gitadapter.CheckpointRequest, repository github.Repository, issue github.Issue, previous, nextTemplate store.Run) (gitadapter.CheckpointResult, store.Run, error) {
+	payload := checkpointEffectPayload{
+		Request: checkpointRequestJSON{
+			RunID:        request.RunID,
+			WorktreePath: request.WorktreePath,
+			ParentSHA:    request.ParentSHA,
+			Kind:         string(request.Kind),
+			Paths:        append([]string(nil), request.Paths...),
+			Message:      request.Message,
+		},
+		Repository: repository,
+		Issue:      issue,
+		Previous:   previous,
+		Next:       nextTemplate,
+	}
+	effect, err := s.newPendingEffect(request.RunID, store.PendingEffectKindCheckpoint, request.ParentSHA+"\x00"+string(request.Kind)+"\x00"+strings.Join(request.Paths, "\x00"), payload)
+	if err != nil {
+		return gitadapter.CheckpointResult{}, nextTemplate, err
+	}
+	var checkpoint gitadapter.CheckpointResult
+	next := nextTemplate
+	action := func() error {
+		checkpoint, err = workspace.CreateCheckpoint(ctx, request)
+		if err != nil {
+			return fmt.Errorf("create checkpoint: %w", err)
+		}
+		if !github.ValidCommitSHA(checkpoint.SHA) {
+			return errors.New("GitWorkspace returned an invalid checkpoint SHA")
+		}
+		next.CheckpointSHA = checkpoint.SHA
+		if request.Kind == gitadapter.CheckpointKindTest {
+			next.TestCheckpointSHA = checkpoint.SHA
+		}
+		if err := s.applyStateTransitionEffects(ctx, &next, stateTransition{
+			Repository: repository,
+			Issue:      issue,
+			Previous:   previous,
+			Next:       next,
+		}); err != nil {
+			return err
+		}
+		next.UpdatedAt = s.deps.Now().UTC()
+		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return fmt.Errorf("persist checkpoint run projection: %w", err)
+		}
+		if recorder, ok := runStore.(evaluationRecorder); ok {
+			if err := recordEvaluationTransition(ctx, recorder, previous, next, next.UpdatedAt); err != nil {
+				return fmt.Errorf("record checkpoint state transition: %w", err)
+			}
+		}
+		return nil
+	}
+	if err := s.withPendingEffect(ctx, runStore, effect, action); err != nil {
+		return checkpoint, next, err
+	}
+	return checkpoint, next, nil
+}
+
+// replayPendingCheckpoint completes a checkpoint reservation by replaying the
+// idempotent Git marker and its persisted run transition.
+func (s *Service) replayPendingCheckpoint(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload checkpointEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	workspace := s.gitWorkspace()
+	if workspace == nil {
+		return store.Run{}, errors.New("GitWorkspace is required to replay checkpoint")
+	}
+	current, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run during checkpoint replay: %w", err)
+	}
+	if current != nil {
+		if current.ID != effect.RunID {
+			return store.Run{}, fmt.Errorf("checkpoint replay belongs to run %q, current run is %q", effect.RunID, current.ID)
+		}
+		if current.Revision > payload.Next.Revision {
+			return store.Run{}, fmt.Errorf("checkpoint replay revision %d is older than current revision %d", payload.Next.Revision, current.Revision)
+		}
+		if current.Revision < payload.Next.Revision && current.Revision != payload.Previous.Revision {
+			return store.Run{}, fmt.Errorf("checkpoint replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+		}
+	}
+	request := checkpointRequest(payload.Request)
+	checkpoint, err := workspace.CreateCheckpoint(ctx, request)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("replay checkpoint: %w", err)
+	}
+	if !github.ValidCommitSHA(checkpoint.SHA) {
+		return store.Run{}, errors.New("replayed checkpoint returned an invalid SHA")
+	}
+	next := payload.Next
+	next.CheckpointSHA = checkpoint.SHA
+	if request.Kind == gitadapter.CheckpointKindTest {
+		next.TestCheckpointSHA = checkpoint.SHA
+	}
+	if err := s.applyStateTransitionEffects(ctx, &next, stateTransition{
+		Repository: payload.Repository,
+		Issue:      payload.Issue,
+		Previous:   payload.Previous,
+		Next:       next,
+	}); err != nil {
+		return store.Run{}, fmt.Errorf("replay checkpoint state projection: %w", err)
+	}
+	next.UpdatedAt = s.deps.Now().UTC()
+	if current == nil || current.Revision < next.Revision {
+		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return store.Run{}, fmt.Errorf("persist replayed checkpoint: %w", err)
+		}
+	}
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+			return store.Run{}, fmt.Errorf("clear replayed checkpoint: %w", err)
+		}
+	}
+	return next, nil
+}
+
+// replayPendingStateTransition restores the complete persisted run revision
+// associated with a label/comment effect and then acknowledges its journal.
+func (s *Service) replayPendingStateTransition(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
+	var payload stateTransitionEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	if payload.Next.ID == "" || payload.Next.ID != effect.RunID {
+		return store.Run{}, errors.New("pending state transition run identity does not match its journal")
+	}
+	current, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run while replaying state transition: %w", err)
+	}
+	next := payload.Next
+	if current != nil {
+		if current.ID != next.ID {
+			return store.Run{}, fmt.Errorf("pending state transition belongs to run %q, current run is %q", next.ID, current.ID)
+		}
+		if current.Revision > next.Revision {
+			return store.Run{}, fmt.Errorf("pending state transition revision %d is older than current revision %d", next.Revision, current.Revision)
+		}
+		if current.Revision == next.Revision {
+			// The run may already be persisted while the final comment identity was
+			// still in memory. Preserve any newer durable fields, then fill the
+			// effect-owned identity from the replay payload.
+			if current.StatusCommentID != "" {
+				next.StatusCommentID = current.StatusCommentID
+			}
+		}
+		if current.Revision < next.Revision && current.Revision != payload.Previous.Revision {
+			return store.Run{}, fmt.Errorf("pending state transition expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+		}
+	}
+	if payload.StopWorker {
+		if err := s.stopRunWorker(ctx, effect.RunID); err != nil {
+			return store.Run{}, fmt.Errorf("stop worker during state-transition replay: %w", err)
+		}
+	}
+	transition := stateTransition{
+		Repository:        payload.Repository,
+		Issue:             payload.Issue,
+		Previous:          payload.Previous,
+		Next:              next,
+		CreateComment:     payload.CreateComment,
+		StopWorker:        payload.StopWorker,
+		InvalidateResults: payload.InvalidateResults,
+	}
+	if err := s.applyStateTransitionEffects(ctx, &next, transition); err != nil {
+		return store.Run{}, fmt.Errorf("replay state transition effects: %w", err)
+	}
+	next.UpdatedAt = s.deps.Now().UTC()
+	if current == nil || current.Revision < next.Revision {
+		if payload.InvalidateResults {
+			if atomicStore, ok := runStore.(atomicPacketTransitionStore); ok {
+				if err := atomicStore.SaveRunAndInvalidateResults(ctx, payload.Previous.Revision, next); err != nil {
+					return store.Run{}, fmt.Errorf("persist replayed state transition and invalidate results: %w", err)
+				}
+			} else {
+				if err := saveCommandRun(ctx, runStore, payload.Previous.Revision, next); err != nil {
+					return store.Run{}, fmt.Errorf("persist replayed state transition: %w", err)
+				}
+				if err := invalidateRunResults(ctx, runStore, next.ID); err != nil {
+					return store.Run{}, err
+				}
+			}
+		} else if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return store.Run{}, fmt.Errorf("persist replayed state transition: %w", err)
+		}
+	}
+	journal, ok := runStore.(PendingEffectStore)
+	if !ok {
+		return next, nil
+	}
+	if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+		return store.Run{}, fmt.Errorf("clear replayed state transition: %w", err)
+	}
+	return next, nil
+}

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -947,6 +947,20 @@ func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore Ru
 	if err := decodePendingEffect(effect, &payload); err != nil {
 		return store.Run{}, err
 	}
+	currentRun, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run during result acceptance replay: %w", err)
+	}
+	next := payload.Next
+	if currentRun != nil && currentRun.ID != effect.RunID {
+		return store.Run{}, workflowProjectionFailuref("result acceptance replay belongs to run %q, current run is %q", effect.RunID, currentRun.ID)
+	}
+	if currentRun != nil && currentRun.Revision > next.Revision {
+		return store.Run{}, workflowProjectionFailuref("result acceptance revision %d is older than current revision %d", next.Revision, currentRun.Revision)
+	}
+	if currentRun != nil && currentRun.Revision < next.Revision && currentRun.Revision != payload.Previous.Revision {
+		return store.Run{}, workflowProjectionFailuref("result acceptance replay expected revision %d, found %d", payload.Previous.Revision, currentRun.Revision)
+	}
 	invocationStore, ok := runStore.(InvocationStore)
 	if !ok {
 		return store.Run{}, errors.New("operational store does not support result acceptance replay")
@@ -981,20 +995,6 @@ func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore Ru
 		if err := s.stopRunWorker(ctx, effect.RunID); err != nil {
 			return store.Run{}, err
 		}
-	}
-	currentRun, err := readReconciliationRun(ctx, runStore)
-	if err != nil {
-		return store.Run{}, fmt.Errorf("read run during result acceptance replay: %w", err)
-	}
-	next := payload.Next
-	if currentRun != nil && currentRun.ID != effect.RunID {
-		return store.Run{}, workflowProjectionFailuref("result acceptance replay belongs to run %q, current run is %q", effect.RunID, currentRun.ID)
-	}
-	if currentRun != nil && currentRun.Revision > next.Revision {
-		return store.Run{}, workflowProjectionFailuref("result acceptance revision %d is older than current revision %d", next.Revision, currentRun.Revision)
-	}
-	if currentRun != nil && currentRun.Revision < next.Revision && currentRun.Revision != payload.Previous.Revision {
-		return store.Run{}, workflowProjectionFailuref("result acceptance replay expected revision %d, found %d", payload.Previous.Revision, currentRun.Revision)
 	}
 	if currentRun != nil && currentRun.Revision == next.Revision && currentRun.StatusCommentID != "" {
 		next.StatusCommentID = currentRun.StatusCommentID
@@ -1135,6 +1135,25 @@ func (s *Service) replayPendingPullRequest(ctx context.Context, runStore RunStor
 	if client == nil {
 		return store.Run{}, errors.New("pull-request client is required to replay draft pull request")
 	}
+	var current *store.Run
+	if payload.PersistRun {
+		var currentErr error
+		current, currentErr = readReconciliationRun(ctx, runStore)
+		if currentErr != nil {
+			return store.Run{}, fmt.Errorf("read run during pull-request replay: %w", currentErr)
+		}
+		if current != nil {
+			if current.ID != effect.RunID {
+				return store.Run{}, workflowProjectionFailuref("pull-request replay belongs to run %q, current run is %q", effect.RunID, current.ID)
+			}
+			if current.Revision > payload.Next.Revision {
+				return store.Run{}, workflowProjectionFailuref("pull-request replay revision %d is older than current revision %d", payload.Next.Revision, current.Revision)
+			}
+			if current.Revision < payload.Next.Revision && current.Revision != payload.Previous.Revision {
+				return store.Run{}, workflowProjectionFailuref("pull-request replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+			}
+		}
+	}
 	pullRequest, err := s.upsertPullRequestRequest(ctx, client, payload.Repository, payload.Number, payload.Request)
 	if err != nil {
 		return store.Run{}, fmt.Errorf("replay draft pull request: %w", err)
@@ -1153,21 +1172,6 @@ func (s *Service) replayPendingPullRequest(ctx context.Context, runStore RunStor
 			return store.Run{}, fmt.Errorf("run %q disappeared during draft pull-request update replay", effect.RunID)
 		}
 		return *run, nil
-	}
-	current, currentErr := readReconciliationRun(ctx, runStore)
-	if currentErr != nil {
-		return store.Run{}, fmt.Errorf("read run during pull-request replay: %w", currentErr)
-	}
-	if current != nil {
-		if current.ID != effect.RunID {
-			return store.Run{}, workflowProjectionFailuref("pull-request replay belongs to run %q, current run is %q", effect.RunID, current.ID)
-		}
-		if current.Revision > payload.Next.Revision {
-			return store.Run{}, workflowProjectionFailuref("pull-request replay revision %d is older than current revision %d", payload.Next.Revision, current.Revision)
-		}
-		if current.Revision < payload.Next.Revision && current.Revision != payload.Previous.Revision {
-			return store.Run{}, workflowProjectionFailuref("pull-request replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
-		}
 	}
 	next := payload.Next
 	next.PullRequestNumber = pullRequest.Number

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -13,6 +13,7 @@ import (
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
@@ -133,14 +134,15 @@ type harnessResumeEffectPayload struct {
 // resultAcceptanceEffectPayload is the complete durable intent for accepting
 // a validated visible report.
 type resultAcceptanceEffectPayload struct {
-	Repository github.Repository
-	SocketPath string
-	Issue      github.Issue
-	Session    harness.Session
-	Invocation store.Invocation
-	Previous   store.Run
-	Next       store.Run
-	StopWorker bool
+	Repository     github.Repository
+	SocketPath     string
+	Issue          github.Issue
+	Session        harness.Session
+	Invocation     store.Invocation
+	Previous       store.Run
+	Next           store.Run
+	StopWorker     bool
+	AcceptedReport string // JSON-encoded report.Report snapshot for deterministic replay
 }
 
 // workflowProjectionError marks a deterministic conflict between a replay
@@ -872,16 +874,22 @@ func (s *Service) replayPendingCommitStatus(ctx context.Context, runStore RunSto
 
 // acceptResultWithEffect journals harness finalization, invocation state, and
 // the resulting workflow projection as one replayable acceptance operation.
-func (s *Service) acceptResultWithEffect(ctx context.Context, runStore RunStore, invocationStore InvocationStore, registration config.RepositoryRegistration, harnessRuntime harness.Runtime, session harness.Session, invocation store.Invocation, previous, next store.Run, stopWorker bool) (store.Invocation, store.Run, error) {
+func (s *Service) acceptResultWithEffect(ctx context.Context, runStore RunStore, invocationStore InvocationStore, registration config.RepositoryRegistration, harnessRuntime harness.Runtime, session harness.Session, invocation store.Invocation, previous, next store.Run, stopWorker bool, acceptedReport report.Report) (store.Invocation, store.Run, error) {
+	// Encode the accepted report once for durable replay
+	acceptedReportJSON, err := json.Marshal(acceptedReport)
+	if err != nil {
+		return invocation, next, fmt.Errorf("encode accepted report for effect: %w", err)
+	}
 	payload := resultAcceptanceEffectPayload{
-		Repository: github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository},
-		SocketPath: registration.Cmux.SocketPath,
-		Issue:      github.Issue{Number: next.IssueNumber},
-		Session:    session,
-		Invocation: invocation,
-		Previous:   previous,
-		Next:       next,
-		StopWorker: stopWorker,
+		Repository:     github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository},
+		SocketPath:     registration.Cmux.SocketPath,
+		Issue:          github.Issue{Number: next.IssueNumber},
+		Session:        session,
+		Invocation:     invocation,
+		Previous:       previous,
+		Next:           next,
+		StopWorker:     stopWorker,
+		AcceptedReport: string(acceptedReportJSON),
 	}
 	// Keep the issue snapshot in the payload so replay does not have to infer
 	// it from the mutable repository configuration.
@@ -916,6 +924,10 @@ func (s *Service) acceptResultWithEffect(ctx context.Context, runStore RunStore,
 			return errors.New("harness runtime is required to accept result")
 		}
 		if err := harnessRuntime.Finish(ctx, session); err != nil {
+			// Fail-closed: return immediately without clearing the pending effect.
+			// Worker shutdown and workflow projection will not advance while native
+			// exit delivery remains unconfirmed. The pending effect remains until
+			// completion is observable or explicit abandonment is requested.
 			return fmt.Errorf("finish accepted harness session: %w", err)
 		}
 		if stopWorker {
@@ -997,6 +1009,10 @@ func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore Ru
 			return store.Run{}, fmt.Errorf("ensure harness for result acceptance replay: %w", runtimeErr)
 		}
 		if err := harnessRuntime.Finish(ctx, payload.Session); err != nil {
+			// Fail-closed: do not advance worker shutdown or workflow projection
+			// while native exit delivery remains unconfirmed. Retain the pending
+			// effect so a subsequent reconciliation can retry or require explicit
+			// abandonment before allowing projection advancement.
 			return store.Run{}, fmt.Errorf("finish replayed harness session: %w", err)
 		}
 	}

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -60,6 +60,9 @@ type clarificationCommentEffectPayload struct {
 	Repository github.Repository
 	Target     int
 	Body       string
+	// PacketVersion scopes the comment marker to one clarification round so a
+	// replay repairs that round's comment instead of overwriting an earlier one.
+	PacketVersion int
 }
 
 // labelTransitionEffectPayload is the serialized intent for a standalone
@@ -424,7 +427,7 @@ func (s *Service) replayPendingClarificationComment(ctx context.Context, runStor
 	if current == nil {
 		return store.Run{}, fmt.Errorf("run %q disappeared during clarification replay", effect.RunID)
 	}
-	comment, err := s.findOrCreateClarificationComment(ctx, payload.Repository, payload.Target, effect.RunID, payload.Body)
+	comment, err := s.findOrCreateClarificationComment(ctx, payload.Repository, payload.Target, effect.RunID, payload.PacketVersion, payload.Body)
 	if err != nil {
 		return store.Run{}, fmt.Errorf("replay clarification comment: %w", err)
 	}
@@ -670,7 +673,6 @@ func (s *Service) resumeHarnessWithEffect(ctx context.Context, runStore RunStore
 		if err != nil {
 			return fmt.Errorf("resume native harness session: %w", err)
 		}
-		updated = reserved
 		if session.NativeSessionID != "" {
 			updated.NativeSessionID = session.NativeSessionID
 		}

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -140,6 +140,34 @@ type resultAcceptanceEffectPayload struct {
 	StopWorker bool
 }
 
+// workflowProjectionError marks a deterministic conflict between a replay
+// payload and the newer persisted workflow projection. It lets reconciliation
+// distinguish workflow ownership from external infrastructure uncertainty.
+type workflowProjectionError struct {
+	cause error
+}
+
+// Error returns the deterministic workflow conflict.
+func (e *workflowProjectionError) Error() string {
+	if e == nil || e.cause == nil {
+		return "deterministic workflow projection conflict"
+	}
+	return e.cause.Error()
+}
+
+// Unwrap exposes the underlying bounded workflow conflict.
+func (e *workflowProjectionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// workflowProjectionFailuref creates a typed deterministic replay conflict.
+func workflowProjectionFailuref(format string, arguments ...any) error {
+	return &workflowProjectionError{cause: fmt.Errorf(format, arguments...)}
+}
+
 // pendingEffectID derives a stable, bounded identity from the semantic effect
 // rather than from a process-generated UUID. The same operation can therefore
 // be recognized after a restart.
@@ -476,17 +504,17 @@ func (s *Service) replayPendingStatusComment(ctx context.Context, runStore RunSt
 	next := payload.Next
 	if current.Revision < next.Revision {
 		if current.Revision != payload.Previous.Revision {
-			return store.Run{}, fmt.Errorf("status-comment replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+			return store.Run{}, workflowProjectionFailuref("status-comment replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
 		}
 		if err := saveCommandRun(ctx, runStore, payload.Previous.Revision, next); err != nil {
 			return store.Run{}, fmt.Errorf("persist replayed command watermark: %w", err)
 		}
 	} else if current.Revision == next.Revision {
 		if current.ProcessedCommentID != next.ProcessedCommentID || current.LastCommandName != next.LastCommandName {
-			return store.Run{}, fmt.Errorf("status-comment replay revision %d belongs to another command", current.Revision)
+			return store.Run{}, workflowProjectionFailuref("status-comment replay revision %d belongs to another command", current.Revision)
 		}
 	} else if current.ProcessedCommentID != next.ProcessedCommentID {
-		return store.Run{}, fmt.Errorf("status-comment replay was superseded at revision %d", current.Revision)
+		return store.Run{}, workflowProjectionFailuref("status-comment replay was superseded at revision %d", current.Revision)
 	}
 	if err := s.applyStatusCommentEffect(ctx, payload); err != nil {
 		return store.Run{}, fmt.Errorf("replay status comment: %w", err)
@@ -936,7 +964,7 @@ func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore Ru
 			return store.Run{}, fmt.Errorf("reserve replayed accepted invocation: %w", err)
 		}
 	} else if currentInvocation.Status != payload.Invocation.Status || currentInvocation.NativeSessionID != payload.Invocation.NativeSessionID {
-		return store.Run{}, fmt.Errorf("invocation %q changed during result acceptance replay", payload.Invocation.ID)
+		return store.Run{}, workflowProjectionFailuref("invocation %q changed during result acceptance replay", payload.Invocation.ID)
 	}
 	_, harnessRuntime, runtimeErr := s.ensureAgentRuntime(payload.SocketPath, config.Harness(payload.Invocation.Harness))
 	if runtimeErr != nil {
@@ -960,13 +988,13 @@ func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore Ru
 	}
 	next := payload.Next
 	if currentRun != nil && currentRun.ID != effect.RunID {
-		return store.Run{}, fmt.Errorf("result acceptance replay belongs to run %q, current run is %q", effect.RunID, currentRun.ID)
+		return store.Run{}, workflowProjectionFailuref("result acceptance replay belongs to run %q, current run is %q", effect.RunID, currentRun.ID)
 	}
 	if currentRun != nil && currentRun.Revision > next.Revision {
-		return store.Run{}, fmt.Errorf("result acceptance revision %d is older than current revision %d", next.Revision, currentRun.Revision)
+		return store.Run{}, workflowProjectionFailuref("result acceptance revision %d is older than current revision %d", next.Revision, currentRun.Revision)
 	}
 	if currentRun != nil && currentRun.Revision < next.Revision && currentRun.Revision != payload.Previous.Revision {
-		return store.Run{}, fmt.Errorf("result acceptance replay expected revision %d, found %d", payload.Previous.Revision, currentRun.Revision)
+		return store.Run{}, workflowProjectionFailuref("result acceptance replay expected revision %d, found %d", payload.Previous.Revision, currentRun.Revision)
 	}
 	if currentRun != nil && currentRun.Revision == next.Revision && currentRun.StatusCommentID != "" {
 		next.StatusCommentID = currentRun.StatusCommentID
@@ -1132,13 +1160,13 @@ func (s *Service) replayPendingPullRequest(ctx context.Context, runStore RunStor
 	}
 	if current != nil {
 		if current.ID != effect.RunID {
-			return store.Run{}, fmt.Errorf("pull-request replay belongs to run %q, current run is %q", effect.RunID, current.ID)
+			return store.Run{}, workflowProjectionFailuref("pull-request replay belongs to run %q, current run is %q", effect.RunID, current.ID)
 		}
 		if current.Revision > payload.Next.Revision {
-			return store.Run{}, fmt.Errorf("pull-request replay revision %d is older than current revision %d", payload.Next.Revision, current.Revision)
+			return store.Run{}, workflowProjectionFailuref("pull-request replay revision %d is older than current revision %d", payload.Next.Revision, current.Revision)
 		}
 		if current.Revision < payload.Next.Revision && current.Revision != payload.Previous.Revision {
-			return store.Run{}, fmt.Errorf("pull-request replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+			return store.Run{}, workflowProjectionFailuref("pull-request replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
 		}
 	}
 	next := payload.Next
@@ -1267,13 +1295,13 @@ func (s *Service) replayPendingCheckpoint(ctx context.Context, runStore RunStore
 	}
 	if current != nil {
 		if current.ID != effect.RunID {
-			return store.Run{}, fmt.Errorf("checkpoint replay belongs to run %q, current run is %q", effect.RunID, current.ID)
+			return store.Run{}, workflowProjectionFailuref("checkpoint replay belongs to run %q, current run is %q", effect.RunID, current.ID)
 		}
 		if current.Revision > payload.Next.Revision {
-			return store.Run{}, fmt.Errorf("checkpoint replay revision %d is older than current revision %d", payload.Next.Revision, current.Revision)
+			return store.Run{}, workflowProjectionFailuref("checkpoint replay revision %d is older than current revision %d", payload.Next.Revision, current.Revision)
 		}
 		if current.Revision < payload.Next.Revision && current.Revision != payload.Previous.Revision {
-			return store.Run{}, fmt.Errorf("checkpoint replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+			return store.Run{}, workflowProjectionFailuref("checkpoint replay expected revision %d, found %d", payload.Previous.Revision, current.Revision)
 		}
 	}
 	request := checkpointRequest(payload.Request)
@@ -1328,10 +1356,10 @@ func (s *Service) replayPendingStateTransition(ctx context.Context, runStore Run
 	next := payload.Next
 	if current != nil {
 		if current.ID != next.ID {
-			return store.Run{}, fmt.Errorf("pending state transition belongs to run %q, current run is %q", next.ID, current.ID)
+			return store.Run{}, workflowProjectionFailuref("pending state transition belongs to run %q, current run is %q", next.ID, current.ID)
 		}
 		if current.Revision > next.Revision {
-			return store.Run{}, fmt.Errorf("pending state transition revision %d is older than current revision %d", next.Revision, current.Revision)
+			return store.Run{}, workflowProjectionFailuref("pending state transition revision %d is older than current revision %d", next.Revision, current.Revision)
 		}
 		if current.Revision == next.Revision {
 			// The run may already be persisted while the final comment identity was
@@ -1342,7 +1370,7 @@ func (s *Service) replayPendingStateTransition(ctx context.Context, runStore Run
 			}
 		}
 		if current.Revision < next.Revision && current.Revision != payload.Previous.Revision {
-			return store.Run{}, fmt.Errorf("pending state transition expected revision %d, found %d", payload.Previous.Revision, current.Revision)
+			return store.Run{}, workflowProjectionFailuref("pending state transition expected revision %d, found %d", payload.Previous.Revision, current.Revision)
 		}
 	}
 	if payload.StopWorker {

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -781,6 +781,13 @@ func (s *Service) pushOnce(ctx context.Context, workspace gitadapter.GitWorkspac
 			return nil
 		}
 	}
+	state, err := workspace.Inspect(ctx, request.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("inspect local worktree before push: %w", err)
+	}
+	if strings.TrimSpace(expectedSHA) != "" && state.HeadSHA != expectedSHA {
+		return fmt.Errorf("local worktree HEAD %q does not match pending push checkpoint %q", state.HeadSHA, expectedSHA)
+	}
 	if err := workspace.Push(ctx, request); err != nil {
 		return err
 	}
@@ -897,8 +904,8 @@ func (s *Service) acceptResultWithEffect(ctx context.Context, runStore RunStore,
 		}
 		if currentInvocation.Status == store.InvocationStatusActive {
 			// Mark the invocation terminal before Finish crosses the external
-			// boundary. A restart after this reservation can safely replay the
-			// idempotent Finish operation when its response was lost.
+			// boundary. A restart after this reservation safely abandons Finish
+			// because the native exit command has no observable idempotency key.
 			if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
 				return fmt.Errorf("reserve accepted invocation: %w", err)
 			}
@@ -941,9 +948,10 @@ func (s *Service) acceptResultWithEffect(ctx context.Context, runStore RunStore,
 	return invocation, next, nil
 }
 
-// replayPendingResultAcceptance completes a report acceptance and retries the
-// idempotent harness finalization when the prior process stopped before its
-// response was observed.
+// replayPendingResultAcceptance completes a report acceptance without
+// repeating harness finalization after its terminal invocation reservation.
+// The external exit command has no observable idempotency key, so an ambiguous
+// prior attempt is safely abandoned while the durable projections converge.
 func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
 	var payload resultAcceptanceEffectPayload
 	if err := decodePendingEffect(effect, &payload); err != nil {
@@ -974,7 +982,8 @@ func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore Ru
 	if currentInvocation == nil {
 		return store.Run{}, fmt.Errorf("invocation %q disappeared during result acceptance replay", payload.Invocation.ID)
 	}
-	if currentInvocation.Status == store.InvocationStatusActive {
+	finishNeeded := currentInvocation.Status == store.InvocationStatusActive
+	if finishNeeded {
 		// Reserve the terminal invocation projection before replaying Finish.
 		if err := invocationStore.SaveInvocation(ctx, payload.Invocation); err != nil {
 			return store.Run{}, fmt.Errorf("reserve replayed accepted invocation: %w", err)
@@ -982,12 +991,14 @@ func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore Ru
 	} else if currentInvocation.Status != payload.Invocation.Status || currentInvocation.NativeSessionID != payload.Invocation.NativeSessionID {
 		return store.Run{}, workflowProjectionFailuref("invocation %q changed during result acceptance replay", payload.Invocation.ID)
 	}
-	_, harnessRuntime, runtimeErr := s.ensureAgentRuntime(payload.SocketPath, config.Harness(payload.Invocation.Harness))
-	if runtimeErr != nil {
-		return store.Run{}, fmt.Errorf("ensure harness for result acceptance replay: %w", runtimeErr)
-	}
-	if err := harnessRuntime.Finish(ctx, payload.Session); err != nil {
-		return store.Run{}, fmt.Errorf("finish replayed harness session: %w", err)
+	if finishNeeded {
+		_, harnessRuntime, runtimeErr := s.ensureAgentRuntime(payload.SocketPath, config.Harness(payload.Invocation.Harness))
+		if runtimeErr != nil {
+			return store.Run{}, fmt.Errorf("ensure harness for result acceptance replay: %w", runtimeErr)
+		}
+		if err := harnessRuntime.Finish(ctx, payload.Session); err != nil {
+			return store.Run{}, fmt.Errorf("finish replayed harness session: %w", err)
+		}
 	}
 	if payload.StopWorker {
 		// Stopping is idempotent for the run-scoped worker. Repeat it even when

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1207,5 +1208,123 @@ func TestStateTransitionRetryAfterTransientFailureIsNotBlocked(t *testing.T) {
 	}
 	if pending, err := opened.PendingEffect(ctx, run.ID); err != nil || pending != nil {
 		t.Fatalf("pending effect after successful retry = %#v, error = %v; want cleared", pending, err)
+	}
+}
+
+// markerAwareGitHub resolves FindStatusComment by the requested marker, so a
+// test can tell one coordinator-owned comment apart from another on the same
+// issue. The shared effectMatrixGitHub deliberately keeps a single comment.
+type markerAwareGitHub struct {
+	issue    github.Issue
+	comments []github.Comment
+	creates  int
+	edits    int
+}
+
+// Issue returns the fixed issue projection.
+func (g *markerAwareGitHub) Issue(context.Context, github.Repository, int) (github.Issue, error) {
+	return g.issue, nil
+}
+
+// CreateLabel is unused by clarification publication.
+func (g *markerAwareGitHub) CreateLabel(context.Context, github.Repository, github.Label) error {
+	return nil
+}
+
+// ReplaceIssueLabels records the complete desired label set.
+func (g *markerAwareGitHub) ReplaceIssueLabels(_ context.Context, _ github.Repository, _ int, labels []string) error {
+	g.issue.Labels = append([]string(nil), labels...)
+	return nil
+}
+
+// CreateIssueComment appends a new comment with a distinct identity.
+func (g *markerAwareGitHub) CreateIssueComment(_ context.Context, _ github.Repository, _ int, body string) (github.Comment, error) {
+	g.creates++
+	comment := github.Comment{ID: fmt.Sprintf("comment-%d", g.creates), Body: body}
+	g.comments = append(g.comments, comment)
+	return comment, nil
+}
+
+// FindStatusComment returns the first comment carrying the requested marker.
+func (g *markerAwareGitHub) FindStatusComment(_ context.Context, _ github.Repository, _ int, marker string) (github.Comment, error) {
+	for _, comment := range g.comments {
+		if strings.Contains(comment.Body, marker) {
+			return comment, nil
+		}
+	}
+	return github.Comment{}, nil
+}
+
+// EditIssueComment rewrites one existing comment body in place.
+func (g *markerAwareGitHub) EditIssueComment(_ context.Context, _ github.Repository, id, body string) error {
+	g.edits++
+	for index, comment := range g.comments {
+		if comment.ID == id {
+			g.comments[index].Body = body
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown comment %q", id)
+}
+
+// TestClarificationRoundsDoNotOverwriteEachOther verifies that a second round
+// of questions is published as its own comment. The marker is scoped to the
+// specification packet version, so replay stays idempotent within a round while
+// an answered round's questions remain readable on the issue.
+func TestClarificationRoundsDoNotOverwriteEachOther(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+
+	firstPacket, err := json.Marshal(SpecificationPacket{Version: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.Status = store.StatusWaitingForHuman
+	run.PendingQuestions = []store.PendingQuestion{{ID: "format", Prompt: "Which format should be used?"}}
+	run.SpecificationPacket = string(firstPacket)
+	run.ClarificationNotificationSent = true
+	if err := opened.SaveRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	githubRuntime := &markerAwareGitHub{issue: github.Issue{Number: run.IssueNumber}}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+
+	published, err := service.ensureClarificationPublication(ctx, effectMatrixRegistration(), opened, run)
+	if err != nil {
+		t.Fatalf("first clarification round = %v", err)
+	}
+	// Publishing the same round again must recognize the existing comment.
+	republished, err := service.ensureClarificationPublication(ctx, effectMatrixRegistration(), opened, published)
+	if err != nil {
+		t.Fatalf("replayed first clarification round = %v", err)
+	}
+	if githubRuntime.creates != 1 {
+		t.Fatalf("comment creates after replaying one round = %d, want one", githubRuntime.creates)
+	}
+
+	// The answer advances the packet version and clears the round identity.
+	secondPacket, err := json.Marshal(SpecificationPacket{Version: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRound := republished
+	secondRound.SpecificationPacket = string(secondPacket)
+	secondRound.PendingQuestions = []store.PendingQuestion{{ID: "scope", Prompt: "Which scope applies?"}}
+	secondRound.ClarificationCommentID = ""
+	if _, err := service.ensureClarificationPublication(ctx, effectMatrixRegistration(), opened, secondRound); err != nil {
+		t.Fatalf("second clarification round = %v", err)
+	}
+	if githubRuntime.creates != 2 {
+		t.Fatalf("comment creates after a second round = %d, want two", githubRuntime.creates)
+	}
+	if len(githubRuntime.comments) != 2 {
+		t.Fatalf("comments on the issue = %d, want both rounds retained", len(githubRuntime.comments))
+	}
+	if !strings.Contains(githubRuntime.comments[0].Body, "Which format should be used?") {
+		t.Fatalf("first round comment was overwritten: %q", githubRuntime.comments[0].Body)
+	}
+	if !strings.Contains(githubRuntime.comments[1].Body, "Which scope applies?") {
+		t.Fatalf("second round comment = %q, want the new questions", githubRuntime.comments[1].Body)
 	}
 }

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -1099,7 +1099,7 @@ func (*effectMatrixWorker) RunCommand(context.Context, worker.CommandRequest) (w
 	return worker.CommandResult{}, nil
 }
 
-// Stop satisfies the worker seam for effect tests.
+// Stop records the stop call and returns nil.
 func (w *effectMatrixWorker) Stop(context.Context, string) error {
 	w.stopCalls++
 	return nil

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -1151,3 +1151,61 @@ func (h *effectMatrixHarness) Finish(context.Context, harness.Session) error {
 }
 
 var _ harness.Runtime = (*effectMatrixHarness)(nil)
+
+// TestStateTransitionRetryAfterTransientFailureIsNotBlocked verifies that a
+// retried transition is not refused by its own leftover reservation. Every
+// production caller stamps a fresh UpdatedAt and reads the issue again before
+// retrying, so the second attempt's payload always differs from the first even
+// though the effect identity is unchanged. Treating that as a conflict blocked
+// all further progression for the run until the coordinator process restarted.
+func TestStateTransitionRetryAfterTransientFailureIsNotBlocked(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+
+	githubRuntime := &effectMatrixGitHub{
+		issue:           github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentRunning}},
+		failCommentOnce: true,
+	}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	repository := github.Repository{Owner: "example", Name: "project"}
+
+	next := run
+	next.Status = store.StatusWaitingForHuman
+	next.Revision++
+	next.UpdatedAt = time.Unix(100, 0).UTC()
+	if _, err := service.applyStateTransition(ctx, opened, stateTransition{
+		Repository: repository, Issue: githubRuntime.issue,
+		Previous: run, Next: next, CreateComment: true,
+	}); err == nil {
+		t.Fatal("applyStateTransition() first attempt = nil, want the injected response loss")
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending effect after response loss = %#v, error = %v; want a durable reservation", pending, err)
+	}
+
+	// The caller retries the same logical transition. Only the wall clock and
+	// the freshly read issue snapshot moved.
+	retry := next
+	retry.UpdatedAt = time.Unix(101, 0).UTC()
+	updated, err := service.applyStateTransition(ctx, opened, stateTransition{
+		Repository: repository, Issue: githubRuntime.issue,
+		Previous: run, Next: retry, CreateComment: true,
+	})
+	if err != nil {
+		t.Fatalf("applyStateTransition() retry = %v, want the reservation to be reused", err)
+	}
+	if errors.Is(err, store.ErrPendingEffectConflict) {
+		t.Fatal("retry was refused by its own leftover reservation")
+	}
+	if updated.Status != store.StatusWaitingForHuman {
+		t.Fatalf("retried transition status = %q, want %q", updated.Status, store.StatusWaitingForHuman)
+	}
+	if githubRuntime.createCommentCalls != 1 {
+		t.Fatalf("status comment creations = %d, want exactly one across both attempts", githubRuntime.createCommentCalls)
+	}
+	if pending, err := opened.PendingEffect(ctx, run.ID); err != nil || pending != nil {
+		t.Fatalf("pending effect after successful retry = %#v, error = %v; want cleared", pending, err)
+	}
+}

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -38,6 +38,7 @@ func TestExternalEffectsReserveBeforeAndClearAfterFailure(t *testing.T) {
 		{name: "pull request creation", kind: store.PendingEffectKindPullRequest},
 		{name: "checkpoint commit", kind: store.PendingEffectKindCheckpoint},
 		{name: "worker launch", kind: store.PendingEffectKindWorkerLaunch},
+		{name: "harness resume", kind: store.PendingEffectKindHarnessResume},
 		{name: "result acceptance", kind: store.PendingEffectKindResultAcceptance},
 		{name: "clarification comment", kind: store.PendingEffectKindClarificationComment},
 	}
@@ -576,6 +577,117 @@ func TestResultAcceptanceEffectReplaysTheActualFinish(t *testing.T) {
 	}
 }
 
+// TestHarnessResumeEffectDoesNotDuplicateAfterResponseLoss verifies the
+// persisted resume reservation prevents a second native command after the
+// first native response is lost.
+func TestHarnessResumeEffectDoesNotDuplicateAfterResponseLoss(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	invocation := store.Invocation{
+		ID: "inv-resume-effects", RunID: run.ID, Harness: harness.NameCodex, Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-resume-effects", Status: store.InvocationStatusActive, CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &journalRecoveryHarness{nativeSessionID: invocation.NativeSessionID, failResumeOnce: true}
+	service := newEffectMatrixService(nil, nil, nil, nil)
+	request := harness.StartRequest{InvocationID: invocation.ID, RunID: run.ID, Role: invocation.Role, Stage: string(invocation.Stage), ResumeSessionID: invocation.NativeSessionID}
+	if _, err := service.resumeHarnessWithEffect(ctx, opened, opened, "", runtime, invocation, request); err == nil {
+		t.Fatal("resumeHarnessWithEffect() = nil, want response-loss error")
+	}
+	if runtime.resumeCalls != 1 {
+		t.Fatalf("native resumes after first attempt = %d, want one", runtime.resumeCalls)
+	}
+	persisted, err := opened.Invocation(ctx, run.ID, invocation.ID)
+	if err != nil || persisted == nil || persisted.RecoveryResumeCount != 1 {
+		t.Fatalf("reserved invocation = %#v, error = %v; want resume count one", persisted, err)
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil || pending.Kind != store.PendingEffectKindHarnessResume {
+		t.Fatalf("pending harness resume = %#v, error = %v", pending, err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(nil, nil, nil, nil)
+	restarted.deps.Harness = runtime
+	if _, err := restarted.replayPendingHarnessResume(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingHarnessResume() = %v", err)
+	}
+	if runtime.resumeCalls != 1 {
+		t.Fatalf("native resumes after replay = %d, want no duplicate", runtime.resumeCalls)
+	}
+	pending, err = reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending != nil {
+		t.Fatalf("pending harness resume after replay = %#v, error = %v; want cleared", pending, err)
+	}
+}
+
+// TestCommandProjectionEffectReplaysTheWatermarkAndComment verifies a
+// response lost after the command comment edit leaves a replayable watermark
+// and does not edit the same comment twice after restart.
+func TestCommandProjectionEffectReplaysTheWatermarkAndComment(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(run)},
+		failEditOnce:  true,
+	}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	repository := github.Repository{Owner: "example", Name: "project"}
+	previous := run
+	next := run
+	next.Revision++
+	next.ProcessedCommentID = "comment-command-effects"
+	next.ProcessedCommentRevision = next.Revision
+	next.LastCommandName = "answer"
+	next.LastCommandOutcome = string(CommandAccepted)
+	next.LastCommandMessage = "clarification accepted"
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if _, err := service.persistCommandProjectionWithEffect(ctx, blocked, repository, previous, next); err == nil {
+		t.Fatal("persistCommandProjectionWithEffect() before reservation = nil, want reservation failure")
+	}
+	if githubRuntime.editCommentCalls != 0 {
+		t.Fatalf("comment edits before command reservation = %d, want zero", githubRuntime.editCommentCalls)
+	}
+	if _, err := service.persistCommandProjectionWithEffect(ctx, opened, repository, previous, next); err == nil {
+		t.Fatal("persistCommandProjectionWithEffect() = nil, want response-loss error")
+	}
+	if githubRuntime.editCommentCalls != 1 {
+		t.Fatalf("comment edits after first command attempt = %d, want one", githubRuntime.editCommentCalls)
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil || pending.Kind != store.PendingEffectKindStatusComment {
+		t.Fatalf("pending command projection = %#v, error = %v", pending, err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if githubRuntime.editCommentCalls != 1 {
+		t.Fatalf("comment edits after command replay = %d, want no duplicate", githubRuntime.editCommentCalls)
+	}
+	current, err := reopened.CurrentRun(ctx)
+	if err != nil || current == nil || current.ProcessedCommentID != next.ProcessedCommentID || current.Revision != next.Revision {
+		t.Fatalf("persisted command projection = %#v, error = %v; want watermark revision %d", current, err, next.Revision)
+	}
+}
+
 // TestClarificationPublicationRecoversACommentAfterResponseLoss verifies the
 // marker lookup closes the create-to-persist gap without a second comment.
 func TestClarificationPublicationRecoversACommentAfterResponseLoss(t *testing.T) {
@@ -675,8 +787,10 @@ type effectMatrixGitHub struct {
 	statusComment      github.Comment
 	failLabelOnce      bool
 	failCommentOnce    bool
+	failEditOnce       bool
 	replaceLabelCalls  int
 	createCommentCalls int
+	editCommentCalls   int
 }
 
 // Issue returns the mutable issue projection used by effect replay.
@@ -721,8 +835,13 @@ func (g *effectMatrixGitHub) FindStatusComment(context.Context, github.Repositor
 
 // EditIssueComment updates the existing coordinator-owned comment.
 func (g *effectMatrixGitHub) EditIssueComment(_ context.Context, _ github.Repository, id, body string) error {
+	g.editCommentCalls++
 	g.statusComment.ID = id
 	g.statusComment.Body = body
+	if g.failEditOnce {
+		g.failEditOnce = false
+		return errors.New("GitHub comment edit response lost")
+	}
 	return nil
 }
 

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -602,14 +602,19 @@ func TestResultAcceptanceEffectReplaysTheActualFinish(t *testing.T) {
 	next.Revision++
 	githubRuntime.statusComment.Body = statusCommentBody(next)
 	session := harness.Session{InvocationID: invocation.ID, NativeSessionID: invocation.NativeSessionID, Surface: terminal.Surface{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)}}
+	testReport := report.Report{
+		SchemaVersion: 1, InvocationID: invocation.ID, RunID: run.ID,
+		Harness: invocation.Harness, Role: invocation.Role, Stage: string(invocation.Stage),
+		Outcome: report.OutcomeCompleted, Summary: "test acceptance",
+	}
 	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
-	if _, _, err := service.acceptResultWithEffect(ctx, blocked, blocked, effectMatrixRegistration(), harnessRuntime, session, accepted, run, next, false); err == nil {
+	if _, _, err := service.acceptResultWithEffect(ctx, blocked, blocked, effectMatrixRegistration(), harnessRuntime, session, accepted, run, next, false, testReport); err == nil {
 		t.Fatal("acceptResultWithEffect() before reservation = nil, want reservation failure")
 	}
 	if harnessRuntime.finishMutations != 0 {
 		t.Fatalf("harness finishes before result-acceptance reservation = %d, want zero", harnessRuntime.finishMutations)
 	}
-	if _, _, err := service.acceptResultWithEffect(ctx, opened, opened, effectMatrixRegistration(), harnessRuntime, session, accepted, run, next, false); err == nil {
+	if _, _, err := service.acceptResultWithEffect(ctx, opened, opened, effectMatrixRegistration(), harnessRuntime, session, accepted, run, next, false, testReport); err == nil {
 		t.Fatal("acceptResultWithEffect() = nil, want response-loss error")
 	}
 	if harnessRuntime.finishMutations != 1 {
@@ -710,7 +715,12 @@ func TestResultAcceptanceReplayRejectsNewerPersistedRevisionBeforeSideEffects(t 
 	next := run
 	next.Revision++
 	session := harness.Session{InvocationID: invocation.ID, NativeSessionID: invocation.NativeSessionID}
-	if _, _, err := service.acceptResultWithEffect(ctx, opened, opened, effectMatrixRegistration(), harnessRuntime, session, accepted, previous, next, true); err == nil {
+	testReport := report.Report{
+		SchemaVersion: 1, InvocationID: invocation.ID, RunID: run.ID,
+		Harness: invocation.Harness, Role: invocation.Role, Stage: string(invocation.Stage),
+		Outcome: report.OutcomeCompleted, Summary: "test stale acceptance",
+	}
+	if _, _, err := service.acceptResultWithEffect(ctx, opened, opened, effectMatrixRegistration(), harnessRuntime, session, accepted, previous, next, true, testReport); err == nil {
 		t.Fatal("acceptResultWithEffect() = nil, want response-loss error")
 	}
 	if harnessRuntime.finishCalls != 1 || harnessRuntime.finishMutations != 1 || workerRuntime.stopCalls != 0 {

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -1,0 +1,935 @@
+package factory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestExternalEffectsReserveBeforeAndClearAfterFailure verifies the common
+// journal boundary for every external mutation named by issue 21. A failure
+// before reservation produces no mutation; a failure after the mutation keeps
+// the intent durable, and a fresh coordinator retries the same idempotent
+// effect without producing a second mutation.
+func TestExternalEffectsReserveBeforeAndClearAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	effects := []struct {
+		name string
+		kind store.PendingEffectKind
+	}{
+		{name: "status comment", kind: store.PendingEffectKindStatusComment},
+		{name: "labels", kind: store.PendingEffectKindLabelTransition},
+		{name: "commit status", kind: store.PendingEffectKindCommitStatus},
+		{name: "push", kind: store.PendingEffectKindPush},
+		{name: "pull request creation", kind: store.PendingEffectKindPullRequest},
+		{name: "checkpoint commit", kind: store.PendingEffectKindCheckpoint},
+		{name: "worker launch", kind: store.PendingEffectKindWorkerLaunch},
+		{name: "result acceptance", kind: store.PendingEffectKindResultAcceptance},
+		{name: "clarification comment", kind: store.PendingEffectKindClarificationComment},
+	}
+
+	for _, test := range effects {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			databaseDirectory := t.TempDir()
+			if err := os.Chmod(databaseDirectory, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			databasePath := databaseDirectory + "/effects.db"
+			opened, err := store.Open(ctx, databasePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			journal := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+			service := &Service{deps: Dependencies{Now: func() time.Time { return time.Unix(10, 0).UTC() }}}
+			effect := store.PendingEffect{
+				RunID: "run-effects", ID: "effect-" + string(test.kind), Kind: test.kind,
+				Payload: "{}", CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(1, 0).UTC(),
+			}
+			beforeCalls := 0
+			if err := service.withPendingEffect(ctx, journal, effect, func() error {
+				beforeCalls++
+				return nil
+			}); err == nil {
+				t.Fatal("withPendingEffect() before failure = nil, want reservation failure")
+			}
+			if beforeCalls != 0 {
+				t.Fatalf("external calls before reservation = %d, want zero", beforeCalls)
+			}
+			pending, err := journal.PendingEffect(ctx, effect.RunID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pending != nil {
+				t.Fatalf("pending effect after reservation failure = %#v, want nil", pending)
+			}
+
+			journal.saveErr = nil
+			applied := false
+			calls := 0
+			firstAttempt := true
+			apply := func() error {
+				if !applied {
+					applied = true
+					calls++
+				}
+				if firstAttempt {
+					firstAttempt = false
+					return errors.New("response lost after external mutation")
+				}
+				return nil
+			}
+			if err := service.withPendingEffect(ctx, journal, effect, apply); err == nil {
+				t.Fatal("withPendingEffect() after failure = nil, want lost-response error")
+			}
+			pending, err = journal.PendingEffect(ctx, effect.RunID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pending == nil || pending.ID != effect.ID {
+				t.Fatalf("pending effect after lost response = %#v, want %q", pending, effect.ID)
+			}
+			if calls != 1 {
+				t.Fatalf("external calls after first attempt = %d, want one", calls)
+			}
+			if err := journal.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			reopened, err := store.Open(ctx, databasePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = reopened.Close() }()
+			restarted := &Service{deps: Dependencies{Now: func() time.Time { return time.Unix(20, 0).UTC() }}}
+			if err := restarted.withPendingEffect(ctx, reopened, effect, apply); err != nil {
+				t.Fatalf("withPendingEffect() after restart = %v", err)
+			}
+			if calls != 1 {
+				t.Fatalf("external calls after idempotent restart = %d, want one", calls)
+			}
+			pending, err = reopened.PendingEffect(ctx, effect.RunID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pending != nil {
+				t.Fatalf("pending effect after idempotent restart = %#v, want nil", pending)
+			}
+		})
+	}
+}
+
+// effectTestStore injects a reservation failure while retaining the real
+// SQLite journal implementation for restart durability assertions.
+type effectTestStore struct {
+	*store.Store
+	saveErr error
+}
+
+// SavePendingEffect optionally fails before delegating to SQLite.
+func (s *effectTestStore) SavePendingEffect(ctx context.Context, effect store.PendingEffect) error {
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	return s.Store.SavePendingEffect(ctx, effect)
+}
+
+// TestStateTransitionEffectReplaysTheActualCommentAndLabelMutation verifies
+// that a response lost after GitHub accepted a state transition is recovered
+// by observing the existing label set and coordinator comment.
+func TestStateTransitionEffectReplaysTheActualCommentAndLabelMutation(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	githubRuntime := &effectMatrixGitHub{
+		issue:           github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentRunning}},
+		failCommentOnce: true,
+	}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	previous := run
+	next := run
+	next.Status = store.StatusWaitingForHuman
+	next.Revision++
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if _, err := service.applyStateTransition(ctx, blocked, stateTransition{
+		Repository:    github.Repository{Owner: "example", Name: "project"},
+		Issue:         githubRuntime.issue,
+		Previous:      previous,
+		Next:          next,
+		CreateComment: true,
+	}); err == nil {
+		t.Fatal("applyStateTransition() before reservation = nil, want reservation failure")
+	}
+	if githubRuntime.createCommentCalls != 0 || githubRuntime.replaceLabelCalls != 0 {
+		t.Fatalf("GitHub mutations before state-transition reservation = comments %d, labels %d; want zero", githubRuntime.createCommentCalls, githubRuntime.replaceLabelCalls)
+	}
+	_, err := service.applyStateTransition(ctx, opened, stateTransition{
+		Repository:    github.Repository{Owner: "example", Name: "project"},
+		Issue:         githubRuntime.issue,
+		Previous:      previous,
+		Next:          next,
+		CreateComment: true,
+	})
+	if err == nil {
+		t.Fatal("applyStateTransition() = nil, want response-loss error")
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending state transition = %#v, error = %v; want durable effect", pending, err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v, want existing GitHub projections to complete the effect", err)
+	}
+	if githubRuntime.createCommentCalls != 1 || githubRuntime.replaceLabelCalls != 1 {
+		t.Fatalf("GitHub mutations after replay = comments %d, labels %d; want one each", githubRuntime.createCommentCalls, githubRuntime.replaceLabelCalls)
+	}
+	if pending, err := reopened.PendingEffect(ctx, run.ID); err != nil || pending != nil {
+		t.Fatalf("pending state transition after replay = %#v, error = %v; want cleared", pending, err)
+	}
+}
+
+// TestLabelEffectReplaysTheActualIssueLabelMutation verifies standalone label
+// replacement recognizes the desired label set after a lost response.
+func TestLabelEffectReplaysTheActualIssueLabelMutation(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentRunning}},
+		failLabelOnce: true,
+	}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	payload := labelTransitionEffectPayload{
+		Repository:  github.Repository{Owner: "example", Name: "project"},
+		IssueNumber: run.IssueNumber,
+		Labels:      []string{"ordinary", github.LabelAgentFailed},
+	}
+	effect, err := service.newPendingEffect(run.ID, store.PendingEffectKindLabelTransition, "labels", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if err := service.withPendingEffect(ctx, blocked, effect, func() error {
+		return githubRuntime.ReplaceIssueLabels(ctx, payload.Repository, payload.IssueNumber, payload.Labels)
+	}); err == nil {
+		t.Fatal("label mutation before reservation = nil, want reservation failure")
+	}
+	if githubRuntime.replaceLabelCalls != 0 {
+		t.Fatalf("issue label mutations before reservation = %d, want zero", githubRuntime.replaceLabelCalls)
+	}
+	if err := service.withPendingEffect(ctx, opened, effect, func() error {
+		return githubRuntime.ReplaceIssueLabels(ctx, payload.Repository, payload.IssueNumber, payload.Labels)
+	}); err == nil {
+		t.Fatal("label mutation = nil, want response-loss error")
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending label effect = %#v, error = %v", pending, err)
+	}
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if githubRuntime.replaceLabelCalls != 1 {
+		t.Fatalf("issue label mutations = %d, want one", githubRuntime.replaceLabelCalls)
+	}
+}
+
+// TestCommitStatusEffectReplaysTheActualStatusMutation verifies exact status
+// identity lookup suppresses a duplicate after GitHub accepted a status.
+func TestCommitStatusEffectReplaysTheActualStatusMutation(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	statusRuntime := &effectMatrixCommitStatus{failOnce: true}
+	service := newEffectMatrixService(nil, statusRuntime, nil, nil)
+	publisher := commitStatusPublisher{service: service, runStore: opened, runID: run.ID, delegate: statusRuntime}
+	status := github.CommitStatus{SHA: "checkpoint", State: github.CommitStatusSuccess, Context: "factory/test", Description: "passed"}
+	blocked := publisher
+	blocked.runStore = &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if err := blocked.CreateCommitStatus(ctx, github.Repository{Owner: "example", Name: "project"}, status); err == nil {
+		t.Fatal("CreateCommitStatus() before reservation = nil, want reservation failure")
+	}
+	if statusRuntime.createCalls != 0 {
+		t.Fatalf("commit status mutations before reservation = %d, want zero", statusRuntime.createCalls)
+	}
+	if err := publisher.CreateCommitStatus(ctx, github.Repository{Owner: "example", Name: "project"}, status); err == nil {
+		t.Fatal("CreateCommitStatus() = nil, want response-loss error")
+	}
+	if statusRuntime.createCalls != 1 || len(statusRuntime.statuses) != 1 {
+		t.Fatalf("status mutation after first attempt = calls %d statuses %d, want one", statusRuntime.createCalls, len(statusRuntime.statuses))
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(nil, statusRuntime, nil, nil)
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending commit status = %#v, error = %v", pending, err)
+	}
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if statusRuntime.createCalls != 1 {
+		t.Fatalf("commit status mutations after replay = %d, want one", statusRuntime.createCalls)
+	}
+}
+
+// TestPushEffectReplaysTheActualRemoteMutation verifies remote-head
+// observation suppresses a second push after a transport response is lost.
+func TestPushEffectReplaysTheActualRemoteMutation(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	workspace := &effectMatrixGitWorkspace{expectedRemoteHead: "checkpoint", failPushOnce: true}
+	service := newEffectMatrixService(nil, nil, workspace, nil)
+	request := gitadapter.PushRequest{WorktreePath: "/worktree", Branch: run.Branch}
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if err := service.pushWithEffect(ctx, blocked, run.ID, workspace, request, workspace.expectedRemoteHead); err == nil {
+		t.Fatal("pushWithEffect() before reservation = nil, want reservation failure")
+	}
+	if workspace.pushMutations != 0 {
+		t.Fatalf("push mutations before reservation = %d, want zero", workspace.pushMutations)
+	}
+	if err := service.pushWithEffect(ctx, opened, run.ID, workspace, request, workspace.expectedRemoteHead); err == nil {
+		t.Fatal("pushWithEffect() = nil, want response-loss error")
+	}
+	if workspace.pushMutations != 1 {
+		t.Fatalf("push mutations after first attempt = %d, want one", workspace.pushMutations)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(nil, nil, workspace, nil)
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending push = %#v, error = %v", pending, err)
+	}
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if workspace.pushMutations != 1 {
+		t.Fatalf("push mutations after replay = %d, want one", workspace.pushMutations)
+	}
+}
+
+// TestPullRequestEffectReplaysTheActualCreation verifies branch identity
+// lookup recognizes a PR created before the create response was lost.
+func TestPullRequestEffectReplaysTheActualCreation(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	pullRequests := &effectMatrixPullRequests{failCreateOnce: true}
+	service := newEffectMatrixService(nil, nil, nil, pullRequests)
+	request := github.PullRequestRequest{Title: "Factory PR", Body: "body", HeadBranch: run.Branch, BaseBranch: "main", Draft: true}
+	payload := pullRequestEffectPayload{Repository: github.Repository{Owner: "example", Name: "project"}, Request: request}
+	effect, err := service.newPendingEffect(run.ID, store.PendingEffectKindPullRequest, "create", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if err := service.withPendingEffect(ctx, blocked, effect, func() error {
+		_, err := service.upsertPullRequestRequest(ctx, pullRequests, payload.Repository, 0, request)
+		return err
+	}); err == nil {
+		t.Fatal("pull-request creation before reservation = nil, want reservation failure")
+	}
+	if pullRequests.createCalls != 0 {
+		t.Fatalf("pull-request creations before reservation = %d, want zero", pullRequests.createCalls)
+	}
+	if err := service.withPendingEffect(ctx, opened, effect, func() error {
+		_, err := service.upsertPullRequestRequest(ctx, pullRequests, payload.Repository, 0, request)
+		return err
+	}); err == nil {
+		t.Fatal("pull-request creation = nil, want response-loss error")
+	}
+	if pullRequests.createCalls != 1 {
+		t.Fatalf("pull-request creations after first attempt = %d, want one", pullRequests.createCalls)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(nil, nil, nil, pullRequests)
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending pull request = %#v, error = %v", pending, err)
+	}
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if pullRequests.createCalls != 1 {
+		t.Fatalf("pull-request creations after replay = %d, want one", pullRequests.createCalls)
+	}
+}
+
+// TestCheckpointEffectReplaysTheActualCommit verifies the Git checkpoint
+// marker adapter returns the existing commit after a lost commit response.
+func TestCheckpointEffectReplaysTheActualCommit(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	next := run
+	next.Revision++
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID},
+	}
+	githubRuntime.statusComment.Body = statusCommentBody(next)
+	workspace := &effectMatrixGitWorkspace{failCheckpointOnce: true}
+	service := newEffectMatrixService(githubRuntime, nil, workspace, nil)
+	request := gitadapter.CheckpointRequest{RunID: run.ID, WorktreePath: run.Worktree, ParentSHA: "parent", Kind: gitadapter.CheckpointKindImplementation, Message: "checkpoint"}
+	payload := checkpointEffectPayload{
+		Request:    checkpointRequestJSON{RunID: request.RunID, WorktreePath: request.WorktreePath, ParentSHA: request.ParentSHA, Kind: string(request.Kind), Message: request.Message},
+		Repository: github.Repository{Owner: "example", Name: "project"},
+		Issue:      githubRuntime.issue,
+		Previous:   run,
+		Next:       next,
+	}
+	effect, err := service.newPendingEffect(run.ID, store.PendingEffectKindCheckpoint, "checkpoint", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if err := service.withPendingEffect(ctx, blocked, effect, func() error {
+		_, err := workspace.CreateCheckpoint(ctx, request)
+		return err
+	}); err == nil {
+		t.Fatal("checkpoint creation before reservation = nil, want reservation failure")
+	}
+	if workspace.checkpointMutations != 0 {
+		t.Fatalf("checkpoint commits before reservation = %d, want zero", workspace.checkpointMutations)
+	}
+	if err := service.withPendingEffect(ctx, opened, effect, func() error {
+		_, err := workspace.CreateCheckpoint(ctx, request)
+		return err
+	}); err == nil {
+		t.Fatal("checkpoint creation = nil, want response-loss error")
+	}
+	if workspace.checkpointMutations != 1 {
+		t.Fatalf("checkpoint commits after first attempt = %d, want one", workspace.checkpointMutations)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(githubRuntime, nil, workspace, nil)
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending checkpoint = %#v, error = %v", pending, err)
+	}
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if workspace.checkpointMutations != 1 {
+		t.Fatalf("checkpoint commits after replay = %d, want one", workspace.checkpointMutations)
+	}
+}
+
+// TestWorkerLaunchEffectReplaysTheActualWorkerStart verifies Docker-style
+// run identity reuse prevents a second worker creation after response loss.
+func TestWorkerLaunchEffectReplaysTheActualWorkerStart(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	workerRuntime := &effectMatrixWorker{failStartOnce: true}
+	service := newEffectMatrixService(nil, nil, nil, nil)
+	service.deps.Worker = workerRuntime
+	request := worker.StartRequest{RunID: run.ID, WorktreePath: run.Worktree, GitMetadataPath: "/git", Image: "worker", ImageDigest: "digest", Role: "implementation"}
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if err := service.startWorkerWithEffect(ctx, blocked, request); err == nil {
+		t.Fatal("startWorkerWithEffect() before reservation = nil, want reservation failure")
+	}
+	if workerRuntime.startMutations != 0 {
+		t.Fatalf("worker creations before reservation = %d, want zero", workerRuntime.startMutations)
+	}
+	if err := service.startWorkerWithEffect(ctx, opened, request); err == nil {
+		t.Fatal("startWorkerWithEffect() = nil, want response-loss error")
+	}
+	if workerRuntime.startMutations != 1 {
+		t.Fatalf("worker creations after first attempt = %d, want one", workerRuntime.startMutations)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(nil, nil, nil, nil)
+	restarted.deps.Worker = workerRuntime
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending worker launch = %#v, error = %v", pending, err)
+	}
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if workerRuntime.startMutations != 1 {
+		t.Fatalf("worker creations after replay = %d, want one", workerRuntime.startMutations)
+	}
+}
+
+// TestResultAcceptanceEffectReplaysTheActualFinish verifies a lost harness
+// finalization response is retried idempotently before the run is projected.
+func TestResultAcceptanceEffectReplaysTheActualFinish(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID},
+	}
+	harnessRuntime := &effectMatrixHarness{failFinishOnce: true}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	service.deps.Harness = harnessRuntime
+	invocation := store.Invocation{
+		ID: "inv-effects", RunID: run.ID, Harness: harness.NameCodex, Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-effects", WorkspaceID: "workspace-effects", ImplementationSurfaceID: "surface-effects",
+		Status: store.InvocationStatusActive, CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	accepted := invocation
+	accepted.Status = store.InvocationStatusCompleted
+	next := run
+	next.Revision++
+	githubRuntime.statusComment.Body = statusCommentBody(next)
+	session := harness.Session{InvocationID: invocation.ID, NativeSessionID: invocation.NativeSessionID, Surface: terminal.Surface{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)}}
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if _, _, err := service.acceptResultWithEffect(ctx, blocked, blocked, effectMatrixRegistration(), harnessRuntime, session, accepted, run, next, false); err == nil {
+		t.Fatal("acceptResultWithEffect() before reservation = nil, want reservation failure")
+	}
+	if harnessRuntime.finishMutations != 0 {
+		t.Fatalf("harness finishes before result-acceptance reservation = %d, want zero", harnessRuntime.finishMutations)
+	}
+	if _, _, err := service.acceptResultWithEffect(ctx, opened, opened, effectMatrixRegistration(), harnessRuntime, session, accepted, run, next, false); err == nil {
+		t.Fatal("acceptResultWithEffect() = nil, want response-loss error")
+	}
+	if harnessRuntime.finishMutations != 1 {
+		t.Fatalf("harness finishes after first attempt = %d, want one", harnessRuntime.finishMutations)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	restarted := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	restarted.deps.Harness = harnessRuntime
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending result acceptance = %#v, error = %v", pending, err)
+	}
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if harnessRuntime.finishMutations != 1 || harnessRuntime.finishCalls != 2 {
+		t.Fatalf("harness finish calls/mutations after replay = %d/%d, want 2/1", harnessRuntime.finishCalls, harnessRuntime.finishMutations)
+	}
+}
+
+// TestClarificationPublicationRecoversACommentAfterResponseLoss verifies the
+// marker lookup closes the create-to-persist gap without a second comment.
+func TestClarificationPublicationRecoversACommentAfterResponseLoss(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	packet, err := json.Marshal(SpecificationPacket{Version: specificationPacketVersion})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.Status = store.StatusWaitingForHuman
+	run.PendingQuestions = []store.PendingQuestion{{ID: "format", Prompt: "Which format should be used?"}}
+	run.SpecificationPacket = string(packet)
+	run.ClarificationNotificationSent = true
+	if err := opened.SaveRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	githubRuntime := &effectMatrixGitHub{issue: github.Issue{Number: run.IssueNumber}, failCommentOnce: true}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
+	if _, err := service.ensureClarificationPublication(ctx, effectMatrixRegistration(), blocked, run); err == nil {
+		t.Fatal("ensureClarificationPublication() before reservation = nil, want reservation failure")
+	}
+	if githubRuntime.createCommentCalls != 0 {
+		t.Fatalf("clarification comment creates before reservation = %d, want zero", githubRuntime.createCommentCalls)
+	}
+	if _, err := service.ensureClarificationPublication(ctx, effectMatrixRegistration(), opened, run); err == nil {
+		t.Fatal("ensureClarificationPublication() = nil, want response-loss error")
+	}
+	if githubRuntime.createCommentCalls != 1 {
+		t.Fatalf("clarification comment creates after first attempt = %d, want one", githubRuntime.createCommentCalls)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	current, err := reopened.CurrentRun(ctx)
+	if err != nil || current == nil {
+		t.Fatalf("current waiting run = %#v, error = %v", current, err)
+	}
+	restarted := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	if _, err := restarted.ensureClarificationPublication(ctx, effectMatrixRegistration(), reopened, *current); err != nil {
+		t.Fatalf("ensureClarificationPublication() after restart = %v", err)
+	}
+	if githubRuntime.createCommentCalls != 1 {
+		t.Fatalf("clarification comment creates after restart = %d, want one", githubRuntime.createCommentCalls)
+	}
+	if current, err := reopened.CurrentRun(ctx); err != nil || current == nil || current.ClarificationCommentID != "comment-effects" {
+		t.Fatalf("persisted clarification identity = %#v, error = %v; want comment-effects", current, err)
+	}
+}
+
+// openEffectMatrixStore creates a real SQLite operational store with one run
+// so each operation-level test can close and reopen the journal.
+func openEffectMatrixStore(t *testing.T, ctx context.Context) (*store.Store, string, store.Run) {
+	t.Helper()
+	databaseDirectory := t.TempDir()
+	if err := os.Chmod(databaseDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	databasePath := filepath.Join(databaseDirectory, "effects.db")
+	opened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := store.Run{
+		ID: "run-effects", RepositoryPath: "/repo", IssueNumber: 42, Stage: store.StageImplementation,
+		Status: store.StatusActive, Branch: "factory/run-effects", Worktree: "/worktree", StatusCommentID: "status-effects",
+		CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(1, 0).UTC(),
+	}
+	if err := opened.SaveRun(ctx, run); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	return opened, databasePath, run
+}
+
+// newEffectMatrixService wires only the external seam needed by one effect
+// replay test, leaving all production defaults out of the assertion.
+func newEffectMatrixService(githubRuntime github.Client, statuses github.CommitStatusPublisher, workspace gitadapter.GitWorkspace, pullRequests github.PullRequestClient) *Service {
+	return &Service{deps: Dependencies{GitHub: githubRuntime, CommitStatuses: statuses, GitWorkspace: workspace, PullRequests: pullRequests, Now: func() time.Time { return time.Unix(10, 0).UTC() }}}
+}
+
+// effectMatrixRegistration supplies the repository identity needed by result
+// acceptance payloads without loading host configuration.
+func effectMatrixRegistration() config.RepositoryRegistration {
+	return config.RepositoryRegistration{GitHub: config.GitHubConfig{Owner: "example", Repository: "project"}}
+}
+
+// effectMatrixGitHub is a stateful GitHub fake that mutates its projection
+// before optionally returning a lost-response error.
+type effectMatrixGitHub struct {
+	issue              github.Issue
+	statusComment      github.Comment
+	failLabelOnce      bool
+	failCommentOnce    bool
+	replaceLabelCalls  int
+	createCommentCalls int
+}
+
+// Issue returns the mutable issue projection used by effect replay.
+func (g *effectMatrixGitHub) Issue(context.Context, github.Repository, int) (github.Issue, error) {
+	issue := g.issue
+	issue.Labels = append([]string(nil), g.issue.Labels...)
+	return issue, nil
+}
+
+// CreateLabel satisfies the GitHub client seam for effect tests.
+func (*effectMatrixGitHub) CreateLabel(context.Context, github.Repository, github.Label) error {
+	return nil
+}
+
+// ReplaceIssueLabels mutates the issue before optionally losing its response.
+func (g *effectMatrixGitHub) ReplaceIssueLabels(_ context.Context, _ github.Repository, _ int, labels []string) error {
+	g.replaceLabelCalls++
+	g.issue.Labels = append([]string(nil), labels...)
+	if g.failLabelOnce {
+		g.failLabelOnce = false
+		return errors.New("GitHub label response lost")
+	}
+	return nil
+}
+
+// CreateIssueComment mutates the status comment before optionally losing its
+// response, modeling the create boundary that caused duplicate comments.
+func (g *effectMatrixGitHub) CreateIssueComment(_ context.Context, _ github.Repository, _ int, body string) (github.Comment, error) {
+	g.createCommentCalls++
+	g.statusComment = github.Comment{ID: "comment-effects", Body: body}
+	if g.failCommentOnce {
+		g.failCommentOnce = false
+		return github.Comment{}, errors.New("GitHub comment response lost")
+	}
+	return g.statusComment, nil
+}
+
+// FindStatusComment returns the coordinator-owned comment projection.
+func (g *effectMatrixGitHub) FindStatusComment(context.Context, github.Repository, int, string) (github.Comment, error) {
+	return g.statusComment, nil
+}
+
+// EditIssueComment updates the existing coordinator-owned comment.
+func (g *effectMatrixGitHub) EditIssueComment(_ context.Context, _ github.Repository, id, body string) error {
+	g.statusComment.ID = id
+	g.statusComment.Body = body
+	return nil
+}
+
+var _ github.Client = (*effectMatrixGitHub)(nil)
+
+// effectMatrixCommitStatus is a stateful Commit Status fake with exact-status
+// readback and a response-loss injection after the first mutation.
+type effectMatrixCommitStatus struct {
+	statuses    []github.CommitStatus
+	failOnce    bool
+	createCalls int
+}
+
+// ListCommitStatuses returns all statuses currently attached to the SHA.
+func (s *effectMatrixCommitStatus) ListCommitStatuses(context.Context, github.Repository, string) ([]github.CommitStatus, error) {
+	return append([]github.CommitStatus(nil), s.statuses...), nil
+}
+
+// CreateCommitStatus records one status and can lose its response afterward.
+func (s *effectMatrixCommitStatus) CreateCommitStatus(_ context.Context, _ github.Repository, status github.CommitStatus) error {
+	s.createCalls++
+	s.statuses = append(s.statuses, status)
+	if s.failOnce {
+		s.failOnce = false
+		return errors.New("GitHub status response lost")
+	}
+	return nil
+}
+
+var _ github.CommitStatusPublisher = (*effectMatrixCommitStatus)(nil)
+var _ github.CommitStatusReader = (*effectMatrixCommitStatus)(nil)
+
+// effectMatrixPullRequests models branch-scoped PR creation and discovery.
+type effectMatrixPullRequests struct {
+	existing       github.PullRequest
+	failCreateOnce bool
+	createCalls    int
+}
+
+// FindPullRequest returns the PR created by the first attempt, if any.
+func (p *effectMatrixPullRequests) FindPullRequest(context.Context, github.Repository, string, string) (github.PullRequest, error) {
+	return p.existing, nil
+}
+
+// CreatePullRequest creates one PR and can lose its response after mutation.
+func (p *effectMatrixPullRequests) CreatePullRequest(_ context.Context, _ github.Repository, request github.PullRequestRequest) (github.PullRequest, error) {
+	p.createCalls++
+	p.existing = github.PullRequest{Number: 17, URL: "https://github.com/example/project/pull/17", Title: request.Title, Body: request.Body, Draft: request.Draft, HeadBranch: request.HeadBranch, BaseBranch: request.BaseBranch}
+	if p.failCreateOnce {
+		p.failCreateOnce = false
+		return github.PullRequest{}, errors.New("GitHub pull-request response lost")
+	}
+	return p.existing, nil
+}
+
+// UpdatePullRequest satisfies the pull-request seam for this creation test.
+func (p *effectMatrixPullRequests) UpdatePullRequest(_ context.Context, _ github.Repository, _ int, request github.PullRequestRequest) (github.PullRequest, error) {
+	p.existing.Title = request.Title
+	p.existing.Body = request.Body
+	p.existing.Draft = request.Draft
+	return p.existing, nil
+}
+
+var _ github.PullRequestClient = (*effectMatrixPullRequests)(nil)
+
+// effectMatrixGitWorkspace models Git's idempotent checkpoint and remote-head
+// projections while exposing semantic mutation counts to the tests.
+type effectMatrixGitWorkspace struct {
+	expectedRemoteHead  string
+	remoteHead          string
+	failPushOnce        bool
+	pushMutations       int
+	checkpointSHA       string
+	failCheckpointOnce  bool
+	checkpointMutations int
+}
+
+// Create creates no worktree in this focused effect fake.
+func (*effectMatrixGitWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	return gitadapter.Workspace{}, nil
+}
+
+// Remove removes no worktree in this focused effect fake.
+func (*effectMatrixGitWorkspace) Remove(context.Context, string, gitadapter.Workspace) error {
+	return nil
+}
+
+// Inspect returns the parent checkpoint as the stable worktree projection.
+func (w *effectMatrixGitWorkspace) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	return gitadapter.WorktreeState{HeadSHA: w.checkpointSHA}, nil
+}
+
+// CreateCheckpoint creates one semantic checkpoint and returns it on every
+// later call, even when the first response was lost.
+func (w *effectMatrixGitWorkspace) CreateCheckpoint(context.Context, gitadapter.CheckpointRequest) (gitadapter.CheckpointResult, error) {
+	if w.checkpointSHA == "" {
+		w.checkpointSHA = strings.Repeat("a", 40)
+		w.checkpointMutations++
+		if w.failCheckpointOnce {
+			w.failCheckpointOnce = false
+			return gitadapter.CheckpointResult{SHA: w.checkpointSHA, Created: true}, errors.New("Git commit response lost")
+		}
+		return gitadapter.CheckpointResult{SHA: w.checkpointSHA, Created: true}, nil
+	}
+	return gitadapter.CheckpointResult{SHA: w.checkpointSHA}, nil
+}
+
+// Push publishes the expected remote head and can lose the first response.
+func (w *effectMatrixGitWorkspace) Push(context.Context, gitadapter.PushRequest) error {
+	w.remoteHead = w.expectedRemoteHead
+	w.pushMutations++
+	if w.failPushOnce {
+		w.failPushOnce = false
+		return errors.New("Git push response lost")
+	}
+	return nil
+}
+
+// SynchronizeBase satisfies the Git workspace seam for effect tests.
+func (*effectMatrixGitWorkspace) SynchronizeBase(context.Context, gitadapter.BaseSyncRequest) error {
+	return nil
+}
+
+// RemoteBranchHead returns the remote projection used to suppress a replayed
+// push.
+func (w *effectMatrixGitWorkspace) RemoteBranchHead(context.Context, gitadapter.PushRequest) (string, error) {
+	return w.remoteHead, nil
+}
+
+var _ gitadapter.GitWorkspace = (*effectMatrixGitWorkspace)(nil)
+var _ gitadapter.RemoteBranchInspector = (*effectMatrixGitWorkspace)(nil)
+
+// effectMatrixWorker models Docker's run-identity reuse behavior.
+type effectMatrixWorker struct {
+	started        bool
+	failStartOnce  bool
+	startMutations int
+}
+
+// Start creates one worker and reuses it on replay.
+func (w *effectMatrixWorker) Start(context.Context, worker.StartRequest) error {
+	if w.started {
+		return nil
+	}
+	w.started = true
+	w.startMutations++
+	if w.failStartOnce {
+		w.failStartOnce = false
+		return errors.New("Docker start response lost")
+	}
+	return nil
+}
+
+// Resume satisfies the worker seam for effect tests.
+func (*effectMatrixWorker) Resume(context.Context, worker.ResumeRequest) error { return nil }
+
+// RunCommand satisfies the worker seam for effect tests.
+func (*effectMatrixWorker) RunCommand(context.Context, worker.CommandRequest) (worker.CommandResult, error) {
+	return worker.CommandResult{}, nil
+}
+
+// Stop satisfies the worker seam for effect tests.
+func (*effectMatrixWorker) Stop(context.Context, string) error { return nil }
+
+// Inspect returns the current worker projection.
+func (w *effectMatrixWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+	return worker.Inspection{Exists: w.started, Running: w.started}, nil
+}
+
+var _ worker.WorkerRuntime = (*effectMatrixWorker)(nil)
+
+// effectMatrixHarness models an idempotent harness finalization command whose
+// first response is lost after the visible mutation.
+type effectMatrixHarness struct {
+	finished        bool
+	failFinishOnce  bool
+	finishCalls     int
+	finishMutations int
+}
+
+// Capabilities reports the harness identity used by the result payload.
+func (*effectMatrixHarness) Capabilities() harness.Capabilities {
+	return harness.Capabilities{Name: harness.NameCodex, InteractiveResume: true}
+}
+
+// Start satisfies the harness lifecycle seam for effect tests.
+func (*effectMatrixHarness) Start(context.Context, harness.StartRequest) (harness.Session, error) {
+	return harness.Session{}, nil
+}
+
+// Resume satisfies the harness lifecycle seam for effect tests.
+func (*effectMatrixHarness) Resume(context.Context, harness.StartRequest) (harness.Session, error) {
+	return harness.Session{}, nil
+}
+
+// Finish performs one semantic finalization and reports a lost first response.
+func (h *effectMatrixHarness) Finish(context.Context, harness.Session) error {
+	h.finishCalls++
+	if !h.finished {
+		h.finished = true
+		h.finishMutations++
+		if h.failFinishOnce {
+			h.failFinishOnce = false
+			return errors.New("harness finish response lost")
+		}
+	}
+	return nil
+}
+
+var _ harness.Runtime = (*effectMatrixHarness)(nil)

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -406,6 +406,44 @@ func TestPullRequestEffectReplaysTheActualCreation(t *testing.T) {
 	}
 }
 
+// TestPullRequestReplayRejectsNewerPersistedRevisionBeforeMutation verifies a
+// response-loss replay refuses a stale run before inspecting or updating its PR.
+func TestPullRequestReplayRejectsNewerPersistedRevisionBeforeMutation(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	pullRequests := &effectMatrixPullRequests{failCreateOnce: true}
+	service := newEffectMatrixService(nil, nil, nil, pullRequests)
+	repository := github.Repository{Owner: "example", Name: "project"}
+	previous := run
+	next := run
+	next.Revision++
+	request := github.PullRequestRequest{Title: "Factory PR", Body: "body", HeadBranch: run.Branch, BaseBranch: "main", Draft: true}
+	if _, _, err := service.upsertPullRequestAndPersistWithEffect(ctx, opened, pullRequests, repository, github.Issue{Number: run.IssueNumber}, previous, next, request, 0); err == nil {
+		t.Fatal("upsertPullRequestAndPersistWithEffect() = nil, want response-loss error")
+	}
+	if pullRequests.createCalls != 1 {
+		t.Fatalf("pull-request creations after first attempt = %d, want one", pullRequests.createCalls)
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending pull request = %#v, error = %v", pending, err)
+	}
+
+	newer := run
+	newer.Revision = next.Revision + 1
+	if err := opened.SaveRun(ctx, newer); err != nil {
+		t.Fatalf("persist newer run revision: %v", err)
+	}
+	pullRequests.existing.Body = "operator changed body"
+	if _, err := service.replayPendingEffect(ctx, opened, *pending); err == nil || !strings.Contains(err.Error(), "older than current revision") {
+		t.Fatalf("replayPendingEffect() error = %v, want newer-revision refusal", err)
+	}
+	if pullRequests.findCalls != 1 || pullRequests.updateCalls != 0 || pullRequests.createCalls != 1 {
+		t.Fatalf("pull-request effects after stale replay = finds=%d updates=%d creates=%d, want 1/0/1", pullRequests.findCalls, pullRequests.updateCalls, pullRequests.createCalls)
+	}
+}
+
 // TestCheckpointEffectReplaysTheActualCommit verifies the Git checkpoint
 // marker adapter returns the existing commit after a lost commit response.
 func TestCheckpointEffectReplaysTheActualCommit(t *testing.T) {
@@ -574,6 +612,59 @@ func TestResultAcceptanceEffectReplaysTheActualFinish(t *testing.T) {
 	}
 	if harnessRuntime.finishMutations != 1 || harnessRuntime.finishCalls != 2 {
 		t.Fatalf("harness finish calls/mutations after replay = %d/%d, want 2/1", harnessRuntime.finishCalls, harnessRuntime.finishMutations)
+	}
+}
+
+// TestResultAcceptanceReplayRejectsNewerPersistedRevisionBeforeSideEffects
+// verifies a response-loss replay refuses a stale run before reserving or
+// repeating harness finalization and worker shutdown.
+func TestResultAcceptanceReplayRejectsNewerPersistedRevisionBeforeSideEffects(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	harnessRuntime := &effectMatrixHarness{failFinishOnce: true}
+	workerRuntime := &effectMatrixWorker{started: true}
+	service := newEffectMatrixService(nil, nil, nil, nil)
+	service.deps.Harness = harnessRuntime
+	service.deps.Worker = workerRuntime
+	invocation := store.Invocation{
+		ID: "inv-stale-acceptance", RunID: run.ID, Harness: harness.NameCodex, Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-stale-acceptance", Status: store.InvocationStatusActive, CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	accepted := invocation
+	accepted.Status = store.InvocationStatusCompleted
+	previous := run
+	next := run
+	next.Revision++
+	session := harness.Session{InvocationID: invocation.ID, NativeSessionID: invocation.NativeSessionID}
+	if _, _, err := service.acceptResultWithEffect(ctx, opened, opened, effectMatrixRegistration(), harnessRuntime, session, accepted, previous, next, true); err == nil {
+		t.Fatal("acceptResultWithEffect() = nil, want response-loss error")
+	}
+	if harnessRuntime.finishCalls != 1 || harnessRuntime.finishMutations != 1 || workerRuntime.stopCalls != 0 {
+		t.Fatalf("first result acceptance effects = finishes=%d/%d stops=%d, want 1/1/0", harnessRuntime.finishCalls, harnessRuntime.finishMutations, workerRuntime.stopCalls)
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending result acceptance = %#v, error = %v", pending, err)
+	}
+
+	newer := run
+	newer.Revision = next.Revision + 1
+	if err := opened.SaveRun(ctx, newer); err != nil {
+		t.Fatalf("persist newer run revision: %v", err)
+	}
+	if _, err := service.replayPendingEffect(ctx, opened, *pending); err == nil || !strings.Contains(err.Error(), "older than current revision") {
+		t.Fatalf("replayPendingEffect() error = %v, want newer-revision refusal", err)
+	}
+	if harnessRuntime.finishCalls != 1 || harnessRuntime.finishMutations != 1 || workerRuntime.stopCalls != 0 {
+		t.Fatalf("stale result acceptance effects = finishes=%d/%d stops=%d, want unchanged 1/1/0", harnessRuntime.finishCalls, harnessRuntime.finishMutations, workerRuntime.stopCalls)
+	}
+	persisted, err := opened.Invocation(ctx, run.ID, invocation.ID)
+	if err != nil || persisted == nil || persisted.Status != store.InvocationStatusCompleted {
+		t.Fatalf("persisted invocation after stale replay = %#v, error = %v; want original terminal reservation", persisted, err)
 	}
 }
 
@@ -878,11 +969,14 @@ var _ github.CommitStatusReader = (*effectMatrixCommitStatus)(nil)
 type effectMatrixPullRequests struct {
 	existing       github.PullRequest
 	failCreateOnce bool
+	findCalls      int
 	createCalls    int
+	updateCalls    int
 }
 
 // FindPullRequest returns the PR created by the first attempt, if any.
 func (p *effectMatrixPullRequests) FindPullRequest(context.Context, github.Repository, string, string) (github.PullRequest, error) {
+	p.findCalls++
 	return p.existing, nil
 }
 
@@ -899,6 +993,7 @@ func (p *effectMatrixPullRequests) CreatePullRequest(_ context.Context, _ github
 
 // UpdatePullRequest satisfies the pull-request seam for this creation test.
 func (p *effectMatrixPullRequests) UpdatePullRequest(_ context.Context, _ github.Repository, _ int, request github.PullRequestRequest) (github.PullRequest, error) {
+	p.updateCalls++
 	p.existing.Title = request.Title
 	p.existing.Body = request.Body
 	p.existing.Draft = request.Draft
@@ -979,6 +1074,7 @@ type effectMatrixWorker struct {
 	started        bool
 	failStartOnce  bool
 	startMutations int
+	stopCalls      int
 }
 
 // Start creates one worker and reuses it on replay.
@@ -1004,7 +1100,10 @@ func (*effectMatrixWorker) RunCommand(context.Context, worker.CommandRequest) (w
 }
 
 // Stop satisfies the worker seam for effect tests.
-func (*effectMatrixWorker) Stop(context.Context, string) error { return nil }
+func (w *effectMatrixWorker) Stop(context.Context, string) error {
+	w.stopCalls++
+	return nil
+}
 
 // Inspect returns the current worker projection.
 func (w *effectMatrixWorker) Inspect(context.Context, string) (worker.Inspection, error) {

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -15,6 +15,7 @@ import (
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
@@ -317,7 +318,7 @@ func TestCommitStatusEffectReplaysTheActualStatusMutation(t *testing.T) {
 func TestPushEffectReplaysTheActualRemoteMutation(t *testing.T) {
 	ctx := context.Background()
 	opened, databasePath, run := openEffectMatrixStore(t, ctx)
-	workspace := &effectMatrixGitWorkspace{expectedRemoteHead: "checkpoint", failPushOnce: true}
+	workspace := &effectMatrixGitWorkspace{expectedRemoteHead: "checkpoint", checkpointSHA: "checkpoint", failPushOnce: true}
 	service := newEffectMatrixService(nil, nil, workspace, nil)
 	request := gitadapter.PushRequest{WorktreePath: "/worktree", Branch: run.Branch}
 	blocked := &effectTestStore{Store: opened, saveErr: errors.New("reservation unavailable")}
@@ -351,6 +352,25 @@ func TestPushEffectReplaysTheActualRemoteMutation(t *testing.T) {
 	}
 	if workspace.pushMutations != 1 {
 		t.Fatalf("push mutations after replay = %d, want one", workspace.pushMutations)
+	}
+}
+
+// TestPushEffectRejectsAChangedLocalHead verifies a replay cannot publish a
+// different local commit under the durable effect's original checkpoint ID.
+func TestPushEffectRejectsAChangedLocalHead(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	workspace := &effectMatrixGitWorkspace{expectedRemoteHead: "checkpoint", checkpointSHA: "new-local-head"}
+	service := newEffectMatrixService(nil, nil, workspace, nil)
+	request := gitadapter.PushRequest{WorktreePath: run.Worktree, Branch: run.Branch}
+
+	err := service.pushWithEffect(ctx, opened, run.ID, workspace, request, workspace.expectedRemoteHead)
+	if err == nil || !strings.Contains(err.Error(), "local worktree HEAD") {
+		t.Fatalf("pushWithEffect() error = %v, want changed-local-HEAD refusal", err)
+	}
+	if workspace.pushMutations != 0 {
+		t.Fatalf("push mutations = %d, want zero for changed local HEAD", workspace.pushMutations)
 	}
 }
 
@@ -556,7 +576,8 @@ func TestWorkerLaunchEffectReplaysTheActualWorkerStart(t *testing.T) {
 }
 
 // TestResultAcceptanceEffectReplaysTheActualFinish verifies a lost harness
-// finalization response is retried idempotently before the run is projected.
+// finalization response is safely abandoned rather than issued a second time
+// before the remaining durable projections are completed.
 func TestResultAcceptanceEffectReplaysTheActualFinish(t *testing.T) {
 	ctx := context.Background()
 	opened, databasePath, run := openEffectMatrixStore(t, ctx)
@@ -611,8 +632,56 @@ func TestResultAcceptanceEffectReplaysTheActualFinish(t *testing.T) {
 	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
 		t.Fatalf("replayPendingEffect() = %v", err)
 	}
-	if harnessRuntime.finishMutations != 1 || harnessRuntime.finishCalls != 2 {
-		t.Fatalf("harness finish calls/mutations after replay = %d/%d, want 2/1", harnessRuntime.finishCalls, harnessRuntime.finishMutations)
+	if harnessRuntime.finishMutations != 1 || harnessRuntime.finishCalls != 1 {
+		t.Fatalf("harness finish calls/mutations after replay = %d/%d, want 1/1", harnessRuntime.finishCalls, harnessRuntime.finishMutations)
+	}
+}
+
+// TestRepeatedTestAcceptanceResumesAnUnfinishedStageProjection verifies a
+// terminal invocation is not mistaken for a fully projected test-stage result
+// when the durable run still points at that stage.
+func TestRepeatedTestAcceptanceResumesAnUnfinishedStageProjection(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	run.Stage = store.StageTest
+	run.SpecificationPacket = "{}"
+	if err := opened.SaveRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	resultDirectory := t.TempDir()
+	invocation := store.Invocation{
+		ID: "inv-test-projection", RunID: run.ID, Harness: harness.NameCodex, Role: "test", Stage: store.StageTest,
+		NativeSessionID: "session-test-projection", ResultDirectory: resultDirectory,
+		Status: store.InvocationStatusCompleted, CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	value := report.Report{
+		SchemaVersion: report.SchemaVersion, InvocationID: invocation.ID, RunID: run.ID,
+		Harness: invocation.Harness, Role: invocation.Role, Stage: string(invocation.Stage),
+		Outcome: report.OutcomeCompleted, Summary: "red test is ready",
+		TestHandoff: &report.TestHandoff{FocusedTestCommand: "go test ./...", ExpectedFailureReason: "wanted failure"},
+		ReportedAt:  time.Unix(2, 0).UTC(),
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(resultDirectory, report.ReportFileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registration := config.RepositoryRegistration{Path: run.RepositoryPath, OperationalDataPath: "effects.db", GitHub: config.GitHubConfig{Owner: "example", Repository: "project"}}
+	workspace := &effectMatrixGitWorkspace{checkpointSHA: run.CheckpointSHA}
+	service := newEffectMatrixService(nil, nil, workspace, nil)
+	service.configPath = "/host/config.yaml"
+	service.deps.Config = effectMatrixConfig{host: config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{registration}}}
+	service.deps.OpenStore = func(context.Context, string) (OperationalStore, error) { return opened, nil }
+	service.startupChecked = true
+
+	_, err = service.AcceptAgentReport(ctx, AgentReportRequest{RunID: run.ID, InvocationID: invocation.ID})
+	if err == nil || !strings.Contains(err.Error(), "worker runtime is required for red-test verification") {
+		t.Fatalf("AcceptAgentReport() error = %v, want unfinished test projection to resume", err)
 	}
 }
 
@@ -871,6 +940,21 @@ func newEffectMatrixService(githubRuntime github.Client, statuses github.CommitS
 func effectMatrixRegistration() config.RepositoryRegistration {
 	return config.RepositoryRegistration{GitHub: config.GitHubConfig{Owner: "example", Repository: "project"}}
 }
+
+// effectMatrixConfig supplies one host registration to public-seam effect
+// tests without involving the filesystem-backed configuration repository.
+type effectMatrixConfig struct {
+	host config.HostConfig
+}
+
+// Load returns the configured host registration.
+func (c effectMatrixConfig) Load(string) (config.HostConfig, error) { return c.host, nil }
+
+// Save satisfies ConfigRepository for the read-only fixture.
+func (effectMatrixConfig) Save(string, config.HostConfig) error { return nil }
+
+// Create returns the configured host registration.
+func (c effectMatrixConfig) Create(string) (config.HostConfig, error) { return c.host, nil }
 
 // effectMatrixGitHub is a stateful GitHub fake that mutates its projection
 // before optionally returning a lost-response error.

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -55,6 +55,11 @@ type Factory interface {
 	PollCommands(context.Context, CommandPollRequest) ([]CommandResult, error)
 	// PollLifecycle observes merge and closure decisions for the current run.
 	PollLifecycle(context.Context, LifecycleRequest) (LifecycleResult, error)
+	// Reconcile completes one restart reconciliation pass for the current run.
+	Reconcile(context.Context) (RecoveryResult, error)
+	// AbandonPendingEffect explicitly discards one ambiguous effect after human
+	// review and leaves the run waiting for human reconciliation.
+	AbandonPendingEffect(context.Context, AbandonPendingEffectRequest) (RecoveryResult, error)
 	// EvaluationReport reads content-free local evaluation summaries and aggregates.
 	EvaluationReport(context.Context, EvaluationReportRequest) (EvaluationReportResult, error)
 	// DeleteEvaluation deliberately removes selected terminal evaluation summaries.
@@ -159,11 +164,39 @@ type Service struct {
 	runtimeSocketPath string
 	runtimePathSet    bool
 	harnessRuntimes   map[config.Harness]harness.Runtime
-	startupMu         sync.Mutex
-	startupChecked    bool
-	startupErr        error
-	pollMu            sync.Mutex
-	pollCancel        context.CancelFunc
+	// startedInvocations records invocations launched by this coordinator
+	// process, so same-process duplicate commands are not mistaken for restart
+	// recovery.
+	startedInvocations map[string]struct{}
+	startupMu          sync.Mutex
+	startupChecked     bool
+	startupErr         error
+	pollMu             sync.Mutex
+	pollCancel         context.CancelFunc
+}
+
+// markInvocationStarted records an invocation launched by this coordinator
+// process so a repeated command in the same process is rejected rather than
+// mistaken for a restart recovery.
+func (s *Service) markInvocationStarted(invocationID string) {
+	if strings.TrimSpace(invocationID) == "" {
+		return
+	}
+	s.runtimeMu.Lock()
+	defer s.runtimeMu.Unlock()
+	if s.startedInvocations == nil {
+		s.startedInvocations = make(map[string]struct{})
+	}
+	s.startedInvocations[invocationID] = struct{}{}
+}
+
+// invocationStartedHere reports whether this service already launched the
+// persisted invocation during its current process lifetime.
+func (s *Service) invocationStartedHere(invocationID string) bool {
+	s.runtimeMu.Lock()
+	defer s.runtimeMu.Unlock()
+	_, exists := s.startedInvocations[invocationID]
+	return exists
 }
 
 type InitResult struct {
@@ -461,9 +494,29 @@ func (s *Service) Status(ctx context.Context) (StatusResult, error) {
 	if err != nil {
 		return StatusResult{}, err
 	}
-	if result.LatestRun != nil && !store.IsTerminalStatus(result.LatestRun.Status) {
-		diagnosis := s.diagnoseInterruptedRun(ctx, registration, *result.LatestRun)
-		result.Recovery = &diagnosis
+	if result.LatestRun != nil {
+		var pending *store.PendingEffect
+		if journal, ok := opened.(PendingEffectStore); ok {
+			pending, err = journal.PendingEffect(ctx, result.LatestRun.ID)
+			if err != nil {
+				return StatusResult{}, fmt.Errorf("read pending effect for status: %w", err)
+			}
+		}
+		if !store.IsTerminalStatus(result.LatestRun.Status) {
+			diagnosis := s.diagnoseInterruptedRunWithStore(ctx, registration, opened, *result.LatestRun)
+			diagnosis.PendingEffect = pending
+			appendPendingEffectAction(&diagnosis)
+			result.Recovery = &diagnosis
+		} else if pending != nil {
+			// A terminal projection can be durable before the final journal clear.
+			// Keep that ambiguity visible without downgrading the terminal run or
+			// replaying an external effect from the read-only status command.
+			diagnosis := newRecoveryDiagnosis(result.LatestRun.ID)
+			diagnosis.PendingEffect = pending
+			diagnosis.SourcesAgree = false
+			appendPendingEffectAction(&diagnosis)
+			result.Recovery = &diagnosis
+		}
 	}
 	return result, nil
 }

--- a/internal/factory/first_invocation_test.go
+++ b/internal/factory/first_invocation_test.go
@@ -309,7 +309,7 @@ func (f *fakeGitHub) setStatusComment(run store.Run) error {
 	if run.StatusCommentID == "" {
 		return &statusCommentFixtureError{message: "claim did not persist a status comment identity"}
 	}
-	f.statusComment = github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: " + run.ID + " -->"}
+	f.statusComment = github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)}
 	return nil
 }
 

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -547,8 +547,8 @@ func prepareGitMetadataProjection(runID, repositoryPath, worktreePath string) (s
 		return "", errors.New("repository git metadata must be a directory")
 	}
 
-	projectionParent := filepath.Join(filepath.Dir(worktreePath), ".factory-git")
-	projection := filepath.Join(projectionParent, runID)
+	projection := gitMetadataProjectionPath(runID, worktreePath)
+	projectionParent := filepath.Dir(projection)
 	if projectionInfo, statErr := os.Stat(projection); statErr == nil {
 		if !projectionInfo.IsDir() {
 			return "", fmt.Errorf("git metadata projection %q is not a directory", projection)
@@ -592,6 +592,12 @@ func prepareGitMetadataProjection(runID, repositoryPath, worktreePath string) (s
 		return "", fmt.Errorf("publish git metadata projection: %w", err)
 	}
 	return projection, nil
+}
+
+// gitMetadataProjectionPath returns the stable read-only Git metadata path for
+// a run without inspecting or mutating the repository.
+func gitMetadataProjectionPath(runID, worktreePath string) string {
+	return filepath.Join(filepath.Dir(worktreePath), ".factory-git", runID)
 }
 
 // copyGitMetadata copies permitted regular Git metadata from source to

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -303,7 +303,7 @@ func (s *Service) runGateSuite(ctx context.Context, registration config.Reposito
 	if err != nil {
 		return gate.SuiteResult{}, fmt.Errorf("prepare worker git metadata: %w", err)
 	}
-	if err := s.deps.Worker.Start(ctx, worker.StartRequest{
+	workerRequest := worker.StartRequest{
 		RunID:           run.ID,
 		WorktreePath:    run.Worktree,
 		GitMetadataPath: gitMetadataPath,
@@ -311,14 +311,19 @@ func (s *Service) runGateSuite(ctx context.Context, registration config.Reposito
 		ImageDigest:     run.ImageDigest,
 		Caches:          workerCaches(packet.RepositoryConfig.Caches),
 		Role:            "gate",
-	}); err != nil {
+	}
+	if err := s.startWorkerWithEffect(ctx, runStore, workerRequest); err != nil {
 		return gate.SuiteResult{}, err
 	}
 	skipSetup := setupAlreadySucceeded(ctx, runStore, run, phase, fingerprint)
+	statuses := s.deps.CommitStatuses
+	if statuses != nil {
+		statuses = commitStatusPublisher{service: s, runStore: runStore, runID: run.ID, delegate: statuses}
+	}
 	return (gate.Runner{
 		Runtime:    s.deps.Worker,
 		Repository: github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository},
-		Statuses:   s.deps.CommitStatuses,
+		Statuses:   statuses,
 	}).RunSuite(ctx, gate.SuiteRequest{
 		RunID:                  run.ID,
 		CheckpointSHA:          run.CheckpointSHA,

--- a/internal/factory/harness_selection_test.go
+++ b/internal/factory/harness_selection_test.go
@@ -100,13 +100,13 @@ func TestStartAgentAcceptsAnIssueHarnessOverridePermittedByPolicy(t *testing.T) 
 	policy := validRepositoryConfig()
 	policy.AllowedOverrides = append(policy.AllowedOverrides, config.OverrideHarness)
 	policy.ModelOptions["implementation"] = []string{"claude-opus-5"}
-	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{})
 
 	run := *runStore.current
 	run.HarnessOverride = string(config.HarnessClaude)
 	if err := runStore.SaveRun(context.Background(), run); err != nil {
 		t.Fatal(err)
 	}
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, policy, config.AuthenticationConfig{})
 	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
 	if err != nil {
 		t.Fatalf("StartAgent() error = %v", err)
@@ -200,7 +200,7 @@ func newDispatchingAgentService(t *testing.T, runStore *agentRunStore, runtime *
 	}}}
 	githubRuntime := &fakeGitHub{
 		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
-		statusComment: github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: " + run.ID + " -->"},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)},
 	}
 	worktree := &inspectingWorktree{
 		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{Worktree: run.Worktree}},

--- a/internal/factory/lifecycle.go
+++ b/internal/factory/lifecycle.go
@@ -183,8 +183,11 @@ func (s *Service) transitionTerminal(ctx context.Context, registration config.Re
 	if store.IsTerminalStatus(previous.Status) {
 		return previous, nil
 	}
-	if err := s.stopRunWorker(ctx, previous.ID); err != nil {
-		return next, err
+	journaled := false
+	if _, journaled = runStore.(PendingEffectStore); !journaled {
+		if err := s.stopRunWorker(ctx, previous.ID); err != nil {
+			return next, err
+		}
 	}
 	repository := commandRepository(registration)
 	if next.StatusCommentID == "" {
@@ -203,6 +206,7 @@ func (s *Service) transitionTerminal(ctx context.Context, registration config.Re
 		Issue:      issue,
 		Previous:   previous,
 		Next:       next,
+		StopWorker: journaled,
 	})
 	if err != nil {
 		return updated, err

--- a/internal/factory/lock_test.go
+++ b/internal/factory/lock_test.go
@@ -1,12 +1,15 @@
 package factory
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/github"
 )
 
 // TestCoordinatorLockPreventsASecondOwner verifies the host lock is enforced
@@ -32,6 +35,49 @@ func TestCoordinatorLockPreventsASecondOwner(t *testing.T) {
 	}
 	if err := second.release(); err != nil {
 		t.Fatalf("second release() error = %v", err)
+	}
+}
+
+// TestStartAcquiresTheCoordinatorLockBeforeReconciliation verifies a losing
+// process cannot open the operational store or replay durable mutations owned
+// by the process that already holds the repository lock.
+func TestStartAcquiresTheCoordinatorLockBeforeReconciliation(t *testing.T) {
+	t.Parallel()
+
+	registration := config.RepositoryRegistration{
+		Path:                 filepath.Join(t.TempDir(), "repository"),
+		OperationalDataPath:  filepath.Join(t.TempDir(), "factory.db"),
+		RepositoryConfigPath: filepath.Join(t.TempDir(), "factory.yaml"),
+		Polling:              config.PollingConfig{Interval: "1s", Backoff: "1s"},
+	}
+	owner, err := acquireCoordinatorLock(coordinatorLockPath(registration))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = owner.release() }()
+	openCalls := 0
+	service := &Service{configPath: "/host/config.yaml", deps: Dependencies{
+		Config: lockTestConfig{host: config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{registration}}},
+		OpenStore: func(context.Context, string) (OperationalStore, error) {
+			openCalls++
+			return nil, errors.New("operational store must remain unopened")
+		},
+		LoadRepository: func(string) (config.RepositoryConfig, error) {
+			return config.RepositoryConfig{TargetBranch: "main"}, nil
+		},
+		IssuePoller: lockTestIssuePoller{},
+		Lease:       lockTestLease{},
+		StartupDiagnosis: func(context.Context) (DoctorResult, error) {
+			return DoctorResult{Report: doctor.Report{Results: []doctor.Result{doctor.Success("startup")}}}, nil
+		},
+	}}
+
+	err = service.Start(context.Background())
+	if !errors.Is(err, ErrCoordinatorAlreadyRunning) {
+		t.Fatalf("Start() error = %v, want ErrCoordinatorAlreadyRunning", err)
+	}
+	if openCalls != 0 {
+		t.Fatalf("operational store opens = %d, want zero before lock ownership", openCalls)
 	}
 }
 
@@ -94,3 +140,31 @@ func TestCoordinatorLockRejectsSymlinkedLockFiles(t *testing.T) {
 		t.Fatalf("symlink target content = %q, want unchanged PID marker", content)
 	}
 }
+
+// lockTestConfig supplies the one repository used by the lock-order fixture.
+type lockTestConfig struct {
+	host config.HostConfig
+}
+
+// Load returns the configured host registration.
+func (c lockTestConfig) Load(string) (config.HostConfig, error) { return c.host, nil }
+
+// Save satisfies ConfigRepository for the read-only fixture.
+func (lockTestConfig) Save(string, config.HostConfig) error { return nil }
+
+// Create returns the configured host registration.
+func (c lockTestConfig) Create(string) (config.HostConfig, error) { return c.host, nil }
+
+// lockTestIssuePoller satisfies the queue seam without making a request.
+type lockTestIssuePoller struct{}
+
+// ListEligibleIssues returns an empty queue.
+func (lockTestIssuePoller) ListEligibleIssues(context.Context, github.Repository) ([]github.Issue, error) {
+	return nil, nil
+}
+
+// lockTestLease satisfies the lease seam without publishing a heartbeat.
+type lockTestLease struct{}
+
+// RenewLease accepts the fixture heartbeat.
+func (lockTestLease) RenewLease(context.Context, github.Repository, github.Lease) error { return nil }

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -88,6 +88,9 @@ func (s *Service) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if err := s.reconcileRegisteredRun(ctx, registration); err != nil {
+		return fmt.Errorf("reconcile persisted run at startup: %w", err)
+	}
 	if s.issuePoller() == nil {
 		return errors.New("GitHub issue poller is required to start the coordinator")
 	}
@@ -164,6 +167,27 @@ func (s *Service) Start(ctx context.Context) error {
 		leaseRunID = result.Run.ID
 		delay = interval
 	}
+}
+
+// reconcileRegisteredRun opens the operational store once before the polling
+// loop acquires its host lock. This makes a process restart converge an active
+// run before queue work is considered.
+func (s *Service) reconcileRegisteredRun(ctx context.Context, registration config.RepositoryRegistration) error {
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return fmt.Errorf("open operational store for startup reconciliation: %w", err)
+	}
+	runStore, ok := opened.(RunStore)
+	if !ok {
+		_ = opened.Close()
+		return errors.New("operational store does not support startup reconciliation")
+	}
+	defer func() { _ = runStore.Close() }()
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return fmt.Errorf("read persisted run for startup reconciliation: %w", err)
+	}
+	return s.ensureProgressionStartup(ctx, registration, runStore, run)
 }
 
 // Stop asks the current coordinator process to stop polling. A same-process

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -72,10 +72,11 @@ func (e *StartupBlockedError) Error() string {
 }
 
 // Start runs the supervised polling loop until its context is cancelled. It
-// diagnoses the full host before taking the lock, renews a visible GitHub
-// lease, and backs off read-only queue or lease transport failures without
-// changing run state or retry budgets. Claim failures are returned because the
-// claim state machine may already have performed compensating effects.
+// diagnoses the full host before taking the lock, acquires exclusive ownership
+// before reconciliation, renews a visible GitHub lease, and backs off read-only
+// queue or lease transport failures without changing run state or retry
+// budgets. Claim failures are returned because the claim state machine may
+// already have performed compensating effects.
 func (s *Service) Start(ctx context.Context) error {
 	diagnosis, err := s.startupDiagnosis(ctx)
 	if err != nil {
@@ -87,9 +88,6 @@ func (s *Service) Start(ctx context.Context) error {
 	registration, repositoryConfig, err := s.pollConfiguration()
 	if err != nil {
 		return err
-	}
-	if err := s.reconcileRegisteredRun(ctx, registration); err != nil {
-		return fmt.Errorf("reconcile persisted run at startup: %w", err)
 	}
 	if s.issuePoller() == nil {
 		return errors.New("GitHub issue poller is required to start the coordinator")
@@ -106,6 +104,9 @@ func (s *Service) Start(ctx context.Context) error {
 		return err
 	}
 	defer func() { _ = lock.release() }()
+	if err := s.reconcileRegisteredRun(ctx, registration); err != nil {
+		return fmt.Errorf("reconcile persisted run at startup: %w", err)
+	}
 
 	pollContext, cancel := context.WithCancel(ctx)
 	if !s.setPollCancel(cancel) {
@@ -169,9 +170,9 @@ func (s *Service) Start(ctx context.Context) error {
 	}
 }
 
-// reconcileRegisteredRun opens the operational store once before the polling
-// loop acquires its host lock. This makes a process restart converge an active
-// run before queue work is considered.
+// reconcileRegisteredRun opens the operational store once after the polling
+// loop owns its host lock. This makes a process restart converge and resume an
+// active run before queue work is considered.
 func (s *Service) reconcileRegisteredRun(ctx context.Context, registration config.RepositoryRegistration) error {
 	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
 	if err != nil {
@@ -187,7 +188,7 @@ func (s *Service) reconcileRegisteredRun(ctx context.Context, registration confi
 	if err != nil {
 		return fmt.Errorf("read persisted run for startup reconciliation: %w", err)
 	}
-	return s.ensureProgressionStartup(ctx, registration, runStore, run)
+	return s.ensureAgentStartup(ctx, registration, runStore, run, AgentRequest{})
 }
 
 // Stop asks the current coordinator process to stop polling. A same-process

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -305,11 +305,10 @@ func inspectRemoteBranchProjection(ctx context.Context, diagnosis *RecoveryDiagn
 	})
 }
 
-// inspectInvocationProjection verifies the active invocation's durable
-// external identities without launching or mutating anything. A missing native
-// session is left for the progression seam to reject as an incomplete launch;
-// treating it as a state mutation here would make concurrent first launches
-// indistinguishable from restart recovery.
+// inspectInvocationProjection verifies the newest invocation's durable
+// external identities without launching or mutating anything. The active
+// invocation is preferred, while the latest terminal invocation keeps stages
+// between visible agents from bypassing worker, cmux, or native-session checks.
 func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, registration config.RepositoryRegistration, runStore OperationalStore, run store.Run) {
 	if runStore == nil {
 		return
@@ -354,7 +353,33 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 		return
 	}
 	if active == nil {
-		return
+		latestStore, exposesLatest := runStore.(LatestInvocationStore)
+		if !exposesLatest {
+			if _, journaled := runStore.(PendingEffectStore); journaled {
+				addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyInfrastructure,
+					Source:   "operational store",
+					Field:    "latest invocation",
+					Expected: "latest invocation lookup",
+					Observed: "store does not expose latest invocation projection",
+				})
+			}
+			return
+		}
+		active, err = latestStore.LatestInvocation(ctx, run.ID)
+		if err != nil {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "operational store",
+				Field:    "latest invocation",
+				Expected: "read latest invocation",
+				Observed: err.Error(),
+			})
+			return
+		}
+		if active == nil {
+			return
+		}
 	}
 	diagnosis.InvocationExists = true
 	hasNativeSession := strings.TrimSpace(active.NativeSessionID) != ""

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -283,15 +283,26 @@ func inspectRemoteBranchProjection(ctx context.Context, diagnosis *RecoveryDiagn
 		})
 		return
 	}
-	if head != run.CheckpointSHA {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
-			Kind:     RecoveryDiscrepancyInfrastructure,
-			Source:   "remote branch",
-			Field:    "head",
-			Expected: run.CheckpointSHA,
-			Observed: head,
-		})
+	if head == run.CheckpointSHA {
+		return
 	}
+	// A checkpoint is committed and persisted before the gate suite runs, and
+	// pushed only afterwards. A remote head that is an ancestor of the local
+	// checkpoint is therefore an ordinary unpushed commit, not a disagreement:
+	// the branch has not diverged and the pending push effect still owns it.
+	if ancestry, ok := workspace.(gitadapter.AncestryInspector); ok && head != "" {
+		reachable, ancestryErr := ancestry.IsAncestor(ctx, run.Worktree, head, run.CheckpointSHA)
+		if ancestryErr == nil && reachable {
+			return
+		}
+	}
+	addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+		Kind:     RecoveryDiscrepancyInfrastructure,
+		Source:   "remote branch",
+		Field:    "head",
+		Expected: run.CheckpointSHA,
+		Observed: head,
+	})
 }
 
 // inspectInvocationProjection verifies the active invocation's durable

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
 // RecoveryRequiredCode is the stable code for the pre-reconciliation safety
@@ -391,22 +392,57 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 				Expected: "running",
 				Observed: "stopped",
 			})
-		} else if packet, packetErr := decodeSpecificationPacket(run.SpecificationPacket); packetErr != nil {
-			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
-				Kind:     RecoveryDiscrepancyWorkflow,
-				Source:   "run",
-				Field:    "specification packet",
-				Expected: "decodable packet for active worker",
-				Observed: packetErr.Error(),
-			})
-		} else if !workerImageMatches(workerInspection.Image, packet.RepositoryConfig.WorkerBuild.Image, run.ImageDigest) {
-			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
-				Kind:     RecoveryDiscrepancyInfrastructure,
-				Source:   "worker",
-				Field:    "image",
-				Expected: packet.RepositoryConfig.WorkerBuild.Image + "@" + run.ImageDigest,
-				Observed: workerInspection.Image,
-			})
+		} else {
+			packet, packetErr := decodeSpecificationPacket(run.SpecificationPacket)
+			if packetErr != nil {
+				addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyWorkflow,
+					Source:   "run",
+					Field:    "specification packet",
+					Expected: "decodable packet for active worker",
+					Observed: packetErr.Error(),
+				})
+			} else {
+				if !workerImageMatches(workerInspection.Image, packet.RepositoryConfig.WorkerBuild.Image, run.ImageDigest) {
+					addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+						Kind:     RecoveryDiscrepancyInfrastructure,
+						Source:   "worker",
+						Field:    "image",
+						Expected: packet.RepositoryConfig.WorkerBuild.Image + "@" + run.ImageDigest,
+						Observed: workerInspection.Image,
+					})
+				}
+				workerRequest := worker.StartRequest{
+					RunID:             run.ID,
+					WorktreePath:      run.Worktree,
+					GitMetadataPath:   gitMetadataProjectionPath(run.ID, run.Worktree),
+					Image:             packet.RepositoryConfig.WorkerBuild.Image,
+					ImageDigest:       run.ImageDigest,
+					Caches:            workerCaches(packet.RepositoryConfig.Caches),
+					InvocationPath:    active.InvocationDirectory,
+					ResultPath:        active.ResultDirectory,
+					CredentialStoreID: active.CredentialStoreID,
+					Role:              active.Role,
+				}
+				known, matches := workerInspection.MountContractStatus(workerRequest)
+				if !known {
+					addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+						Kind:     RecoveryDiscrepancyInfrastructure,
+						Source:   "worker",
+						Field:    "mount contract inspection",
+						Expected: "adapter-owned worker mount identities",
+						Observed: "unavailable",
+					})
+				} else if !matches {
+					addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+						Kind:     RecoveryDiscrepancyInfrastructure,
+						Source:   "worker",
+						Field:    "mount contract",
+						Expected: "persisted worktree, Git, cache, invocation, result, and role identities",
+						Observed: "worker mount identity mismatch",
+					})
+				}
+			}
 		}
 	}
 
@@ -667,8 +703,13 @@ func (s *Service) reconcileInterruptedRun(ctx context.Context, registration conf
 		if replayErr != nil {
 			diagnosis := s.diagnoseInterruptedRunWithStore(ctx, registration, runStore, run)
 			diagnosis.PendingEffect = pending
+			replayKind := RecoveryDiscrepancyInfrastructure
+			var workflowErr *workflowProjectionError
+			if errors.As(replayErr, &workflowErr) {
+				replayKind = RecoveryDiscrepancyWorkflow
+			}
 			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
-				Kind:     RecoveryDiscrepancyInfrastructure,
+				Kind:     replayKind,
 				Source:   "pending effect",
 				Field:    string(pending.Kind),
 				Expected: "complete or recognize the recorded effect",
@@ -678,11 +719,11 @@ func (s *Service) reconcileInterruptedRun(ctx context.Context, registration conf
 			if !store.IsTerminalStatus(run.Status) {
 				paused, pauseErr := s.pauseRunLocally(ctx, runStore, run, diagnosis)
 				if pauseErr != nil {
-					return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(&InfrastructureDiscrepancyError{Diagnosis: diagnosis}, pauseErr)
+					return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(recoveryErrorWithCause(diagnosis, replayErr), pauseErr)
 				}
-				return paused, diagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+				return paused, diagnosis, RecoveryOutcomeWaitingForHuman, recoveryErrorWithCause(diagnosis, replayErr)
 			}
-			return run, diagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+			return run, diagnosis, RecoveryOutcomeWaitingForHuman, recoveryErrorWithCause(diagnosis, replayErr)
 		}
 		run = updated
 		if resumeWasAlreadyReserved {
@@ -1154,8 +1195,17 @@ func recoveryRequiredError(diagnosis RecoveryDiagnosis) error {
 // recoveryDiscrepancyError classifies a legacy-store startup refusal while
 // retaining RecoveryRequiredError through the typed error's unwrap chain.
 func recoveryDiscrepancyError(diagnosis RecoveryDiagnosis) error {
+	return recoveryErrorWithCause(diagnosis, nil)
+}
+
+// recoveryErrorWithCause returns the typed category for a diagnosis and keeps
+// the compatibility recovery error discoverable through the unwrap chain.
+func recoveryErrorWithCause(diagnosis RecoveryDiagnosis, cause error) error {
 	if hasWorkflowDiscrepancy(diagnosis) {
-		return &WorkflowFailureError{RunID: diagnosis.RunID, Cause: recoveryRequiredError(diagnosis)}
+		if cause == nil {
+			cause = errors.New(recoveryDiscrepancyReason(diagnosis))
+		}
+		return &WorkflowFailureError{RunID: diagnosis.RunID, Cause: errors.Join(cause, recoveryRequiredError(diagnosis))}
 	}
 	return &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
 }

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,16 +12,45 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/config"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
 )
 
 // RecoveryRequiredCode is the stable code for the pre-reconciliation safety
 // boundary. Issue #21 supersedes this refusal with complete reconciliation.
 const RecoveryRequiredCode = "recovery-required"
 
+// RecoveryDiscrepancyKind identifies whether a restart disagreement is an
+// infrastructure observation or a workflow-owned failure.
+type RecoveryDiscrepancyKind string
+
+const (
+	// RecoveryDiscrepancyInfrastructure means the coordinator could not prove
+	// that a host or external projection matches the durable run identity.
+	RecoveryDiscrepancyInfrastructure RecoveryDiscrepancyKind = "infrastructure"
+	// RecoveryDiscrepancyWorkflow means the durable workflow itself contains an
+	// invalid or failed state and must not be retried as infrastructure.
+	RecoveryDiscrepancyWorkflow RecoveryDiscrepancyKind = "workflow"
+)
+
+// RecoveryOutcome identifies the result of one reconciliation attempt.
+type RecoveryOutcome string
+
+const (
+	// RecoveryOutcomeReconciled means the persisted and external projections
+	// agree and the run may continue.
+	RecoveryOutcomeReconciled RecoveryOutcome = "reconciled"
+	// RecoveryOutcomeWaitingForHuman means reconciliation paused the run because
+	// a disagreement could not be resolved safely.
+	RecoveryOutcomeWaitingForHuman RecoveryOutcome = "waiting_for_human"
+)
+
 // RecoveryDiscrepancy describes one observed disagreement between persisted
 // run identity and an external projection.
 type RecoveryDiscrepancy struct {
+	// Kind distinguishes infrastructure uncertainty from workflow failure.
+	Kind RecoveryDiscrepancyKind
 	// Source identifies the projection that disagrees with persisted state.
 	Source string
 	// Field identifies the identity field that differs.
@@ -31,9 +61,9 @@ type RecoveryDiscrepancy struct {
 	Observed string
 }
 
-// RecoveryDiagnosis is the read-only result of checking an interrupted run.
-// SourcesAgree may be true while recovery is still required: before issue #21,
-// agreement is diagnosed but never treated as permission to resume.
+// RecoveryDiagnosis is the result of a read-only comparison of an interrupted
+// run and its persisted and external projections. It contains no claim that
+// reconciliation has mutated or repaired any projection.
 type RecoveryDiagnosis struct {
 	// Code is always RecoveryRequiredCode for a non-terminal run.
 	Code string
@@ -47,10 +77,102 @@ type RecoveryDiagnosis struct {
 	InvocationExists bool
 	// SafeActions identifies operator actions that do not claim recovery.
 	SafeActions []string
+	// PendingEffect is the effect that was present when diagnosis ran, if any.
+	PendingEffect *store.PendingEffect
 }
 
-// RecoveryRequiredError refuses progression for a persisted non-terminal run.
-// It carries the same diagnosis exposed by Status and performs no recovery.
+// RecoveryResult contains the durable run after an explicit reconciliation
+// request and the final read-only diagnosis used to make the decision.
+type RecoveryResult struct {
+	// Run is the reconciled run projection, when a non-terminal run exists.
+	Run *store.Run
+	// Diagnosis is the final cross-system comparison.
+	Diagnosis RecoveryDiagnosis
+	// Outcome identifies whether the run was reconciled or paused.
+	Outcome RecoveryOutcome
+}
+
+// AbandonPendingEffectRequest identifies one pending effect that a human has
+// inspected and decided not to replay. The reason is included in the waiting
+// projection so the decision remains visible without storing sensitive detail.
+type AbandonPendingEffectRequest struct {
+	// RunID optionally constrains the operation to one persisted run.
+	RunID string
+	// EffectID is the exact durable effect identity shown by factory status.
+	EffectID string
+	// Reason is the bounded operator explanation for abandoning the effect.
+	Reason string
+}
+
+// InfrastructureDiscrepancyError reports a restart disagreement that is not a
+// deterministic workflow failure. The run has already been paused when the
+// coordinator could publish that state safely.
+type InfrastructureDiscrepancyError struct {
+	// Diagnosis contains every observed discrepancy.
+	Diagnosis RecoveryDiagnosis
+}
+
+// Error returns the stable infrastructure discrepancy category and details.
+func (e *InfrastructureDiscrepancyError) Error() string {
+	if e == nil {
+		return "recovery infrastructure discrepancy"
+	}
+	if len(e.Diagnosis.Discrepancies) == 0 {
+		return fmt.Sprintf("recovery infrastructure discrepancy: run %q is waiting for human reconciliation", e.Diagnosis.RunID)
+	}
+	details := make([]string, 0, len(e.Diagnosis.Discrepancies))
+	for _, discrepancy := range e.Diagnosis.Discrepancies {
+		details = append(details, fmt.Sprintf("%s.%s expected=%q observed=%q", discrepancy.Source, discrepancy.Field, discrepancy.Expected, discrepancy.Observed))
+	}
+	return fmt.Sprintf("recovery infrastructure discrepancy: run %q is waiting for human reconciliation: %s", e.Diagnosis.RunID, strings.Join(details, ", "))
+}
+
+// Unwrap preserves compatibility with callers that used the pre-reconciliation
+// RecoveryRequiredError while exposing the stronger infrastructure category to
+// new callers.
+func (e *InfrastructureDiscrepancyError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return &RecoveryRequiredError{Diagnosis: e.Diagnosis}
+}
+
+// WorkflowFailureError reports a workflow-owned failure without mislabeling it
+// as an unavailable host or external service.
+type WorkflowFailureError struct {
+	// RunID identifies the affected workflow.
+	RunID string
+	// Cause is the deterministic workflow failure.
+	Cause error
+}
+
+// Error returns the workflow failure category and its bounded cause.
+func (e *WorkflowFailureError) Error() string {
+	if e == nil {
+		return "workflow failure during recovery"
+	}
+	return fmt.Sprintf("workflow failure during recovery for run %q: %v", e.RunID, e.Cause)
+}
+
+// Unwrap exposes the deterministic workflow cause.
+func (e *WorkflowFailureError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// RecoveryInfrastructureError is a compatibility alias for callers that use
+// the longer typed-error vocabulary.
+type RecoveryInfrastructureError = InfrastructureDiscrepancyError
+
+// RecoveryWorkflowError is a compatibility alias for callers that use the
+// recovery-prefixed workflow error vocabulary.
+type RecoveryWorkflowError = WorkflowFailureError
+
+// RecoveryRequiredError preserves the compatibility error returned by legacy
+// stores that cannot expose a pending-effect journal. Journaled stores return
+// the typed reconciliation errors instead.
 type RecoveryRequiredError struct {
 	// Diagnosis is the complete read-only startup diagnosis.
 	Diagnosis RecoveryDiagnosis
@@ -91,19 +213,694 @@ func (e *RecoveryRequiredError) Code() string { return RecoveryRequiredCode }
 // identity projections without mutating Git, GitHub, the worker, the terminal,
 // the harness, or operational workflow state.
 func (s *Service) diagnoseInterruptedRun(ctx context.Context, registration config.RepositoryRegistration, run store.Run) RecoveryDiagnosis {
+	return s.diagnoseInterruptedRunWithStore(ctx, registration, nil, run)
+}
+
+// diagnoseInterruptedRunWithStore extends the read-only recovery diagnosis
+// with persisted invocation, worker, terminal, native-session, and remote
+// branch projections when the operational store exposes those identities.
+func (s *Service) diagnoseInterruptedRunWithStore(ctx context.Context, registration config.RepositoryRegistration, runStore OperationalStore, run store.Run) RecoveryDiagnosis {
 	diagnosis := newRecoveryDiagnosis(run.ID)
 	comparePersistedRunIdentity(&diagnosis, registration.Path, run)
+	if _, err := decodeSpecificationPacket(run.SpecificationPacket); err != nil {
+		addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyWorkflow,
+			Source:   "run",
+			Field:    "specification packet",
+			Expected: "decodable specification packet",
+			Observed: err.Error(),
+		})
+	}
 
 	inspector := s.worktreeInspector()
 	inspectWorktreeProjection(ctx, &diagnosis, inspector, registration.Path, run)
 
 	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
 	inspectGitHubProjection(ctx, &diagnosis, s.deps.GitHub, s.pullRequestClient(), repository, run)
+	inspectRemoteBranchProjection(ctx, &diagnosis, s.gitWorkspace(), run)
+	s.inspectInvocationProjection(ctx, &diagnosis, registration, runStore, run)
 	diagnosis.SourcesAgree = len(diagnosis.Discrepancies) == 0
 	return diagnosis
 }
 
-// newRecoveryDiagnosis creates the stable result envelope and operator actions.
+// inspectRemoteBranchProjection verifies a pushed run branch when the Git
+// adapter offers a read-only remote-head projection. Earlier stages may not
+// have pushed a branch yet, so only a tracked pull request requires this check.
+func inspectRemoteBranchProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, workspace gitadapter.GitWorkspace, run store.Run) {
+	if run.PullRequestNumber <= 0 {
+		return
+	}
+	if workspace == nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "remote branch",
+			Field:    "inspection",
+			Expected: "read-only remote branch inspector",
+			Observed: "inspector unavailable",
+		})
+		return
+	}
+	inspector, ok := workspace.(gitadapter.RemoteBranchInspector)
+	if !ok {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "remote branch",
+			Field:    "inspection",
+			Expected: "read-only remote branch inspector",
+			Observed: "inspector unavailable",
+		})
+		return
+	}
+	head, err := inspector.RemoteBranchHead(ctx, gitadapter.PushRequest{WorktreePath: run.Worktree, Branch: run.Branch})
+	if err != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "remote branch",
+			Field:    "head",
+			Expected: run.CheckpointSHA,
+			Observed: err.Error(),
+		})
+		return
+	}
+	if head != run.CheckpointSHA {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "remote branch",
+			Field:    "head",
+			Expected: run.CheckpointSHA,
+			Observed: head,
+		})
+	}
+}
+
+// inspectInvocationProjection verifies the active invocation's durable
+// external identities without launching or mutating anything. A missing native
+// session is left for the progression seam to reject as an incomplete launch;
+// treating it as a state mutation here would make concurrent first launches
+// indistinguishable from restart recovery.
+func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, registration config.RepositoryRegistration, runStore OperationalStore, run store.Run) {
+	if runStore == nil {
+		return
+	}
+	history, hasHistory := runStore.(InvocationHistoryStore)
+	if hasHistory {
+		exists, err := history.HasInvocation(ctx, run.ID)
+		if err != nil {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "operational store",
+				Field:    "invocation history",
+				Expected: "read invocation history",
+				Observed: err.Error(),
+			})
+			return
+		}
+		diagnosis.InvocationExists = exists
+	}
+	activeStore, ok := runStore.(ActiveInvocationStore)
+	if !ok {
+		if _, journaled := runStore.(PendingEffectStore); journaled {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "operational store",
+				Field:    "active invocation",
+				Expected: "active invocation lookup",
+				Observed: "store does not expose active invocation projection",
+			})
+		}
+		return
+	}
+	active, err := activeStore.ActiveInvocation(ctx, run.ID)
+	if err != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "operational store",
+			Field:    "active invocation",
+			Expected: "read active invocation",
+			Observed: err.Error(),
+		})
+		return
+	}
+	if active == nil {
+		return
+	}
+	diagnosis.InvocationExists = true
+	hasNativeSession := strings.TrimSpace(active.NativeSessionID) != ""
+	if !hasNativeSession {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "native session",
+			Field:    "identity",
+			Expected: "persisted native session identifier",
+			Observed: "empty",
+		})
+	}
+	if s.deps.Worker == nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "worker",
+			Field:    "runtime",
+			Expected: "worker runtime for active invocation",
+			Observed: "worker runtime unavailable",
+		})
+		return
+	}
+	workerInspection, inspectErr := s.deps.Worker.Inspect(ctx, run.ID)
+	if inspectErr != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "worker",
+			Field:    "inspection",
+			Expected: "read active worker",
+			Observed: inspectErr.Error(),
+		})
+	} else {
+		if !workerInspection.Exists {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "worker",
+				Field:    "existence",
+				Expected: "persisted worker",
+				Observed: "missing",
+			})
+		} else if !workerInspection.Running {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "worker",
+				Field:    "lifecycle",
+				Expected: "running",
+				Observed: "stopped",
+			})
+		} else if packet, packetErr := decodeSpecificationPacket(run.SpecificationPacket); packetErr != nil {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyWorkflow,
+				Source:   "run",
+				Field:    "specification packet",
+				Expected: "decodable packet for active worker",
+				Observed: packetErr.Error(),
+			})
+		} else if !workerImageMatches(workerInspection.Image, packet.RepositoryConfig.WorkerBuild.Image, run.ImageDigest) {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "worker",
+				Field:    "image",
+				Expected: packet.RepositoryConfig.WorkerBuild.Image + "@" + run.ImageDigest,
+				Observed: workerInspection.Image,
+			})
+		}
+	}
+
+	terminalRuntime := s.deps.Terminal
+	if terminalRuntime == nil {
+		terminalRuntime = terminal.NewCmuxRuntime(nil, registration.Cmux.SocketPath)
+	}
+	terminalInspector, ok := terminalRuntime.(terminal.WorkspaceInspector)
+	if !ok {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "cmux",
+			Field:    "inspection",
+			Expected: "read persisted workspace and surface identities",
+			Observed: "terminal inspector unavailable",
+		})
+	} else {
+		inspectTerminalProjection(ctx, diagnosis, terminalInspector, *active)
+	}
+
+	_, harnessRuntime, runtimeErr := s.ensureAgentRuntime(registration.Cmux.SocketPath, config.Harness(active.Harness))
+	if runtimeErr != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "harness",
+			Field:    "adapter",
+			Expected: active.Harness,
+			Observed: runtimeErr.Error(),
+		})
+		return
+	}
+	if !hasNativeSession {
+		return
+	}
+	if inspector, ok := harnessRuntime.(harness.NativeSessionInspector); ok {
+		observed, providerErr := inspector.NativeSessionID(ctx, harness.NativeSessionRequest{RunID: run.ID, Harness: active.Harness})
+		if providerErr != nil {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "native session",
+				Field:    "identity",
+				Expected: active.NativeSessionID,
+				Observed: providerErr.Error(),
+			})
+		} else if observed != active.NativeSessionID {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "native session",
+				Field:    "identity",
+				Expected: active.NativeSessionID,
+				Observed: observed,
+			})
+		}
+	} else {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "native session",
+			Field:    "inspection",
+			Expected: "adapter-owned native session inspection",
+			Observed: "harness adapter does not expose native session inspection",
+		})
+	}
+}
+
+// inspectTerminalProjection compares every persisted non-empty cmux handle
+// with the current read-only topology.
+func inspectTerminalProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, inspector terminal.WorkspaceInspector, invocation store.Invocation) {
+	workspaceID := terminal.WorkspaceID(invocation.WorkspaceID)
+	if workspaceID == "" {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: "workspace", Expected: "persisted workspace identity", Observed: "empty"})
+		return
+	}
+	observed, err := inspector.InspectWorkspace(ctx, workspaceID)
+	if err != nil {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: "inspection", Expected: string(workspaceID), Observed: err.Error()})
+		return
+	}
+	if !observed.Exists {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: "workspace", Expected: string(workspaceID), Observed: "missing"})
+		return
+	}
+	if observed.WorkspaceID != "" && observed.WorkspaceID != workspaceID {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: "workspace identity", Expected: string(workspaceID), Observed: string(observed.WorkspaceID)})
+	}
+	expectedSurfaces := []struct {
+		name string
+		id   string
+	}{
+		{name: "status", id: invocation.StatusSurfaceID},
+		{name: "implementation", id: invocation.ImplementationSurfaceID},
+		{name: "checks", id: invocation.ChecksSurfaceID},
+	}
+	observedIDs := make(map[string]struct{}, len(observed.Surfaces))
+	observedSurfaces := make(map[string]terminal.Surface, len(observed.Surfaces))
+	for _, surface := range observed.Surfaces {
+		observedIDs[string(surface.ID)] = struct{}{}
+		observedSurfaces[string(surface.ID)] = surface
+	}
+	for _, expected := range expectedSurfaces {
+		if strings.TrimSpace(expected.id) == "" {
+			continue
+		}
+		if _, exists := observedIDs[expected.id]; !exists {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: expected.name + " surface", Expected: expected.id, Observed: "missing"})
+			continue
+		}
+		if surface := observedSurfaces[expected.id]; surface.WorkspaceID != "" && surface.WorkspaceID != workspaceID {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: expected.name + " workspace", Expected: string(workspaceID), Observed: string(surface.WorkspaceID)})
+		}
+	}
+}
+
+// Reconcile performs one explicit restart reconciliation for the registered
+// repository. Start and every progression entry point invoke the same private
+// pass automatically; this method exposes the separate read-only diagnosis and
+// the reconciliation outcome to operators and embedders.
+func (s *Service) Reconcile(ctx context.Context) (RecoveryResult, error) {
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return RecoveryResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return RecoveryResult{}, fmt.Errorf("read active run for reconciliation: %w", err)
+	}
+	if run == nil {
+		return RecoveryResult{Outcome: RecoveryOutcomeReconciled}, nil
+	}
+	updated, diagnosis, outcome, reconcileErr := s.reconcileInterruptedRun(ctx, registration, runStore, *run)
+	appendPendingEffectAction(&diagnosis)
+	result := RecoveryResult{Run: &updated, Diagnosis: diagnosis, Outcome: outcome}
+	return result, reconcileErr
+}
+
+// AbandonPendingEffect clears one durable effect only after an explicit human
+// decision, then pauses the run so a later progression cannot guess whether a
+// partially applied external mutation should be replayed.
+func (s *Service) AbandonPendingEffect(ctx context.Context, request AbandonPendingEffectRequest) (RecoveryResult, error) {
+	if strings.TrimSpace(request.EffectID) == "" || strings.ContainsAny(request.EffectID, "\x00\r\n") {
+		return RecoveryResult{}, errors.New("pending effect id is required")
+	}
+	if strings.TrimSpace(request.Reason) == "" || len(request.Reason) > 512 || strings.ContainsAny(request.Reason, "\x00\r\n") {
+		return RecoveryResult{}, errors.New("pending effect abandonment reason is required")
+	}
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return RecoveryResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return RecoveryResult{}, fmt.Errorf("read run for pending effect abandonment: %w", err)
+	}
+	if run == nil {
+		return RecoveryResult{Outcome: RecoveryOutcomeReconciled}, nil
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return RecoveryResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
+	}
+	abandoner, ok := runStore.(PendingEffectAbandoner)
+	if !ok {
+		return RecoveryResult{}, errors.New("operational store does not support pending effect abandonment")
+	}
+	journal, ok := runStore.(PendingEffectStore)
+	if !ok {
+		return RecoveryResult{}, errors.New("operational store does not support pending effect inspection")
+	}
+	pending, err := journal.PendingEffect(ctx, run.ID)
+	if err != nil {
+		return RecoveryResult{}, fmt.Errorf("read pending effect for abandonment: %w", err)
+	}
+	if pending == nil {
+		return RecoveryResult{Run: run, Diagnosis: reconciledRecoveryDiagnosis(run.ID), Outcome: RecoveryOutcomeReconciled}, nil
+	}
+	if pending.ID != request.EffectID {
+		return RecoveryResult{}, fmt.Errorf("pending effect for run %q is %q, not %q", run.ID, pending.ID, request.EffectID)
+	}
+	abandoned := *pending
+	if err := abandoner.AbandonPendingEffect(ctx, run.ID, request.EffectID, request.Reason); err != nil {
+		return RecoveryResult{}, fmt.Errorf("abandon pending effect %q: %w", request.EffectID, err)
+	}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+	diagnosis.PendingEffect = &abandoned
+	diagnosis.SourcesAgree = false
+	addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+		Kind:     RecoveryDiscrepancyInfrastructure,
+		Source:   "pending effect",
+		Field:    string(pending.Kind),
+		Expected: "human-reviewed effect outcome",
+		Observed: "abandoned: " + safeStatusCommentValue(request.Reason),
+	})
+	if store.IsTerminalStatus(run.Status) {
+		return RecoveryResult{Run: run, Diagnosis: diagnosis, Outcome: RecoveryOutcomeReconciled}, nil
+	}
+	paused, pauseErr := s.pauseForRecovery(ctx, registration, runStore, *run, diagnosis)
+	if pauseErr != nil {
+		return RecoveryResult{Run: &paused, Diagnosis: diagnosis, Outcome: RecoveryOutcomeWaitingForHuman}, fmt.Errorf("pause run after abandoning pending effect: %w", pauseErr)
+	}
+	return RecoveryResult{Run: &paused, Diagnosis: diagnosis, Outcome: RecoveryOutcomeWaitingForHuman}, nil
+}
+
+// readReconciliationRun returns the active run, or the latest terminal run
+// when no active run exists. The latter matters because result acceptance can
+// persist its terminal projection immediately before the journal clear; a
+// restart must still drain that one pending effect.
+func readReconciliationRun(ctx context.Context, runStore OperationalStore) (*store.Run, error) {
+	run, err := runStore.CurrentRun(ctx)
+	if err != nil || run != nil {
+		return run, err
+	}
+	latestStore, ok := runStore.(LatestRunStore)
+	if !ok {
+		return nil, nil
+	}
+	return latestStore.LatestRun(ctx)
+}
+
+// reconcileInterruptedRun consumes a durable pending effect, then compares all
+// available projections. Only a known in-flight effect or the explicitly
+// recoverable loss of a worker may be continued automatically; every other
+// disagreement pauses the run for human reconciliation.
+func (s *Service) reconcileInterruptedRun(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, RecoveryDiagnosis, RecoveryOutcome, error) {
+	journal, ok := runStore.(PendingEffectStore)
+	if !ok {
+		if store.IsTerminalStatus(run.Status) {
+			return run, reconciledRecoveryDiagnosis(run.ID), RecoveryOutcomeReconciled, nil
+		}
+		diagnosis := s.diagnoseInterruptedRun(ctx, registration, run)
+		return run, diagnosis, RecoveryOutcomeWaitingForHuman, recoveryDiscrepancyError(diagnosis)
+	}
+	if pending, err := journal.PendingEffect(ctx, run.ID); err != nil {
+		diagnosis := s.diagnoseInterruptedRunWithStore(ctx, registration, runStore, run)
+		addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "operational store",
+			Field:    "pending effect",
+			Expected: "read pending effect journal",
+			Observed: err.Error(),
+		})
+		diagnosis.SourcesAgree = false
+		paused := run
+		if !store.IsTerminalStatus(run.Status) {
+			var pauseErr error
+			paused, pauseErr = s.pauseRunLocally(ctx, runStore, run, diagnosis)
+			if pauseErr != nil {
+				return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(&InfrastructureDiscrepancyError{Diagnosis: diagnosis}, pauseErr)
+			}
+		}
+		return paused, diagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+	} else if pending != nil {
+		resumeWasAlreadyReserved := harnessResumeWasAlreadyReserved(ctx, runStore, *pending)
+		updated, replayErr := s.replayPendingEffect(ctx, runStore, *pending)
+		if replayErr != nil {
+			diagnosis := s.diagnoseInterruptedRunWithStore(ctx, registration, runStore, run)
+			diagnosis.PendingEffect = pending
+			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "pending effect",
+				Field:    string(pending.Kind),
+				Expected: "complete or recognize the recorded effect",
+				Observed: replayErr.Error(),
+			})
+			diagnosis.SourcesAgree = false
+			if !store.IsTerminalStatus(run.Status) {
+				paused, pauseErr := s.pauseRunLocally(ctx, runStore, run, diagnosis)
+				if pauseErr != nil {
+					return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(&InfrastructureDiscrepancyError{Diagnosis: diagnosis}, pauseErr)
+				}
+				return paused, diagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+			}
+			return run, diagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+		}
+		run = updated
+		if resumeWasAlreadyReserved {
+			// The reservation was persisted before the native command, so a
+			// pending row with the reservation already consumed is ambiguous:
+			// the command may have succeeded just before the prior process died.
+			// Never issue a second native resume; force human verification.
+			resumeDiagnosis := s.diagnoseInterruptedRunWithStore(ctx, registration, runStore, run)
+			addRecoveryDiscrepancy(&resumeDiagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "harness",
+				Field:    "native session resume",
+				Expected: "one unambiguous persisted resume result",
+				Observed: "resume reservation crossed the persistence boundary before the journal was cleared",
+			})
+			resumeDiagnosis.SourcesAgree = false
+			paused, pauseErr := s.pauseForRecovery(ctx, registration, runStore, run, resumeDiagnosis)
+			if pauseErr != nil {
+				return paused, resumeDiagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(&InfrastructureDiscrepancyError{Diagnosis: resumeDiagnosis}, pauseErr)
+			}
+			return paused, resumeDiagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: resumeDiagnosis}
+		}
+	}
+	if store.IsTerminalStatus(run.Status) {
+		return run, reconciledRecoveryDiagnosis(run.ID), RecoveryOutcomeReconciled, nil
+	}
+	diagnosis := s.diagnoseInterruptedRunWithStore(ctx, registration, runStore, run)
+	if pending, err := journal.PendingEffect(ctx, run.ID); err == nil {
+		diagnosis.PendingEffect = pending
+	}
+	if diagnosis.SourcesAgree {
+		updated, repairErr := s.completePendingCheckRepair(ctx, registration, runStore, run)
+		if repairErr != nil {
+			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "check-repair",
+				Field:    "attempt reservation",
+				Expected: "active resumed invocation or no pending attempt",
+				Observed: repairErr.Error(),
+			})
+			diagnosis.SourcesAgree = false
+		} else {
+			run = updated
+		}
+	}
+	if !diagnosis.SourcesAgree {
+		paused, pauseErr := s.pauseForRecovery(ctx, registration, runStore, run, diagnosis)
+		if pauseErr != nil {
+			if hasWorkflowDiscrepancy(diagnosis) {
+				return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(&WorkflowFailureError{RunID: run.ID, Cause: errors.New(recoveryDiscrepancyReason(diagnosis))}, pauseErr)
+			}
+			return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(&InfrastructureDiscrepancyError{Diagnosis: diagnosis}, pauseErr)
+		}
+		if hasWorkflowDiscrepancy(diagnosis) {
+			return paused, diagnosis, RecoveryOutcomeWaitingForHuman, &WorkflowFailureError{RunID: run.ID, Cause: errors.New(recoveryDiscrepancyReason(diagnosis))}
+		}
+		return paused, diagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+	}
+	return run, diagnosis, RecoveryOutcomeReconciled, nil
+}
+
+// harnessResumeWasAlreadyReserved reports whether a pending native-resume
+// effect had already persisted its one-resume ceiling before this replay.
+// Such an effect is ambiguous and must not issue another native command.
+func harnessResumeWasAlreadyReserved(ctx context.Context, runStore RunStore, effect store.PendingEffect) bool {
+	if effect.Kind != store.PendingEffectKindHarnessResume {
+		return false
+	}
+	var payload harnessResumeEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil {
+		return false
+	}
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return false
+	}
+	invocation, err := invocationStore.Invocation(ctx, effect.RunID, payload.Invocation.ID)
+	return err == nil && invocation != nil && invocation.RecoveryResumeCount >= payload.TargetResumeCount
+}
+
+// completePendingCheckRepair closes the durable check-repair reservation once
+// its replacement invocation has crossed the native resume boundary. A
+// restart after that boundary must not consume the same retry budget twice or
+// leave the run permanently blocked at implementation.
+func (s *Service) completePendingCheckRepair(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, error) {
+	if run.CheckRepairPendingAttempt == 0 {
+		return run, nil
+	}
+	activeStore, ok := runStore.(ActiveInvocationStore)
+	if !ok {
+		return run, errors.New("operational store does not support active check-repair lookup")
+	}
+	active, err := activeStore.ActiveInvocation(ctx, run.ID)
+	if err != nil {
+		return run, fmt.Errorf("read active check-repair invocation: %w", err)
+	}
+	if active == nil {
+		return run, errors.New("pending check-repair attempt has no active invocation")
+	}
+	if active.RecoveryResumeCount == 0 {
+		return run, nil
+	}
+	if s.deps.GitHub == nil {
+		return run, errors.New("GitHub client is required to complete check-repair reservation")
+	}
+	issue, err := s.deps.GitHub.Issue(ctx, commandRepository(registration), run.IssueNumber)
+	if err != nil {
+		return run, fmt.Errorf("read issue while completing check-repair reservation: %w", err)
+	}
+	next := run
+	next.CheckRepairAttempts = run.CheckRepairPendingAttempt
+	next.CheckRepairPendingAttempt = 0
+	next.LifecycleReason = fmt.Sprintf("check-repair attempt %d active", next.CheckRepairAttempts)
+	next.UpdatedAt = s.deps.Now().UTC()
+	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository: commandRepository(registration),
+		Issue:      issue,
+		Previous:   run,
+		Next:       next,
+	})
+	if err != nil {
+		return run, fmt.Errorf("persist completed check-repair reservation: %w", err)
+	}
+	return updated, nil
+}
+
+// reconciledRecoveryDiagnosis returns the compact result for a terminal run
+// whose pending journal, if any, has been consumed successfully.
+func reconciledRecoveryDiagnosis(runID string) RecoveryDiagnosis {
+	diagnosis := newRecoveryDiagnosis(runID)
+	diagnosis.SourcesAgree = true
+	return diagnosis
+}
+
+// pauseRunLocally records a human-visible waiting state without attempting a
+// second external effect. It is used when the existing pending effect or its
+// journal cannot be replayed safely, so that the one-effect invariant remains
+// intact for an operator to resolve.
+func (s *Service) pauseRunLocally(ctx context.Context, runStore RunStore, run store.Run, diagnosis RecoveryDiagnosis) (store.Run, error) {
+	if run.Status == store.StatusWaitingForHuman && strings.HasPrefix(run.LifecycleReason, "restart reconciliation paused:") {
+		return run, nil
+	}
+	next := run
+	next.Status = store.StatusWaitingForHuman
+	next.LifecycleReason = recoveryDiscrepancyReason(diagnosis)
+	next.Revision = run.Revision + 1
+	next.UpdatedAt = s.deps.Now().UTC()
+	if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+		return next, fmt.Errorf("persist local restart reconciliation pause: %w", err)
+	}
+	return next, nil
+}
+
+// pauseForRecovery records a discrepancy in the durable workflow projection
+// and uses the ordinary state-transition effect journal to publish the waiting
+// label and status comment when those projections are available.
+func (s *Service) pauseForRecovery(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, diagnosis RecoveryDiagnosis) (store.Run, error) {
+	reason := recoveryDiscrepancyReason(diagnosis)
+	if run.Status == store.StatusWaitingForHuman && strings.HasPrefix(run.LifecycleReason, "restart reconciliation paused:") {
+		return run, nil
+	}
+	next := run
+	next.Status = store.StatusWaitingForHuman
+	next.LifecycleReason = reason
+	next.UpdatedAt = s.deps.Now().UTC()
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		pending, err := journal.PendingEffect(ctx, run.ID)
+		if err != nil {
+			paused, pauseErr := s.pauseRunLocally(ctx, runStore, run, diagnosis)
+			if pauseErr != nil {
+				return paused, errors.Join(fmt.Errorf("inspect pending effect before pausing for reconciliation: %w", err), pauseErr)
+			}
+			return paused, fmt.Errorf("inspect pending effect before pausing for reconciliation: %w", err)
+		}
+		if pending != nil {
+			return s.pauseRunLocally(ctx, runStore, run, diagnosis)
+		}
+	}
+	if s.deps.GitHub == nil || strings.TrimSpace(next.StatusCommentID) == "" {
+		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return next, fmt.Errorf("persist restart reconciliation pause: %w", err)
+		}
+		return next, nil
+	}
+	issue, err := s.deps.GitHub.Issue(ctx, commandRepository(registration), next.IssueNumber)
+	if err != nil {
+		if saveErr := saveRunWithRetry(ctx, runStore, next); saveErr != nil {
+			return next, errors.Join(fmt.Errorf("read issue while pausing for reconciliation: %w", err), saveErr)
+		}
+		return next, fmt.Errorf("read issue while pausing for reconciliation: %w", err)
+	}
+	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
+		Repository: commandRepository(registration),
+		Issue:      issue,
+		Previous:   run,
+		Next:       next,
+	})
+	if err != nil {
+		return updated, fmt.Errorf("publish restart reconciliation pause: %w", err)
+	}
+	return updated, nil
+}
+
+// recoveryDiscrepancyReason renders a bounded single-line workflow reason so
+// the human can identify exactly which projection prevented continuation.
+func recoveryDiscrepancyReason(diagnosis RecoveryDiagnosis) string {
+	parts := make([]string, 0, len(diagnosis.Discrepancies))
+	for _, discrepancy := range diagnosis.Discrepancies {
+		parts = append(parts, fmt.Sprintf("%s.%s expected=%q observed=%q", discrepancy.Source, discrepancy.Field, safeStatusCommentValue(discrepancy.Expected), safeStatusCommentValue(discrepancy.Observed)))
+	}
+	if len(parts) == 0 {
+		return "restart reconciliation paused: unresolved discrepancy"
+	}
+	return "restart reconciliation paused: " + strings.Join(parts, "; ")
+}
+
+// newRecoveryDiagnosis creates the read-only comparison envelope and operator
+// actions that explain how a human can resolve a disagreement.
 func newRecoveryDiagnosis(runID string) RecoveryDiagnosis {
 	return RecoveryDiagnosis{
 		Code:  RecoveryRequiredCode,
@@ -111,46 +908,56 @@ func newRecoveryDiagnosis(runID string) RecoveryDiagnosis {
 		SafeActions: []string{
 			"inspect the diagnosis with `factory status`",
 			"verify the repository, worktree, branch, checkpoint, issue label, status comment, and pull request",
-			"wait for issue #21 before attempting automatic recovery",
+			"resolve the recorded discrepancy before retrying the run",
 		},
 	}
+}
+
+// appendPendingEffectAction makes the explicit abandonment path discoverable
+// in status output without implying that an ambiguous mutation is safe to
+// discard automatically.
+func appendPendingEffectAction(diagnosis *RecoveryDiagnosis) {
+	if diagnosis == nil || diagnosis.PendingEffect == nil {
+		return
+	}
+	diagnosis.SafeActions = append(diagnosis.SafeActions, fmt.Sprintf("after human review, run `factory reconcile --abandon-effect %s --reason <reason>`", diagnosis.PendingEffect.ID))
 }
 
 // comparePersistedRunIdentity validates the values that can be checked before
 // consulting external projections.
 func comparePersistedRunIdentity(diagnosis *RecoveryDiagnosis, repositoryPath string, run store.Run) {
 	if strings.TrimSpace(run.ID) == "" {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "identifier", Expected: "non-empty run identifier", Observed: "empty"})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "identifier", Expected: "non-empty run identifier", Observed: "empty"})
 	}
 	if strings.TrimSpace(run.RepositoryPath) == "" {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "repository", Expected: repositoryPath, Observed: "empty"})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "repository", Expected: repositoryPath, Observed: "empty"})
 	} else if strings.TrimSpace(repositoryPath) == "" || resolvePath(run.RepositoryPath) != resolvePath(repositoryPath) {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "repository", Expected: repositoryPath, Observed: run.RepositoryPath})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "repository", Expected: repositoryPath, Observed: run.RepositoryPath})
 	}
 	if strings.TrimSpace(run.Worktree) == "" {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "worktree", Expected: "non-empty worktree path", Observed: "empty"})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "worktree", Expected: "non-empty worktree path", Observed: "empty"})
 	} else if !filepath.IsAbs(run.Worktree) {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "worktree", Expected: "absolute worktree path", Observed: run.Worktree})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "worktree", Expected: "absolute worktree path", Observed: run.Worktree})
 	}
 	if strings.TrimSpace(run.Branch) == "" {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "branch", Expected: "non-empty branch", Observed: "empty"})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "branch", Expected: "non-empty branch", Observed: "empty"})
 	} else if strings.TrimSpace(run.ID) != "" {
 		expectedBranch := "factory/" + run.ID
 		if run.Branch != expectedBranch {
-			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "branch identity", Expected: expectedBranch, Observed: run.Branch})
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "branch identity", Expected: expectedBranch, Observed: run.Branch})
 		}
 	}
 	if strings.TrimSpace(run.CheckpointSHA) == "" {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "checkpoint", Expected: "non-empty checkpoint SHA", Observed: "empty"})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "checkpoint", Expected: "non-empty checkpoint SHA", Observed: "empty"})
 	}
 	if run.IssueNumber <= 0 {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "issue", Expected: "positive issue number", Observed: fmt.Sprintf("%d", run.IssueNumber)})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "issue", Expected: "positive issue number", Observed: fmt.Sprintf("%d", run.IssueNumber)})
 	}
 	if run.PullRequestNumber < 0 {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "pull request", Expected: "zero or positive pull-request number", Observed: fmt.Sprintf("%d", run.PullRequestNumber)})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "pull request", Expected: "zero or positive pull-request number", Observed: fmt.Sprintf("%d", run.PullRequestNumber)})
 	}
 	if run.PullRequestNumber == 0 && strings.TrimSpace(run.PullRequestURL) != "" {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "run", Field: "pull request", Expected: "number for persisted pull-request URL", Observed: run.PullRequestURL})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyWorkflow, Source: "run", Field: "pull request", Expected: "number for persisted pull-request URL", Observed: run.PullRequestURL})
 	}
 }
 
@@ -223,6 +1030,8 @@ func inspectGitHubProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, 
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: run.StatusCommentID, Observed: "missing"})
 	} else if !strings.Contains(comment.Body, marker) {
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment marker", Expected: marker, Observed: "marker missing"})
+	} else if comment.Body != statusCommentBody(run) {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: statusCommentBody(run), Observed: comment.Body})
 	} else if strings.TrimSpace(run.StatusCommentID) == "" {
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: "persisted comment " + comment.ID, Observed: "persisted identity missing"})
 	} else if comment.ID != run.StatusCommentID {
@@ -313,10 +1122,40 @@ func addRecoveryDiscrepancy(diagnosis *RecoveryDiagnosis, discrepancy RecoveryDi
 	if strings.TrimSpace(discrepancy.Source) == "" {
 		discrepancy.Source = "unknown"
 	}
+	if discrepancy.Kind == "" {
+		// Persisted run invariants are deterministic workflow failures. Every
+		// other untyped observation is uncertainty in an external projection and
+		// therefore infrastructure-owned.
+		if discrepancy.Source == "run" {
+			discrepancy.Kind = RecoveryDiscrepancyWorkflow
+		} else {
+			discrepancy.Kind = RecoveryDiscrepancyInfrastructure
+		}
+	}
 	diagnosis.Discrepancies = append(diagnosis.Discrepancies, discrepancy)
+}
+
+// hasWorkflowDiscrepancy reports whether reconciliation found deterministic
+// workflow data that cannot be repaired by retrying an external adapter.
+func hasWorkflowDiscrepancy(diagnosis RecoveryDiagnosis) bool {
+	for _, discrepancy := range diagnosis.Discrepancies {
+		if discrepancy.Kind == RecoveryDiscrepancyWorkflow {
+			return true
+		}
+	}
+	return false
 }
 
 // recoveryRequiredError wraps a diagnosis in the typed progression refusal.
 func recoveryRequiredError(diagnosis RecoveryDiagnosis) error {
 	return &RecoveryRequiredError{Diagnosis: diagnosis}
+}
+
+// recoveryDiscrepancyError classifies a legacy-store startup refusal while
+// retaining RecoveryRequiredError through the typed error's unwrap chain.
+func recoveryDiscrepancyError(diagnosis RecoveryDiagnosis) error {
+	if hasWorkflowDiscrepancy(diagnosis) {
+		return &WorkflowFailureError{RunID: diagnosis.RunID, Cause: recoveryRequiredError(diagnosis)}
+	}
+	return &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
 }

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -1,0 +1,347 @@
+package factory
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/prompt"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+const journalRecoveryImageDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart verifies the
+// real startup reconciliation path accepts matching projections, resumes the
+// native session once, persists the resume ceiling, and performs no second
+// resume when a fresh coordinator starts again.
+func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(worktreePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	packet := SpecificationPacket{
+		Version: specificationPacketVersion,
+		Issue:   github.Issue{Number: 42, Title: "Journaled recovery", Body: "resume the active invocation"},
+		RepositoryConfig: config.RepositoryConfig{
+			TargetBranch: "main",
+			WorkerBuild:  config.WorkerBuildConfig{Image: "ghcr.io/example/factory-worker"},
+		},
+	}
+	packetData, err := json.Marshal(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	run := store.Run{
+		ID:                  "run-journaled-recovery",
+		RepositoryPath:      root,
+		IssueNumber:         packet.Issue.Number,
+		Stage:               store.StageImplementation,
+		Status:              store.StatusActive,
+		Branch:              "factory/run-journaled-recovery",
+		Worktree:            worktreePath,
+		CheckpointSHA:       "checkpoint-journaled-recovery",
+		ImageDigest:         journalRecoveryImageDigest,
+		Coordinator:         "coordinator-test",
+		StatusCommentID:     "status-journaled-recovery",
+		SpecificationPacket: string(packetData),
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	invocationDirectory := filepath.Join(root, "invocation")
+	resultDirectory := filepath.Join(root, "results")
+	if err := os.MkdirAll(invocationDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(resultDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	invocation := store.Invocation{
+		ID:                      "inv-journaled-recovery",
+		RunID:                   run.ID,
+		Harness:                 harness.NameCodex,
+		Role:                    "implementation",
+		Stage:                   store.StageImplementation,
+		Model:                   "gpt-5",
+		NativeSessionID:         "session-journaled-recovery",
+		WorkspaceID:             "workspace-journaled-recovery",
+		StatusSurfaceID:         "surface-status-journaled-recovery",
+		ImplementationSurfaceID: "surface-implementation-journaled-recovery",
+		ChecksSurfaceID:         "surface-checks-journaled-recovery",
+		InvocationDirectory:     invocationDirectory,
+		ResultDirectory:         resultDirectory,
+		PromptVersion:           prompt.VersionFor("implementation", string(store.StageImplementation)),
+		Status:                  store.InvocationStatusActive,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+	opened, err := store.Open(ctx, filepath.Join(root, "state", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	if err := opened.SaveRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeInvocationPacket(invocationDirectory, InvocationPacket{
+		SchemaVersion:       invocationPacketVersion,
+		InvocationID:        invocation.ID,
+		RunID:               run.ID,
+		Role:                invocation.Role,
+		Stage:               invocation.Stage,
+		SpecificationPacket: run.SpecificationPacket,
+		PromptVersion:       invocation.PromptVersion,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	registration := config.RepositoryRegistration{
+		Path:   root,
+		GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+	}
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{factoryLabelForStatus(run.Status)}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(run)},
+	}
+	workspace := &journalRecoveryWorkspace{state: gitadapter.WorktreeState{
+		RepositoryPath: root,
+		Branch:         run.Branch,
+		HeadSHA:        run.CheckpointSHA,
+	}}
+	workerRequest := worker.StartRequest{
+		RunID:           run.ID,
+		WorktreePath:    run.Worktree,
+		GitMetadataPath: gitMetadataProjectionPath(run.ID, run.Worktree),
+		Image:           packet.RepositoryConfig.WorkerBuild.Image,
+		ImageDigest:     run.ImageDigest,
+		InvocationPath:  invocation.InvocationDirectory,
+		ResultPath:      invocation.ResultDirectory,
+		Role:            invocation.Role,
+	}
+	workerRuntime := &journalRecoveryWorker{inspection: worker.Inspection{
+		Exists:           true,
+		Running:          true,
+		Image:            workerRequest.Image + "@" + workerRequest.ImageDigest,
+		MountFingerprint: worker.MountContractFingerprint(workerRequest),
+	}}
+	terminalRuntime := &journalRecoveryTerminal{inspection: terminal.WorkspaceInspection{
+		Exists:      true,
+		WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID),
+		Surfaces: []terminal.Surface{
+			{ID: terminal.SurfaceID(invocation.StatusSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+			{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+			{ID: terminal.SurfaceID(invocation.ChecksSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+		},
+	}}
+	harnessRuntime := &journalRecoveryHarness{nativeSessionID: invocation.NativeSessionID}
+	service := &Service{deps: Dependencies{
+		GitHub:       githubRuntime,
+		GitWorkspace: workspace,
+		Worker:       workerRuntime,
+		Terminal:     terminalRuntime,
+		Harness:      harnessRuntime,
+		Now:          func() time.Time { return now },
+	}}
+
+	updatedRun := run
+	if err := service.ensureAgentStartup(ctx, registration, opened, &updatedRun, AgentRequest{}); err != nil {
+		t.Fatalf("first journaled startup = %v", err)
+	}
+	if harnessRuntime.resumeCalls != 1 {
+		t.Fatalf("native resumes after first startup = %d, want one", harnessRuntime.resumeCalls)
+	}
+	persisted, err := opened.Invocation(ctx, run.ID, invocation.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted == nil || persisted.RecoveryResumeCount != 1 {
+		t.Fatalf("persisted invocation after first startup = %#v, want resume count one", persisted)
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending != nil {
+		t.Fatalf("pending effect after first startup = %#v, want cleared", pending)
+	}
+
+	fresh := &Service{deps: service.deps}
+	freshRun, err := opened.CurrentRun(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if freshRun == nil {
+		t.Fatal("fresh coordinator fixture lost its run")
+	}
+	if err := fresh.ensureAgentStartup(ctx, registration, opened, freshRun, AgentRequest{}); err != nil {
+		t.Fatalf("second journaled startup = %v", err)
+	}
+	if harnessRuntime.resumeCalls != 1 {
+		t.Fatalf("native resumes after second startup = %d, want no duplicate", harnessRuntime.resumeCalls)
+	}
+}
+
+// journalRecoveryWorkspace supplies the read-only Git projection and no-op
+// task methods needed by the journaled startup fixture.
+type journalRecoveryWorkspace struct {
+	state gitadapter.WorktreeState
+}
+
+// Create satisfies the Git workspace seam for a recovery-only fixture.
+func (*journalRecoveryWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	return gitadapter.Workspace{}, nil
+}
+
+// Remove satisfies the Git workspace seam for a recovery-only fixture.
+func (*journalRecoveryWorkspace) Remove(context.Context, string, gitadapter.Workspace) error {
+	return nil
+}
+
+// Inspect returns the persisted worktree projection.
+func (w *journalRecoveryWorkspace) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	return w.state, nil
+}
+
+// CreateCheckpoint satisfies the Git workspace seam for a recovery-only fixture.
+func (*journalRecoveryWorkspace) CreateCheckpoint(context.Context, gitadapter.CheckpointRequest) (gitadapter.CheckpointResult, error) {
+	return gitadapter.CheckpointResult{}, nil
+}
+
+// Push satisfies the Git workspace seam for a recovery-only fixture.
+func (*journalRecoveryWorkspace) Push(context.Context, gitadapter.PushRequest) error { return nil }
+
+// SynchronizeBase satisfies the Git workspace seam for a recovery-only fixture.
+func (*journalRecoveryWorkspace) SynchronizeBase(context.Context, gitadapter.BaseSyncRequest) error {
+	return nil
+}
+
+var _ gitadapter.GitWorkspace = (*journalRecoveryWorkspace)(nil)
+
+// journalRecoveryWorker supplies a matching active worker projection without
+// exposing the worker's private runtime identity to the factory test.
+type journalRecoveryWorker struct {
+	inspection worker.Inspection
+}
+
+// Start satisfies WorkerRuntime for the no-launch recovery fixture.
+func (*journalRecoveryWorker) Start(context.Context, worker.StartRequest) error { return nil }
+
+// Resume satisfies WorkerRuntime for the no-launch recovery fixture.
+func (*journalRecoveryWorker) Resume(context.Context, worker.ResumeRequest) error { return nil }
+
+// RunCommand satisfies WorkerRuntime for the no-launch recovery fixture.
+func (*journalRecoveryWorker) RunCommand(context.Context, worker.CommandRequest) (worker.CommandResult, error) {
+	return worker.CommandResult{}, nil
+}
+
+// Stop satisfies WorkerRuntime for the no-launch recovery fixture.
+func (*journalRecoveryWorker) Stop(context.Context, string) error { return nil }
+
+// Inspect returns the matching active worker projection.
+func (w *journalRecoveryWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+	return w.inspection, nil
+}
+
+var _ worker.WorkerRuntime = (*journalRecoveryWorker)(nil)
+
+// journalRecoveryTerminal supplies the persisted cmux workspace projection.
+type journalRecoveryTerminal struct {
+	inspection terminal.WorkspaceInspection
+}
+
+// EnsureControlWorkspace satisfies TerminalRuntime for the recovery fixture.
+func (*journalRecoveryTerminal) EnsureControlWorkspace(context.Context, terminal.WorkspaceRequest) (terminal.Workspace, error) {
+	return terminal.Workspace{ID: "workspace-control"}, nil
+}
+
+// EnsureRunWorkspace satisfies TerminalRuntime for the recovery fixture.
+func (*journalRecoveryTerminal) EnsureRunWorkspace(context.Context, terminal.RunWorkspaceRequest) (terminal.RunWorkspace, error) {
+	return terminal.RunWorkspace{}, nil
+}
+
+// CreateSurface satisfies TerminalRuntime for the recovery fixture.
+func (*journalRecoveryTerminal) CreateSurface(context.Context, terminal.SurfaceRequest) (terminal.Surface, error) {
+	return terminal.Surface{}, nil
+}
+
+// LaunchSurface satisfies TerminalRuntime for the recovery fixture.
+func (*journalRecoveryTerminal) LaunchSurface(context.Context, terminal.SurfaceID, terminal.Command) error {
+	return nil
+}
+
+// SendInput satisfies TerminalRuntime for the recovery fixture.
+func (*journalRecoveryTerminal) SendInput(context.Context, terminal.SurfaceID, []byte) error {
+	return nil
+}
+
+// Notify satisfies TerminalRuntime for the recovery fixture.
+func (*journalRecoveryTerminal) Notify(context.Context, terminal.Notification) error { return nil }
+
+// CloseSurface satisfies TerminalRuntime for the recovery fixture.
+func (*journalRecoveryTerminal) CloseSurface(context.Context, terminal.SurfaceID) error { return nil }
+
+// CloseWorkspace satisfies TerminalRuntime for the recovery fixture.
+func (*journalRecoveryTerminal) CloseWorkspace(context.Context, terminal.WorkspaceID) error {
+	return nil
+}
+
+// InspectWorkspace returns the persisted terminal topology.
+func (t *journalRecoveryTerminal) InspectWorkspace(context.Context, terminal.WorkspaceID) (terminal.WorkspaceInspection, error) {
+	return t.inspection, nil
+}
+
+var _ terminal.TerminalRuntime = (*journalRecoveryTerminal)(nil)
+var _ terminal.WorkspaceInspector = (*journalRecoveryTerminal)(nil)
+
+// journalRecoveryHarness supplies native-session identity and counts resume
+// calls so the startup test can detect duplicate continuation.
+type journalRecoveryHarness struct {
+	nativeSessionID string
+	resumeCalls     int
+}
+
+// Capabilities reports Codex's native continuation support.
+func (*journalRecoveryHarness) Capabilities() harness.Capabilities {
+	return harness.Capabilities{Name: harness.NameCodex, InteractiveResume: true}
+}
+
+// Start satisfies Runtime for the restart-only fixture.
+func (*journalRecoveryHarness) Start(context.Context, harness.StartRequest) (harness.Session, error) {
+	return harness.Session{}, nil
+}
+
+// Resume counts one native continuation and returns its stable identity.
+func (h *journalRecoveryHarness) Resume(_ context.Context, request harness.StartRequest) (harness.Session, error) {
+	h.resumeCalls++
+	return harness.Session{InvocationID: request.InvocationID, NativeSessionID: h.nativeSessionID, Surface: request.Surface}, nil
+}
+
+// Finish satisfies Runtime for the restart-only fixture.
+func (*journalRecoveryHarness) Finish(context.Context, harness.Session) error { return nil }
+
+// NativeSessionID returns the stable native session projection.
+func (h *journalRecoveryHarness) NativeSessionID(context.Context, harness.NativeSessionRequest) (string, error) {
+	return h.nativeSessionID, nil
+}
+
+var _ harness.Runtime = (*journalRecoveryHarness)(nil)
+var _ harness.NativeSessionInspector = (*journalRecoveryHarness)(nil)

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
+// journalRecoveryImageDigest is the frozen worker image identity used by the
+// journaled restart fixture.
 const journalRecoveryImageDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 // TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart verifies the

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -118,9 +118,11 @@ func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T)
 		t.Fatal(err)
 	}
 
+	databasePath := filepath.Join(root, "state", "factory.db")
 	registration := config.RepositoryRegistration{
-		Path:   root,
-		GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		Path:                root,
+		OperationalDataPath: databasePath,
+		GitHub:              config.GitHubConfig{Owner: "example", Repository: "project"},
 	}
 	githubRuntime := &effectMatrixGitHub{
 		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{factoryLabelForStatus(run.Status)}},
@@ -163,11 +165,13 @@ func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T)
 		Worker:       workerRuntime,
 		Terminal:     terminalRuntime,
 		Harness:      harnessRuntime,
-		Now:          func() time.Time { return now },
+		OpenStore: func(ctx context.Context, path string) (OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		Now: func() time.Time { return now },
 	}}
 
-	updatedRun := run
-	if err := service.ensureAgentStartup(ctx, registration, opened, &updatedRun, AgentRequest{}); err != nil {
+	if err := service.reconcileRegisteredRun(ctx, registration); err != nil {
 		t.Fatalf("first journaled startup = %v", err)
 	}
 	if harnessRuntime.resumeCalls != 1 {
@@ -196,12 +200,69 @@ func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T)
 	if freshRun == nil {
 		t.Fatal("fresh coordinator fixture lost its run")
 	}
-	if err := fresh.ensureAgentStartup(ctx, registration, opened, freshRun, AgentRequest{}); err != nil {
+	if err := fresh.reconcileRegisteredRun(ctx, registration); err != nil {
 		t.Fatalf("second journaled startup = %v", err)
 	}
 	if harnessRuntime.resumeCalls != 1 {
 		t.Fatalf("native resumes after second startup = %d, want no duplicate", harnessRuntime.resumeCalls)
 	}
+}
+
+// TestRecoveryInspectsTheLatestTerminalInvocation verifies a stage boundary
+// cannot bypass Docker, cmux, and native-session reconciliation merely because
+// its newest persisted invocation is already terminal.
+func TestRecoveryInspectsTheLatestTerminalInvocation(t *testing.T) {
+	now := time.Unix(1, 0).UTC()
+	run := store.Run{ID: "run-terminal-projection", Stage: store.StageDraftPR, Status: store.StatusActive}
+	invocation := store.Invocation{
+		ID: "inv-terminal-projection", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-terminal-projection", WorkspaceID: "workspace-terminal-projection",
+		ImplementationSurfaceID: "surface-terminal-projection",
+		Status:                  store.InvocationStatusCompleted, CreatedAt: now, UpdatedAt: now,
+	}
+	workerRuntime := &journalRecoveryWorker{inspectErr: errors.New("worker projection unavailable")}
+	terminalRuntime := &journalRecoveryTerminal{inspection: terminal.WorkspaceInspection{
+		Exists: true, WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID),
+		Surfaces: []terminal.Surface{{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)}},
+	}}
+	service := &Service{deps: Dependencies{
+		Worker: workerRuntime, Terminal: terminalRuntime,
+		Harness: &journalRecoveryHarness{nativeSessionID: invocation.NativeSessionID},
+	}}
+	baseStore := &repairLaunchStore{run: run, invocations: map[string]store.Invocation{invocation.ID: invocation}}
+	runStore := &terminalProjectionStore{repairLaunchStore: baseStore}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+
+	service.inspectInvocationProjection(context.Background(), &diagnosis, config.RepositoryRegistration{}, runStore, run)
+	if workerRuntime.inspectCalls != 1 {
+		t.Fatalf("worker inspections = %d, want one for latest terminal invocation", workerRuntime.inspectCalls)
+	}
+	found := false
+	for _, discrepancy := range diagnosis.Discrepancies {
+		if discrepancy.Source == "worker" && discrepancy.Field == "inspection" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("recovery discrepancies = %#v, want terminal worker inspection failure", diagnosis.Discrepancies)
+	}
+}
+
+// terminalProjectionStore exposes a latest terminal invocation while reporting
+// that no active invocation exists at the stage boundary.
+type terminalProjectionStore struct {
+	*repairLaunchStore
+}
+
+// ActiveInvocation reports the expected absence of an active invocation.
+func (*terminalProjectionStore) ActiveInvocation(context.Context, string) (*store.Invocation, error) {
+	return nil, nil
+}
+
+// HasInvocation reports the terminal invocation history.
+func (*terminalProjectionStore) HasInvocation(context.Context, string) (bool, error) {
+	return true, nil
 }
 
 // journalRecoveryWorkspace supplies the read-only Git projection and no-op
@@ -243,7 +304,9 @@ var _ gitadapter.GitWorkspace = (*journalRecoveryWorkspace)(nil)
 // journalRecoveryWorker supplies a matching active worker projection without
 // exposing the worker's private runtime identity to the factory test.
 type journalRecoveryWorker struct {
-	inspection worker.Inspection
+	inspection   worker.Inspection
+	inspectErr   error
+	inspectCalls int
 }
 
 // Start satisfies WorkerRuntime for the no-launch recovery fixture.
@@ -262,7 +325,8 @@ func (*journalRecoveryWorker) Stop(context.Context, string) error { return nil }
 
 // Inspect returns the matching active worker projection.
 func (w *journalRecoveryWorker) Inspect(context.Context, string) (worker.Inspection, error) {
-	return w.inspection, nil
+	w.inspectCalls++
+	return w.inspection, w.inspectErr
 }
 
 var _ worker.WorkerRuntime = (*journalRecoveryWorker)(nil)

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -3,6 +3,7 @@ package factory
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -319,6 +320,7 @@ var _ terminal.WorkspaceInspector = (*journalRecoveryTerminal)(nil)
 type journalRecoveryHarness struct {
 	nativeSessionID string
 	resumeCalls     int
+	failResumeOnce  bool
 }
 
 // Capabilities reports Codex's native continuation support.
@@ -334,7 +336,12 @@ func (*journalRecoveryHarness) Start(context.Context, harness.StartRequest) (har
 // Resume counts one native continuation and returns its stable identity.
 func (h *journalRecoveryHarness) Resume(_ context.Context, request harness.StartRequest) (harness.Session, error) {
 	h.resumeCalls++
-	return harness.Session{InvocationID: request.InvocationID, NativeSessionID: h.nativeSessionID, Surface: request.Surface}, nil
+	session := harness.Session{InvocationID: request.InvocationID, NativeSessionID: h.nativeSessionID, Surface: request.Surface}
+	if h.failResumeOnce {
+		h.failResumeOnce = false
+		return session, errors.New("native resume response lost")
+	}
+	return session, nil
 }
 
 // Finish satisfies Runtime for the restart-only fixture.

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -354,3 +355,88 @@ func (h *journalRecoveryHarness) NativeSessionID(context.Context, harness.Native
 
 var _ harness.Runtime = (*journalRecoveryHarness)(nil)
 var _ harness.NativeSessionInspector = (*journalRecoveryHarness)(nil)
+
+// ancestryGitWorkspace reports a remote head plus a fixed ancestry answer so a
+// reconciliation test can distinguish an unpushed checkpoint from a diverged
+// branch without running Git.
+type ancestryGitWorkspace struct {
+	remoteHead string
+	ancestor   bool
+	calls      int
+}
+
+// Create satisfies the Git workspace seam.
+func (*ancestryGitWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	return gitadapter.Workspace{}, nil
+}
+
+// Remove satisfies the Git workspace seam.
+func (*ancestryGitWorkspace) Remove(context.Context, string, gitadapter.Workspace) error { return nil }
+
+// Inspect satisfies the read-only worktree seam.
+func (*ancestryGitWorkspace) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	return gitadapter.WorktreeState{}, nil
+}
+
+// CreateCheckpoint satisfies the Git workspace seam.
+func (*ancestryGitWorkspace) CreateCheckpoint(context.Context, gitadapter.CheckpointRequest) (gitadapter.CheckpointResult, error) {
+	return gitadapter.CheckpointResult{}, nil
+}
+
+// Push satisfies the Git workspace seam.
+func (*ancestryGitWorkspace) Push(context.Context, gitadapter.PushRequest) error { return nil }
+
+// SynchronizeBase satisfies the Git workspace seam.
+func (*ancestryGitWorkspace) SynchronizeBase(context.Context, gitadapter.BaseSyncRequest) error {
+	return nil
+}
+
+// RemoteBranchHead returns the configured remote projection.
+func (w *ancestryGitWorkspace) RemoteBranchHead(context.Context, gitadapter.PushRequest) (string, error) {
+	return w.remoteHead, nil
+}
+
+// IsAncestor reports the configured reachability answer.
+func (w *ancestryGitWorkspace) IsAncestor(_ context.Context, _, _, _ string) (bool, error) {
+	w.calls++
+	return w.ancestor, nil
+}
+
+var _ gitadapter.GitWorkspace = (*ancestryGitWorkspace)(nil)
+var _ gitadapter.RemoteBranchInspector = (*ancestryGitWorkspace)(nil)
+var _ gitadapter.AncestryInspector = (*ancestryGitWorkspace)(nil)
+
+// TestRemoteBranchBehindCheckpointIsNotADiscrepancy verifies that an unpushed
+// checkpoint does not pause the run. A checkpoint is committed and persisted
+// before the gate suite runs and pushed only afterwards, so a remote head that
+// is an ancestor of the local checkpoint is an ordinary in-flight state.
+func TestRemoteBranchBehindCheckpointIsNotADiscrepancy(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	run := store.Run{
+		ID: "run-remote", Branch: "factory/run-remote", Worktree: "/worktree",
+		CheckpointSHA: strings.Repeat("b", 40), PullRequestNumber: 7,
+	}
+	behind := &ancestryGitWorkspace{remoteHead: strings.Repeat("a", 40), ancestor: true}
+	diagnosis := RecoveryDiagnosis{}
+	inspectRemoteBranchProjection(ctx, &diagnosis, behind, run)
+	if len(diagnosis.Discrepancies) != 0 {
+		t.Fatalf("discrepancies for an unpushed checkpoint = %#v, want none", diagnosis.Discrepancies)
+	}
+	if behind.calls != 1 {
+		t.Fatalf("ancestry checks = %d, want one", behind.calls)
+	}
+
+	// A remote head that is not reachable from the checkpoint has diverged and
+	// must still pause the run.
+	diverged := &ancestryGitWorkspace{remoteHead: strings.Repeat("c", 40), ancestor: false}
+	divergedDiagnosis := RecoveryDiagnosis{}
+	inspectRemoteBranchProjection(ctx, &divergedDiagnosis, diverged, run)
+	if len(divergedDiagnosis.Discrepancies) != 1 {
+		t.Fatalf("discrepancies for a diverged branch = %#v, want one", divergedDiagnosis.Discrepancies)
+	}
+	if divergedDiagnosis.Discrepancies[0].Field != "head" {
+		t.Fatalf("diverged discrepancy field = %q, want %q", divergedDiagnosis.Discrepancies[0].Field, "head")
+	}
+}

--- a/internal/factory/recovery_test.go
+++ b/internal/factory/recovery_test.go
@@ -30,7 +30,7 @@ func TestProgressionRefusesAnAgreeingInterruptedRun(t *testing.T) {
 	run := recoveryRun(worktreePath)
 	githubAdapter := &fakeGitHub{
 		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
-		statusComment: github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: run-recovery -->"},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)},
 	}
 	worktree := &recoveryWorktree{state: gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA}}
 	storeAdapter := &recoveryRunStore{run: run}
@@ -105,8 +105,15 @@ func TestStatusReportsEveryRecoveryDiscrepancy(t *testing.T) {
 		},
 		{
 			name: "mismatched status comment",
-			configure: func(_ *store.Run, _ *recoveryWorktree, githubAdapter *fakeGitHub, _ *fakePullRequests) {
-				githubAdapter.statusComment = github.Comment{ID: "comment-other", Body: "<!-- factory-status: run-recovery -->"}
+			configure: func(run *store.Run, _ *recoveryWorktree, githubAdapter *fakeGitHub, _ *fakePullRequests) {
+				githubAdapter.statusComment = github.Comment{ID: "comment-other", Body: factory.StatusCommentBody(*run)}
+			},
+			wantFields: []string{"github.status comment"},
+		},
+		{
+			name: "stale status comment body",
+			configure: func(run *store.Run, _ *recoveryWorktree, githubAdapter *fakeGitHub, _ *fakePullRequests) {
+				githubAdapter.statusComment.Body = factory.StatusCommentBody(*run) + "\nstale projection"
 			},
 			wantFields: []string{"github.status comment"},
 		},
@@ -140,7 +147,7 @@ func TestStatusReportsEveryRecoveryDiscrepancy(t *testing.T) {
 			run := recoveryRun(worktreePath)
 			githubAdapter := &fakeGitHub{
 				issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
-				statusComment: github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: run-recovery -->"},
+				statusComment: github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)},
 			}
 			worktree := &recoveryWorktree{state: gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA}}
 			pullRequests := &fakePullRequests{}
@@ -171,6 +178,82 @@ func TestStatusReportsEveryRecoveryDiscrepancy(t *testing.T) {
 				t.Fatalf("status effects = saved=%d labels=%d comments=%d, want none", len(storeAdapter.saved), len(githubAdapter.replacedHistory), len(githubAdapter.editedComments))
 			}
 		})
+	}
+}
+
+// TestAbandonPendingEffectLeavesTheRunWaitingForHuman verifies that an
+// explicitly abandoned ambiguous mutation is removed from the journal while
+// the workflow remains paused instead of silently continuing.
+func TestAbandonPendingEffectLeavesTheRunWaitingForHuman(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	worktreePath := filepath.Join(root, "worktree")
+	if err := mkdir(worktreePath); err != nil {
+		t.Fatal(err)
+	}
+	databasePath := filepath.Join(root, "state", "factory.db")
+	ctx := context.Background()
+	opened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := recoveryRun(worktreePath)
+	run.RepositoryPath = root
+	run.Coordinator = "coordinator-test"
+	if err := opened.SaveRun(ctx, run); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	effect := store.PendingEffect{RunID: run.ID, ID: "effect-abandon", Kind: store.PendingEffectKindPush, Payload: "{}"}
+	if err := opened.SavePendingEffect(ctx, effect); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: root, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		OperationalDataPath: databasePath, RepositoryConfigPath: filepath.Join(root, "factory.yaml"),
+	}}}
+	githubAdapter := &fakeGitHub{
+		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)},
+	}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:    &fakeConfig{value: host},
+		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) { return store.Open(ctx, path) },
+		GitHub:    githubAdapter,
+		Now:       func() time.Time { return time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC) },
+	})
+	result, err := service.AbandonPendingEffect(ctx, factory.AbandonPendingEffectRequest{RunID: run.ID, EffectID: effect.ID, Reason: "operator verified the remote branch manually"})
+	if err != nil {
+		t.Fatalf("AbandonPendingEffect() error = %v", err)
+	}
+	if result.Run == nil || result.Run.Status != store.StatusWaitingForHuman || result.Outcome != factory.RecoveryOutcomeWaitingForHuman {
+		t.Fatalf("abandon result = %#v, want waiting-for-human run", result)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending != nil {
+		t.Fatalf("pending effect after abandonment = %#v, want nil", pending)
+	}
+	latest, err := reopened.LatestRun(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if latest == nil || latest.Status != store.StatusWaitingForHuman {
+		t.Fatalf("latest run after abandonment = %#v, want waiting-for-human", latest)
 	}
 }
 

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -407,6 +407,21 @@ func (s *Service) routeCheckRepair(ctx context.Context, registration config.Repo
 			baseResult.Remaining = remainingCheckRepairBudget(updated.CheckRepairAttempts, updated.CheckRepairBudget)
 			return baseResult, nil
 		}
+		if journal, journaled := runStore.(PendingEffectStore); journaled {
+			pending, pendingErr := journal.PendingEffect(ctx, run.ID)
+			if pendingErr != nil {
+				return baseResult, errors.Join(launchErr, fmt.Errorf("inspect pending check-repair effect: %w", pendingErr))
+			}
+			if pending != nil {
+				// The failed launch has a durable external intent. Do not issue a
+				// competing stop or state transition; startup reconciliation owns
+				// the retry and the one-effect invariant.
+				baseResult.Run = updated
+				baseResult.Attempt = updated.CheckRepairAttempts
+				baseResult.Remaining = remainingCheckRepairBudget(updated.CheckRepairAttempts, updated.CheckRepairBudget)
+				return baseResult, launchErr
+			}
+		}
 		next := updated
 		next.CheckRepairBudget = run.CheckRepairBudget
 		if errors.Is(launchErr, ErrCheckRepairSessionUnavailable) {
@@ -552,6 +567,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 	workerStarted := false
 	attemptReserved := false
 	resumeStarted := false
+	_, journaled := runStore.(PendingEffectStore)
 	reservedRun := run
 	persistedInvocation := invocation
 	defer func() {
@@ -560,8 +576,16 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		}
 		rollbackContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
-		if workerStarted {
+		if workerStarted && !(journaled && resumeStarted) {
 			_ = s.deps.Worker.Stop(rollbackContext, run.ID)
+		}
+		if journaled && resumeStarted {
+			// A journaled resume crossed an external boundary. Leave its active
+			// worker and invocation available for the pending state/resume
+			// effect to reconcile instead of declaring a successful session
+			// unusable during error cleanup.
+			updated = reservedRun
+			return
 		}
 		if attemptReserved && !resumeStarted {
 			rollbackErr := s.persistAgentRunState(rollbackContext, registration, runStore, reservedRun, run)
@@ -619,7 +643,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 	if err != nil {
 		return store.Invocation{}, run, fmt.Errorf("prepare check-repair Git metadata: %w", err)
 	}
-	if err := s.deps.Worker.Start(ctx, worker.StartRequest{
+	workerRequest := worker.StartRequest{
 		RunID:             run.ID,
 		WorktreePath:      run.Worktree,
 		GitMetadataPath:   gitMetadataPath,
@@ -630,7 +654,8 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		ResultPath:        resultDirectory,
 		CredentialStoreID: credentialStoreID,
 		Role:              previous.Role,
-	}); err != nil {
+	}
+	if err := s.startWorkerWithEffect(ctx, runStore, workerRequest); err != nil {
 		return store.Invocation{}, run, fmt.Errorf("start worker for check repair: %w", err)
 	}
 	workerStarted = true
@@ -647,7 +672,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 	reservedRun = next
 	attemptReserved = true
 	updated = reservedRun
-	session, err := harnessRuntime.Resume(ctx, harness.StartRequest{
+	resumeRequest := harness.StartRequest{
 		InvocationID:    invocation.ID,
 		RunID:           run.ID,
 		Role:            previous.Role,
@@ -658,18 +683,16 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		Model:           previous.Model,
 		ReasoningEffort: previous.ReasoningEffort,
 		ResumeSessionID: previous.NativeSessionID,
-	})
-	if err != nil {
-		return store.Invocation{}, run, fmt.Errorf("resume %s implementation agent for check repair: %w", previous.Harness, err)
 	}
-	resumeStarted = true
-	if session.NativeSessionID != "" {
-		invocation.NativeSessionID = session.NativeSessionID
+	resumedInvocation, resumeErr := s.resumeHarnessWithEffect(ctx, runStore, invocationStore, registration.Cmux.SocketPath, harnessRuntime, invocation, resumeRequest)
+	if resumedInvocation.RecoveryResumeCount > invocation.RecoveryResumeCount {
+		resumeStarted = true
 	}
+	if resumeErr != nil {
+		return store.Invocation{}, run, fmt.Errorf("resume %s implementation agent for check repair: %w", previous.Harness, resumeErr)
+	}
+	invocation = resumedInvocation
 	persistedInvocation = invocation
-	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
-		return store.Invocation{}, run, fmt.Errorf("persist check-repair native session: %w", err)
-	}
 	if recorder, ok := runStore.(evaluationRecorder); ok {
 		if err := recorder.RecordEvaluationAttempt(ctx, run.ID, store.EvaluationAttemptCheckRepair); err != nil {
 			return store.Invocation{}, run, fmt.Errorf("record check-repair attempt: %w", err)

--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -148,7 +148,7 @@ func (s *Service) captureReviewDiff(ctx context.Context, run store.Run) (string,
 // The stable context is deliberately independent of invocation identity so a
 // later review replaces the status for the same checkpoint rather than adding
 // an unrelated status stream.
-func (s *Service) publishSpecificationReviewStatus(ctx context.Context, registration config.RepositoryRegistration, run store.Run, state github.CommitStatusState, description string) error {
+func (s *Service) publishSpecificationReviewStatus(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, state github.CommitStatusState, description string) error {
 	if s.deps.CommitStatuses == nil {
 		return errors.New("commit-status publisher is required for specification review")
 	}
@@ -156,7 +156,9 @@ func (s *Service) publishSpecificationReviewStatus(ctx context.Context, registra
 		return errors.New("specification review requires a valid checkpoint SHA")
 	}
 	description = reviewStatusDescription(description)
-	return s.deps.CommitStatuses.CreateCommitStatus(ctx, github.Repository{
+	statuses := github.CommitStatusPublisher(s.deps.CommitStatuses)
+	statuses = commitStatusPublisher{service: s, runStore: runStore, runID: run.ID, delegate: statuses}
+	return statuses.CreateCommitStatus(ctx, github.Repository{
 		Owner: registration.GitHub.Owner,
 		Name:  registration.GitHub.Repository,
 	}, github.CommitStatus{
@@ -287,14 +289,14 @@ func (s *Service) acceptSpecificationReviewReport(ctx context.Context, registrat
 		return AgentResult{}, fmt.Errorf("unsupported specification review outcome %q", value.Outcome)
 	}
 	run.UpdatedAt = s.deps.Now().UTC()
-	if err := s.publishSpecificationReviewStatus(ctx, registration, *run, statusState, statusDescription); err != nil {
+	if err := s.publishSpecificationReviewStatus(ctx, registration, runStore, *run, statusState, statusDescription); err != nil {
 		return AgentResult{}, fmt.Errorf("publish specification review status: %w", err)
 	}
 	if err := s.persistAgentRunState(ctx, registration, runStore, previous, *run); err != nil {
 		return AgentResult{}, fmt.Errorf("persist specification review state: %w", err)
 	}
 	if value.Outcome == report.OutcomeCompleted {
-		if err := s.refreshSpecificationReviewPullRequest(ctx, registration, *run); err != nil {
+		if err := s.refreshSpecificationReviewPullRequest(ctx, registration, runStore, *run); err != nil {
 			return AgentResult{}, err
 		}
 	}
@@ -310,7 +312,7 @@ func (s *Service) acceptSpecificationReviewReport(ctx context.Context, registrat
 
 // refreshSpecificationReviewPullRequest updates only the generated review
 // subsection of the tracked draft PR, preserving all human-authored text.
-func (s *Service) refreshSpecificationReviewPullRequest(ctx context.Context, registration config.RepositoryRegistration, run store.Run) error {
+func (s *Service) refreshSpecificationReviewPullRequest(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) error {
 	client := s.pullRequestClient()
 	if client == nil {
 		return errors.New("GitHub client does not support pull-request operations")
@@ -328,13 +330,24 @@ func (s *Service) refreshSpecificationReviewPullRequest(ctx context.Context, reg
 		return fmt.Errorf("tracked pull request #%d was not found for review projection", run.PullRequestNumber)
 	}
 	body := mergeGeneratedReviewSection(existing.Body, generatedReviewSection(run))
-	updated, err := client.UpdatePullRequest(ctx, repository, existing.Number, github.PullRequestRequest{
+	updateRequest := github.PullRequestRequest{
 		Title:      defaultString(existing.Title, defaultString(packet.Issue.Title, fmt.Sprintf("Issue #%d", packet.Issue.Number))),
 		Body:       body,
 		HeadBranch: run.Branch,
 		BaseBranch: packet.RepositoryConfig.TargetBranch,
 		Draft:      true,
-	})
+	}
+	updated := existing
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		if err := s.updatePullRequestWithEffect(ctx, runStore, run.ID, client, repository, existing.Number, updateRequest); err != nil {
+			return fmt.Errorf("update pull request with specification review: %w", err)
+		}
+		updated.Body = updateRequest.Body
+		updated.Title = updateRequest.Title
+		updated.Draft = updateRequest.Draft
+	} else {
+		updated, err = client.UpdatePullRequest(ctx, repository, existing.Number, updateRequest)
+	}
 	if err != nil {
 		return fmt.Errorf("update pull request with specification review: %w", err)
 	}

--- a/internal/factory/review_test.go
+++ b/internal/factory/review_test.go
@@ -189,7 +189,7 @@ func newReviewFixture(t *testing.T) reviewFixture {
 	if err := runStore.SaveRun(context.Background(), run); err != nil {
 		t.Fatalf("SaveRun() review fixture error = %v", err)
 	}
-	githubAdapter.statusComment = github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: " + run.ID + " -->"}
+	githubAdapter.statusComment = github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)}
 	worktree.state.HeadSHA = reviewCheckpoint
 	worktree.state.ChangedPaths = nil
 	runStore.gateResults[run.ID] = []store.GateResult{

--- a/internal/factory/test_stage.go
+++ b/internal/factory/test_stage.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
@@ -424,41 +425,62 @@ func (s *Service) acceptTestStageReport(ctx context.Context, registration config
 	if workspace == nil {
 		return AgentResult{}, errors.New("GitWorkspace is required for the test checkpoint")
 	}
-	checkpoint, err := workspace.CreateCheckpoint(ctx, gitadapter.CheckpointRequest{
+	protected, err := protectedTestPathsForCheckpoint(run.Worktree, verifiedState.ChangedPaths)
+	if err != nil {
+		return AgentResult{}, err
+	}
+	checkpointRequest := gitadapter.CheckpointRequest{
 		RunID:        run.ID,
 		WorktreePath: run.Worktree,
 		ParentSHA:    run.CheckpointSHA,
 		Kind:         gitadapter.CheckpointKindTest,
 		Paths:        append([]string(nil), verifiedState.ChangedPaths...),
 		Message:      "verified focused test is red",
-	})
+	}
+	previous := *run
+	handoff := convertTestHandoff(*value.TestHandoff)
+	next := *run
+	next.TestCheckpointSHA = ""
+	next.SpecificationReview = nil
+	next.TestHandoff = &handoff
+	next.ProtectedTestPaths = protected
+	next.Stage = store.StageImplementation
+	next.Status = store.StatusActive
+	next.PendingQuestions = nil
+	next.LifecycleReason = "test stage completed; protected handoff ready for implementation"
+	next.Revision = previous.Revision + 1
+	next.UpdatedAt = s.deps.Now().UTC()
+	checkpoint := gitadapter.CheckpointResult{}
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		repository := commandRepository(registration)
+		issue, issueErr := s.deps.GitHub.Issue(ctx, repository, run.IssueNumber)
+		if issueErr != nil {
+			return AgentResult{}, fmt.Errorf("read issue for test handoff checkpoint: %w", issueErr)
+		}
+		packet, packetErr := decodeSpecificationPacket(run.SpecificationPacket)
+		if packetErr != nil {
+			return AgentResult{}, fmt.Errorf("decode specification packet for test handoff checkpoint: %w", packetErr)
+		}
+		issue = ensureIssueIdentity(issue, packet.Issue, run.IssueNumber)
+		checkpoint, next, err = s.checkpointAndPersistWithEffect(ctx, runStore, workspace, checkpointRequest, repository, issue, previous, next)
+	} else {
+		checkpoint, err = workspace.CreateCheckpoint(ctx, checkpointRequest)
+	}
 	if err != nil {
 		return AgentResult{}, fmt.Errorf("create test checkpoint: %w", err)
 	}
-	protected, err := protectedTestPathsForCheckpoint(run.Worktree, verifiedState.ChangedPaths)
-	if err != nil {
-		return AgentResult{}, err
+	if !github.ValidCommitSHA(checkpoint.SHA) {
+		return AgentResult{}, errors.New("test checkpoint returned an invalid commit SHA")
 	}
-	handoff := convertTestHandoff(*value.TestHandoff)
-	run.TestCheckpointSHA = checkpoint.SHA
-	run.CheckpointSHA = checkpoint.SHA
-	run.SpecificationReview = nil
-	run.TestHandoff = &handoff
-	run.ProtectedTestPaths = protected
-	run.Stage = store.StageImplementation
-	run.Status = store.StatusActive
-	run.PendingQuestions = nil
-	run.LifecycleReason = "test stage completed; protected handoff ready for implementation"
-	run.UpdatedAt = s.deps.Now().UTC()
-	previous := *run
-	previous.Stage = store.StageTest
-	previous.Status = store.StatusActive
-	previous.CheckpointSHA = verifiedState.HeadSHA
-	previous.TestCheckpointSHA = ""
-	previous.TestHandoff = nil
-	previous.ProtectedTestPaths = nil
-	if err := s.persistAgentRunState(ctx, registration, runStore, previous, *run); err != nil {
-		return AgentResult{}, fmt.Errorf("persist test handoff: %w", err)
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		*run = next
+	} else {
+		next.TestCheckpointSHA = checkpoint.SHA
+		next.CheckpointSHA = checkpoint.SHA
+		if err := s.persistAgentRunState(ctx, registration, runStore, previous, next); err != nil {
+			return AgentResult{}, fmt.Errorf("persist test handoff: %w", err)
+		}
+		*run = next
 	}
 	if _, err := s.startAgentWithStore(ctx, registration, runStore, run, AgentRequest{RunID: run.ID, Role: "implementation", Stage: store.StageImplementation}); err != nil {
 		return AgentResult{}, fmt.Errorf("launch implementation after test handoff: %w", err)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -116,6 +116,12 @@ type GitWorkspace interface {
 	SynchronizeBase(context.Context, BaseSyncRequest) error
 }
 
+// RemoteBranchInspector is the optional read-only projection used to
+// recognize a completed push after a coordinator restart.
+type RemoteBranchInspector interface {
+	RemoteBranchHead(context.Context, PushRequest) (string, error)
+}
+
 // CommandRunner is the executable seam for host-side Git commands.
 type CommandRunner interface {
 	Run(context.Context, string, []string) ([]byte, error)
@@ -379,6 +385,35 @@ func (m *LocalWorktreeManager) Push(ctx context.Context, request PushRequest) er
 		return fmt.Errorf("push run branch %q: %w", request.Branch, err)
 	}
 	return nil
+}
+
+// RemoteBranchHead reads the exact origin branch head without changing the
+// local checkout. An empty result means the remote branch does not exist.
+func (m *LocalWorktreeManager) RemoteBranchHead(ctx context.Context, request PushRequest) (string, error) {
+	if strings.TrimSpace(request.WorktreePath) == "" {
+		return "", errors.New("remote branch worktree path is required")
+	}
+	if !filepath.IsAbs(request.WorktreePath) {
+		return "", errors.New("remote branch worktree path must be absolute")
+	}
+	if strings.TrimSpace(request.Branch) == "" {
+		return "", errors.New("remote branch is required")
+	}
+	if err := validateRefPart(request.Branch); err != nil {
+		return "", fmt.Errorf("remote branch: %w", err)
+	}
+	output, err := m.runner().Run(ctx, request.WorktreePath, []string{"ls-remote", "--heads", DefaultRemoteName, "refs/heads/" + request.Branch})
+	if err != nil {
+		return "", fmt.Errorf("read remote branch %q: %w", request.Branch, err)
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) == 0 {
+		return "", nil
+	}
+	if !validCommitSHA(fields[0]) {
+		return "", errors.New("remote branch response did not contain a full commit identity")
+	}
+	return fields[0], nil
 }
 
 // SynchronizeBase fetches the named target branch and fast-forwards the run

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -122,6 +122,13 @@ type RemoteBranchInspector interface {
 	RemoteBranchHead(context.Context, PushRequest) (string, error)
 }
 
+// AncestryInspector is the optional read-only projection that reports whether
+// one commit is reachable from another. Reconciliation uses it to tell an
+// unpushed local checkpoint apart from a genuinely diverged remote branch.
+type AncestryInspector interface {
+	IsAncestor(ctx context.Context, worktreePath, ancestor, descendant string) (bool, error)
+}
+
 // CommandRunner is the executable seam for host-side Git commands.
 type CommandRunner interface {
 	Run(context.Context, string, []string) ([]byte, error)
@@ -414,6 +421,30 @@ func (m *LocalWorktreeManager) RemoteBranchHead(ctx context.Context, request Pus
 		return "", errors.New("remote branch response did not contain a full commit identity")
 	}
 	return fields[0], nil
+}
+
+// IsAncestor reports whether ancestor is reachable from descendant without
+// changing the local checkout. An unknown commit is reported as not reachable
+// rather than as an error, so a pruned remote object cannot claim agreement.
+func (m *LocalWorktreeManager) IsAncestor(ctx context.Context, worktreePath, ancestor, descendant string) (bool, error) {
+	if strings.TrimSpace(worktreePath) == "" {
+		return false, errors.New("ancestry worktree path is required")
+	}
+	if !filepath.IsAbs(worktreePath) {
+		return false, errors.New("ancestry worktree path must be absolute")
+	}
+	if !validCommitSHA(ancestor) || !validCommitSHA(descendant) {
+		return false, errors.New("ancestry requires two full commit identities")
+	}
+	if ancestor == descendant {
+		return true, nil
+	}
+	if _, err := m.runner().Run(ctx, worktreePath, []string{"merge-base", "--is-ancestor", ancestor, descendant}); err != nil {
+		// git exits non-zero both for "not an ancestor" and for an unknown
+		// commit. Neither proves agreement, so both report false.
+		return false, nil
+	}
+	return true, nil
 }
 
 // SynchronizeBase fetches the named target branch and fast-forwards the run

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -191,6 +191,12 @@ type CommitStatusPublisher interface {
 	CreateCommitStatus(context.Context, Repository, CommitStatus) error
 }
 
+// CommitStatusReader is the read-only projection used to recognize a status
+// that GitHub accepted before the coordinator process stopped.
+type CommitStatusReader interface {
+	ListCommitStatuses(context.Context, Repository, string) ([]CommitStatus, error)
+}
+
 // Client is the small host-side seam used by the claim coordinator. It keeps
 // GitHub credentials inside the local gh process and returns only workflow
 // data to the coordinator.
@@ -247,6 +253,7 @@ type GhClient struct {
 var _ CommentReader = (*GhClient)(nil)
 var _ IssuePoller = (*GhClient)(nil)
 var _ LeaseClient = (*GhClient)(nil)
+var _ CommitStatusReader = (*GhClient)(nil)
 
 // NewClient returns a GitHub CLI-backed client.
 func NewClient() *GhClient { return &GhClient{Runner: commandRunner{}} }
@@ -553,6 +560,39 @@ func (c *GhClient) CreateCommitStatus(ctx context.Context, repository Repository
 	return nil
 }
 
+// ListCommitStatuses reads all statuses attached to one exact commit so a
+// pending status effect can be recognized without publishing a duplicate.
+func (c *GhClient) ListCommitStatuses(ctx context.Context, repository Repository, sha string) ([]CommitStatus, error) {
+	if !ValidCommitSHA(sha) {
+		return nil, errors.New("commit status SHA must contain exactly 40 or 64 lowercase hexadecimal characters")
+	}
+	output, err := c.callBytes(ctx, []string{"api", fmt.Sprintf("repos/%s/commits/%s/statuses", repository.String(), sha), "--method", "GET", "--paginate", "--slurp"}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list commit statuses for %s: %w", sha, err)
+	}
+	var pages [][]commitStatusResponse
+	if err := json.Unmarshal(output, &pages); err != nil {
+		var flat []commitStatusResponse
+		if flatErr := json.Unmarshal(output, &flat); flatErr != nil {
+			return nil, fmt.Errorf("decode commit statuses for %s: %w", sha, flatErr)
+		}
+		pages = [][]commitStatusResponse{flat}
+	}
+	statuses := make([]CommitStatus, 0)
+	for _, page := range pages {
+		for _, response := range page {
+			statuses = append(statuses, CommitStatus{
+				SHA:         sha,
+				State:       CommitStatusState(response.State),
+				Context:     response.Context,
+				Description: response.Description,
+				TargetURL:   response.TargetURL,
+			})
+		}
+	}
+	return statuses, nil
+}
+
 // callJSON executes a GitHub CLI request and decodes its JSON response.
 func (c *GhClient) callJSON(ctx context.Context, args []string, payload any, destination any) error {
 	output, err := c.callBytes(ctx, args, payload)
@@ -680,6 +720,15 @@ func truncateStatusDescription(value string, limit int) string {
 // commitResponse is the branch-head projection needed by lease publishing.
 type commitResponse struct {
 	SHA string `json:"sha"`
+}
+
+// commitStatusResponse is the GitHub status projection needed for replay
+// recognition; GitHub's numeric status id is intentionally not retained.
+type commitStatusResponse struct {
+	State       string `json:"state"`
+	Context     string `json:"context"`
+	Description string `json:"description"`
+	TargetURL   string `json:"target_url"`
 }
 
 // commentResponse is the subset of a GitHub comment response needed to retain

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -39,6 +39,19 @@ func (*Claude) Capabilities() Capabilities {
 	return Capabilities{Name: NameClaude, InteractiveResume: true}
 }
 
+// NativeSessionID returns the Claude Code session identity observed in the
+// worker's persisted project state for restart reconciliation.
+func (c *Claude) NativeSessionID(ctx context.Context, request NativeSessionRequest) (string, error) {
+	if request.Harness != "" && request.Harness != NameClaude {
+		return "", fmt.Errorf("Claude adapter cannot inspect harness %q", request.Harness)
+	}
+	provider, ok := c.Worker.(worker.NativeSessionProvider)
+	if !ok {
+		return "", errors.New("worker runtime does not support native session inspection")
+	}
+	return provider.NativeSessionID(ctx, worker.NativeSessionRequest{RunID: request.RunID, Harness: NameClaude})
+}
+
 // Start launches a fresh Claude Code TUI with an adapter-assigned native
 // session identifier in a worker-backed terminal surface.
 func (c *Claude) Start(ctx context.Context, request StartRequest) (Session, error) {

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -29,6 +29,20 @@ func (*Codex) Capabilities() Capabilities {
 	return Capabilities{Name: NameCodex, InteractiveResume: true}
 }
 
+// NativeSessionID returns the Codex session identity observed in the worker's
+// role home for restart reconciliation. The worker lookup remains behind this
+// adapter capability so coordinator code stays harness-neutral.
+func (c *Codex) NativeSessionID(ctx context.Context, request NativeSessionRequest) (string, error) {
+	if request.Harness != "" && request.Harness != NameCodex {
+		return "", fmt.Errorf("Codex adapter cannot inspect harness %q", request.Harness)
+	}
+	provider, ok := c.Worker.(worker.NativeSessionProvider)
+	if !ok {
+		return "", errors.New("worker runtime does not support native session inspection")
+	}
+	return provider.NativeSessionID(ctx, worker.NativeSessionRequest{RunID: request.RunID, Harness: NameCodex})
+}
+
 // Start launches a fresh Codex TUI in a worker-backed terminal surface.
 func (c *Codex) Start(ctx context.Context, request StartRequest) (Session, error) {
 	if request.ResumeSessionID != "" {

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -75,6 +75,22 @@ type Capabilities struct {
 	InteractiveResume bool
 }
 
+// NativeSessionRequest identifies the worker-backed native session projection
+// that an adapter may inspect during restart reconciliation.
+type NativeSessionRequest struct {
+	// RunID identifies the worker run whose native session is checked.
+	RunID string
+	// Harness identifies the adapter-owned session format.
+	Harness string
+}
+
+// NativeSessionInspector is an optional adapter capability for comparing a
+// persisted native session identity with the current worker projection.
+type NativeSessionInspector interface {
+	// NativeSessionID returns the currently observed native session identity.
+	NativeSessionID(context.Context, NativeSessionRequest) (string, error)
+}
+
 // Runtime is the portable harness lifecycle seam used by the coordinator.
 type Runtime interface {
 	// Capabilities reports the adapter identity and supported lifecycle.
@@ -83,7 +99,9 @@ type Runtime interface {
 	Start(context.Context, StartRequest) (Session, error)
 	// Resume launches a native-resume session.
 	Resume(context.Context, StartRequest) (Session, error)
-	// Finish detaches the visible surface after accepted completion.
+	// Finish detaches the visible surface after accepted completion. Adapters
+	// must make this operation idempotent because reconciliation may replay it
+	// after a response-loss boundary.
 	Finish(context.Context, Session) error
 }
 

--- a/internal/store/pending_effect_test.go
+++ b/internal/store/pending_effect_test.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestPendingEffectSurvivesStoreRestart verifies the single pending-effect
+// journal is durable and accepts an idempotent retry of the same effect.
+func TestPendingEffectSurvivesStoreRestart(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "factory.db")
+	created := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	effect := PendingEffect{
+		RunID:     "run-1",
+		ID:        "effect-1",
+		Kind:      PendingEffectKindLabelTransition,
+		Payload:   `{"labels":["agent-running"]}`,
+		CreatedAt: created,
+		UpdatedAt: created,
+	}
+
+	opened, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SavePendingEffect(ctx, effect); err != nil {
+		t.Fatalf("SavePendingEffect() error = %v", err)
+	}
+	if err := opened.SavePendingEffect(ctx, effect); err != nil {
+		t.Fatalf("idempotent SavePendingEffect() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.PendingEffect(ctx, effect.RunID)
+	if err != nil {
+		t.Fatalf("PendingEffect() error = %v", err)
+	}
+	if got == nil || got.ID != effect.ID || got.Kind != effect.Kind || got.Payload != effect.Payload {
+		t.Fatalf("PendingEffect() = %#v, want %#v", got, effect)
+	}
+}
+
+// TestPendingEffectRejectsASecondEffect verifies the one-effect invariant is
+// enforced by the operational store rather than by process-local callers.
+func TestPendingEffectRejectsASecondEffect(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	opened, err := Open(ctx, filepath.Join(directory, "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	first := PendingEffect{RunID: "run-1", ID: "effect-1", Kind: PendingEffectKindPush, Payload: "{}"}
+	second := PendingEffect{RunID: "run-1", ID: "effect-2", Kind: PendingEffectKindPullRequest, Payload: "{}"}
+	if err := opened.SavePendingEffect(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SavePendingEffect(ctx, second); !errors.Is(err, ErrPendingEffectConflict) {
+		t.Fatalf("second SavePendingEffect() error = %v, want ErrPendingEffectConflict", err)
+	}
+	if err := opened.ClearPendingEffect(ctx, first.RunID, first.ID); err != nil {
+		t.Fatalf("ClearPendingEffect() error = %v", err)
+	}
+	cleared, err := opened.PendingEffect(ctx, first.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleared != nil {
+		t.Fatalf("PendingEffect() after clear = %#v, want nil", cleared)
+	}
+}

--- a/internal/store/pending_effect_test.go
+++ b/internal/store/pending_effect_test.go
@@ -92,3 +92,58 @@ func TestPendingEffectRejectsASecondEffect(t *testing.T) {
 		t.Fatalf("PendingEffect() after clear = %#v, want nil", cleared)
 	}
 }
+
+// TestPendingEffectRetryRefreshesTheReplayPayload verifies that re-reserving
+// the same effect identity with a newer payload succeeds. Effect payloads embed
+// volatile state such as the run's update time and a freshly read issue
+// snapshot, so a retried attempt after a transient adapter failure never
+// produces a byte-identical payload. Treating that as a conflict would block
+// every later reservation for the run until the process restarted.
+func TestPendingEffectRetryRefreshesTheReplayPayload(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	opened, err := Open(ctx, filepath.Join(directory, "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+
+	created := time.Date(2026, 8, 27, 10, 0, 0, 0, time.UTC)
+	first := PendingEffect{
+		RunID: "run-1", ID: "state_transition:abc", Kind: PendingEffectKindStateTransition,
+		Payload:   `{"Next":{"Revision":5,"UpdatedAt":"2026-08-27T10:00:00Z"}}`,
+		CreatedAt: created, UpdatedAt: created,
+	}
+	if err := opened.SavePendingEffect(ctx, first); err != nil {
+		t.Fatalf("first SavePendingEffect() error = %v", err)
+	}
+	retry := first
+	retry.Payload = `{"Next":{"Revision":5,"UpdatedAt":"2026-08-27T10:00:05Z"}}`
+	retry.UpdatedAt = created.Add(5 * time.Second)
+	if err := opened.SavePendingEffect(ctx, retry); err != nil {
+		t.Fatalf("retried SavePendingEffect() error = %v, want the reservation to be refreshed", err)
+	}
+	current, err := opened.PendingEffect(ctx, first.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current == nil || current.Payload != retry.Payload {
+		t.Fatalf("PendingEffect() payload = %#v, want the retried payload %q", current, retry.Payload)
+	}
+	if current.CreatedAt.UTC() != created {
+		t.Fatalf("PendingEffect() created_at = %s, want the original reservation time %s", current.CreatedAt, created)
+	}
+	// A genuinely different effect must still be refused.
+	other := PendingEffect{
+		RunID: "run-1", ID: "push:def", Kind: PendingEffectKindPush, Payload: "{}",
+		CreatedAt: created, UpdatedAt: created,
+	}
+	if err := opened.SavePendingEffect(ctx, other); !errors.Is(err, ErrPendingEffectConflict) {
+		t.Fatalf("SavePendingEffect() for a different effect = %v, want ErrPendingEffectConflict", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,7 +20,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 20
+const CurrentSchemaVersion = 22
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -29,6 +29,10 @@ var ErrRevisionConflict = errors.New("run revision conflict")
 // ErrRevisionNotAdvanced reports that a compare-and-set update did not move
 // the run to a strictly newer revision.
 var ErrRevisionNotAdvanced = errors.New("run revision did not advance")
+
+// ErrPendingEffectConflict reports that a run already has a different
+// external effect reserved in its durable journal.
+var ErrPendingEffectConflict = errors.New("pending effect conflict")
 
 // runTimestampLayout keeps serialized run timestamps fixed-width so SQLite
 // text ordering matches chronological ordering for sub-second timestamps.
@@ -62,6 +66,58 @@ const (
 // progression state to reconcile.
 func IsTerminalStatus(status Status) bool {
 	return status == StatusComplete || status == StatusCancelled || status == StatusFailed
+}
+
+// PendingEffectKind identifies the external mutation reserved before a
+// coordinator process crosses its restart boundary.
+type PendingEffectKind string
+
+const (
+	// PendingEffectKindStateTransition covers the paired issue-label and status
+	// comment projection for one run revision.
+	PendingEffectKindStateTransition PendingEffectKind = "state_transition"
+	// PendingEffectKindLabelTransition identifies a standalone issue-label
+	// projection when a caller does not use a complete state transition.
+	PendingEffectKindLabelTransition PendingEffectKind = "label_transition"
+	// PendingEffectKindStatusComment identifies a standalone status-comment
+	// projection when a caller does not use a complete state transition.
+	PendingEffectKindStatusComment PendingEffectKind = "status_comment"
+	// PendingEffectKindCommitStatus identifies one exact-SHA Commit Status.
+	PendingEffectKindCommitStatus PendingEffectKind = "commit_status"
+	// PendingEffectKindPush identifies one run-branch push.
+	PendingEffectKindPush PendingEffectKind = "push"
+	// PendingEffectKindPullRequest identifies one draft pull-request mutation.
+	PendingEffectKindPullRequest PendingEffectKind = "pull_request"
+	// PendingEffectKindCheckpoint identifies one checkpoint commit.
+	PendingEffectKindCheckpoint PendingEffectKind = "checkpoint"
+	// PendingEffectKindWorkerLaunch identifies one worker creation or reuse.
+	PendingEffectKindWorkerLaunch PendingEffectKind = "worker_launch"
+	// PendingEffectKindHarnessResume identifies one native-session resume.
+	PendingEffectKindHarnessResume PendingEffectKind = "harness_resume"
+	// PendingEffectKindResultAcceptance identifies one accepted report
+	// projection.
+	PendingEffectKindResultAcceptance PendingEffectKind = "result_acceptance"
+	// PendingEffectKindClarificationComment identifies one clarification
+	// question comment and its persisted comment identity.
+	PendingEffectKindClarificationComment PendingEffectKind = "clarification_comment"
+)
+
+// PendingEffect is the bounded intent record for one external mutation. A run
+// may have at most one row, so a restart can inspect and finish the exact
+// operation that was in flight without replaying an unrelated effect.
+type PendingEffect struct {
+	// RunID identifies the run owning the effect.
+	RunID string
+	// ID is the deterministic idempotency key for the effect.
+	ID string
+	// Kind identifies the adapter operation represented by Payload.
+	Kind PendingEffectKind
+	// Payload is bounded JSON containing the complete replay intent.
+	Payload string
+	// CreatedAt is the first reservation time.
+	CreatedAt time.Time
+	// UpdatedAt is the latest reservation time.
+	UpdatedAt time.Time
 }
 
 // InvocationStatus describes the lifecycle of one visible harness invocation.
@@ -364,6 +420,9 @@ type Invocation struct {
 	PromptVersion string
 	// Status is the invocation lifecycle state.
 	Status InvocationStatus
+	// RecoveryResumeCount records the number of coordinator-owned native resume
+	// attempts completed for this invocation. Reconciliation permits one.
+	RecoveryResumeCount int
 	// CreatedAt is the immutable invocation creation time.
 	CreatedAt time.Time
 	// UpdatedAt is the latest coordinator update time.
@@ -718,6 +777,141 @@ func (s *Store) SaveRun(ctx context.Context, run Run) error {
 		return fmt.Errorf("save run: %w", err)
 	}
 	return nil
+}
+
+// PendingEffect returns the one durable external-effect reservation for a run,
+// or nil when the run has no mutation awaiting reconciliation.
+func (s *Store) PendingEffect(ctx context.Context, runID string) (*PendingEffect, error) {
+	if strings.TrimSpace(runID) == "" {
+		return nil, errors.New("pending effect run id is required")
+	}
+	row := s.db.QueryRowContext(ctx, `
+		SELECT run_id, effect_id, kind, payload, created_at, updated_at
+		FROM pending_effects
+		WHERE run_id = ?`, runID)
+	return scanPendingEffect(row)
+}
+
+// SavePendingEffect reserves one external mutation. Re-saving the same
+// run/effect identity and payload is a no-op; a different effect is rejected
+// until the existing reservation is completed or abandoned.
+func (s *Store) SavePendingEffect(ctx context.Context, effect PendingEffect) error {
+	effect, err := normalizePendingEffect(effect)
+	if err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		INSERT INTO pending_effects (run_id, effect_id, kind, payload, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id) DO NOTHING`,
+		effect.RunID, effect.ID, effect.Kind, effect.Payload,
+		effect.CreatedAt.UTC().Format(runTimestampLayout),
+		effect.UpdatedAt.UTC().Format(runTimestampLayout)); err != nil {
+		return fmt.Errorf("save pending effect: %w", err)
+	}
+	current, err := s.PendingEffect(ctx, effect.RunID)
+	if err != nil {
+		return err
+	}
+	if current == nil || current.ID != effect.ID || current.Kind != effect.Kind || current.Payload != effect.Payload {
+		return fmt.Errorf("%w: run %q already has effect %q", ErrPendingEffectConflict, effect.RunID, pendingEffectIdentity(current))
+	}
+	return nil
+}
+
+// ClearPendingEffect completes a matching external-effect reservation. A
+// missing row is already complete; a different row is left untouched so a
+// caller cannot accidentally acknowledge another operation.
+func (s *Store) ClearPendingEffect(ctx context.Context, runID, effectID string) error {
+	if strings.TrimSpace(runID) == "" {
+		return errors.New("pending effect run id is required")
+	}
+	if strings.TrimSpace(effectID) == "" {
+		return errors.New("pending effect id is required")
+	}
+	result, err := s.db.ExecContext(ctx, "DELETE FROM pending_effects WHERE run_id = ? AND effect_id = ?", runID, effectID)
+	if err != nil {
+		return fmt.Errorf("clear pending effect: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("inspect cleared pending effect: %w", err)
+	}
+	if changed == 1 {
+		return nil
+	}
+	current, err := s.PendingEffect(ctx, runID)
+	if err != nil {
+		return err
+	}
+	if current != nil && current.ID != effectID {
+		return fmt.Errorf("%w: cannot clear effect %q while effect %q is pending", ErrPendingEffectConflict, effectID, current.ID)
+	}
+	return nil
+}
+
+// AbandonPendingEffect removes a matching reservation after an operator has
+// deliberately decided that the effect must not be replayed. The reason is
+// intentionally supplied by the caller and is not retained in the store.
+func (s *Store) AbandonPendingEffect(ctx context.Context, runID, effectID, _ string) error {
+	return s.ClearPendingEffect(ctx, runID, effectID)
+}
+
+// scanPendingEffect decodes one pending-effect row and its canonical
+// timestamps.
+func scanPendingEffect(row *sql.Row) (*PendingEffect, error) {
+	var effect PendingEffect
+	var kind, createdAt, updatedAt string
+	if err := row.Scan(&effect.RunID, &effect.ID, &kind, &effect.Payload, &createdAt, &updatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read pending effect: %w", err)
+	}
+	effect.Kind = PendingEffectKind(kind)
+	var err error
+	effect.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse pending effect created_at: %w", err)
+	}
+	effect.UpdatedAt, err = time.Parse(time.RFC3339Nano, updatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse pending effect updated_at: %w", err)
+	}
+	return &effect, nil
+}
+
+// normalizePendingEffect validates the bounded journal identity and fills
+// absent timestamps before persistence.
+func normalizePendingEffect(effect PendingEffect) (PendingEffect, error) {
+	if strings.TrimSpace(effect.RunID) == "" {
+		return PendingEffect{}, errors.New("pending effect run id is required")
+	}
+	if strings.TrimSpace(effect.ID) == "" || strings.ContainsAny(effect.ID, "\x00\r\n") {
+		return PendingEffect{}, errors.New("pending effect id is required and must be a single line")
+	}
+	if strings.TrimSpace(string(effect.Kind)) == "" || strings.ContainsAny(string(effect.Kind), "\x00\r\n") {
+		return PendingEffect{}, errors.New("pending effect kind is required and must be a single line")
+	}
+	if strings.TrimSpace(effect.Payload) == "" || len(effect.Payload) > 1<<20 || !json.Valid([]byte(effect.Payload)) {
+		return PendingEffect{}, errors.New("pending effect payload must be valid bounded JSON")
+	}
+	if effect.CreatedAt.IsZero() {
+		effect.CreatedAt = time.Now().UTC()
+	}
+	if effect.UpdatedAt.IsZero() {
+		effect.UpdatedAt = effect.CreatedAt
+	}
+	return effect, nil
+}
+
+// pendingEffectIdentity keeps a conflict error useful even if a malformed
+// legacy row is ever encountered.
+func pendingEffectIdentity(effect *PendingEffect) string {
+	if effect == nil {
+		return "<missing>"
+	}
+	return effect.ID
 }
 
 // SaveRunIfRevision persists one command result only when the run still has
@@ -1173,6 +1367,9 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 	if invocation.Status == "" {
 		return errors.New("invocation status is required")
 	}
+	if invocation.RecoveryResumeCount < 0 {
+		return errors.New("invocation recovery resume count must not be negative")
+	}
 	if strings.ContainsAny(invocation.CredentialStoreID, "\x00\r\n") {
 		return errors.New("invocation credential store id contains control characters")
 	}
@@ -1190,9 +1387,9 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 		INSERT INTO invocations (
 			id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 			native_session_id, workspace_id, status_surface_id,
-			implementation_surface_id, checks_surface_id, invocation_directory,
-			result_directory, permitted_paths, prompt_version, status, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				implementation_surface_id, checks_surface_id, invocation_directory,
+				result_directory, permitted_paths, prompt_version, status, recovery_resume_count, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			run_id = excluded.run_id,
 			harness = excluded.harness,
@@ -1208,10 +1405,11 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 			checks_surface_id = excluded.checks_surface_id,
 			invocation_directory = excluded.invocation_directory,
 			result_directory = excluded.result_directory,
-			permitted_paths = excluded.permitted_paths,
-			prompt_version = excluded.prompt_version,
-			status = excluded.status,
-			updated_at = excluded.updated_at`,
+				permitted_paths = excluded.permitted_paths,
+				prompt_version = excluded.prompt_version,
+				status = excluded.status,
+				recovery_resume_count = excluded.recovery_resume_count,
+				updated_at = excluded.updated_at`,
 		invocation.ID,
 		invocation.RunID,
 		invocation.Harness,
@@ -1230,6 +1428,7 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 		string(permittedPathJSON),
 		invocation.PromptVersion,
 		invocation.Status,
+		invocation.RecoveryResumeCount,
 		invocation.CreatedAt.UTC().Format(runTimestampLayout),
 		invocation.UpdatedAt.UTC().Format(runTimestampLayout),
 	)
@@ -1326,7 +1525,7 @@ func (s *Store) Invocation(ctx context.Context, runID, invocationID string) (*In
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, status, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ? AND id = ?`, runID, invocationID)
 	return scanInvocation(row)
@@ -1343,7 +1542,7 @@ func (s *Store) LatestInvocation(ctx context.Context, runID string) (*Invocation
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, status, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ?
 		ORDER BY updated_at DESC, id DESC
@@ -1376,7 +1575,7 @@ func (s *Store) ActiveInvocation(ctx context.Context, runID string) (*Invocation
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, status, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ? AND status = ?
 		ORDER BY updated_at DESC
@@ -1407,6 +1606,7 @@ func scanInvocation(row *sql.Row) (*Invocation, error) {
 		&permittedPathJSON,
 		&invocation.PromptVersion,
 		&invocation.Status,
+		&invocation.RecoveryResumeCount,
 		&createdAt,
 		&updatedAt,
 	); err != nil {
@@ -2071,6 +2271,21 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 				if _, err := tx.ExecContext(ctx, statement); err != nil {
 					return fmt.Errorf("apply store migration 20: %w", err)
 				}
+			}
+		case 21:
+			if _, err := tx.ExecContext(ctx, `CREATE TABLE pending_effects (
+				run_id TEXT PRIMARY KEY,
+				effect_id TEXT NOT NULL,
+				kind TEXT NOT NULL,
+				payload TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)`); err != nil {
+				return fmt.Errorf("apply store migration 21: %w", err)
+			}
+		case 22:
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE invocations ADD COLUMN recovery_resume_count INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return fmt.Errorf("apply store migration 22: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -792,9 +792,10 @@ func (s *Store) PendingEffect(ctx context.Context, runID string) (*PendingEffect
 	return scanPendingEffect(row)
 }
 
-// SavePendingEffect reserves one external mutation. Re-saving the same
-// run/effect identity and payload is a no-op; a different effect is rejected
-// until the existing reservation is completed or abandoned.
+// SavePendingEffect reserves one external mutation. The effect identity is the
+// reservation; re-saving the same run/effect identity refreshes the replay
+// payload so a retried attempt can carry a newer external snapshot. A different
+// effect is rejected until the existing reservation is completed or abandoned.
 func (s *Store) SavePendingEffect(ctx context.Context, effect PendingEffect) error {
 	effect, err := normalizePendingEffect(effect)
 	if err != nil {
@@ -803,7 +804,11 @@ func (s *Store) SavePendingEffect(ctx context.Context, effect PendingEffect) err
 	if _, err := s.db.ExecContext(ctx, `
 		INSERT INTO pending_effects (run_id, effect_id, kind, payload, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?)
-		ON CONFLICT(run_id) DO NOTHING`,
+		ON CONFLICT(run_id) DO UPDATE SET
+			payload = excluded.payload,
+			updated_at = excluded.updated_at
+		WHERE pending_effects.effect_id = excluded.effect_id
+		  AND pending_effects.kind = excluded.kind`,
 		effect.RunID, effect.ID, effect.Kind, effect.Payload,
 		effect.CreatedAt.UTC().Format(runTimestampLayout),
 		effect.UpdatedAt.UTC().Format(runTimestampLayout)); err != nil {
@@ -813,7 +818,7 @@ func (s *Store) SavePendingEffect(ctx context.Context, effect PendingEffect) err
 	if err != nil {
 		return err
 	}
-	if current == nil || current.ID != effect.ID || current.Kind != effect.Kind || current.Payload != effect.Payload {
+	if current == nil || current.ID != effect.ID || current.Kind != effect.Kind {
 		return fmt.Errorf("%w: run %q already has effect %q", ErrPendingEffectConflict, effect.RunID, pendingEffectIdentity(current))
 	}
 	return nil

--- a/internal/terminal/runtime.go
+++ b/internal/terminal/runtime.go
@@ -82,6 +82,24 @@ type RunWorkspace struct {
 	Checks Surface
 }
 
+// WorkspaceInspection is a read-only terminal topology projection used during
+// restart reconciliation. It contains only opaque workspace and surface
+// identities; screen contents are deliberately absent.
+type WorkspaceInspection struct {
+	// Exists reports whether the requested workspace is present in the adapter.
+	Exists bool
+	// WorkspaceID is the observed opaque workspace handle.
+	WorkspaceID WorkspaceID
+	// Surfaces contains the currently visible surfaces in the workspace.
+	Surfaces []Surface
+}
+
+// WorkspaceInspector is the optional read-only topology seam used to verify
+// persisted cmux handles before a native session is resumed.
+type WorkspaceInspector interface {
+	InspectWorkspace(context.Context, WorkspaceID) (WorkspaceInspection, error)
+}
+
 // SurfaceRequest asks the adapter to create one additional terminal surface.
 type SurfaceRequest struct {
 	// WorkspaceID identifies the owning workspace.
@@ -357,6 +375,33 @@ func (r *CmuxRuntime) CloseWorkspace(ctx context.Context, workspaceID WorkspaceI
 		return fmt.Errorf("close terminal workspace: %w", err)
 	}
 	return nil
+}
+
+// InspectWorkspace reads one workspace and its surface identities without
+// mutating cmux or interpreting terminal output.
+func (r *CmuxRuntime) InspectWorkspace(ctx context.Context, workspaceID WorkspaceID) (WorkspaceInspection, error) {
+	if strings.TrimSpace(string(workspaceID)) == "" {
+		return WorkspaceInspection{}, errors.New("workspace id is required")
+	}
+	topology, err := r.topology(ctx, []string{"tree", "--workspace", string(workspaceID), "--json", "--id-format", "uuids"})
+	if err != nil {
+		return WorkspaceInspection{}, err
+	}
+	for _, window := range topology.Windows {
+		for _, workspace := range window.Workspaces {
+			if workspace.ID != string(workspaceID) {
+				continue
+			}
+			inspection := WorkspaceInspection{Exists: true, WorkspaceID: workspaceID}
+			for _, pane := range workspace.Panes {
+				for _, surface := range pane.Surfaces {
+					inspection.Surfaces = append(inspection.Surfaces, Surface{ID: SurfaceID(surface.ID), WorkspaceID: workspaceID, Name: surface.Title})
+				}
+			}
+			return inspection, nil
+		}
+	}
+	return WorkspaceInspection{WorkspaceID: workspaceID}, nil
 }
 
 // run executes one cmux command through the injected or production runner.
@@ -665,3 +710,4 @@ func (r *CmuxRuntime) topology(ctx context.Context, args []string) (topologyResp
 }
 
 var _ TerminalRuntime = (*CmuxRuntime)(nil)
+var _ WorkspaceInspector = (*CmuxRuntime)(nil)

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -553,19 +553,25 @@ func dockerStderrDetail(err error) error {
 	return err
 }
 
-// NativeSessionIDs discovers Codex sessions from persisted role-home files,
+// NativeSessionIDs discovers harness sessions from persisted role-home files,
 // never by scraping terminal output. An empty result means the harness has not
 // persisted a session file yet.
 func (r *DockerRuntime) NativeSessionIDs(ctx context.Context, request NativeSessionRequest) ([]string, error) {
 	if err := validateRunID(request.RunID); err != nil {
 		return nil, err
 	}
-	if request.Harness != "codex" {
+	var command string
+	switch request.Harness {
+	case "codex":
+		command = `find "$HOME/.codex/sessions" -type f -name 'rollout-*.jsonl' -print 2>/dev/null | sort | sed -n -E 's#^.*/rollout-.*-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$#\1#p'`
+	case "claude":
+		command = `find "$HOME/.claude/projects" -type f -name '*.jsonl' -print 2>/dev/null | sort | sed -n -E 's#^.*/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$#\1#p'`
+	default:
 		return nil, fmt.Errorf("native session lookup does not support harness %q", request.Harness)
 	}
 	result, err := r.RunCommand(ctx, CommandRequest{
 		RunID:             request.RunID,
-		Command:           `find "$HOME/.codex/sessions" -type f -name 'rollout-*.jsonl' -print 2>/dev/null | sort | sed -n -E 's#^.*/rollout-.*-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$#\1#p'`,
+		Command:           command,
 		EnvironmentPolicy: EnvironmentPolicyClean,
 		Role:              "coordinator",
 	})
@@ -598,7 +604,7 @@ func (r *DockerRuntime) NativeSessionIDs(ctx context.Context, request NativeSess
 	return identifiers, nil
 }
 
-// NativeSessionID returns the newest currently persisted Codex session for
+// NativeSessionID returns the newest currently persisted harness session for
 // compatibility with runtimes that only need one identifier.
 func (r *DockerRuntime) NativeSessionID(ctx context.Context, request NativeSessionRequest) (string, error) {
 	identifiers, err := r.NativeSessionIDs(ctx, request)

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -584,7 +584,7 @@ func (r *DockerRuntime) NativeSessionIDs(ctx context.Context, request NativeSess
 	case "codex":
 		command = `find "$HOME/.codex/sessions" -type f -name 'rollout-*.jsonl' -print 2>/dev/null | sort | sed -n -E 's#^.*/rollout-.*-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$#\1#p'`
 	case "claude":
-		command = `find "$HOME/.claude/projects" -type f -name '*.jsonl' -print 2>/dev/null | sort | sed -n -E 's#^.*/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$#\1#p'`
+		command = `find "$HOME/.claude/projects" -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null | sort -n | sed -n -E 's#^[0-9.]+ .*/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$#\1#p'`
 	default:
 		return nil, fmt.Errorf("native session lookup does not support harness %q", request.Harness)
 	}

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -234,12 +234,31 @@ type Inspection struct {
 	Image string
 	// Mounts are the container's configured bind mounts.
 	Mounts []ContainerMount
+	// MountFingerprint is an opaque identity for the complete immutable mount
+	// contract. An empty value means the runtime could not inspect sources.
+	MountFingerprint string
 	// mountIdentities maps stable in-worker destinations to adapter-private
 	// mount identities used to detect stale bind or volume configuration.
 	mountIdentities map[string]string
+	// mountReadOnly maps stable in-worker destinations to their access mode.
+	mountReadOnly map[string]bool
 	// mountDestinations is the compatibility fallback for runtimes that expose
 	// only destination names rather than Docker's structured inspect payload.
 	mountDestinations map[string]struct{}
+}
+
+// MountContractStatus reports whether this inspection contains adapter-owned
+// source identities and whether every immutable mount matches the start
+// request. It exposes only booleans so host paths and volume names remain
+// private to the worker adapter.
+func (i Inspection) MountContractStatus(request StartRequest) (known bool, matches bool) {
+	if i.mountIdentities != nil {
+		return true, workerMountsPresent(request, i)
+	}
+	if i.MountFingerprint == "" {
+		return false, false
+	}
+	return true, i.MountFingerprint == MountContractFingerprint(request)
 }
 
 // ContainerMount describes one configured container bind mount.
@@ -781,6 +800,7 @@ func parseDockerInspectionJSON(data []byte) (Inspection, error) {
 		return Inspection{}, fmt.Errorf("docker inspect returned malformed JSON: %w", err)
 	}
 	mountIdentities := make(map[string]string, len(document.Mounts))
+	mountReadOnly := make(map[string]bool, len(document.Mounts))
 	mounts := make([]ContainerMount, 0, len(document.Mounts))
 	for _, mount := range document.Mounts {
 		if strings.TrimSpace(mount.Destination) == "" {
@@ -790,6 +810,7 @@ func parseDockerInspectionJSON(data []byte) (Inspection, error) {
 		if identity != "" {
 			mountIdentities[mount.Destination] = identity
 		}
+		mountReadOnly[mount.Destination] = !mount.RW
 		mounts = append(mounts, ContainerMount{
 			Source:      mount.Source,
 			Destination: mount.Destination,
@@ -797,11 +818,13 @@ func parseDockerInspectionJSON(data []byte) (Inspection, error) {
 		})
 	}
 	return Inspection{
-		Exists:          true,
-		Running:         document.State.Running,
-		Image:           document.Config.Image,
-		Mounts:          mounts,
-		mountIdentities: mountIdentities,
+		Exists:           true,
+		Running:          document.State.Running,
+		Image:            document.Config.Image,
+		Mounts:           mounts,
+		MountFingerprint: mountFingerprint(mountIdentities, mountReadOnly),
+		mountIdentities:  mountIdentities,
+		mountReadOnly:    mountReadOnly,
 	}, nil
 }
 
@@ -815,6 +838,38 @@ func dockerMountIdentity(_ string, source, name string) string {
 		return "bind:" + filepath.Clean(source)
 	}
 	return ""
+}
+
+// MountContractFingerprint derives the adapter-neutral identity of a worker's
+// complete immutable mount contract without returning any source paths.
+func MountContractFingerprint(request StartRequest) string {
+	return mountFingerprint(expectedWorkerMounts(request), expectedWorkerMountReadOnly(request))
+}
+
+// mountFingerprint hashes mount destinations and adapter-owned source
+// identities in stable order so recovery can compare contracts without
+// exposing Docker paths or volume names through the worker seam.
+func mountFingerprint(identities map[string]string, readOnly map[string]bool) string {
+	destinations := make([]string, 0, len(identities))
+	for destination := range identities {
+		destinations = append(destinations, destination)
+	}
+	sort.Strings(destinations)
+	var builder strings.Builder
+	for _, destination := range destinations {
+		builder.WriteString(destination)
+		builder.WriteByte('\x00')
+		builder.WriteString(identities[destination])
+		builder.WriteByte('\x00')
+		if readOnly[destination] {
+			builder.WriteString("ro")
+		} else {
+			builder.WriteString("rw")
+		}
+		builder.WriteByte('\x00')
+	}
+	digest := sha256.Sum256([]byte(builder.String()))
+	return hex.EncodeToString(digest[:])
 }
 
 // runDocker executes one host-side Docker CLI invocation and captures both
@@ -947,8 +1002,18 @@ func validateStartRequest(request StartRequest) error {
 func workerMountsPresent(request StartRequest, inspection Inspection) bool {
 	wanted := expectedWorkerMounts(request)
 	if inspection.mountIdentities != nil {
+		if len(inspection.mountIdentities) != len(wanted) {
+			return false
+		}
+		readOnly := expectedWorkerMountReadOnly(request)
+		if len(inspection.mountReadOnly) != len(readOnly) {
+			return false
+		}
 		for destination, identity := range wanted {
 			if inspection.mountIdentities[destination] != identity {
+				return false
+			}
+			if inspection.mountReadOnly[destination] != readOnly[destination] {
 				return false
 			}
 		}
@@ -998,6 +1063,29 @@ func expectedWorkerMounts(request StartRequest) map[string]string {
 	}
 	for _, cache := range request.Caches {
 		wanted[filepath.Join(CachePath, cache.Name)] = "bind:" + filepath.Clean(cache.HostPath)
+	}
+	return wanted
+}
+
+// expectedWorkerMountReadOnly returns the access mode for every immutable mount
+// that must be present before a worker can be reused.
+func expectedWorkerMountReadOnly(request StartRequest) map[string]bool {
+	wanted := map[string]bool{
+		WorktreePath:    false,
+		GitMetadataPath: true,
+		"/home/factory": false,
+	}
+	if request.CredentialStoreID != "" {
+		wanted[CredentialPath] = false
+	}
+	if request.InvocationPath != "" {
+		wanted[InvocationPath] = true
+	}
+	if request.ResultPath != "" {
+		wanted[ResultPath] = false
+	}
+	for _, cache := range request.Caches {
+		wanted[filepath.Join(CachePath, cache.Name)] = cache.ReadOnly
 	}
 	return wanted
 }

--- a/internal/worker/runtime_internal_test.go
+++ b/internal/worker/runtime_internal_test.go
@@ -29,6 +29,7 @@ func TestDockerInspectionRejectsAStaleInvocationSource(t *testing.T) {
 		Running:         true,
 		Image:           imageReference(request.Image, request.ImageDigest),
 		mountIdentities: identities,
+		mountReadOnly:   expectedWorkerMountReadOnly(request),
 	}
 	matchingInvocation := wanted[InvocationPath]
 	inspection.mountIdentities[InvocationPath] = "bind:/host/old-packet"
@@ -39,23 +40,35 @@ func TestDockerInspectionRejectsAStaleInvocationSource(t *testing.T) {
 	if !workerMountsPresent(request, inspection) {
 		t.Fatal("workerMountsPresent() rejected matching worker sources")
 	}
+	known, matches := inspection.MountContractStatus(request)
+	if !known || !matches {
+		t.Fatalf("MountContractStatus() = known %t, matches %t; want true, true", known, matches)
+	}
+	unknown, matches := (Inspection{Exists: true}).MountContractStatus(request)
+	if unknown || matches {
+		t.Fatalf("unknown MountContractStatus() = known %t, matches %t; want false, false", unknown, matches)
+	}
 }
 
 // TestParseDockerInspectionJSONKeepsMountSourcesAdapterPrivate verifies the
 // structured Docker response is reduced to source identities in the adapter.
 func TestParseDockerInspectionJSONKeepsMountSourcesAdapterPrivate(t *testing.T) {
 	inspection, err := parseDockerInspectionJSON([]byte(`{
-      "State": {"Running": true},
-      "Config": {"Image": "ghcr.io/example/factory-worker@` + internalWorkerDigest + `"},
-      "Mounts": [
-        {"Type": "bind", "Source": "/host/worktree", "Destination": "/work"},
-        {"Type": "volume", "Name": "factory-role-implementation-abc", "Destination": "/home/factory"}
-      ]
-    }`))
+	      "State": {"Running": true},
+	      "Config": {"Image": "ghcr.io/example/factory-worker@` + internalWorkerDigest + `"},
+	      "Mounts": [
+	        {"Type": "bind", "Source": "/host/worktree", "Destination": "/work", "RW": true},
+	        {"Type": "bind", "Source": "/host/git", "Destination": "/git", "RW": false},
+	        {"Type": "volume", "Name": "` + roleVolumeName("run-inspection", "implementation") + `", "Destination": "/home/factory", "RW": true}
+	      ]
+	    }`))
 	if err != nil {
 		t.Fatalf("parseDockerInspectionJSON() error = %v", err)
 	}
-	if !inspection.Running || inspection.Image == "" || inspection.mountIdentities[WorktreePath] != "bind:/host/worktree" || inspection.mountIdentities["/home/factory"] != "volume:factory-role-implementation-abc" {
+	if !inspection.Running || inspection.Image == "" || inspection.mountIdentities[WorktreePath] != "bind:/host/worktree" || inspection.mountIdentities["/home/factory"] != "volume:"+roleVolumeName("run-inspection", "implementation") {
 		t.Fatalf("inspection = %#v, want reduced lifecycle and mount identities", inspection)
+	}
+	if inspection.MountFingerprint != MountContractFingerprint(StartRequest{RunID: "run-inspection", WorktreePath: "/host/worktree", GitMetadataPath: "/host/git", Role: "implementation"}) {
+		t.Fatalf("MountFingerprint = %q, want the matching contract fingerprint", inspection.MountFingerprint)
 	}
 }

--- a/internal/worker/runtime_internal_test.go
+++ b/internal/worker/runtime_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 )
 
+// internalWorkerDigest is the immutable worker image identity used by runtime
+// inspection contract tests.
 const internalWorkerDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 // TestDockerInspectionRejectsAStaleInvocationSource verifies an existing


### PR DESCRIPTION
## Summary

- Add a durable one-effect journal with idempotent replay for external mutations.
- Reconcile persisted run, worktree/Git, GitHub, worker, cmux, and native-session projections fail-closed.
- Persist restart state, add typed discrepancy outcomes, and provide operator effect abandonment.
- Cover response-loss and pre-reservation behavior across the concrete effect adapters.

## Verification

- `GOCACHE=/private/tmp/sw-factory-go-cache-issue21-check make check`
- `GOCACHE=/private/tmp/sw-factory-go-cache-issue21-race go test -race ./internal/factory ./internal/store`

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recovery reconciliation to resume interrupted runs, repair state, and replay pending actions safely.
  * Added CLI tools to inspect recovery status and abandon selected pending effects.
  * Added durable tracking and replay for external actions, including comments, statuses, pushes, pull requests, workers, and checkpoints.
  * Added support for resuming persisted agent sessions after coordinator restarts.

* **Bug Fixes**
  * Repeated report acceptance no longer finalizes runs twice.
  * Recovery discrepancies are classified and surfaced for human review.
  * Remote branches behind a saved checkpoint are handled correctly.
  * Clarification comments remain distinct across specification versions.

* **Chores**
  * Updated the operational database schema to version 22.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->