### PR TITLE
Recover worker and harness interruptions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,7 +11,7 @@ _Avoid_: Job, task, workflow instance
 **GitHub lifecycle observation**:
 One coordinator read of the tracked issue and pull request that can identify
 successful merge completion or an unmerged closure requiring cancellation.
-_Avoid_: Screen scrape, automatic resume
+_Avoid_: Screen scrape, hidden workflow transition
 
 **Specification packet**:
 The versioned, frozen statement of product intent for a run, consisting of the claimed issue snapshot and accepted clarifications or revisions.
@@ -44,12 +44,13 @@ _Avoid_: Reconciliation, recovery
 **Reconciliation**:
 The coordinator's restart pass that consumes one durable pending effect when
 safe, repairs the projections that effect owns, and otherwise pauses the run
-with a typed discrepancy.
-_Avoid_: Diagnosis, automatic retry
+with a typed discrepancy. It may recreate a missing worker from the frozen
+invocation identity and permits one coordinator-owned native harness resume.
+_Avoid_: Diagnosis, unbounded retry
 
 **Recovery-required result**:
 A typed discrepancy result that reports the agreement state and discovered discrepancies; journaled runs reconcile safe effects automatically and pause unresolved disagreements for a human, while legacy stores retain the fail-closed refusal.
-_Avoid_: Recovered run, automatic continuation
+_Avoid_: Recovered run, implicit operator approval
 
 **Startup diagnosis**:
 A complete pre-claim report of host configuration, external access, repository, terminal, worker, harness, authentication, and operational-store readiness. Every subsystem contributes its own bounded check, and the doctor reports all failures before a run can start.

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -85,8 +85,9 @@ with a complete native-session identity is resumed once against its persisted
 worker and terminal handles. If the worker is missing or stopped, the
 coordinator recreates it from the frozen image digest and invocation mount
 identity while preserving the worktree and role volume. An unexpected native
-harness exit receives exactly one automatic resume attempt; a second unexpected
-failure pauses the run for manual recovery. Rate limits enter a
+harness exit, including one observed after launch by the supervisor's worker-side
+process check, receives exactly one automatic resume attempt; a second
+unexpected failure pauses the run for manual recovery. Rate limits enter a
 `waiting_for_harness` state, stop the worker, notify the operator, and are
 retried by the supervisor without consuming workflow or check-repair budget.
 Expired authentication enters `waiting_for_human` with a typed, redacted

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -82,12 +82,37 @@ claim or test handoff awaiting its first invocation, not an interrupted run.
 
 The exception applies only to first-agent startup. A persisted active invocation
 with a complete native-session identity is resumed once against its persisted
-worker and terminal handles; a missing identity or any other recovery
-discrepancy pauses the run for a human. Terminal report acceptance is replayed
-from its durable effect record without finalizing the same invocation twice.
-Gates, reports, transitions, draft pull requests, and other progression paths
-reconcile the durable effect journal and external identities before they resume
-an interrupted run.
+worker and terminal handles. If the worker is missing or stopped, the
+coordinator recreates it from the frozen image digest and invocation mount
+identity while preserving the worktree and role volume. An unexpected native
+harness exit receives exactly one automatic resume attempt; a second unexpected
+failure pauses the run for manual recovery. Rate limits enter a
+`waiting_for_harness` state, stop the worker, notify the operator, and are
+retried by the supervisor without consuming workflow or check-repair budget.
+Expired authentication enters `waiting_for_human` with a typed, redacted
+failure and tells the operator to refresh credentials. A missing native identity
+or any other recovery discrepancy pauses the run for a human. Terminal report
+acceptance is replayed from its durable effect record without finalizing the
+same invocation twice. Gates, reports, transitions, draft pull requests, and
+other progression paths reconcile the durable effect journal and external
+identities before they resume an interrupted run.
+
+When automatic recovery is exhausted, an operator can use the explicit
+recovery commands:
+
+```sh
+factory resume --config /Users/me/.config/factory/config.yaml --run-id run-123
+factory attach --config /Users/me/.config/factory/config.yaml --run-id run-123
+factory auth refresh --config /Users/me/.config/factory/config.yaml --run-id run-123
+```
+
+`factory resume` retries harness capacity or performs a manual native resume
+without spending the automatic recovery allowance. A manually resumed session
+sets a durable attach gate; workflow progression and report acceptance remain
+blocked until `factory attach` restores the worker and visible terminal
+topology and clears that gate. `factory auth refresh` reads the explicitly
+registered host credential source and reseeds only the factory-managed worker
+credential volume; it never writes the source file or host harness directory.
 
 The `TerminalRuntime` seam owns workspace, surface, input, notification, and
 lifecycle behavior. The macOS adapter invokes cmux; workflow code never sees

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -103,6 +103,11 @@ invocation mounts are stale, the adapter recreates it from the persisted
 factory-managed credential volume survive that recreation; the invocation and
 result directories are mounted again from their persisted paths.
 
+The harness adapters inspect the worker process table through the same command
+seam used by gates. If the persisted native session process exits after launch,
+the coordinator records that interruption and applies its bounded resume policy
+without using terminal text as a correctness signal.
+
 When harness capacity is unavailable, the coordinator stops the worker and
 records `waiting_for_harness`; the polling supervisor retries after capacity
 returns. An expired credential stops the worker and waits for an explicit

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -92,3 +92,21 @@ does not scrape its output. A harness publishes completion with
 `factory-report`, which atomically writes a schema-versioned JSON report below
 `/results`; the coordinator validates that report against the persisted
 invocation, current worktree, permitted paths, and stage invariants.
+
+## Recovery lifecycle
+
+The worker lifecycle is recoverable independently of workflow budget. A stopped
+worker is resumed only when its frozen image and complete mount contract still
+match the persisted invocation. If the worker is missing or its immutable
+invocation mounts are stale, the adapter recreates it from the persisted
+`image@digest` request. The bind-mounted worktree, named role volume, and
+factory-managed credential volume survive that recreation; the invocation and
+result directories are mounted again from their persisted paths.
+
+When harness capacity is unavailable, the coordinator stops the worker and
+records `waiting_for_harness`; the polling supervisor retries after capacity
+returns. An expired credential stops the worker and waits for an explicit
+`factory auth refresh`. A native harness resume that needs operator judgment is
+followed by `factory attach`, which can recreate the worker or cmux workspace
+before releasing the workflow attach gate. No worker recreation or harness
+capacity wait changes the run's workflow retry budget.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -236,7 +236,7 @@ func runResume(ctx context.Context, args []string, defaultConfigPath string, out
 		case result.Run.Status == store.StatusWaitingForHuman:
 			status = "waiting for human"
 		}
-		if !writeOutput(output, errorsOutput, "agent %s\nrun: %s\ninvocation: %s\nstatus: %s\n", status, result.Run.ID, result.Invocation.ID, result.Run.Status) {
+		if !writeOutput(output, errorsOutput, "agent %s\nrun: %s\ninvocation: %s\nstatus: %s\n", status, result.Run.ID, result.Invocation.ID, status) {
 			return 1
 		}
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -34,6 +34,9 @@ var commandTable = []commandDefinition{
 	{name: "doctor", handler: runDoctor},
 	{name: "start", handler: runStart},
 	{name: "stop", handler: runStop},
+	{name: "resume", handler: runResume},
+	{name: "attach", handler: runAttach},
+	{name: "auth", handler: runAuth},
 	{name: "issue", handler: runIssue},
 	{name: "agent", handler: runAgent},
 	{name: "agent-report", handler: runAgentReport},
@@ -202,6 +205,102 @@ func runStop(ctx context.Context, args []string, defaultConfigPath string, outpu
 		return 0
 	}
 	if !writeOutput(output, errorsOutput, "factory is not running\n") {
+		return 1
+	}
+	return 0
+}
+
+// runResume performs one explicit native-session or harness-capacity recovery
+// for the active run. A successful native resume remains behind the attach
+// gate until the operator acknowledges the visible terminal session.
+func runResume(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("resume", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "active factory run identifier")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("resume does not accept positional arguments"))
+		return 2
+	}
+	result, err := factory.New(*configPath).Resume(ctx, factory.ResumeRequest{RunID: *runID})
+	if result.Invocation.ID != "" {
+		status := "resumed"
+		switch {
+		case result.WaitingForAttach:
+			status = "resumed; attach required"
+		case result.Run.Status == store.StatusWaitingForHarness:
+			status = "waiting for harness capacity"
+		case result.Run.Status == store.StatusWaitingForHuman:
+			status = "waiting for human"
+		}
+		if !writeOutput(output, errorsOutput, "agent %s\nrun: %s\ninvocation: %s\nstatus: %s\n", status, result.Run.ID, result.Invocation.ID, result.Run.Status) {
+			return 1
+		}
+	}
+	if err != nil {
+		var attachRequired *factory.ManualResumeRequiredError
+		if errors.As(err, &attachRequired) && result.WaitingForAttach {
+			return 0
+		}
+		writeError(errorsOutput, err)
+		return 1
+	}
+	return 0
+}
+
+// runAttach restores the worker and visible terminal topology, then releases
+// the manual native-session gate for the active run.
+func runAttach(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("attach", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "active factory run identifier")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("attach does not accept positional arguments"))
+		return 2
+	}
+	result, err := factory.New(*configPath).Attach(ctx, factory.AttachRequest{RunID: *runID})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "agent attached\nrun: %s\ninvocation: %s\nstatus: %s\n", result.Run.ID, result.Invocation.ID, result.Run.Status) {
+		return 1
+	}
+	return 0
+}
+
+// runAuth dispatches authentication maintenance subcommands. The refresh
+// operation only seeds a factory-managed worker credential store.
+func runAuth(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	if len(args) == 0 || args[0] != "refresh" {
+		writeError(errorsOutput, errors.New("auth requires the refresh subcommand"))
+		return 2
+	}
+	flags := flag.NewFlagSet("auth refresh", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "active factory run identifier")
+	harnessName := flags.String("harness", "", "codex or claude; empty uses the invocation harness")
+	if err := flags.Parse(args[1:]); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("auth refresh does not accept positional arguments"))
+		return 2
+	}
+	result, err := factory.New(*configPath).RefreshAuth(ctx, factory.AuthRefreshRequest{RunID: *runID, Harness: config.Harness(*harnessName)})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "authentication refreshed\nrun: %s\ninvocation: %s\nharness: %s\n", result.Run.ID, result.Invocation.ID, result.Harness) {
 		return 1
 	}
 	return 0

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -114,6 +114,11 @@ func TestRunRequiresACommand(t *testing.T) {
 	if !strings.Contains(output.String(), "a command is required") {
 		t.Fatalf("output = %q", output.String())
 	}
+	for _, command := range []string{"resume", "attach", "auth"} {
+		if !strings.Contains(output.String(), command) {
+			t.Fatalf("missing %q recovery command in help-like error: %q", command, output.String())
+		}
+	}
 }
 
 func TestRunInitRejectsPositionalArguments(t *testing.T) {

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -179,6 +179,9 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	if invocation == nil {
 		return AgentResult{}, fmt.Errorf("invocation %q does not belong to run %q", request.InvocationID, run.ID)
 	}
+	if invocation.AttachRequired {
+		return AgentResult{}, fmt.Errorf("invocation %q requires `factory attach` before report acceptance", invocation.ID)
+	}
 	if invocation.Status != store.InvocationStatusActive {
 		if journal, journaled := runStore.(PendingEffectStore); journaled {
 			pending, pendingErr := journal.PendingEffect(ctx, run.ID)
@@ -380,6 +383,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 			nextRun.Revision = previousRun.Revision
 		}
 		nextRun.UpdatedAt = s.deps.Now().UTC()
+		stopWorkerAfterReport := value.Outcome == report.OutcomeNeedsClarification || isReviewReport
 		acceptedInvocation, nextRun, err = s.acceptResultWithEffect(ctx, runStore, invocationStore, registration, harnessRuntime, harness.Session{
 			InvocationID:    acceptedInvocation.ID,
 			NativeSessionID: nativeSessionID,
@@ -388,7 +392,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 				WorkspaceID: terminal.WorkspaceID(acceptedInvocation.WorkspaceID),
 				Name:        acceptedInvocation.Role,
 			},
-		}, acceptedInvocation, previousRun, nextRun, value.Outcome == report.OutcomeNeedsClarification, value)
+		}, acceptedInvocation, previousRun, nextRun, stopWorkerAfterReport, value)
 		if err != nil {
 			return AgentResult{}, err
 		}

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -49,6 +49,9 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 			return AgentLaunchResult{}, fmt.Errorf("look up active visible invocation: %w", lookupErr)
 		}
 		if active != nil {
+			if active.AttachRequired {
+				return AgentLaunchResult{}, fmt.Errorf("run %q has a manually resumed invocation that requires `factory attach`", run.ID)
+			}
 			if !s.invocationStartedHere(active.ID) && active.RecoveryResumeCount > 0 {
 				s.markInvocationStarted(active.ID)
 				return AgentLaunchResult{Invocation: *active}, nil
@@ -187,9 +190,10 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	}
 	invocationPersisted := false
 	workerStarted := false
+	preserveInvocation := false
 	cleanupSurface := terminal.Surface{}
 	defer func() {
-		if returnErr == nil || !invocationPersisted {
+		if returnErr == nil || !invocationPersisted || preserveInvocation {
 			return
 		}
 		if journal, journaled := runStore.(PendingEffectStore); journaled {
@@ -314,7 +318,85 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		ReasoningEffort: policy.ReasoningEffort,
 	})
 	if err != nil {
-		return AgentLaunchResult{}, fmt.Errorf("launch %s %s agent: %w", policy.Harness, role, err)
+		classified := harness.ClassifyError(err, string(policy.Harness))
+		if harness.IsRateLimited(classified) {
+			preserveInvocation = true
+			invocation.Status = store.InvocationStatusSuperseded
+			invocation.UpdatedAt = s.deps.Now().UTC()
+			if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
+				return AgentLaunchResult{}, fmt.Errorf("persist rate-limited invocation: %w", saveErr)
+			}
+			if _, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, *run, string(policy.Harness)); waitErr != nil {
+				return AgentLaunchResult{Invocation: invocation}, errors.Join(classified, waitErr)
+			}
+			return AgentLaunchResult{Invocation: invocation}, classified
+		}
+		if harness.IsAuthenticationExpired(classified) {
+			preserveInvocation = true
+			if session.NativeSessionID == "" {
+				invocation.Status = store.InvocationStatusSuperseded
+			} else {
+				invocation.NativeSessionID = session.NativeSessionID
+			}
+			invocation.UpdatedAt = s.deps.Now().UTC()
+			if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
+				return AgentLaunchResult{}, fmt.Errorf("persist authentication failure state: %w", saveErr)
+			}
+			if _, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, string(policy.Harness)); pauseErr != nil {
+				return AgentLaunchResult{Invocation: invocation}, errors.Join(classified, pauseErr)
+			}
+			return AgentLaunchResult{Invocation: invocation}, classified
+		}
+		if harness.IsUnexpectedExit(classified) && session.NativeSessionID != "" {
+			preserveInvocation = true
+			invocation.NativeSessionID = session.NativeSessionID
+			invocation.UpdatedAt = s.deps.Now().UTC()
+			if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
+				return AgentLaunchResult{}, fmt.Errorf("persist unexpected harness exit state: %w", saveErr)
+			}
+			resumed, resumeErr := s.resumePersistedInvocation(ctx, registration, runStore, *run, invocation)
+			if resumeErr == nil {
+				previousRun := *run
+				run.Stage = stage
+				run.Status = store.StatusActive
+				run.UpdatedAt = s.deps.Now().UTC()
+				if stateErr := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); stateErr != nil {
+					return AgentLaunchResult{Invocation: resumed}, stateErr
+				}
+				s.markInvocationStarted(resumed.ID)
+				return AgentLaunchResult{Invocation: resumed, Prompt: promptText}, nil
+			}
+			resumeClassified := classifyHarnessRuntimeErrorForInvocation(invocation, resumeErr)
+			if harness.IsRateLimited(resumeClassified) {
+				if _, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, *run, string(policy.Harness)); waitErr != nil {
+					return AgentLaunchResult{Invocation: resumed}, errors.Join(resumeClassified, waitErr)
+				}
+				return AgentLaunchResult{Invocation: resumed}, resumeClassified
+			}
+			if harness.IsAuthenticationExpired(resumeClassified) {
+				if _, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, string(policy.Harness)); pauseErr != nil {
+					return AgentLaunchResult{Invocation: resumed}, errors.Join(resumeClassified, pauseErr)
+				}
+				return AgentLaunchResult{Invocation: resumed}, resumeClassified
+			}
+			if _, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, string(policy.Harness), classified); pauseErr != nil {
+				return AgentLaunchResult{Invocation: resumed}, errors.Join(classified, pauseErr)
+			}
+			return AgentLaunchResult{Invocation: resumed}, classified
+		}
+		if harness.IsUnexpectedExit(classified) {
+			preserveInvocation = true
+			invocation.Status = store.InvocationStatusSuperseded
+			invocation.UpdatedAt = s.deps.Now().UTC()
+			if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
+				return AgentLaunchResult{}, fmt.Errorf("persist unresumable harness exit state: %w", saveErr)
+			}
+			if _, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, string(policy.Harness), classified); pauseErr != nil {
+				return AgentLaunchResult{Invocation: invocation}, errors.Join(classified, pauseErr)
+			}
+			return AgentLaunchResult{Invocation: invocation}, classified
+		}
+		return AgentLaunchResult{}, fmt.Errorf("launch %s %s agent: %w", policy.Harness, role, classified)
 	}
 	if session.NativeSessionID != "" {
 		invocation.NativeSessionID = session.NativeSessionID
@@ -346,8 +428,24 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 // resumePersistedInvocation restores one active invocation after a coordinator
 // restart. It reuses the persisted worker, workspace, surface, harness, and
 // native session identity; it never creates a second invocation for the run.
+// The worker is stopped before reattachment so a cmux restart cannot leave an
+// orphaned harness process alongside the resumed native session; its worktree
+// and role volumes remain intact.
 func (s *Service) resumePersistedInvocation(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, invocation store.Invocation) (store.Invocation, error) {
-	if invocation.RecoveryResumeCount > 0 {
+	return s.resumePersistedInvocationWithMode(ctx, registration, runStore, run, invocation, true)
+}
+
+// resumePersistedInvocationManually performs an operator-requested native
+// resume. Manual recovery is allowed after the one automatic attempt, but it
+// records that the resulting session must be attached before progression.
+func (s *Service) resumePersistedInvocationManually(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, invocation store.Invocation) (store.Invocation, error) {
+	return s.resumePersistedInvocationWithMode(ctx, registration, runStore, run, invocation, false)
+}
+
+// resumePersistedInvocationWithMode restores one invocation through either the
+// bounded automatic recovery path or the explicit operator path.
+func (s *Service) resumePersistedInvocationWithMode(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, invocation store.Invocation, automatic bool) (store.Invocation, error) {
+	if automatic && invocation.RecoveryResumeCount > 0 {
 		return invocation, nil
 	}
 	invocationStore, ok := runStore.(InvocationStore)
@@ -356,6 +454,9 @@ func (s *Service) resumePersistedInvocation(ctx context.Context, registration co
 	}
 	if strings.TrimSpace(invocation.NativeSessionID) == "" {
 		return invocation, errors.New("active invocation has no persisted native session identifier")
+	}
+	if err := s.stopRunWorker(ctx, run.ID); err != nil {
+		return invocation, err
 	}
 	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
 	if err != nil {
@@ -376,75 +477,18 @@ func (s *Service) resumePersistedInvocation(ctx context.Context, registration co
 	if err != nil {
 		return invocation, err
 	}
-	gitMetadataPath, err := prepareGitMetadataProjection(run.ID, registration.Path, run.Worktree)
+	if _, err := s.ensureWorkerForInvocation(ctx, registration, runStore, run, invocation); err != nil {
+		return invocation, err
+	}
+	workspaceID, implementationSurface, statusSurface, checksSurface, restored, err := s.restoreInvocationTerminal(ctx, terminalRuntime, run, invocation)
 	if err != nil {
-		return invocation, fmt.Errorf("prepare recovery Git metadata: %w", err)
+		return invocation, err
 	}
-	workerRequest := worker.StartRequest{
-		RunID:             run.ID,
-		WorktreePath:      run.Worktree,
-		GitMetadataPath:   gitMetadataPath,
-		Image:             packet.RepositoryConfig.WorkerBuild.Image,
-		ImageDigest:       run.ImageDigest,
-		Caches:            workerCaches(packet.RepositoryConfig.Caches),
-		InvocationPath:    invocation.InvocationDirectory,
-		ResultPath:        invocation.ResultDirectory,
-		CredentialStoreID: invocation.CredentialStoreID,
-		Role:              invocation.Role,
-	}
-	if s.deps.Worker == nil {
-		return invocation, errors.New("worker runtime is required for invocation recovery")
-	}
-	inspection, err := s.deps.Worker.Inspect(ctx, run.ID)
-	if err != nil {
-		return invocation, fmt.Errorf("inspect worker for invocation recovery: %w", err)
-	}
-	if inspection.Exists {
-		if !workerImageMatches(inspection.Image, workerRequest.Image, workerRequest.ImageDigest) {
-			return invocation, fmt.Errorf("persisted worker image %q does not match frozen image %q@%s", inspection.Image, workerRequest.Image, workerRequest.ImageDigest)
-		}
-		if inspection.Running {
-			known, matches := inspection.MountContractStatus(workerRequest)
-			if !known {
-				return invocation, errors.New("persisted running worker does not expose mount contract identity")
-			}
-			if !matches {
-				return invocation, errors.New("persisted running worker mount contract does not match the invocation")
-			}
-		}
-	}
-	if !inspection.Exists || !inspection.Running {
-		if err := s.startWorkerWithEffect(ctx, runStore, workerRequest); err != nil {
-			return invocation, fmt.Errorf("start missing worker during invocation recovery: %w", err)
-		}
-	}
-	workspaceID := terminal.WorkspaceID(invocation.WorkspaceID)
-	implementationSurface := terminal.Surface{
-		ID:          terminal.SurfaceID(invocation.ImplementationSurfaceID),
-		WorkspaceID: workspaceID,
-		Name:        invocation.Role,
-	}
-	if workspaceID == "" || implementationSurface.ID == "" {
-		runWorkspace, workspaceErr := terminalRuntime.EnsureRunWorkspace(ctx, terminal.RunWorkspaceRequest{
-			RunID:            run.ID,
-			Name:             "factory-" + run.ID,
-			Description:      fmt.Sprintf("factory run for issue #%d", run.IssueNumber),
-			WorkingDirectory: run.Worktree,
-		})
-		if workspaceErr != nil {
-			return invocation, fmt.Errorf("restore run terminal workspace: %w", workspaceErr)
-		}
-		workspaceID = runWorkspace.ID
-		implementationSurface = runWorkspace.Implementation
-		if invocation.Role == "test" {
-			implementationSurface = runWorkspace.Checks
-		} else if invocation.Role == "spec_review" {
-			implementationSurface = terminal.Surface{WorkspaceID: runWorkspace.ID, Name: "spec-review"}
-		}
-		invocation.WorkspaceID = string(runWorkspace.ID)
-		invocation.StatusSurfaceID = string(runWorkspace.Status.ID)
+	if restored {
+		invocation.WorkspaceID = string(workspaceID)
+		invocation.StatusSurfaceID = string(statusSurface.ID)
 		invocation.ImplementationSurfaceID = string(implementationSurface.ID)
-		invocation.ChecksSurfaceID = string(runWorkspace.Checks.ID)
+		invocation.ChecksSurfaceID = string(checksSurface.ID)
 		if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
 			return invocation, fmt.Errorf("persist restored terminal handles: %w", err)
 		}
@@ -462,7 +506,12 @@ func (s *Service) resumePersistedInvocation(ctx context.Context, registration co
 		ReasoningEffort: invocation.ReasoningEffort,
 		ResumeSessionID: invocation.NativeSessionID,
 	}
-	updated, err := s.resumeHarnessWithEffect(ctx, runStore, invocationStore, registration.Cmux.SocketPath, harnessRuntime, invocation, resumeRequest)
+	var updated store.Invocation
+	if automatic {
+		updated, err = s.resumeHarnessWithEffect(ctx, runStore, invocationStore, registration.Cmux.SocketPath, harnessRuntime, invocation, resumeRequest)
+	} else {
+		updated, err = s.resumeHarnessManuallyWithEffect(ctx, runStore, invocationStore, registration.Cmux.SocketPath, harnessRuntime, invocation, resumeRequest)
+	}
 	if err != nil {
 		return updated, err
 	}

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -333,11 +333,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		}
 		if harness.IsAuthenticationExpired(classified) {
 			preserveInvocation = true
-			if session.NativeSessionID == "" {
-				invocation.Status = store.InvocationStatusSuperseded
-			} else {
-				invocation.NativeSessionID = session.NativeSessionID
-			}
+			invocation.Status = store.InvocationStatusSuperseded
 			invocation.UpdatedAt = s.deps.Now().UTC()
 			if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
 				return AgentLaunchResult{}, fmt.Errorf("persist authentication failure state: %w", saveErr)
@@ -347,49 +343,12 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 			}
 			return AgentLaunchResult{Invocation: invocation}, classified
 		}
-		if harness.IsUnexpectedExit(classified) && session.NativeSessionID != "" {
-			preserveInvocation = true
-			invocation.NativeSessionID = session.NativeSessionID
-			invocation.UpdatedAt = s.deps.Now().UTC()
-			if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
-				return AgentLaunchResult{}, fmt.Errorf("persist unexpected harness exit state: %w", saveErr)
-			}
-			resumed, resumeErr := s.resumePersistedInvocation(ctx, registration, runStore, *run, invocation)
-			if resumeErr == nil {
-				previousRun := *run
-				run.Stage = stage
-				run.Status = store.StatusActive
-				run.UpdatedAt = s.deps.Now().UTC()
-				if stateErr := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); stateErr != nil {
-					return AgentLaunchResult{Invocation: resumed}, stateErr
-				}
-				s.markInvocationStarted(resumed.ID)
-				return AgentLaunchResult{Invocation: resumed, Prompt: promptText}, nil
-			}
-			resumeClassified := classifyHarnessRuntimeErrorForInvocation(invocation, resumeErr)
-			if harness.IsRateLimited(resumeClassified) {
-				if _, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, *run, string(policy.Harness)); waitErr != nil {
-					return AgentLaunchResult{Invocation: resumed}, errors.Join(resumeClassified, waitErr)
-				}
-				return AgentLaunchResult{Invocation: resumed}, resumeClassified
-			}
-			if harness.IsAuthenticationExpired(resumeClassified) {
-				if _, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, string(policy.Harness)); pauseErr != nil {
-					return AgentLaunchResult{Invocation: resumed}, errors.Join(resumeClassified, pauseErr)
-				}
-				return AgentLaunchResult{Invocation: resumed}, resumeClassified
-			}
-			if _, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, string(policy.Harness), classified); pauseErr != nil {
-				return AgentLaunchResult{Invocation: resumed}, errors.Join(classified, pauseErr)
-			}
-			return AgentLaunchResult{Invocation: resumed}, classified
-		}
 		if harness.IsUnexpectedExit(classified) {
 			preserveInvocation = true
 			invocation.Status = store.InvocationStatusSuperseded
 			invocation.UpdatedAt = s.deps.Now().UTC()
 			if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
-				return AgentLaunchResult{}, fmt.Errorf("persist unresumable harness exit state: %w", saveErr)
+				return AgentLaunchResult{}, fmt.Errorf("persist unexpected harness exit state: %w", saveErr)
 			}
 			if _, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, string(policy.Harness), classified); pauseErr != nil {
 				return AgentLaunchResult{Invocation: invocation}, errors.Join(classified, pauseErr)

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -54,6 +54,63 @@ func TestStartAgentPersistsAReadOnlyPacketAndRecoverableSurfaceState(t *testing.
 	}
 }
 
+// TestManualResumeRequiresAttachBeforeAnotherRecoveryCommand verifies an
+// explicit native resume is durable, does not consume the automatic ceiling,
+// and remains gated until the operator acknowledges the visible session.
+func TestManualResumeRequiresAttachBeforeAnotherRecoveryCommand(t *testing.T) {
+	service, runStore, runtime, _, harnessRuntime := newAgentService(t)
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+
+	invocation := runStore.invocations[launch.Invocation.ID]
+	invocation.NativeSessionID = "session-original"
+	if err := runStore.SaveInvocation(context.Background(), invocation); err != nil {
+		t.Fatalf("persist native session identity: %v", err)
+	}
+	workerRequest := runtime.starts[0]
+	runtime.inspectResult = &worker.Inspection{
+		Exists:           true,
+		Running:          true,
+		Image:            workerRequest.Image + "@" + workerRequest.ImageDigest,
+		MountFingerprint: worker.MountContractFingerprint(workerRequest),
+	}
+
+	resumed, err := service.Resume(context.Background(), factory.ResumeRequest{RunID: launch.Invocation.RunID})
+	var gateErr *factory.ManualResumeRequiredError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("Resume() error = %v, want ManualResumeRequiredError", err)
+	}
+	if !resumed.WaitingForAttach || resumed.Invocation.RecoveryResumeCount != 0 || !resumed.Invocation.AttachRequired {
+		t.Fatalf("manual resume result = %#v, want attach gate without automatic budget use", resumed)
+	}
+	if resumed.Run.Status != store.StatusWaitingForHuman {
+		t.Fatalf("run after manual resume = %q, want waiting_for_human", resumed.Run.Status)
+	}
+	if len(harnessRuntime.resumes) != 1 {
+		t.Fatalf("native resume calls = %d, want one", len(harnessRuntime.resumes))
+	}
+
+	if _, err := service.Resume(context.Background(), factory.ResumeRequest{RunID: launch.Invocation.RunID}); !errors.As(err, &gateErr) {
+		t.Fatalf("second Resume() error = %v, want the durable attach gate", err)
+	}
+	if len(harnessRuntime.resumes) != 1 {
+		t.Fatalf("native resume calls after gated retry = %d, want no duplicate", len(harnessRuntime.resumes))
+	}
+
+	attached, err := service.Attach(context.Background(), factory.AttachRequest{RunID: launch.Invocation.RunID})
+	if err != nil {
+		t.Fatalf("Attach() error = %v", err)
+	}
+	if attached.Run.Status != store.StatusActive || attached.Invocation.AttachRequired {
+		t.Fatalf("attach result = %#v, want active run with cleared gate", attached)
+	}
+	if got := runStore.invocations[launch.Invocation.ID]; got.AttachRequired {
+		t.Fatalf("persisted invocation after attach = %#v, want cleared gate", got)
+	}
+}
+
 // TestStartAgentRejectsADuplicateActiveInvocation verifies restart-safe
 // coordination prevents a second visible session for one active run.
 func TestStartAgentRejectsADuplicateActiveInvocation(t *testing.T) {
@@ -943,14 +1000,16 @@ func (*agentRunStore) Close() error { return nil }
 
 // agentWorker records the worker start request without running Docker.
 type agentWorker struct {
-	starts      []worker.StartRequest
-	stops       int
-	commands    []worker.CommandRequest
-	results     []worker.CommandResult
-	events      *[]string
-	interactive []worker.InteractiveRequest
-	codexSeeds  []worker.CredentialSeedRequest
-	claudeSeeds []worker.CredentialSeedRequest
+	starts        []worker.StartRequest
+	stops         int
+	commands      []worker.CommandRequest
+	results       []worker.CommandResult
+	events        *[]string
+	interactive   []worker.InteractiveRequest
+	codexSeeds    []worker.CredentialSeedRequest
+	claudeSeeds   []worker.CredentialSeedRequest
+	inspectResult *worker.Inspection
+	inspectErr    error
 }
 
 // Start records one worker start.
@@ -983,8 +1042,15 @@ func (w *agentWorker) Stop(context.Context, string) error {
 	return nil
 }
 
-// Inspect implements WorkerRuntime.
-func (*agentWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+// Inspect implements WorkerRuntime and optionally returns a configured worker
+// projection for recovery contract tests.
+func (w *agentWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+	if w.inspectErr != nil {
+		return worker.Inspection{}, w.inspectErr
+	}
+	if w.inspectResult != nil {
+		return *w.inspectResult, nil
+	}
 	return worker.Inspection{Exists: true, Running: true}, nil
 }
 
@@ -1043,7 +1109,7 @@ type agentHarness struct {
 
 // Capabilities reports the harness identity this fake stands in for.
 func (*agentHarness) Capabilities() harness.Capabilities {
-	return harness.Capabilities{Name: harness.NameCodex}
+	return harness.Capabilities{Name: harness.NameCodex, InteractiveResume: true}
 }
 
 // Start records the coordinator-owned prompt request.

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -273,6 +273,9 @@ func (s *Service) Transition(ctx context.Context, request TransitionRequest) (st
 	if request.RunID != "" && request.RunID != run.ID {
 		return store.Run{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
 	}
+	if err := s.ensureInvocationAttached(ctx, runStore, *run); err != nil {
+		return store.Run{}, err
+	}
 	if request.Stage == store.StageTest || request.Stage == store.StageImplementation {
 		if strings.TrimSpace(run.SpecificationPacket) == "" {
 			return store.Run{}, errors.New("stage transition requires a frozen specification packet")
@@ -648,6 +651,10 @@ func (s *Service) ensureProgressionStartup(ctx context.Context, registration con
 		return s.startupErr
 	}
 	*run = updated
+	if err := s.ensureInvocationAttached(ctx, runStore, *run); err != nil {
+		s.startupErr = err
+		return s.startupErr
+	}
 	return s.startupErr
 }
 
@@ -674,44 +681,6 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 	if err != nil {
 		s.startupErr = err
 		return s.startupErr
-	}
-	if activeStore, ok := runStore.(ActiveInvocationStore); ok {
-		active, lookupErr := activeStore.ActiveInvocation(ctx, run.ID)
-		if lookupErr != nil {
-			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
-				Kind:     RecoveryDiscrepancyInfrastructure,
-				Source:   "operational store",
-				Field:    "active invocation",
-				Expected: "read active invocation",
-				Observed: lookupErr.Error(),
-			})
-			diagnosis.SourcesAgree = false
-			return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
-		}
-		if active != nil && !s.invocationStartedHere(active.ID) && active.RecoveryResumeCount == 0 {
-			if strings.TrimSpace(active.NativeSessionID) == "" {
-				addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
-					Kind:     RecoveryDiscrepancyInfrastructure,
-					Source:   "harness",
-					Field:    "native session identity",
-					Expected: "persisted native session identifier",
-					Observed: "empty; launch may still be in progress",
-				})
-				diagnosis.SourcesAgree = false
-				return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
-			}
-			if _, resumeErr := s.resumePersistedInvocation(ctx, registration, runStore, *run, *active); resumeErr != nil {
-				addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
-					Kind:     RecoveryDiscrepancyInfrastructure,
-					Source:   "harness",
-					Field:    "native session resume",
-					Expected: "resume persisted session exactly once",
-					Observed: resumeErr.Error(),
-				})
-				diagnosis.SourcesAgree = false
-				return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
-			}
-		}
 	}
 	if run.CheckRepairPendingAttempt != 0 {
 		updated, completionErr := s.completePendingCheckRepair(ctx, registration, runStore, *run)

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -66,6 +66,9 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 	if request.RunID != "" && request.RunID != run.ID {
 		return DraftPullRequestResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
 	}
+	if err := s.ensureInvocationAttached(ctx, runStore, *run); err != nil {
+		return DraftPullRequestResult{}, err
+	}
 	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
 	if err != nil {
 		return DraftPullRequestResult{}, err

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -129,6 +129,9 @@ type harnessResumeEffectPayload struct {
 	Request           harness.StartRequest
 	Invocation        store.Invocation
 	TargetResumeCount int
+	// Manual marks an operator-requested resume. It does not consume the
+	// automatic recovery ceiling and requires a later explicit attach.
+	Manual bool
 }
 
 // resultAcceptanceEffectPayload is the complete durable intent for accepting
@@ -645,7 +648,7 @@ func (s *Service) resumeHarnessWithEffect(ctx context.Context, runStore RunStore
 		// the native command followed by invocation persistence.
 		session, err := runtime.Resume(ctx, request)
 		if err != nil {
-			return invocation, fmt.Errorf("resume native harness session: %w", err)
+			return invocation, fmt.Errorf("resume native harness session: %w", classifyHarnessRuntimeError(runtime, err))
 		}
 		updated := reserved
 		if session.NativeSessionID != "" {
@@ -666,6 +669,7 @@ func (s *Service) resumeHarnessWithEffect(ctx context.Context, runStore RunStore
 		return invocation, err
 	}
 	updated := invocation
+	var waitingFailure error
 	apply := func() error {
 		if err := invocationStore.SaveInvocation(ctx, reserved); err != nil {
 			return fmt.Errorf("reserve native session resume: %w", err)
@@ -673,7 +677,19 @@ func (s *Service) resumeHarnessWithEffect(ctx context.Context, runStore RunStore
 		updated = reserved
 		session, err := runtime.Resume(ctx, request)
 		if err != nil {
-			return fmt.Errorf("resume native harness session: %w", err)
+			classified := classifyHarnessRuntimeError(runtime, err)
+			if harness.IsRateLimited(classified) || harness.IsAuthenticationExpired(classified) {
+				// Capacity and expired-auth failures happen before a native
+				// continuation boundary. Roll the reservation back and clear the
+				// effect so the same invocation remains retryable.
+				if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
+					return fmt.Errorf("rollback native session resume after %s: %w", classified, saveErr)
+				}
+				updated = invocation
+				waitingFailure = classified
+				return nil
+			}
+			return fmt.Errorf("resume native harness session: %w", classified)
 		}
 		if session.NativeSessionID != "" {
 			updated.NativeSessionID = session.NativeSessionID
@@ -690,7 +706,101 @@ func (s *Service) resumeHarnessWithEffect(ctx context.Context, runStore RunStore
 		// the one-resume ceiling even when the journal or native adapter fails.
 		return reserved, err
 	}
+	if waitingFailure != nil {
+		return invocation, waitingFailure
+	}
 	return updated, nil
+}
+
+// resumeHarnessManuallyWithEffect performs an explicit operator resume. The
+// native command is journaled, but the automatic recovery counter is left
+// unchanged because manual intervention is outside that bounded policy.
+func (s *Service) resumeHarnessManuallyWithEffect(ctx context.Context, runStore RunStore, invocationStore InvocationStore, socketPath string, runtime harness.Runtime, invocation store.Invocation, request harness.StartRequest) (store.Invocation, error) {
+	if runtime == nil {
+		return invocation, errors.New("harness runtime is required for manual native resume")
+	}
+	if _, journaled := runStore.(PendingEffectStore); !journaled {
+		return s.resumeHarnessManually(ctx, invocationStore, runtime, invocation, request)
+	}
+	payload := harnessResumeEffectPayload{
+		SocketPath: socketPath, Request: request, Invocation: invocation,
+		TargetResumeCount: invocation.RecoveryResumeCount, Manual: true,
+	}
+	effect, err := s.newPendingEffect(invocation.RunID, store.PendingEffectKindHarnessResume, invocation.ID+"\x00manual", payload)
+	if err != nil {
+		return invocation, err
+	}
+	updated := invocation
+	reserved := invocation
+	reserved.AttachRequired = true
+	reserved.UpdatedAt = s.deps.Now().UTC()
+	var waitingFailure error
+	apply := func() error {
+		if err := invocationStore.SaveInvocation(ctx, reserved); err != nil {
+			return fmt.Errorf("reserve manual native session resume: %w", err)
+		}
+		updated = reserved
+		session, resumeErr := runtime.Resume(ctx, request)
+		if resumeErr != nil {
+			classified := classifyHarnessRuntimeError(runtime, resumeErr)
+			if harness.IsRateLimited(classified) || harness.IsAuthenticationExpired(classified) {
+				// A capacity or credential rejection happens before the
+				// operator can attach a resumed session. Restore the original
+				// invocation so the explicit command remains retryable.
+				if saveErr := invocationStore.SaveInvocation(ctx, invocation); saveErr != nil {
+					return fmt.Errorf("rollback manual native session resume after %s: %w", classified, saveErr)
+				}
+				updated = invocation
+				waitingFailure = classified
+				return nil
+			}
+			return fmt.Errorf("resume native harness session manually: %w", classified)
+		}
+		if session.NativeSessionID != "" {
+			updated.NativeSessionID = session.NativeSessionID
+		}
+		updated.UpdatedAt = s.deps.Now().UTC()
+		if err := invocationStore.SaveInvocation(ctx, updated); err != nil {
+			return fmt.Errorf("persist manually resumed native session: %w", err)
+		}
+		return nil
+	}
+	if err := s.withPendingEffect(ctx, runStore, effect, apply); err != nil {
+		return updated, err
+	}
+	if waitingFailure != nil {
+		return invocation, waitingFailure
+	}
+	return updated, nil
+}
+
+// resumeHarnessManually executes the compatibility path for stores without a
+// pending-effect journal.
+func (s *Service) resumeHarnessManually(ctx context.Context, invocationStore InvocationStore, runtime harness.Runtime, invocation store.Invocation, request harness.StartRequest) (store.Invocation, error) {
+	session, err := runtime.Resume(ctx, request)
+	if err != nil {
+		return invocation, fmt.Errorf("resume native harness session manually: %w", classifyHarnessRuntimeError(runtime, err))
+	}
+	updated := invocation
+	updated.AttachRequired = true
+	if session.NativeSessionID != "" {
+		updated.NativeSessionID = session.NativeSessionID
+	}
+	updated.UpdatedAt = s.deps.Now().UTC()
+	if err := invocationStore.SaveInvocation(ctx, updated); err != nil {
+		return updated, fmt.Errorf("persist manually resumed native session: %w", err)
+	}
+	return updated, nil
+}
+
+// classifyHarnessRuntimeError turns adapter status text into a redacted typed
+// failure while preserving unrelated infrastructure errors.
+func classifyHarnessRuntimeError(runtime harness.Runtime, err error) error {
+	name := ""
+	if runtime != nil {
+		name = runtime.Capabilities().Name
+	}
+	return harness.ClassifyError(err, name)
 }
 
 // replayPendingHarnessResume completes a native-resume reservation. A durable
@@ -713,7 +823,31 @@ func (s *Service) replayPendingHarnessResume(ctx context.Context, runStore RunSt
 	if invocation == nil {
 		return store.Run{}, fmt.Errorf("invocation %q disappeared during harness resume replay", payload.Invocation.ID)
 	}
-	if invocation.RecoveryResumeCount < payload.TargetResumeCount {
+	if payload.Manual {
+		if !invocation.AttachRequired {
+			reserved := *invocation
+			reserved.AttachRequired = true
+			reserved.UpdatedAt = s.deps.Now().UTC()
+			if err := invocationStore.SaveInvocation(ctx, reserved); err != nil {
+				return store.Run{}, fmt.Errorf("reserve replayed manual native session resume: %w", err)
+			}
+			_, harnessRuntime, runtimeErr := s.ensureAgentRuntime(payload.SocketPath, config.Harness(payload.Invocation.Harness))
+			if runtimeErr != nil {
+				return store.Run{}, fmt.Errorf("ensure harness for manual native resume replay: %w", runtimeErr)
+			}
+			session, resumeErr := harnessRuntime.Resume(ctx, payload.Request)
+			if resumeErr != nil {
+				return store.Run{}, fmt.Errorf("resume native harness session during manual replay: %w", classifyHarnessRuntimeError(harnessRuntime, resumeErr))
+			}
+			if session.NativeSessionID != "" {
+				reserved.NativeSessionID = session.NativeSessionID
+			}
+			reserved.UpdatedAt = s.deps.Now().UTC()
+			if err := invocationStore.SaveInvocation(ctx, reserved); err != nil {
+				return store.Run{}, fmt.Errorf("persist replayed manual native session: %w", err)
+			}
+		}
+	} else if invocation.RecoveryResumeCount < payload.TargetResumeCount {
 		reserved := *invocation
 		reserved.RecoveryResumeCount = payload.TargetResumeCount
 		reserved.UpdatedAt = s.deps.Now().UTC()
@@ -726,7 +860,7 @@ func (s *Service) replayPendingHarnessResume(ctx context.Context, runStore RunSt
 		}
 		session, resumeErr := harnessRuntime.Resume(ctx, payload.Request)
 		if resumeErr != nil {
-			return store.Run{}, fmt.Errorf("resume native harness session during replay: %w", resumeErr)
+			return store.Run{}, fmt.Errorf("resume native harness session during replay: %w", classifyHarnessRuntimeError(harnessRuntime, resumeErr))
 		}
 		if session.NativeSessionID != "" {
 			reserved.NativeSessionID = session.NativeSessionID

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -837,7 +837,11 @@ func (s *Service) replayPendingHarnessResume(ctx context.Context, runStore RunSt
 			}
 			session, resumeErr := harnessRuntime.Resume(ctx, payload.Request)
 			if resumeErr != nil {
-				return store.Run{}, fmt.Errorf("resume native harness session during manual replay: %w", classifyHarnessRuntimeError(harnessRuntime, resumeErr))
+				classified := classifyHarnessRuntimeError(harnessRuntime, resumeErr)
+				if harness.IsRateLimited(classified) || harness.IsAuthenticationExpired(classified) {
+					return store.Run{}, rollbackPendingHarnessResume(ctx, runStore, effect, *invocation, classified, "manual")
+				}
+				return store.Run{}, fmt.Errorf("resume native harness session during manual replay: %w", classified)
 			}
 			if session.NativeSessionID != "" {
 				reserved.NativeSessionID = session.NativeSessionID
@@ -860,7 +864,11 @@ func (s *Service) replayPendingHarnessResume(ctx context.Context, runStore RunSt
 		}
 		session, resumeErr := harnessRuntime.Resume(ctx, payload.Request)
 		if resumeErr != nil {
-			return store.Run{}, fmt.Errorf("resume native harness session during replay: %w", classifyHarnessRuntimeError(harnessRuntime, resumeErr))
+			classified := classifyHarnessRuntimeError(harnessRuntime, resumeErr)
+			if harness.IsRateLimited(classified) || harness.IsAuthenticationExpired(classified) {
+				return store.Run{}, rollbackPendingHarnessResume(ctx, runStore, effect, *invocation, classified, "automatic")
+			}
+			return store.Run{}, fmt.Errorf("resume native harness session during replay: %w", classified)
 		}
 		if session.NativeSessionID != "" {
 			reserved.NativeSessionID = session.NativeSessionID
@@ -883,6 +891,29 @@ func (s *Service) replayPendingHarnessResume(ctx context.Context, runStore RunSt
 		return store.Run{}, fmt.Errorf("run %q disappeared during harness resume replay", effect.RunID)
 	}
 	return *run, nil
+}
+
+// rollbackPendingHarnessResume restores the invocation and clears a replay
+// reservation when the adapter rejects the native resume before its boundary.
+// Rate and authentication failures are retryable classifications, so replay
+// must leave the automatic ceiling untouched and let the coordinator publish
+// the appropriate waiting state.
+func rollbackPendingHarnessResume(ctx context.Context, runStore RunStore, effect store.PendingEffect, original store.Invocation, classified error, mode string) error {
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return errors.Join(classified, fmt.Errorf("rollback %s harness resume: invocation store unavailable", mode))
+	}
+	if err := invocationStore.SaveInvocation(ctx, original); err != nil {
+		return errors.Join(classified, fmt.Errorf("rollback %s harness resume: %w", mode, err))
+	}
+	journal, ok := runStore.(PendingEffectStore)
+	if !ok {
+		return classified
+	}
+	if err := journal.ClearPendingEffect(ctx, effect.RunID, effect.ID); err != nil {
+		return errors.Join(classified, fmt.Errorf("clear %s harness resume after rollback: %w", mode, err))
+	}
+	return classified
 }
 
 // pushWithEffect publishes one run branch while recognizing an already

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -883,6 +883,60 @@ func TestHarnessResumeAuthenticationFailureIsTypedAndRedacted(t *testing.T) {
 	}
 }
 
+// TestPendingHarnessResumeReplayPreservesAuthenticationClassification verifies
+// a restart-time replay that reaches the adapter before its reservation is
+// persisted still rolls back cleanly and retains the typed auth failure.
+func TestPendingHarnessResumeReplayPreservesAuthenticationClassification(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	invocation := store.Invocation{
+		ID: "inv-pending-auth-expired", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-pending-auth-expired", Status: store.InvocationStatusActive,
+		CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	service := newEffectMatrixService(nil, nil, nil, nil)
+	payload := harnessResumeEffectPayload{
+		SocketPath: "",
+		Request: harness.StartRequest{
+			InvocationID: invocation.ID, RunID: run.ID, Role: invocation.Role,
+			Stage: string(invocation.Stage), ResumeSessionID: invocation.NativeSessionID,
+		},
+		Invocation: invocation, TargetResumeCount: 1,
+	}
+	effect, err := service.newPendingEffect(run.ID, store.PendingEffectKindHarnessResume, "pending-auth", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SavePendingEffect(ctx, effect); err != nil {
+		t.Fatal(err)
+	}
+	secret := "token=super-secret"
+	runtime := &effectMatrixHarness{resumeErr: errors.New("HTTP 401: " + secret)}
+	service.deps.Harness = runtime
+	_, err = service.replayPendingHarnessResume(ctx, opened, effect)
+	if !harness.IsAuthenticationExpired(err) {
+		t.Fatalf("replayPendingHarnessResume() error = %v, want typed authentication failure", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("replay authentication error leaked credential: %v", err)
+	}
+	persisted, lookupErr := opened.Invocation(ctx, run.ID, invocation.ID)
+	if lookupErr != nil || persisted == nil {
+		t.Fatalf("persisted invocation = %#v, error = %v", persisted, lookupErr)
+	}
+	if persisted.RecoveryResumeCount != 0 {
+		t.Fatalf("persisted replay authentication reservation = %#v, want count zero", persisted)
+	}
+	if pending, pendingErr := opened.PendingEffect(ctx, run.ID); pendingErr != nil || pending != nil {
+		t.Fatalf("pending replay authentication effect = %#v, error = %v; want cleared", pending, pendingErr)
+	}
+}
+
 // TestManualHarnessResumeSetsAnAttachGateWithoutConsumingAutomaticBudget
 // verifies explicit recovery is durable and cannot be mistaken for an
 // automatically authorized continuation.

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -800,6 +800,131 @@ func TestHarnessResumeEffectDoesNotDuplicateAfterResponseLoss(t *testing.T) {
 	}
 }
 
+// TestHarnessResumeRateLimitRollsBackTheAutomaticReservation verifies a
+// temporary capacity failure leaves the one-shot recovery slot unused and the
+// journal clear for a later retry.
+func TestHarnessResumeRateLimitRollsBackTheAutomaticReservation(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	invocation := store.Invocation{
+		ID: "inv-rate-limit", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-rate-limit", Status: store.InvocationStatusActive,
+		CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &effectMatrixHarness{resumeErr: harness.NewRateLimitError(harness.NameCodex)}
+	service := newEffectMatrixService(nil, nil, nil, nil)
+	request := harness.StartRequest{
+		InvocationID: invocation.ID, RunID: run.ID, Role: invocation.Role,
+		Stage: string(invocation.Stage), ResumeSessionID: invocation.NativeSessionID,
+	}
+	if _, err := service.resumeHarnessWithEffect(ctx, opened, opened, "", runtime, invocation, request); !harness.IsRateLimited(err) {
+		t.Fatalf("resumeHarnessWithEffect() error = %v, want typed rate limit", err)
+	}
+	persisted, err := opened.Invocation(ctx, run.ID, invocation.ID)
+	if err != nil || persisted == nil {
+		t.Fatalf("persisted invocation = %#v, error = %v", persisted, err)
+	}
+	if persisted.RecoveryResumeCount != 0 || persisted.AttachRequired {
+		t.Fatalf("persisted rate-limit reservation = %#v, want count zero and no attach gate", persisted)
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil || pending != nil {
+		t.Fatalf("pending rate-limit effect = %#v, error = %v; want cleared", pending, err)
+	}
+	if runtime.resumeCalls != 1 {
+		t.Fatalf("rate-limit resume calls = %d, want one", runtime.resumeCalls)
+	}
+}
+
+// TestHarnessResumeAuthenticationFailureIsTypedAndRedacted verifies an
+// expired credential pauses before consuming the automatic resume slot.
+func TestHarnessResumeAuthenticationFailureIsTypedAndRedacted(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	invocation := store.Invocation{
+		ID: "inv-auth-expired", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-auth-expired", Status: store.InvocationStatusActive,
+		CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	secret := "token=super-secret"
+	runtime := &effectMatrixHarness{resumeErr: errors.New("HTTP 401: " + secret)}
+	service := newEffectMatrixService(nil, nil, nil, nil)
+	request := harness.StartRequest{
+		InvocationID: invocation.ID, RunID: run.ID, Role: invocation.Role,
+		Stage: string(invocation.Stage), ResumeSessionID: invocation.NativeSessionID,
+	}
+	err := error(nil)
+	_, err = service.resumeHarnessWithEffect(ctx, opened, opened, "", runtime, invocation, request)
+	if !harness.IsAuthenticationExpired(err) {
+		t.Fatalf("resumeHarnessWithEffect() error = %v, want typed authentication failure", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("authentication error leaked credential: %v", err)
+	}
+	persisted, lookupErr := opened.Invocation(ctx, run.ID, invocation.ID)
+	if lookupErr != nil || persisted == nil {
+		t.Fatalf("persisted invocation = %#v, error = %v", persisted, lookupErr)
+	}
+	if persisted.RecoveryResumeCount != 0 {
+		t.Fatalf("persisted authentication reservation = %#v, want count zero", persisted)
+	}
+	if pending, pendingErr := opened.PendingEffect(ctx, run.ID); pendingErr != nil || pending != nil {
+		t.Fatalf("pending authentication effect = %#v, error = %v; want cleared", pending, pendingErr)
+	}
+}
+
+// TestManualHarnessResumeSetsAnAttachGateWithoutConsumingAutomaticBudget
+// verifies explicit recovery is durable and cannot be mistaken for an
+// automatically authorized continuation.
+func TestManualHarnessResumeSetsAnAttachGateWithoutConsumingAutomaticBudget(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	invocation := store.Invocation{
+		ID: "inv-manual-resume", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-manual-resume", Status: store.InvocationStatusActive,
+		CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &effectMatrixHarness{}
+	service := newEffectMatrixService(nil, nil, nil, nil)
+	request := harness.StartRequest{
+		InvocationID: invocation.ID, RunID: run.ID, Role: invocation.Role,
+		Stage: string(invocation.Stage), ResumeSessionID: invocation.NativeSessionID,
+	}
+	updated, err := service.resumeHarnessManuallyWithEffect(ctx, opened, opened, "", runtime, invocation, request)
+	if err != nil {
+		t.Fatalf("resumeHarnessManuallyWithEffect() error = %v", err)
+	}
+	if !updated.AttachRequired || updated.RecoveryResumeCount != 0 {
+		t.Fatalf("manual resume = %#v, want attach gate and unchanged automatic count", updated)
+	}
+	if err := service.ensureInvocationAttached(ctx, opened, run); err == nil {
+		t.Fatal("ensureInvocationAttached() = nil, want manual attach gate")
+	} else {
+		var gateErr *ManualResumeRequiredError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("ensureInvocationAttached() error = %v, want ManualResumeRequiredError", err)
+		}
+	}
+	if runtime.resumeCalls != 1 {
+		t.Fatalf("manual resume calls = %d, want one", runtime.resumeCalls)
+	}
+}
+
 // TestCommandProjectionEffectReplaysTheWatermarkAndComment verifies a
 // response lost after the command comment edit leaves a replayable watermark
 // and does not edit the same comment twice after restart.
@@ -1214,6 +1339,8 @@ type effectMatrixHarness struct {
 	failFinishOnce  bool
 	finishCalls     int
 	finishMutations int
+	resumeCalls     int
+	resumeErr       error
 }
 
 // Capabilities reports the harness identity used by the result payload.
@@ -1227,8 +1354,12 @@ func (*effectMatrixHarness) Start(context.Context, harness.StartRequest) (harnes
 }
 
 // Resume satisfies the harness lifecycle seam for effect tests.
-func (*effectMatrixHarness) Resume(context.Context, harness.StartRequest) (harness.Session, error) {
-	return harness.Session{}, nil
+func (h *effectMatrixHarness) Resume(_ context.Context, request harness.StartRequest) (harness.Session, error) {
+	h.resumeCalls++
+	if h.resumeErr != nil {
+		return harness.Session{InvocationID: request.InvocationID, NativeSessionID: request.ResumeSessionID, Surface: request.Surface}, h.resumeErr
+	}
+	return harness.Session{InvocationID: request.InvocationID, NativeSessionID: request.ResumeSessionID, Surface: request.Surface}, nil
 }
 
 // Finish performs one semantic finalization and reports a lost first response.

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -45,6 +45,13 @@ type Factory interface {
 	AcceptAgentReport(context.Context, AgentReportRequest) (AgentResult, error)
 	// RunAgent launches a visible agent and accepts its already-written report.
 	RunAgent(context.Context, AgentRequest) (AgentResult, error)
+	// Resume performs an explicit native-session or harness-capacity recovery.
+	Resume(context.Context, ResumeRequest) (ResumeResult, error)
+	// Attach acknowledges and reattaches a manually resumed visible session.
+	Attach(context.Context, AttachRequest) (AttachResult, error)
+	// RefreshAuth reseeds one factory-managed harness credential from its host
+	// source without modifying the source.
+	RefreshAuth(context.Context, AuthRefreshRequest) (AuthRefreshResult, error)
 	// CreateDraftPullRequest checkpoints the accepted implementation, runs every
 	// configured gate, pushes the branch, and creates or updates one draft PR.
 	CreateDraftPullRequest(context.Context, DraftPullRequestRequest) (DraftPullRequestResult, error)

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -81,6 +81,9 @@ func (s *Service) RunGate(ctx context.Context, request RunGateRequest) (gate.Res
 	if request.RunID != "" && request.RunID != run.ID {
 		return gate.Result{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
 	}
+	if err := s.ensureInvocationAttached(ctx, runStore, *run); err != nil {
+		return gate.Result{}, err
+	}
 	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
 	if err != nil {
 		return gate.Result{}, err
@@ -124,6 +127,9 @@ func (s *Service) RunBaseline(ctx context.Context, request BaselineRequest) (Bas
 	}
 	if request.RunID != "" && request.RunID != run.ID {
 		return BaselineResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
+	}
+	if err := s.ensureInvocationAttached(ctx, runStore, *run); err != nil {
+		return BaselineResult{}, err
 	}
 	baselineReady := run.Stage == store.StageClaim
 	if run.Stage == store.StageTest && run.TestHandoff == nil && !run.TestStageSkipped {

--- a/internal/factory/harness_selection_test.go
+++ b/internal/factory/harness_selection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -71,6 +72,41 @@ func TestStartAgentLaunchesTheHarnessDeclaredForTheRole(t *testing.T) {
 	}
 	if launch.Invocation.NativeSessionID == "" {
 		t.Fatal("invocation has no native session id, want the adapter-assigned Claude session")
+	}
+}
+
+// TestRefreshAuthReseedsTheRegisteredSourceWithoutChangingIt verifies an
+// explicit auth refresh updates only the worker-facing credential projection.
+func TestRefreshAuthReseedsTheRegisteredSourceWithoutChangingIt(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
+	root := t.TempDir()
+	authPath := filepath.Join(root, "auth.json")
+	source := []byte("token=super-secret\n")
+	if err := os.WriteFile(authPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, validRepositoryConfig(), config.AuthenticationConfig{CodexAuthPath: authPath})
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+
+	refreshed, err := service.RefreshAuth(context.Background(), factory.AuthRefreshRequest{RunID: launch.Invocation.RunID})
+	if err != nil {
+		t.Fatalf("RefreshAuth() error = %v", err)
+	}
+	if refreshed.Harness != config.HarnessCodex || refreshed.Invocation.CredentialStoreID == "" {
+		t.Fatalf("RefreshAuth() result = %#v, want Codex and a factory credential store", refreshed)
+	}
+	if len(runtime.codexSeeds) != 2 || runtime.codexSeeds[1].AuthPath != authPath {
+		t.Fatalf("Codex credential seeds = %#v, want launch and refresh from the registered source", runtime.codexSeeds)
+	}
+	unchanged, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(unchanged) != string(source) {
+		t.Fatalf("registered auth source changed to %q", unchanged)
 	}
 }
 

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -257,7 +257,11 @@ func (s *Service) Attach(ctx context.Context, request AttachRequest) (AttachResu
 		}
 		updated.AttachRequired = false
 		updated.UpdatedAt = s.deps.Now().UTC()
-		if err := runStore.(InvocationStore).SaveInvocation(ctx, updated); err != nil {
+		invocationStore, ok := runStore.(InvocationStore)
+		if !ok {
+			return AttachResult{Invocation: updated}, errors.New("operational store does not support invocation persistence")
+		}
+		if err := invocationStore.SaveInvocation(ctx, updated); err != nil {
 			return AttachResult{Invocation: updated}, fmt.Errorf("persist attached invocation: %w", err)
 		}
 	}
@@ -385,22 +389,34 @@ func (s *Service) retryWaitingForHarness(ctx context.Context, registration confi
 			// A consumed automatic slot is a hard boundary. A capacity wait must
 			// never turn a later polling tick into a second native resume.
 			_, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, active.Harness, harness.NewUnexpectedExitError(active.Harness))
-			return pauseErr
+			if pauseErr != nil {
+				return pauseErr
+			}
+			return nil
 		}
 		updated, resumeErr := s.resumePersistedInvocation(ctx, registration, runStore, *run, *active)
 		if resumeErr != nil {
 			classified := classifyHarnessRuntimeErrorForInvocation(*active, resumeErr)
 			if harness.IsRateLimited(classified) {
 				_, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, *run, active.Harness)
-				return waitErr
+				if waitErr != nil {
+					return waitErr
+				}
+				return nil
 			}
 			if harness.IsAuthenticationExpired(classified) {
 				_, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, active.Harness)
-				return errors.Join(classified, pauseErr)
+				if pauseErr != nil {
+					return pauseErr
+				}
+				return nil
 			}
 			if harness.IsUnexpectedExit(classified) {
 				_, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, active.Harness, classified)
-				return errors.Join(classified, pauseErr)
+				if pauseErr != nil {
+					return pauseErr
+				}
+				return nil
 			}
 			return resumeErr
 		}
@@ -462,7 +478,10 @@ func (s *Service) reconcileActiveHarnessLiveness(ctx context.Context, registrati
 		return nil
 	}
 	running, livenessErr := livenessInspector.NativeSessionRunning(ctx, harness.NativeSessionRequest{RunID: run.ID, Harness: active.Harness})
-	if livenessErr == nil && running {
+	if livenessErr != nil {
+		return fmt.Errorf("check native session liveness: %w", livenessErr)
+	}
+	if running {
 		return nil
 	}
 	_, _, _, reconcileErr := s.reconcileInterruptedRunWithMode(ctx, registration, runStore, run, true)

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -1,0 +1,711 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// ResumeRequest selects the active run whose persisted worker and native
+// harness session should be resumed by an operator.
+type ResumeRequest struct {
+	// RunID optionally selects one opaque factory run identifier.
+	RunID string
+}
+
+// ResumeResult reports the invocation restored by an explicit resume command.
+type ResumeResult struct {
+	// Run is the resulting durable run projection.
+	Run store.Run
+	// Invocation is the resumed or newly launched invocation.
+	Invocation store.Invocation
+	// WaitingForAttach reports that the native session must be acknowledged by
+	// factory attach before another workflow action can proceed.
+	WaitingForAttach bool
+}
+
+// AttachRequest selects the active run whose visible native session should be
+// reattached and released for workflow progression.
+type AttachRequest struct {
+	// RunID optionally selects one opaque factory run identifier.
+	RunID string
+}
+
+// AttachResult reports the run and invocation after an attach operation.
+type AttachResult struct {
+	// Run is the resulting durable run projection.
+	Run store.Run
+	// Invocation is the attached invocation.
+	Invocation store.Invocation
+}
+
+// AuthRefreshRequest selects the harness credential source to reseed into the
+// factory-managed worker credential store.
+type AuthRefreshRequest struct {
+	// RunID optionally selects one opaque factory run identifier.
+	RunID string
+	// Harness selects codex or claude. Empty uses the invocation's harness.
+	Harness config.Harness
+}
+
+// AuthRefreshResult reports the credential store identity after a refresh.
+type AuthRefreshResult struct {
+	// Run is unchanged workflow state after credential refresh.
+	Run store.Run
+	// Invocation is the invocation whose worker credential store was reseeded.
+	Invocation store.Invocation
+	// Harness identifies the refreshed adapter.
+	Harness config.Harness
+}
+
+// ManualResumeRequiredError reports that an explicit native resume completed
+// but the operator has not yet acknowledged the visible session.
+type ManualResumeRequiredError struct {
+	// RunID identifies the blocked run.
+	RunID string
+}
+
+// Error explains the attach gate without including any harness output.
+func (e *ManualResumeRequiredError) Error() string {
+	if e == nil {
+		return "manual harness resume requires attach"
+	}
+	return fmt.Sprintf("manual harness resume for run %q requires `factory attach` before progression", e.RunID)
+}
+
+// Resume explicitly restores one persisted native session or retries a run
+// that is waiting for harness capacity. It never consumes the automatic
+// recovery ceiling.
+func (s *Service) Resume(ctx context.Context, request ResumeRequest) (ResumeResult, error) {
+	if err := validateOptionalRunID(request.RunID); err != nil {
+		return ResumeResult{}, err
+	}
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return ResumeResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return ResumeResult{}, fmt.Errorf("read run for resume: %w", err)
+	}
+	if run == nil {
+		return ResumeResult{}, errors.New("no persisted run")
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return ResumeResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
+	}
+	if store.IsTerminalStatus(run.Status) {
+		return ResumeResult{}, fmt.Errorf("cannot resume terminal run %q with status %q", run.ID, run.Status)
+	}
+	if pending, journaled := runStore.(PendingEffectStore); journaled {
+		effect, pendingErr := pending.PendingEffect(ctx, run.ID)
+		if pendingErr != nil {
+			return ResumeResult{}, fmt.Errorf("inspect pending effect before resume: %w", pendingErr)
+		}
+		if effect != nil {
+			updated, _, _, reconcileErr := s.reconcileInterruptedRun(ctx, registration, runStore, *run)
+			*run = updated
+			if reconcileErr != nil {
+				return ResumeResult{Run: *run}, reconcileErr
+			}
+		}
+	}
+
+	activeStore, ok := runStore.(ActiveInvocationStore)
+	if !ok {
+		return ResumeResult{}, errors.New("operational store does not support invocation recovery")
+	}
+	active, err := activeStore.ActiveInvocation(ctx, run.ID)
+	if err != nil {
+		return ResumeResult{}, fmt.Errorf("read active invocation for resume: %w", err)
+	}
+	if active != nil {
+		if active.AttachRequired {
+			return ResumeResult{Run: *run, Invocation: *active, WaitingForAttach: true}, &ManualResumeRequiredError{RunID: run.ID}
+		}
+		if strings.TrimSpace(active.NativeSessionID) == "" {
+			if err := s.supersedeInvocation(ctx, runStore, *active); err != nil {
+				return ResumeResult{}, err
+			}
+			active = nil
+		}
+	}
+	if active == nil {
+		requestForRun := normalizeAgentRequest(agentRequestForRun(*run))
+		launchRun := *run
+		if launchRun.Status != store.StatusActive {
+			launchRun.Status = store.StatusActive
+		}
+		launch, launchErr := s.startAgentWithStore(ctx, registration, runStore, &launchRun, requestForRun)
+		if launchErr != nil {
+			return ResumeResult{Run: *run, Invocation: launch.Invocation}, launchErr
+		}
+		return ResumeResult{Run: launchRun, Invocation: launch.Invocation}, nil
+	}
+
+	updatedInvocation, resumeErr := s.resumePersistedInvocationManually(ctx, registration, runStore, *run, *active)
+	if resumeErr != nil {
+		classified := classifyHarnessRuntimeErrorForInvocation(*active, resumeErr)
+		if harness.IsRateLimited(classified) {
+			paused, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, *run, active.Harness)
+			return ResumeResult{Run: paused, Invocation: updatedInvocation}, errors.Join(classified, waitErr)
+		}
+		if harness.IsAuthenticationExpired(classified) {
+			paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, active.Harness)
+			return ResumeResult{Run: paused, Invocation: updatedInvocation}, errors.Join(classified, pauseErr)
+		}
+		if harness.IsUnexpectedExit(classified) {
+			paused, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, active.Harness, classified)
+			return ResumeResult{Run: paused, Invocation: updatedInvocation}, errors.Join(classified, pauseErr)
+		}
+		return ResumeResult{Run: *run, Invocation: updatedInvocation}, resumeErr
+	}
+
+	if updatedInvocation.AttachRequired {
+		next := *run
+		next.Status = store.StatusWaitingForHuman
+		next.LifecycleReason = "manual native session resumed; attach is required before progression"
+		next.UpdatedAt = s.deps.Now().UTC()
+		if next.Revision <= run.Revision {
+			next.Revision = run.Revision + 1
+		}
+		persistErr := s.persistAgentRunState(ctx, registration, runStore, *run, next)
+		if persistErr != nil {
+			return ResumeResult{Run: next, Invocation: updatedInvocation, WaitingForAttach: true}, errors.Join(&ManualResumeRequiredError{RunID: run.ID}, persistErr)
+		}
+		return ResumeResult{Run: next, Invocation: updatedInvocation, WaitingForAttach: true}, &ManualResumeRequiredError{RunID: run.ID}
+	}
+	return ResumeResult{Run: *run, Invocation: updatedInvocation}, nil
+}
+
+// Attach restores the worker and visible terminal topology, then clears the
+// durable manual-resume gate so report acceptance can proceed.
+func (s *Service) Attach(ctx context.Context, request AttachRequest) (AttachResult, error) {
+	if err := validateOptionalRunID(request.RunID); err != nil {
+		return AttachResult{}, err
+	}
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return AttachResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return AttachResult{}, fmt.Errorf("read run for attach: %w", err)
+	}
+	if run == nil {
+		return AttachResult{}, errors.New("no persisted run")
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return AttachResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
+	}
+	if store.IsTerminalStatus(run.Status) {
+		return AttachResult{}, fmt.Errorf("cannot attach terminal run %q with status %q", run.ID, run.Status)
+	}
+	activeStore, ok := runStore.(ActiveInvocationStore)
+	if !ok {
+		return AttachResult{}, errors.New("operational store does not support invocation recovery")
+	}
+	active, err := activeStore.ActiveInvocation(ctx, run.ID)
+	if err != nil {
+		return AttachResult{}, fmt.Errorf("read active invocation for attach: %w", err)
+	}
+	if active == nil {
+		return AttachResult{}, errors.New("run has no active invocation to attach")
+	}
+	if strings.TrimSpace(active.NativeSessionID) == "" {
+		return AttachResult{}, errors.New("active invocation has no persisted native session identifier")
+	}
+	terminalRuntime, _, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, config.Harness(active.Harness))
+	if err != nil {
+		return AttachResult{}, fmt.Errorf("ensure agent runtime for attach: %w", err)
+	}
+	if _, err := s.ensureWorkerForInvocation(ctx, registration, runStore, *run, *active); err != nil {
+		return AttachResult{}, err
+	}
+	workspaceID, implementationSurface, statusSurface, checksSurface, restored, err := s.restoreInvocationTerminal(ctx, terminalRuntime, *run, *active)
+	if err != nil {
+		return AttachResult{}, err
+	}
+	updated := *active
+	updated.WorkspaceID = string(workspaceID)
+	updated.ImplementationSurfaceID = string(implementationSurface.ID)
+	updated.StatusSurfaceID = string(statusSurface.ID)
+	updated.ChecksSurfaceID = string(checksSurface.ID)
+	if restored || updated.AttachRequired {
+		if restored {
+			// A recreated cmux topology needs a native resume to place the
+			// process into the newly created surface before the attach gate is
+			// cleared.
+			resumed, resumeErr := s.resumePersistedInvocationManually(ctx, registration, runStore, *run, updated)
+			if resumeErr != nil {
+				return AttachResult{Invocation: resumed}, resumeErr
+			}
+			updated = resumed
+		}
+		updated.AttachRequired = false
+		updated.UpdatedAt = s.deps.Now().UTC()
+		if err := runStore.(InvocationStore).SaveInvocation(ctx, updated); err != nil {
+			return AttachResult{Invocation: updated}, fmt.Errorf("persist attached invocation: %w", err)
+		}
+	}
+	next := *run
+	next.Status = store.StatusActive
+	next.LifecycleReason = "manual native session attached"
+	next.UpdatedAt = s.deps.Now().UTC()
+	if next.Revision <= run.Revision {
+		next.Revision = run.Revision + 1
+	}
+	err = s.persistAgentRunState(ctx, registration, runStore, *run, next)
+	if err != nil {
+		return AttachResult{Run: next, Invocation: updated}, err
+	}
+	s.resetStartupState()
+	return AttachResult{Run: next, Invocation: updated}, nil
+}
+
+// RefreshAuth reseeds one host credential source into the factory-managed
+// worker volume. The registration path is read only; no host credential file
+// or source configuration is changed.
+func (s *Service) RefreshAuth(ctx context.Context, request AuthRefreshRequest) (AuthRefreshResult, error) {
+	if err := validateOptionalRunID(request.RunID); err != nil {
+		return AuthRefreshResult{}, err
+	}
+	if request.Harness != "" && request.Harness != config.HarnessCodex && request.Harness != config.HarnessClaude {
+		return AuthRefreshResult{}, fmt.Errorf("unsupported harness %q", request.Harness)
+	}
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return AuthRefreshResult{}, err
+	}
+	defer func() { _ = runStore.Close() }()
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return AuthRefreshResult{}, fmt.Errorf("read run for auth refresh: %w", err)
+	}
+	if run == nil {
+		return AuthRefreshResult{}, errors.New("no persisted run")
+	}
+	if request.RunID != "" && request.RunID != run.ID {
+		return AuthRefreshResult{}, fmt.Errorf("active run is %s, not %s", run.ID, request.RunID)
+	}
+	if store.IsTerminalStatus(run.Status) {
+		return AuthRefreshResult{}, fmt.Errorf("cannot refresh auth for terminal run %q", run.ID)
+	}
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return AuthRefreshResult{}, errors.New("operational store does not support invocation auth refresh")
+	}
+	invocation, err := latestInvocationForAuthRefresh(ctx, runStore, *run)
+	if err != nil {
+		return AuthRefreshResult{}, err
+	}
+	harnessName := request.Harness
+	if harnessName == "" {
+		harnessName = config.Harness(invocation.Harness)
+	}
+	if string(harnessName) != invocation.Harness {
+		return AuthRefreshResult{}, fmt.Errorf("auth refresh harness %q does not match invocation harness %q", harnessName, invocation.Harness)
+	}
+	seed, credentialStoreID, err := s.credentialSeeding(registration, AgentRequest{}, harnessName)
+	if err != nil {
+		return AuthRefreshResult{}, err
+	}
+	if seed == nil || strings.TrimSpace(credentialStoreID) == "" {
+		return AuthRefreshResult{}, fmt.Errorf("no factory-managed %s credential source is registered", harnessName)
+	}
+	if invocation.CredentialStoreID == "" {
+		invocation.CredentialStoreID = credentialStoreID
+		invocation.UpdatedAt = s.deps.Now().UTC()
+		if err := invocationStore.SaveInvocation(ctx, *invocation); err != nil {
+			return AuthRefreshResult{}, fmt.Errorf("persist credential store identity: %w", err)
+		}
+	}
+	if _, err := s.ensureWorkerForInvocation(ctx, registration, runStore, *run, *invocation); err != nil {
+		return AuthRefreshResult{}, err
+	}
+	if err := seed(ctx, run.ID); err != nil {
+		return AuthRefreshResult{}, fmt.Errorf("refresh %s credentials: %w", harnessName, classifyHarnessRuntimeError(nil, err))
+	}
+	return AuthRefreshResult{Run: *run, Invocation: *invocation, Harness: harnessName}, nil
+}
+
+// retryWaitingForHarness performs one automatic retry for a run paused only
+// by temporary harness capacity. It is called by the supervised polling loop.
+func (s *Service) retryWaitingForHarness(ctx context.Context, registration config.RepositoryRegistration) error {
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return fmt.Errorf("open operational store for harness retry: %w", err)
+	}
+	runStore, ok := opened.(RunStore)
+	if !ok {
+		_ = opened.Close()
+		return errors.New("operational store does not support harness retry")
+	}
+	defer func() { _ = runStore.Close() }()
+	run, err := runStore.CurrentRun(ctx)
+	if err != nil {
+		return fmt.Errorf("read run for harness retry: %w", err)
+	}
+	if run == nil || run.Status != store.StatusWaitingForHarness {
+		return nil
+	}
+	activeStore, ok := runStore.(ActiveInvocationStore)
+	if !ok {
+		return errors.New("operational store does not support active invocation lookup")
+	}
+	active, err := activeStore.ActiveInvocation(ctx, run.ID)
+	if err != nil {
+		return fmt.Errorf("read active invocation for harness retry: %w", err)
+	}
+	if active != nil && active.AttachRequired {
+		return nil
+	}
+	if active != nil && strings.TrimSpace(active.NativeSessionID) != "" {
+		if active.RecoveryResumeCount > 0 {
+			// A consumed automatic slot is a hard boundary. A capacity wait must
+			// never turn a later polling tick into a second native resume.
+			_, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, active.Harness, harness.NewUnexpectedExitError(active.Harness))
+			return pauseErr
+		}
+		updated, resumeErr := s.resumePersistedInvocation(ctx, registration, runStore, *run, *active)
+		if resumeErr != nil {
+			classified := classifyHarnessRuntimeErrorForInvocation(*active, resumeErr)
+			if harness.IsRateLimited(classified) {
+				_, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, *run, active.Harness)
+				return waitErr
+			}
+			if harness.IsAuthenticationExpired(classified) {
+				_, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, active.Harness)
+				return errors.Join(classified, pauseErr)
+			}
+			if harness.IsUnexpectedExit(classified) {
+				_, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, *run, active.Harness, classified)
+				return errors.Join(classified, pauseErr)
+			}
+			return resumeErr
+		}
+		next := *run
+		next.Status = store.StatusActive
+		next.LifecycleReason = "harness capacity returned; native session resumed"
+		next.UpdatedAt = s.deps.Now().UTC()
+		next.Revision = run.Revision + 1
+		stateErr := s.persistAgentRunState(ctx, registration, runStore, *run, next)
+		_ = updated
+		return stateErr
+	}
+	if active != nil {
+		if err := s.supersedeInvocation(ctx, runStore, *active); err != nil {
+			return err
+		}
+	}
+	launchRun := *run
+	launchRun.Status = store.StatusActive
+	launch, launchErr := s.startAgentWithStore(ctx, registration, runStore, &launchRun, normalizeAgentRequest(agentRequestForRun(*run)))
+	if launchErr != nil {
+		classified := classifyHarnessRuntimeErrorForInvocation(launch.Invocation, launchErr)
+		if harness.IsRateLimited(classified) {
+			return nil
+		}
+		if harness.IsAuthenticationExpired(classified) || harness.IsUnexpectedExit(classified) {
+			return nil
+		}
+		return launchErr
+	}
+	return nil
+}
+
+// pauseForHarnessCapacity changes an active run to the non-budgeted harness
+// waiting state, stops its worker, and sends one operator notification for the
+// transition.
+func (s *Service) pauseForHarnessCapacity(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, harnessNames ...string) (store.Run, error) {
+	harnessName := "harness"
+	if len(harnessNames) != 0 && strings.TrimSpace(harnessNames[0]) != "" {
+		harnessName = harnessNames[0]
+	}
+	changed := run.Status != store.StatusWaitingForHarness || !strings.HasPrefix(run.LifecycleReason, "harness capacity unavailable")
+	if err := s.stopRunWorker(ctx, run.ID); err != nil {
+		return run, err
+	}
+	if !changed {
+		return run, nil
+	}
+	next := run
+	next.Status = store.StatusWaitingForHarness
+	next.LifecycleReason = fmt.Sprintf("harness capacity unavailable (%s); waiting for capacity", harnessName)
+	next.Revision = run.Revision + 1
+	next.UpdatedAt = s.deps.Now().UTC()
+	updated := next
+	err := s.persistAgentRunState(ctx, registration, runStore, run, next)
+	if err != nil {
+		return updated, err
+	}
+	if notifyErr := s.notifyWorkspace(ctx, registration, "factory harness capacity", fmt.Sprintf("%s is waiting for %s harness capacity", run.ID, harnessName)); notifyErr != nil {
+		return updated, notifyErr
+	}
+	return updated, nil
+}
+
+// pauseForAuthentication records a redacted human-waiting state after the
+// harness rejects its credential. The source credential remains untouched.
+func (s *Service) pauseForAuthentication(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, harnessName string) (store.Run, error) {
+	if err := s.stopRunWorker(ctx, run.ID); err != nil {
+		return run, err
+	}
+	changed := run.Status != store.StatusWaitingForHuman || !strings.HasPrefix(run.LifecycleReason, "harness authentication expired")
+	if !changed {
+		return run, nil
+	}
+	next := run
+	next.Status = store.StatusWaitingForHuman
+	next.LifecycleReason = fmt.Sprintf("harness authentication expired (%s); run is waiting for `factory auth refresh`", harnessName)
+	next.Revision = run.Revision + 1
+	next.UpdatedAt = s.deps.Now().UTC()
+	updated := next
+	err := s.persistAgentRunState(ctx, registration, runStore, run, next)
+	if err != nil {
+		return updated, err
+	}
+	if notifyErr := s.notifyWorkspace(ctx, registration, "factory authentication expired", fmt.Sprintf("%s requires `factory auth refresh` for %s", run.ID, harnessName)); notifyErr != nil {
+		return updated, notifyErr
+	}
+	return updated, nil
+}
+
+// pauseForManualRecovery escalates a failed explicit resume without changing
+// any workflow retry budget.
+func (s *Service) pauseForManualRecovery(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, harnessName string, cause error) (store.Run, error) {
+	if err := s.stopRunWorker(ctx, run.ID); err != nil {
+		return run, err
+	}
+	changed := run.Status != store.StatusWaitingForHuman || !strings.HasPrefix(run.LifecycleReason, "automatic harness recovery exhausted")
+	if !changed {
+		return run, nil
+	}
+	next := run
+	next.Status = store.StatusWaitingForHuman
+	next.LifecycleReason = fmt.Sprintf("automatic harness recovery exhausted (%s); manual resume and attach required", harnessName)
+	next.Revision = run.Revision + 1
+	next.UpdatedAt = s.deps.Now().UTC()
+	updated := next
+	var err error
+	if journal, ok := runStore.(PendingEffectStore); ok {
+		pending, pendingErr := journal.PendingEffect(ctx, run.ID)
+		if pendingErr != nil {
+			return run, fmt.Errorf("inspect pending effect before manual recovery pause: %w", pendingErr)
+		}
+		if pending != nil {
+			err = saveRunWithRetry(ctx, runStore, next)
+		} else {
+			err = s.persistAgentRunState(ctx, registration, runStore, run, next)
+		}
+	} else {
+		err = s.persistAgentRunState(ctx, registration, runStore, run, next)
+	}
+	if err != nil {
+		return updated, err
+	}
+	if notifyErr := s.notifyWorkspace(ctx, registration, "factory harness recovery exhausted", fmt.Sprintf("%s requires manual harness recovery", run.ID)); notifyErr != nil {
+		return updated, errors.Join(cause, notifyErr)
+	}
+	return updated, nil
+}
+
+// ensureWorkerForInvocation validates or recreates the pinned worker for an
+// invocation and returns the exact start request used for credential refresh.
+func (s *Service) ensureWorkerForInvocation(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, invocation store.Invocation) (worker.StartRequest, error) {
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return worker.StartRequest{}, fmt.Errorf("decode specification packet for worker recovery: %w", err)
+	}
+	gitMetadataPath, err := prepareGitMetadataProjection(run.ID, registration.Path, run.Worktree)
+	if err != nil {
+		return worker.StartRequest{}, fmt.Errorf("prepare recovery Git metadata: %w", err)
+	}
+	request := worker.StartRequest{
+		RunID:             run.ID,
+		WorktreePath:      run.Worktree,
+		GitMetadataPath:   gitMetadataPath,
+		Image:             packet.RepositoryConfig.WorkerBuild.Image,
+		ImageDigest:       run.ImageDigest,
+		Caches:            workerCaches(packet.RepositoryConfig.Caches),
+		InvocationPath:    invocation.InvocationDirectory,
+		ResultPath:        invocation.ResultDirectory,
+		CredentialStoreID: invocation.CredentialStoreID,
+		Role:              invocation.Role,
+	}
+	if s.deps.Worker == nil {
+		return worker.StartRequest{}, errors.New("worker runtime is required for invocation recovery")
+	}
+	inspection, err := s.deps.Worker.Inspect(ctx, run.ID)
+	if err != nil {
+		return worker.StartRequest{}, fmt.Errorf("inspect worker for invocation recovery: %w", err)
+	}
+	if inspection.Exists {
+		if !workerImageMatches(inspection.Image, request.Image, request.ImageDigest) {
+			return worker.StartRequest{}, fmt.Errorf("persisted worker image %q does not match frozen image %q@%s", inspection.Image, request.Image, request.ImageDigest)
+		}
+		if inspection.Running {
+			known, matches := inspection.MountContractStatus(request)
+			if known && matches {
+				return request, nil
+			}
+		}
+	}
+	if err := s.startWorkerWithEffect(ctx, runStore, request); err != nil {
+		return worker.StartRequest{}, fmt.Errorf("start or recreate worker during invocation recovery: %w", err)
+	}
+	return request, nil
+}
+
+// restoreInvocationTerminal returns persisted handles when they still exist
+// and recreates the run workspace when cmux lost the workspace or a role
+// surface. It never reads terminal screen contents.
+func (s *Service) restoreInvocationTerminal(ctx context.Context, terminalRuntime terminal.TerminalRuntime, run store.Run, invocation store.Invocation) (terminal.WorkspaceID, terminal.Surface, terminal.Surface, terminal.Surface, bool, error) {
+	workspaceID := terminal.WorkspaceID(invocation.WorkspaceID)
+	implementation := terminal.Surface{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: workspaceID, Name: invocation.Role}
+	status := terminal.Surface{ID: terminal.SurfaceID(invocation.StatusSurfaceID), WorkspaceID: workspaceID, Name: "status"}
+	checks := terminal.Surface{ID: terminal.SurfaceID(invocation.ChecksSurfaceID), WorkspaceID: workspaceID, Name: "checks"}
+	restore := workspaceID == "" || implementation.ID == ""
+	if inspector, ok := terminalRuntime.(terminal.WorkspaceInspector); ok && !restore {
+		observed, err := inspector.InspectWorkspace(ctx, workspaceID)
+		if err != nil {
+			return workspaceID, implementation, status, checks, false, fmt.Errorf("inspect terminal workspace for recovery: %w", err)
+		}
+		if !observed.Exists {
+			restore = true
+		} else {
+			ids := make(map[terminal.SurfaceID]struct{}, len(observed.Surfaces))
+			for _, surface := range observed.Surfaces {
+				ids[surface.ID] = struct{}{}
+			}
+			for _, surface := range []terminal.Surface{implementation, status, checks} {
+				if surface.ID != "" {
+					if _, exists := ids[surface.ID]; !exists {
+						restore = true
+					}
+				}
+			}
+		}
+	}
+	if !restore {
+		return workspaceID, implementation, status, checks, false, nil
+	}
+	runWorkspace, err := terminalRuntime.EnsureRunWorkspace(ctx, terminal.RunWorkspaceRequest{
+		RunID:            run.ID,
+		Name:             "factory-" + run.ID,
+		Description:      fmt.Sprintf("factory run for issue #%d", run.IssueNumber),
+		WorkingDirectory: run.Worktree,
+	})
+	if err != nil {
+		return workspaceID, implementation, status, checks, false, fmt.Errorf("restore run terminal workspace: %w", err)
+	}
+	workspaceID = runWorkspace.ID
+	status = runWorkspace.Status
+	checks = runWorkspace.Checks
+	implementation = runWorkspace.Implementation
+	if invocation.Role == "test" {
+		implementation = runWorkspace.Checks
+	} else if invocation.Role == "spec_review" {
+		implementation = terminal.Surface{WorkspaceID: runWorkspace.ID, Name: "spec-review"}
+	}
+	return workspaceID, implementation, status, checks, true, nil
+}
+
+// latestInvocationForAuthRefresh selects the active invocation or the latest
+// superseded attempt that still carries the worker identity needed to reseed.
+func latestInvocationForAuthRefresh(ctx context.Context, runStore RunStore, run store.Run) (*store.Invocation, error) {
+	if activeStore, ok := runStore.(ActiveInvocationStore); ok {
+		active, err := activeStore.ActiveInvocation(ctx, run.ID)
+		if err != nil {
+			return nil, fmt.Errorf("read active invocation for auth refresh: %w", err)
+		}
+		if active != nil {
+			return active, nil
+		}
+	}
+	latestStore, ok := runStore.(LatestInvocationStore)
+	if !ok {
+		return nil, errors.New("operational store does not support latest invocation lookup")
+	}
+	latest, err := latestStore.LatestInvocation(ctx, run.ID)
+	if err != nil {
+		return nil, fmt.Errorf("read latest invocation for auth refresh: %w", err)
+	}
+	if latest == nil {
+		return nil, errors.New("run has no invocation to refresh")
+	}
+	return latest, nil
+}
+
+// supersedeInvocation closes an incomplete launch before a fresh capacity or
+// authentication retry creates the next immutable invocation identity.
+func (s *Service) supersedeInvocation(ctx context.Context, runStore RunStore, invocation store.Invocation) error {
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return errors.New("operational store does not support invocation recovery")
+	}
+	invocation.Status = store.InvocationStatusSuperseded
+	invocation.UpdatedAt = s.deps.Now().UTC()
+	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
+		return fmt.Errorf("supersede interrupted invocation: %w", err)
+	}
+	return nil
+}
+
+// classifyHarnessRuntimeErrorForInvocation preserves typed harness failures
+// while avoiding any attempt to expose adapter output for known categories.
+func classifyHarnessRuntimeErrorForInvocation(invocation store.Invocation, err error) error {
+	return harness.ClassifyError(err, invocation.Harness)
+}
+
+// validateOptionalRunID rejects command-line control characters before they
+// reach a store lookup or an external adapter.
+func validateOptionalRunID(runID string) error {
+	if strings.ContainsAny(runID, "\x00\r\n") {
+		return errors.New("run id contains control characters")
+	}
+	return nil
+}
+
+// ensureInvocationAttached rejects workflow progression while a manual native
+// resume remains unacknowledged by the operator.
+func (s *Service) ensureInvocationAttached(ctx context.Context, runStore RunStore, run store.Run) error {
+	activeStore, ok := runStore.(ActiveInvocationStore)
+	if !ok {
+		return nil
+	}
+	active, err := activeStore.ActiveInvocation(ctx, run.ID)
+	if err != nil {
+		return fmt.Errorf("read active invocation attach gate: %w", err)
+	}
+	if active != nil && active.AttachRequired {
+		return &ManualResumeRequiredError{RunID: run.ID}
+	}
+	return nil
+}
+
+// resetStartupState lets a successful explicit attach reopen progression seams
+// in a long-lived embedded service that previously cached the attach gate.
+func (s *Service) resetStartupState() {
+	s.startupMu.Lock()
+	defer s.startupMu.Unlock()
+	s.startupChecked = false
+	s.startupErr = nil
+}

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -363,8 +363,11 @@ func (s *Service) retryWaitingForHarness(ctx context.Context, registration confi
 	if err != nil {
 		return fmt.Errorf("read run for harness retry: %w", err)
 	}
-	if run == nil || run.Status != store.StatusWaitingForHarness {
+	if run == nil {
 		return nil
+	}
+	if run.Status != store.StatusWaitingForHarness {
+		return s.reconcileActiveHarnessLiveness(ctx, registration, runStore, *run)
 	}
 	activeStore, ok := runStore.(ActiveInvocationStore)
 	if !ok {
@@ -431,13 +434,50 @@ func (s *Service) retryWaitingForHarness(ctx context.Context, registration confi
 	return nil
 }
 
+// reconcileActiveHarnessLiveness observes an active native session on every
+// supervised polling pass. A process exit is handed to the same reconciliation
+// state machine used at startup, with same-process recovery enabled because
+// this observer has directly established the interruption boundary.
+func (s *Service) reconcileActiveHarnessLiveness(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) error {
+	if run.Status != store.StatusActive {
+		return nil
+	}
+	activeStore, ok := runStore.(ActiveInvocationStore)
+	if !ok {
+		return nil
+	}
+	active, err := activeStore.ActiveInvocation(ctx, run.ID)
+	if err != nil {
+		return fmt.Errorf("read active invocation for liveness monitoring: %w", err)
+	}
+	if active == nil || active.AttachRequired || strings.TrimSpace(active.NativeSessionID) == "" {
+		return nil
+	}
+	_, harnessRuntime, runtimeErr := s.ensureAgentRuntime(registration.Cmux.SocketPath, config.Harness(active.Harness))
+	if runtimeErr != nil {
+		return fmt.Errorf("ensure harness for liveness monitoring: %w", runtimeErr)
+	}
+	livenessInspector, ok := harnessRuntime.(harness.NativeSessionLivenessInspector)
+	if !ok {
+		return nil
+	}
+	running, livenessErr := livenessInspector.NativeSessionRunning(ctx, harness.NativeSessionRequest{RunID: run.ID, Harness: active.Harness})
+	if livenessErr == nil && running {
+		return nil
+	}
+	_, _, _, reconcileErr := s.reconcileInterruptedRunWithMode(ctx, registration, runStore, run, true)
+	if reconcileErr != nil {
+		return reconcileErr
+	}
+	return nil
+}
+
 // pauseForHarnessCapacity changes an active run to the non-budgeted harness
 // waiting state, stops its worker, and sends one operator notification for the
 // transition.
-func (s *Service) pauseForHarnessCapacity(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, harnessNames ...string) (store.Run, error) {
-	harnessName := "harness"
-	if len(harnessNames) != 0 && strings.TrimSpace(harnessNames[0]) != "" {
-		harnessName = harnessNames[0]
+func (s *Service) pauseForHarnessCapacity(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, harnessName string) (store.Run, error) {
+	if strings.TrimSpace(harnessName) == "" {
+		harnessName = "harness"
 	}
 	changed := run.Status != store.StatusWaitingForHarness || !strings.HasPrefix(run.LifecycleReason, "harness capacity unavailable")
 	if err := s.stopRunWorker(ctx, run.ID); err != nil {

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -153,6 +153,12 @@ func (s *Service) Start(ctx context.Context) error {
 		}
 		consecutiveLeaseFailures = 0
 
+		if err := s.retryWaitingForHarness(pollContext, registration); err != nil {
+			if pollingContextDone(err) {
+				return nil
+			}
+			return err
+		}
 		result, err := s.pollOnce(pollContext, registration)
 		if err != nil {
 			if pollingContextDone(err) {
@@ -223,6 +229,9 @@ func (s *Service) Stop(ctx context.Context) (StopResult, error) {
 func (s *Service) PollOnce(ctx context.Context) (PollResult, error) {
 	registration, _, err := s.pollConfiguration()
 	if err != nil {
+		return PollResult{}, err
+	}
+	if err := s.retryWaitingForHarness(ctx, registration); err != nil {
 		return PollResult{}, err
 	}
 	return s.pollOnce(ctx, registration)

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -561,6 +561,30 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 			Observed: "harness adapter does not expose native session inspection",
 		})
 	}
+	if active.Status == store.InvocationStatusActive {
+		if livenessInspector, ok := harnessRuntime.(harness.NativeSessionLivenessInspector); ok {
+			running, livenessErr := livenessInspector.NativeSessionRunning(ctx, harness.NativeSessionRequest{RunID: run.ID, Harness: active.Harness})
+			if livenessErr != nil {
+				addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+					Kind:        RecoveryDiscrepancyInfrastructure,
+					Source:      "harness",
+					Field:       "lifecycle",
+					Expected:    "persisted native session process running",
+					Observed:    livenessErr.Error(),
+					Recoverable: workerProjectionLost,
+				})
+			} else if !running {
+				addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+					Kind:        RecoveryDiscrepancyInfrastructure,
+					Source:      "harness",
+					Field:       "lifecycle",
+					Expected:    "persisted native session process running",
+					Observed:    "exited",
+					Recoverable: true,
+				})
+			}
+		}
+	}
 }
 
 // workerProjectionExpectedStopped reports the workflow states whose terminal
@@ -574,11 +598,12 @@ func workerProjectionExpectedStopped(run store.Run, invocation store.Invocation)
 }
 
 // hasRecoverableInvocationLoss reports whether a previously consumed automatic
-// resume now has a worker or terminal projection that can be rebuilt from the
-// durable invocation identity, but must still be escalated before resuming.
+// resume now has a worker, terminal, or harness projection that can be rebuilt
+// from the durable invocation identity, but must still be escalated before
+// resuming.
 func hasRecoverableInvocationLoss(diagnosis RecoveryDiagnosis) bool {
 	for _, discrepancy := range diagnosis.Discrepancies {
-		if discrepancy.Recoverable && (discrepancy.Source == "worker" || discrepancy.Source == "cmux") {
+		if discrepancy.Recoverable && (discrepancy.Source == "worker" || discrepancy.Source == "cmux" || discrepancy.Source == "harness") {
 			return true
 		}
 	}
@@ -749,6 +774,14 @@ func readReconciliationRun(ctx context.Context, runStore OperationalStore) (*sto
 // recoverable loss of a worker may be continued automatically; every other
 // disagreement pauses the run for human reconciliation.
 func (s *Service) reconcileInterruptedRun(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, RecoveryDiagnosis, RecoveryOutcome, error) {
+	return s.reconcileInterruptedRunWithMode(ctx, registration, runStore, run, false)
+}
+
+// reconcileInterruptedRunWithMode drains a pending effect and reconciles every
+// projection. Live liveness monitoring may opt into same-process recovery
+// because it has directly observed the native process exit; ordinary startup
+// reconciliation keeps the same-process duplicate-launch guard.
+func (s *Service) reconcileInterruptedRunWithMode(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, allowSameProcessRecovery bool) (store.Run, RecoveryDiagnosis, RecoveryOutcome, error) {
 	journal, ok := runStore.(PendingEffectStore)
 	if !ok {
 		if store.IsTerminalStatus(run.Status) {
@@ -796,6 +829,25 @@ func (s *Service) reconcileInterruptedRun(ctx context.Context, registration conf
 			})
 			diagnosis.SourcesAgree = false
 			if !store.IsTerminalStatus(run.Status) {
+				if pending.Kind == store.PendingEffectKindHarnessResume {
+					classified := harness.ClassifyError(replayErr, pendingHarnessName(*pending))
+					if harness.IsRateLimited(classified) {
+						diagnosis.PendingEffect = nil
+						paused, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, run, pendingHarnessName(*pending))
+						if waitErr != nil {
+							return paused, diagnosis, RecoveryOutcomeWaitingForHarness, errors.Join(classified, waitErr)
+						}
+						return paused, diagnosis, RecoveryOutcomeWaitingForHarness, nil
+					}
+					if harness.IsAuthenticationExpired(classified) {
+						diagnosis.PendingEffect = nil
+						paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, run, pendingHarnessName(*pending))
+						if pauseErr != nil {
+							return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(classified, pauseErr)
+						}
+						return paused, diagnosis, RecoveryOutcomeWaitingForHuman, classified
+					}
+				}
 				paused, pauseErr := s.pauseRunLocally(ctx, runStore, run, diagnosis)
 				if pauseErr != nil {
 					return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(recoveryErrorWithCause(diagnosis, replayErr), pauseErr)
@@ -853,7 +905,7 @@ func (s *Service) reconcileInterruptedRun(ctx context.Context, registration conf
 					Observed: activeErr.Error(),
 				})
 				diagnosis.SourcesAgree = false
-			} else if active != nil && !s.invocationStartedHere(active.ID) && active.Status == store.InvocationStatusActive && !active.AttachRequired && strings.TrimSpace(active.NativeSessionID) != "" {
+			} else if active != nil && (allowSameProcessRecovery || !s.invocationStartedHere(active.ID)) && active.Status == store.InvocationStatusActive && !active.AttachRequired && strings.TrimSpace(active.NativeSessionID) != "" {
 				if active.RecoveryResumeCount > 0 && hasRecoverableInvocationLoss(diagnosis) {
 					if _, repairErr := s.ensureWorkerForInvocation(ctx, registration, runStore, run, *active); repairErr != nil {
 						addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
@@ -972,6 +1024,16 @@ func harnessResumeWasAlreadyReserved(ctx context.Context, runStore RunStore, eff
 	return invocation.RecoveryResumeCount >= payload.TargetResumeCount
 }
 
+// pendingHarnessName extracts the non-secret adapter identity from a pending
+// harness-resume payload for a bounded waiting-state message.
+func pendingHarnessName(effect store.PendingEffect) string {
+	var payload harnessResumeEffectPayload
+	if err := decodePendingEffect(effect, &payload); err != nil || strings.TrimSpace(payload.Invocation.Harness) == "" {
+		return "harness"
+	}
+	return payload.Invocation.Harness
+}
+
 // waitingForHarnessDiagnosis describes an intentional capacity wait without
 // manufacturing an infrastructure discrepancy from an absent native session.
 func waitingForHarnessDiagnosis(runID string) RecoveryDiagnosis {
@@ -1039,6 +1101,9 @@ func reconciledRecoveryDiagnosis(runID string) RecoveryDiagnosis {
 // journal cannot be replayed safely, so that the one-effect invariant remains
 // intact for an operator to resolve.
 func (s *Service) pauseRunLocally(ctx context.Context, runStore RunStore, run store.Run, diagnosis RecoveryDiagnosis) (store.Run, error) {
+	if err := s.stopRunWorker(ctx, run.ID); err != nil {
+		return run, err
+	}
 	if run.Status == store.StatusWaitingForHuman && strings.HasPrefix(run.LifecycleReason, "restart reconciliation paused:") {
 		return run, nil
 	}
@@ -1059,6 +1124,9 @@ func (s *Service) pauseRunLocally(ctx context.Context, runStore RunStore, run st
 func (s *Service) pauseForRecovery(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, diagnosis RecoveryDiagnosis) (store.Run, error) {
 	reason := recoveryDiscrepancyReason(diagnosis)
 	if run.Status == store.StatusWaitingForHuman && strings.HasPrefix(run.LifecycleReason, "restart reconciliation paused:") {
+		if err := s.stopRunWorker(ctx, run.ID); err != nil {
+			return run, err
+		}
 		return run, nil
 	}
 	next := run
@@ -1077,6 +1145,9 @@ func (s *Service) pauseForRecovery(ctx context.Context, registration config.Repo
 		if pending != nil {
 			return s.pauseRunLocally(ctx, runStore, run, diagnosis)
 		}
+	}
+	if err := s.stopRunWorker(ctx, run.ID); err != nil {
+		return run, err
 	}
 	if s.deps.GitHub == nil || strings.TrimSpace(next.StatusCommentID) == "" {
 		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
@@ -1395,5 +1466,9 @@ func recoveryErrorWithCause(diagnosis RecoveryDiagnosis, cause error) error {
 		}
 		return &WorkflowFailureError{RunID: diagnosis.RunID, Cause: errors.Join(cause, recoveryRequiredError(diagnosis))}
 	}
-	return &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+	infrastructure := &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
+	if cause != nil && (harness.IsRateLimited(cause) || harness.IsAuthenticationExpired(cause) || harness.IsUnexpectedExit(cause)) {
+		return errors.Join(cause, infrastructure)
+	}
+	return infrastructure
 }

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -45,6 +45,9 @@ const (
 	// RecoveryOutcomeWaitingForHuman means reconciliation paused the run because
 	// a disagreement could not be resolved safely.
 	RecoveryOutcomeWaitingForHuman RecoveryOutcome = "waiting_for_human"
+	// RecoveryOutcomeWaitingForHarness means the harness reported temporary
+	// capacity pressure and the run remains eligible for an automatic retry.
+	RecoveryOutcomeWaitingForHarness RecoveryOutcome = "waiting_for_harness"
 )
 
 // RecoveryDiscrepancy describes one observed disagreement between persisted
@@ -60,6 +63,9 @@ type RecoveryDiscrepancy struct {
 	Expected string
 	// Observed is the value read from the external projection.
 	Observed string
+	// Recoverable marks an infrastructure loss that the coordinator may repair
+	// from the persisted run identity, such as a stopped or missing worker.
+	Recoverable bool
 }
 
 // RecoveryDiagnosis is the result of a read-only comparison of an interrupted
@@ -80,6 +86,9 @@ type RecoveryDiagnosis struct {
 	SafeActions []string
 	// PendingEffect is the effect that was present when diagnosis ran, if any.
 	PendingEffect *store.PendingEffect
+	// Recoverable reports that all discrepancies are coordinator-repairable.
+	// It is informational; reconciliation still records every discrepancy.
+	Recoverable bool
 }
 
 // RecoveryResult contains the durable run after an explicit reconciliation
@@ -240,7 +249,8 @@ func (s *Service) diagnoseInterruptedRunWithStore(ctx context.Context, registrat
 	inspectGitHubProjection(ctx, &diagnosis, s.deps.GitHub, s.pullRequestClient(), repository, run)
 	inspectRemoteBranchProjection(ctx, &diagnosis, s.gitWorkspace(), run)
 	s.inspectInvocationProjection(ctx, &diagnosis, registration, runStore, run)
-	diagnosis.SourcesAgree = len(diagnosis.Discrepancies) == 0
+	diagnosis.SourcesAgree = recoverySourcesAgree(diagnosis)
+	diagnosis.Recoverable = len(diagnosis.Discrepancies) > 0 && diagnosis.SourcesAgree
 	return diagnosis
 }
 
@@ -402,6 +412,7 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 		})
 		return
 	}
+	workerProjectionLost := false
 	workerInspection, inspectErr := s.deps.Worker.Inspect(ctx, run.ID)
 	if inspectErr != nil {
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
@@ -413,21 +424,29 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 		})
 	} else {
 		if !workerInspection.Exists {
-			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
-				Kind:     RecoveryDiscrepancyInfrastructure,
-				Source:   "worker",
-				Field:    "existence",
-				Expected: "persisted worker",
-				Observed: "missing",
-			})
+			workerProjectionLost = hasNativeSession && active.Status == store.InvocationStatusActive
+			if !workerProjectionExpectedStopped(run, *active) {
+				addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+					Kind:        RecoveryDiscrepancyInfrastructure,
+					Source:      "worker",
+					Field:       "existence",
+					Expected:    "persisted worker",
+					Observed:    "missing",
+					Recoverable: workerProjectionLost,
+				})
+			}
 		} else if !workerInspection.Running {
-			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
-				Kind:     RecoveryDiscrepancyInfrastructure,
-				Source:   "worker",
-				Field:    "lifecycle",
-				Expected: "running",
-				Observed: "stopped",
-			})
+			workerProjectionLost = hasNativeSession && active.Status == store.InvocationStatusActive
+			if !workerProjectionExpectedStopped(run, *active) {
+				addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+					Kind:        RecoveryDiscrepancyInfrastructure,
+					Source:      "worker",
+					Field:       "lifecycle",
+					Expected:    "running",
+					Observed:    "stopped",
+					Recoverable: workerProjectionLost,
+				})
+			}
 		} else {
 			packet, packetErr := decodeSpecificationPacket(run.SpecificationPacket)
 			if packetErr != nil {
@@ -517,11 +536,12 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 		observed, providerErr := inspector.NativeSessionID(ctx, harness.NativeSessionRequest{RunID: run.ID, Harness: active.Harness})
 		if providerErr != nil {
 			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
-				Kind:     RecoveryDiscrepancyInfrastructure,
-				Source:   "native session",
-				Field:    "identity",
-				Expected: active.NativeSessionID,
-				Observed: providerErr.Error(),
+				Kind:        RecoveryDiscrepancyInfrastructure,
+				Source:      "native session",
+				Field:       "identity",
+				Expected:    active.NativeSessionID,
+				Observed:    providerErr.Error(),
+				Recoverable: workerProjectionLost,
 			})
 		} else if observed != active.NativeSessionID {
 			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
@@ -543,12 +563,35 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 	}
 }
 
+// workerProjectionExpectedStopped reports the workflow states whose terminal
+// invocation intentionally leaves the worker stopped, such as readiness or a
+// human-waiting review/clarification boundary.
+func workerProjectionExpectedStopped(run store.Run, invocation store.Invocation) bool {
+	if invocation.Status == store.InvocationStatusActive {
+		return false
+	}
+	return run.Stage == store.StageReady || run.Status == store.StatusWaitingForHuman
+}
+
+// hasRecoverableInvocationLoss reports whether a previously consumed automatic
+// resume now has a worker or terminal projection that can be rebuilt from the
+// durable invocation identity, but must still be escalated before resuming.
+func hasRecoverableInvocationLoss(diagnosis RecoveryDiagnosis) bool {
+	for _, discrepancy := range diagnosis.Discrepancies {
+		if discrepancy.Recoverable && (discrepancy.Source == "worker" || discrepancy.Source == "cmux") {
+			return true
+		}
+	}
+	return false
+}
+
 // inspectTerminalProjection compares every persisted non-empty cmux handle
 // with the current read-only topology.
 func inspectTerminalProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, inspector terminal.WorkspaceInspector, invocation store.Invocation) {
+	recoverable := invocation.Status == store.InvocationStatusActive && strings.TrimSpace(invocation.NativeSessionID) != ""
 	workspaceID := terminal.WorkspaceID(invocation.WorkspaceID)
 	if workspaceID == "" {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: "workspace", Expected: "persisted workspace identity", Observed: "empty"})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: "workspace", Expected: "persisted workspace identity", Observed: "empty", Recoverable: recoverable})
 		return
 	}
 	observed, err := inspector.InspectWorkspace(ctx, workspaceID)
@@ -557,7 +600,7 @@ func inspectTerminalProjection(ctx context.Context, diagnosis *RecoveryDiagnosis
 		return
 	}
 	if !observed.Exists {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: "workspace", Expected: string(workspaceID), Observed: "missing"})
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: "workspace", Expected: string(workspaceID), Observed: "missing", Recoverable: recoverable})
 		return
 	}
 	if observed.WorkspaceID != "" && observed.WorkspaceID != workspaceID {
@@ -582,7 +625,7 @@ func inspectTerminalProjection(ctx context.Context, diagnosis *RecoveryDiagnosis
 			continue
 		}
 		if _, exists := observedIDs[expected.id]; !exists {
-			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: expected.name + " surface", Expected: expected.id, Observed: "missing"})
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Kind: RecoveryDiscrepancyInfrastructure, Source: "cmux", Field: expected.name + " surface", Expected: expected.id, Observed: "missing", Recoverable: recoverable})
 			continue
 		}
 		if surface := observedSurfaces[expected.id]; surface.WorkspaceID != "" && surface.WorkspaceID != workspaceID {
@@ -783,12 +826,95 @@ func (s *Service) reconcileInterruptedRun(ctx context.Context, registration conf
 			return paused, resumeDiagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: resumeDiagnosis}
 		}
 	}
+	if run.Status == store.StatusWaitingForHarness {
+		// Capacity waiting is an intentional coordinator state. Its active
+		// invocation may have no native identity yet, so ordinary interrupted
+		// projection checks would incorrectly turn a retryable wait into a human
+		// discrepancy.
+		return run, waitingForHarnessDiagnosis(run.ID), RecoveryOutcomeWaitingForHarness, nil
+	}
 	if store.IsTerminalStatus(run.Status) {
 		return run, reconciledRecoveryDiagnosis(run.ID), RecoveryOutcomeReconciled, nil
 	}
 	diagnosis := s.diagnoseInterruptedRunWithStore(ctx, registration, runStore, run)
 	if pending, err := journal.PendingEffect(ctx, run.ID); err == nil {
 		diagnosis.PendingEffect = pending
+	}
+	if diagnosis.SourcesAgree && run.Status == store.StatusActive {
+		activeStore, activeStoreOK := runStore.(ActiveInvocationStore)
+		if activeStoreOK {
+			active, activeErr := activeStore.ActiveInvocation(ctx, run.ID)
+			if activeErr != nil {
+				addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyInfrastructure,
+					Source:   "operational store",
+					Field:    "active invocation",
+					Expected: "read active invocation before automatic recovery",
+					Observed: activeErr.Error(),
+				})
+				diagnosis.SourcesAgree = false
+			} else if active != nil && !s.invocationStartedHere(active.ID) && active.Status == store.InvocationStatusActive && !active.AttachRequired && strings.TrimSpace(active.NativeSessionID) != "" {
+				if active.RecoveryResumeCount > 0 && hasRecoverableInvocationLoss(diagnosis) {
+					if _, repairErr := s.ensureWorkerForInvocation(ctx, registration, runStore, run, *active); repairErr != nil {
+						addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+							Kind:     RecoveryDiscrepancyInfrastructure,
+							Source:   "worker",
+							Field:    "recreation after automatic recovery",
+							Expected: "worker recreated from the frozen invocation request",
+							Observed: repairErr.Error(),
+						})
+						diagnosis.SourcesAgree = false
+					} else {
+						paused, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, run, active.Harness, harness.NewUnexpectedExitError(active.Harness))
+						if pauseErr != nil {
+							return paused, diagnosis, RecoveryOutcomeWaitingForHuman, pauseErr
+						}
+						return paused, diagnosis, RecoveryOutcomeWaitingForHuman, harness.NewUnexpectedExitError(active.Harness)
+					}
+				}
+				if diagnosis.SourcesAgree && active.RecoveryResumeCount == 0 {
+					_, resumeErr := s.resumePersistedInvocation(ctx, registration, runStore, run, *active)
+					if resumeErr != nil {
+						classified := harness.ClassifyError(resumeErr, active.Harness)
+						if harness.IsRateLimited(classified) {
+							paused, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, run, active.Harness)
+							if waitErr != nil {
+								return paused, diagnosis, RecoveryOutcomeWaitingForHarness, errors.Join(classified, waitErr)
+							}
+							return paused, diagnosis, RecoveryOutcomeWaitingForHarness, nil
+						}
+						if harness.IsAuthenticationExpired(classified) {
+							paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, run, active.Harness)
+							if pauseErr != nil {
+								return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(classified, pauseErr)
+							}
+							return paused, diagnosis, RecoveryOutcomeWaitingForHuman, classified
+						}
+						if harness.IsUnexpectedExit(classified) {
+							paused, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, run, active.Harness, classified)
+							if pauseErr != nil {
+								return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(classified, pauseErr)
+							}
+							return paused, diagnosis, RecoveryOutcomeWaitingForHuman, classified
+						}
+						observed := resumeErr.Error()
+						addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+							Kind:     RecoveryDiscrepancyInfrastructure,
+							Source:   "harness",
+							Field:    "native session resume",
+							Expected: "resume persisted session exactly once",
+							Observed: observed,
+						})
+						diagnosis.SourcesAgree = false
+						paused, pauseErr := s.pauseForRecovery(ctx, registration, runStore, run, diagnosis)
+						if pauseErr != nil {
+							return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(classified, pauseErr)
+						}
+						return paused, diagnosis, RecoveryOutcomeWaitingForHuman, classified
+					}
+				}
+			}
+		}
 	}
 	if diagnosis.SourcesAgree {
 		updated, repairErr := s.completePendingCheckRepair(ctx, registration, runStore, run)
@@ -837,7 +963,21 @@ func harnessResumeWasAlreadyReserved(ctx context.Context, runStore RunStore, eff
 		return false
 	}
 	invocation, err := invocationStore.Invocation(ctx, effect.RunID, payload.Invocation.ID)
-	return err == nil && invocation != nil && invocation.RecoveryResumeCount >= payload.TargetResumeCount
+	if err != nil || invocation == nil {
+		return false
+	}
+	if payload.Manual {
+		return invocation.AttachRequired
+	}
+	return invocation.RecoveryResumeCount >= payload.TargetResumeCount
+}
+
+// waitingForHarnessDiagnosis describes an intentional capacity wait without
+// manufacturing an infrastructure discrepancy from an absent native session.
+func waitingForHarnessDiagnosis(runID string) RecoveryDiagnosis {
+	diagnosis := newRecoveryDiagnosis(runID)
+	diagnosis.SourcesAgree = true
+	return diagnosis
 }
 
 // completePendingCheckRepair closes the durable check-repair reservation once
@@ -1210,6 +1350,18 @@ func addRecoveryDiscrepancy(diagnosis *RecoveryDiagnosis, discrepancy RecoveryDi
 		}
 	}
 	diagnosis.Discrepancies = append(diagnosis.Discrepancies, discrepancy)
+}
+
+// recoverySourcesAgree reports whether every observed discrepancy is within
+// the coordinator's deterministic repair boundary. Recoverable losses remain
+// visible in the diagnosis but do not force an operator pause.
+func recoverySourcesAgree(diagnosis RecoveryDiagnosis) bool {
+	for _, discrepancy := range diagnosis.Discrepancies {
+		if !discrepancy.Recoverable {
+			return false
+		}
+	}
+	return true
 }
 
 // hasWorkflowDiscrepancy reports whether reconciliation found deterministic

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -24,11 +24,11 @@ import (
 // journaled restart fixture.
 const journalRecoveryImageDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-// TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart verifies the
-// real startup reconciliation path accepts matching projections, resumes the
-// native session once, persists the resume ceiling, and performs no second
-// resume when a fresh coordinator starts again.
-func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T) {
+// TestJournaledStartupRecreatesALostWorkerAndResumesOnce verifies the real
+// startup reconciliation path recreates a missing worker from the persisted
+// start request, resumes the native session once, persists the resume ceiling,
+// and performs no second resume when a fresh coordinator starts again.
+func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	worktreePath := filepath.Join(root, "worktree")
@@ -36,6 +36,9 @@ func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T)
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-journaled-recovery\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -133,22 +136,7 @@ func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T)
 		Branch:         run.Branch,
 		HeadSHA:        run.CheckpointSHA,
 	}}
-	workerRequest := worker.StartRequest{
-		RunID:           run.ID,
-		WorktreePath:    run.Worktree,
-		GitMetadataPath: gitMetadataProjectionPath(run.ID, run.Worktree),
-		Image:           packet.RepositoryConfig.WorkerBuild.Image,
-		ImageDigest:     run.ImageDigest,
-		InvocationPath:  invocation.InvocationDirectory,
-		ResultPath:      invocation.ResultDirectory,
-		Role:            invocation.Role,
-	}
-	workerRuntime := &journalRecoveryWorker{inspection: worker.Inspection{
-		Exists:           true,
-		Running:          true,
-		Image:            workerRequest.Image + "@" + workerRequest.ImageDigest,
-		MountFingerprint: worker.MountContractFingerprint(workerRequest),
-	}}
+	workerRuntime := &journalRecoveryWorker{inspection: worker.Inspection{}}
 	terminalRuntime := &journalRecoveryTerminal{inspection: terminal.WorkspaceInspection{
 		Exists:      true,
 		WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID),
@@ -173,6 +161,12 @@ func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T)
 
 	if err := service.reconcileRegisteredRun(ctx, registration); err != nil {
 		t.Fatalf("first journaled startup = %v", err)
+	}
+	if workerRuntime.startCalls != 1 || len(workerRuntime.startRequests) != 1 {
+		t.Fatalf("worker recreation = calls %d requests %d, want one pinned recreation", workerRuntime.startCalls, len(workerRuntime.startRequests))
+	}
+	if workerRuntime.startRequests[0].ImageDigest != run.ImageDigest || workerRuntime.startRequests[0].InvocationPath != invocation.InvocationDirectory || workerRuntime.startRequests[0].ResultPath != invocation.ResultDirectory {
+		t.Fatalf("recreated worker request = %#v, want frozen image and invocation mounts", workerRuntime.startRequests[0])
 	}
 	if harnessRuntime.resumeCalls != 1 {
 		t.Fatalf("native resumes after first startup = %d, want one", harnessRuntime.resumeCalls)
@@ -205,6 +199,76 @@ func TestJournaledStartupResumesOneAgreeingInvocationAcrossRestart(t *testing.T)
 	}
 	if harnessRuntime.resumeCalls != 1 {
 		t.Fatalf("native resumes after second startup = %d, want no duplicate", harnessRuntime.resumeCalls)
+	}
+
+	// Reuse the persisted identity to model a later unexpected exit. The
+	// first automatic failure must escalate, and the next coordinator must
+	// consume the ambiguous reservation without issuing a second resume.
+	persisted.RecoveryResumeCount = 0
+	persisted.UpdatedAt = now.Add(time.Minute)
+	if err := opened.SaveInvocation(ctx, *persisted); err != nil {
+		t.Fatal(err)
+	}
+	activeRun := *freshRun
+	activeRun.Status = store.StatusActive
+	activeRun.UpdatedAt = now.Add(time.Minute)
+	if err := opened.SaveRun(ctx, activeRun); err != nil {
+		t.Fatal(err)
+	}
+	harnessRuntime.resumeErr = harness.NewUnexpectedExitError(harness.NameCodex)
+	failureService := &Service{deps: service.deps}
+	failureErr := failureService.reconcileRegisteredRun(ctx, registration)
+	if !harness.IsUnexpectedExit(failureErr) {
+		t.Fatalf("unexpected exit recovery error = %v, want typed unexpected exit", failureErr)
+	}
+	if harnessRuntime.resumeCalls != 2 {
+		t.Fatalf("automatic resume calls after unexpected exit = %d, want one additional attempt", harnessRuntime.resumeCalls)
+	}
+	persisted, err = opened.Invocation(ctx, run.ID, invocation.ID)
+	if err != nil || persisted == nil || persisted.RecoveryResumeCount != 1 {
+		t.Fatalf("invocation after unexpected exit = %#v, error = %v; want consumed automatic attempt", persisted, err)
+	}
+	escalated, err := opened.CurrentRun(ctx)
+	if err != nil || escalated == nil || escalated.Status != store.StatusWaitingForHuman || !strings.HasPrefix(escalated.LifecycleReason, "automatic harness recovery exhausted") {
+		t.Fatalf("run after unexpected exit = %#v, error = %v; want manual recovery escalation", escalated, err)
+	}
+	lastService := &Service{deps: service.deps}
+	_ = lastService.reconcileRegisteredRun(ctx, registration)
+	if harnessRuntime.resumeCalls != 2 {
+		t.Fatalf("automatic resume calls after escalation restart = %d, want no duplicate", harnessRuntime.resumeCalls)
+	}
+	if pending, err := opened.PendingEffect(ctx, run.ID); err != nil || pending != nil {
+		t.Fatalf("pending effect after escalation restart = %#v, error = %v; want cleared", pending, err)
+	}
+
+	// A later worker loss must be repaired, but the already-consumed automatic
+	// slot must still force a human before another native resume.
+	persisted.RecoveryResumeCount = 1
+	persisted.UpdatedAt = now.Add(2 * time.Minute)
+	if err := opened.SaveInvocation(ctx, *persisted); err != nil {
+		t.Fatal(err)
+	}
+	activeRun = *escalated
+	activeRun.Status = store.StatusActive
+	activeRun.UpdatedAt = now.Add(2 * time.Minute)
+	if err := opened.SaveRun(ctx, activeRun); err != nil {
+		t.Fatal(err)
+	}
+	githubRuntime.issue.Labels = []string{factoryLabelForStatus(activeRun.Status)}
+	githubRuntime.statusComment.Body = statusCommentBody(activeRun)
+	workerRuntime.inspection = worker.Inspection{}
+	harnessRuntime.resumeErr = nil
+	lossService := &Service{deps: service.deps}
+	lossErr := lossService.reconcileRegisteredRun(ctx, registration)
+	if !harness.IsUnexpectedExit(lossErr) {
+		t.Fatalf("post-resume worker loss error = %v, want typed manual-recovery error", lossErr)
+	}
+	if harnessRuntime.resumeCalls != 2 || workerRuntime.startCalls != 2 {
+		t.Fatalf("post-resume worker loss effects = resumes %d, worker recreations %d; want no resume and one recreation", harnessRuntime.resumeCalls, workerRuntime.startCalls)
+	}
+	repairedRun, err := opened.CurrentRun(ctx)
+	if err != nil || repairedRun == nil || repairedRun.Status != store.StatusWaitingForHuman {
+		t.Fatalf("run after post-resume worker loss = %#v, error = %v; want human recovery", repairedRun, err)
 	}
 }
 
@@ -246,6 +310,43 @@ func TestRecoveryInspectsTheLatestTerminalInvocation(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("recovery discrepancies = %#v, want terminal worker inspection failure", diagnosis.Discrepancies)
+	}
+}
+
+// TestRecoveryAcceptsAStoppedWorkerAfterReadiness verifies that a worker
+// stopped by the readiness transition is not mistaken for an interrupted
+// active invocation.
+func TestRecoveryAcceptsAStoppedWorkerAfterReadiness(t *testing.T) {
+	now := time.Unix(2, 0).UTC()
+	run := store.Run{ID: "run-ready-stopped-worker", Stage: store.StageReady, Status: store.StatusActive}
+	invocation := store.Invocation{
+		ID: "inv-ready-stopped-worker", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "spec_review", Stage: store.StageReview,
+		NativeSessionID: "session-ready-stopped-worker", WorkspaceID: "workspace-ready-stopped-worker",
+		StatusSurfaceID: "surface-status-ready-stopped-worker", ImplementationSurfaceID: "surface-ready-stopped-worker",
+		ChecksSurfaceID: "surface-checks-ready-stopped-worker", Status: store.InvocationStatusCompleted,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	workerRuntime := &journalRecoveryWorker{inspection: worker.Inspection{}}
+	terminalRuntime := &journalRecoveryTerminal{inspection: terminal.WorkspaceInspection{
+		Exists: true, WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID),
+		Surfaces: []terminal.Surface{
+			{ID: terminal.SurfaceID(invocation.StatusSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+			{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+			{ID: terminal.SurfaceID(invocation.ChecksSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+		},
+	}}
+	service := &Service{deps: Dependencies{
+		Worker: workerRuntime, Terminal: terminalRuntime,
+		Harness: &journalRecoveryHarness{nativeSessionID: invocation.NativeSessionID},
+	}}
+	baseStore := &repairLaunchStore{run: run, invocations: map[string]store.Invocation{invocation.ID: invocation}}
+	runStore := &terminalProjectionStore{repairLaunchStore: baseStore}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+
+	service.inspectInvocationProjection(context.Background(), &diagnosis, config.RepositoryRegistration{}, runStore, run)
+	if len(diagnosis.Discrepancies) != 0 {
+		t.Fatalf("recovery discrepancies = %#v, want stopped worker accepted after readiness", diagnosis.Discrepancies)
 	}
 }
 
@@ -304,13 +405,26 @@ var _ gitadapter.GitWorkspace = (*journalRecoveryWorkspace)(nil)
 // journalRecoveryWorker supplies a matching active worker projection without
 // exposing the worker's private runtime identity to the factory test.
 type journalRecoveryWorker struct {
-	inspection   worker.Inspection
-	inspectErr   error
-	inspectCalls int
+	inspection    worker.Inspection
+	inspectErr    error
+	inspectCalls  int
+	startCalls    int
+	startRequests []worker.StartRequest
 }
 
-// Start satisfies WorkerRuntime for the no-launch recovery fixture.
-func (*journalRecoveryWorker) Start(context.Context, worker.StartRequest) error { return nil }
+// Start recreates the worker from the coordinator's frozen request and updates
+// the fixture projection so the next restart observes the repaired worker.
+func (w *journalRecoveryWorker) Start(_ context.Context, request worker.StartRequest) error {
+	w.startCalls++
+	w.startRequests = append(w.startRequests, request)
+	w.inspection = worker.Inspection{
+		Exists:           true,
+		Running:          true,
+		Image:            request.Image + "@" + request.ImageDigest,
+		MountFingerprint: worker.MountContractFingerprint(request),
+	}
+	return nil
+}
 
 // Resume satisfies WorkerRuntime for the no-launch recovery fixture.
 func (*journalRecoveryWorker) Resume(context.Context, worker.ResumeRequest) error { return nil }
@@ -386,6 +500,7 @@ type journalRecoveryHarness struct {
 	nativeSessionID string
 	resumeCalls     int
 	failResumeOnce  bool
+	resumeErr       error
 }
 
 // Capabilities reports Codex's native continuation support.
@@ -402,6 +517,9 @@ func (*journalRecoveryHarness) Start(context.Context, harness.StartRequest) (har
 func (h *journalRecoveryHarness) Resume(_ context.Context, request harness.StartRequest) (harness.Session, error) {
 	h.resumeCalls++
 	session := harness.Session{InvocationID: request.InvocationID, NativeSessionID: h.nativeSessionID, Surface: request.Surface}
+	if h.resumeErr != nil {
+		return session, h.resumeErr
+	}
 	if h.failResumeOnce {
 		h.failResumeOnce = false
 		return session, errors.New("native resume response lost")

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -270,6 +270,34 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 	if err != nil || repairedRun == nil || repairedRun.Status != store.StatusWaitingForHuman {
 		t.Fatalf("run after post-resume worker loss = %#v, error = %v; want human recovery", repairedRun, err)
 	}
+
+	// A live polling pass must detect a harness that exits after launch and
+	// route it through the same one-shot automatic native resume policy.
+	persisted.RecoveryResumeCount = 0
+	persisted.UpdatedAt = now.Add(3 * time.Minute)
+	if err := opened.SaveInvocation(ctx, *persisted); err != nil {
+		t.Fatal(err)
+	}
+	activeRun = *repairedRun
+	activeRun.Status = store.StatusActive
+	activeRun.LifecycleReason = "harness resumed after live interruption"
+	activeRun.UpdatedAt = now.Add(3 * time.Minute)
+	if err := opened.SaveRun(ctx, activeRun); err != nil {
+		t.Fatal(err)
+	}
+	githubRuntime.issue.Labels = []string{factoryLabelForStatus(activeRun.Status)}
+	githubRuntime.statusComment.Body = statusCommentBody(activeRun)
+	harnessRuntime.nativeSessionExited = true
+	if err := lossService.retryWaitingForHarness(ctx, registration); err != nil {
+		t.Fatalf("live harness interruption recovery = %v", err)
+	}
+	if harnessRuntime.resumeCalls != 3 {
+		t.Fatalf("native resumes after live harness exit = %d, want one recovery resume", harnessRuntime.resumeCalls)
+	}
+	liveRecovered, err := opened.CurrentRun(ctx)
+	if err != nil || liveRecovered == nil || liveRecovered.Status != store.StatusActive {
+		t.Fatalf("run after live harness recovery = %#v, error = %v; want active run", liveRecovered, err)
+	}
 }
 
 // TestRecoveryInspectsTheLatestTerminalInvocation verifies a stage boundary
@@ -497,10 +525,11 @@ var _ terminal.WorkspaceInspector = (*journalRecoveryTerminal)(nil)
 // journalRecoveryHarness supplies native-session identity and counts resume
 // calls so the startup test can detect duplicate continuation.
 type journalRecoveryHarness struct {
-	nativeSessionID string
-	resumeCalls     int
-	failResumeOnce  bool
-	resumeErr       error
+	nativeSessionID     string
+	resumeCalls         int
+	failResumeOnce      bool
+	resumeErr           error
+	nativeSessionExited bool
 }
 
 // Capabilities reports Codex's native continuation support.
@@ -535,8 +564,15 @@ func (h *journalRecoveryHarness) NativeSessionID(context.Context, harness.Native
 	return h.nativeSessionID, nil
 }
 
+// NativeSessionRunning returns the controlled native process projection used
+// to exercise live interruption detection.
+func (h *journalRecoveryHarness) NativeSessionRunning(context.Context, harness.NativeSessionRequest) (bool, error) {
+	return !h.nativeSessionExited, nil
+}
+
 var _ harness.Runtime = (*journalRecoveryHarness)(nil)
 var _ harness.NativeSessionInspector = (*journalRecoveryHarness)(nil)
+var _ harness.NativeSessionLivenessInspector = (*journalRecoveryHarness)(nil)
 
 // ancestryGitWorkspace reports a remote head plus a fixed ancestry answer so a
 // reconciliation test can distinguish an unpushed checkpoint from a diverged

--- a/internal/factory/recovery_test.go
+++ b/internal/factory/recovery_test.go
@@ -15,6 +15,7 @@ import (
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
 // TestProgressionRefusesAnAgreeingInterruptedRun verifies the fail-closed
@@ -227,6 +228,7 @@ func TestAbandonPendingEffectLeavesTheRunWaitingForHuman(t *testing.T) {
 		Config:    &fakeConfig{value: host},
 		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) { return store.Open(ctx, path) },
 		GitHub:    githubAdapter,
+		Worker:    &recoveryWorker{},
 		Now:       func() time.Time { return time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC) },
 	})
 	result, err := service.AbandonPendingEffect(ctx, factory.AbandonPendingEffectRequest{RunID: run.ID, EffectID: effect.ID, Reason: "operator verified the remote branch manually"})
@@ -284,6 +286,7 @@ func newRecoveryService(t *testing.T, runStore *recoveryRunStore, githubAdapter 
 		Config:    &fakeConfig{value: host},
 		OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
 		GitHub:    githubAdapter, Worktree: worktree,
+		Worker: &recoveryWorker{},
 	}
 	if pullRequests != nil {
 		dependencies.PullRequests = pullRequests
@@ -358,3 +361,28 @@ func (*recoveryRunStore) Close() error { return nil }
 func mkdir(path string) error {
 	return os.MkdirAll(path, 0o755)
 }
+
+// recoveryWorker makes human-waiting recovery tests explicit about the worker
+// stop seam without requiring Docker on the host running the test suite.
+type recoveryWorker struct{}
+
+// Start satisfies the worker runtime for read-only recovery tests.
+func (*recoveryWorker) Start(context.Context, worker.StartRequest) error { return nil }
+
+// Resume satisfies the worker runtime for read-only recovery tests.
+func (*recoveryWorker) Resume(context.Context, worker.ResumeRequest) error { return nil }
+
+// RunCommand satisfies the worker runtime for read-only recovery tests.
+func (*recoveryWorker) RunCommand(context.Context, worker.CommandRequest) (worker.CommandResult, error) {
+	return worker.CommandResult{}, nil
+}
+
+// Stop satisfies the worker runtime for read-only recovery tests.
+func (*recoveryWorker) Stop(context.Context, string) error { return nil }
+
+// Inspect satisfies the worker runtime for read-only recovery tests.
+func (*recoveryWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+	return worker.Inspection{}, nil
+}
+
+var _ worker.WorkerRuntime = (*recoveryWorker)(nil)

--- a/internal/harness/claude.go
+++ b/internal/harness/claude.go
@@ -52,6 +52,15 @@ func (c *Claude) NativeSessionID(ctx context.Context, request NativeSessionReque
 	return provider.NativeSessionID(ctx, worker.NativeSessionRequest{RunID: request.RunID, Harness: NameClaude})
 }
 
+// NativeSessionRunning reports whether a Claude Code process is still running
+// in the worker that owns the persisted session.
+func (c *Claude) NativeSessionRunning(ctx context.Context, request NativeSessionRequest) (bool, error) {
+	if request.Harness != "" && request.Harness != NameClaude {
+		return false, fmt.Errorf("Claude adapter cannot inspect harness %q", request.Harness)
+	}
+	return nativeSessionRunning(ctx, c.Worker, NativeSessionRequest{RunID: request.RunID, Harness: NameClaude}, `[c]laude`)
+}
+
 // Start launches a fresh Claude Code TUI with an adapter-assigned native
 // session identifier in a worker-backed terminal surface.
 func (c *Claude) Start(ctx context.Context, request StartRequest) (Session, error) {
@@ -189,3 +198,4 @@ func validSessionID(value string) bool {
 }
 
 var _ Runtime = (*Claude)(nil)
+var _ NativeSessionLivenessInspector = (*Claude)(nil)

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -43,6 +43,15 @@ func (c *Codex) NativeSessionID(ctx context.Context, request NativeSessionReques
 	return provider.NativeSessionID(ctx, worker.NativeSessionRequest{RunID: request.RunID, Harness: NameCodex})
 }
 
+// NativeSessionRunning reports whether a Codex process is still running in
+// the worker that owns the persisted session.
+func (c *Codex) NativeSessionRunning(ctx context.Context, request NativeSessionRequest) (bool, error) {
+	if request.Harness != "" && request.Harness != NameCodex {
+		return false, fmt.Errorf("Codex adapter cannot inspect harness %q", request.Harness)
+	}
+	return nativeSessionRunning(ctx, c.Worker, NativeSessionRequest{RunID: request.RunID, Harness: NameCodex}, `[c]odex`)
+}
+
 // Start launches a fresh Codex TUI in a worker-backed terminal surface.
 func (c *Codex) Start(ctx context.Context, request StartRequest) (Session, error) {
 	if request.ResumeSessionID != "" {
@@ -144,3 +153,4 @@ func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, erro
 }
 
 var _ Runtime = (*Codex)(nil)
+var _ NativeSessionLivenessInspector = (*Codex)(nil)

--- a/internal/harness/contract_test.go
+++ b/internal/harness/contract_test.go
@@ -2,6 +2,7 @@ package harness_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -138,6 +139,81 @@ func TestHarnessAdaptersSatisfyTheSameContract(t *testing.T) {
 			}
 			if len(fixture.terminal.inputs) != 1 || string(fixture.terminal.inputs[0]) != "/exit\n" {
 				t.Fatalf("surface inputs = %q, want one graceful exit request", fixture.terminal.inputs)
+			}
+		})
+	}
+}
+
+// TestHarnessInterruptionSignalsAreAContract verifies the adapter-facing
+// interruption signals that the coordinator uses for its one-shot recovery,
+// capacity wait, authentication pause, and manual-attach policies. The
+// coordinator's state transitions and resume ceiling are covered by the
+// factory integration tests.
+func TestHarnessInterruptionSignalsAreAContract(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		harness  string
+		marker   string
+		failures []struct {
+			name string
+			raw  string
+			want error
+		}
+	}{
+		{
+			name: "codex", harness: harness.NameCodex, marker: "[c]odex",
+			failures: []struct {
+				name string
+				raw  string
+				want error
+			}{
+				{name: "unexpected exit", raw: "process exited unexpectedly", want: harness.ErrUnexpectedExit},
+				{name: "rate limit", raw: "HTTP 429: capacity", want: harness.ErrRateLimited},
+				{name: "authentication", raw: "HTTP 401: token=hidden", want: harness.ErrAuthenticationExpired},
+			},
+		},
+		{
+			name: "claude", harness: harness.NameClaude, marker: "[c]laude",
+			failures: []struct {
+				name string
+				raw  string
+				want error
+			}{
+				{name: "unexpected exit", raw: "process exited unexpectedly", want: harness.ErrUnexpectedExit},
+				{name: "rate limit", raw: "HTTP 429: capacity", want: harness.ErrRateLimited},
+				{name: "authentication", raw: "HTTP 401: token=hidden", want: harness.ErrAuthenticationExpired},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workerRuntime := &livenessWorker{result: worker.CommandResult{ExitCode: 0}}
+			runtime, err := harness.New(test.harness, workerRuntime, nil)
+			if err != nil {
+				t.Fatalf("harness.New() error = %v", err)
+			}
+			inspector, ok := runtime.(harness.NativeSessionLivenessInspector)
+			if !ok {
+				t.Fatalf("runtime %T does not implement NativeSessionLivenessInspector", runtime)
+			}
+			running, err := inspector.NativeSessionRunning(context.Background(), harness.NativeSessionRequest{RunID: "run-contract", Harness: test.harness})
+			if err != nil || !running || !strings.Contains(workerRuntime.lastRequest.Command, test.marker) {
+				t.Fatalf("running liveness = %v, error = %v, request = %#v", running, err, workerRuntime.lastRequest)
+			}
+			workerRuntime.result.ExitCode = 1
+			exited, err := inspector.NativeSessionRunning(context.Background(), harness.NativeSessionRequest{RunID: "run-contract", Harness: test.harness})
+			if err != nil || exited {
+				t.Fatalf("exited liveness = %v, error = %v, want false", exited, err)
+			}
+			for _, failure := range test.failures {
+				t.Run(failure.name, func(t *testing.T) {
+					classified := harness.ClassifyError(errors.New(failure.raw), test.harness)
+					if !errors.Is(classified, failure.want) {
+						t.Fatalf("ClassifyError(%q) = %v, want %v", failure.raw, classified, failure.want)
+					}
+					if strings.Contains(classified.Error(), "hidden") || strings.Contains(classified.Error(), "token=") {
+						t.Fatalf("classified failure leaked adapter detail: %v", classified)
+					}
+				})
 			}
 		})
 	}

--- a/internal/harness/failure.go
+++ b/internal/harness/failure.go
@@ -1,0 +1,168 @@
+package harness
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FailureKind identifies a harness failure that has a coordinator-owned
+// recovery policy.
+type FailureKind string
+
+const (
+	// FailureUnexpectedExit means the native harness process exited before it
+	// produced a terminal result.
+	FailureUnexpectedExit FailureKind = "unexpected_exit"
+	// FailureRateLimited means the harness asked the coordinator to wait for
+	// capacity rather than treating the run as failed.
+	FailureRateLimited FailureKind = "rate_limited"
+	// FailureAuthenticationExpired means the configured harness credential is
+	// no longer accepted and must be refreshed by an operator.
+	FailureAuthenticationExpired FailureKind = "authentication_expired"
+)
+
+var (
+	// ErrUnexpectedExit is the stable sentinel for an unexpected harness exit.
+	ErrUnexpectedExit = errors.New("harness exited unexpectedly")
+	// ErrRateLimited is the stable sentinel for a temporary harness capacity
+	// limit.
+	ErrRateLimited = errors.New("harness capacity is temporarily limited")
+	// ErrAuthenticationExpired is the stable sentinel for expired harness
+	// authentication.
+	ErrAuthenticationExpired = errors.New("harness authentication has expired")
+)
+
+// FailureError is a typed, redacted harness error. Its message contains only
+// the failure category and harness name; adapter output is never copied into
+// it because adapter output can contain credentials or tokens.
+type FailureError struct {
+	// Kind identifies the coordinator recovery policy.
+	Kind FailureKind
+	// Harness identifies the adapter that reported the failure.
+	Harness string
+}
+
+// Error returns a bounded message that cannot expose adapter output or
+// credential values.
+func (e *FailureError) Error() string {
+	if e == nil {
+		return "harness failure"
+	}
+	category := "harness failure"
+	switch e.Kind {
+	case FailureUnexpectedExit:
+		category = ErrUnexpectedExit.Error()
+	case FailureRateLimited:
+		category = ErrRateLimited.Error()
+	case FailureAuthenticationExpired:
+		category = ErrAuthenticationExpired.Error()
+	}
+	if strings.TrimSpace(e.Harness) == "" {
+		return category
+	}
+	return fmt.Sprintf("%s (%s)", category, e.Harness)
+}
+
+// Unwrap exposes the stable category sentinel while keeping the message
+// independent from the underlying adapter error.
+func (e *FailureError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	switch e.Kind {
+	case FailureUnexpectedExit:
+		return ErrUnexpectedExit
+	case FailureRateLimited:
+		return ErrRateLimited
+	case FailureAuthenticationExpired:
+		return ErrAuthenticationExpired
+	default:
+		return nil
+	}
+}
+
+// UnexpectedExitError names the typed unexpected-exit failure for callers
+// that prefer a semantic type assertion.
+type UnexpectedExitError = FailureError
+
+// RateLimitError names the typed rate-limit failure for callers that prefer a
+// semantic type assertion.
+type RateLimitError = FailureError
+
+// AuthenticationExpiredError names the typed authentication failure for
+// callers that prefer a semantic type assertion.
+type AuthenticationExpiredError = FailureError
+
+// NewUnexpectedExitError creates a redacted unexpected-exit failure.
+func NewUnexpectedExitError(harnessName string) error {
+	return &FailureError{Kind: FailureUnexpectedExit, Harness: safeHarnessName(harnessName)}
+}
+
+// NewRateLimitError creates a redacted temporary-capacity failure.
+func NewRateLimitError(harnessName string) error {
+	return &FailureError{Kind: FailureRateLimited, Harness: safeHarnessName(harnessName)}
+}
+
+// NewAuthenticationExpiredError creates a redacted expired-authentication
+// failure.
+func NewAuthenticationExpiredError(harnessName string) error {
+	return &FailureError{Kind: FailureAuthenticationExpired, Harness: safeHarnessName(harnessName)}
+}
+
+// ClassifyError preserves a typed failure and recognizes common adapter
+// status text without retaining that text in the returned error.
+func ClassifyError(err error, harnessName ...string) error {
+	if err == nil {
+		return nil
+	}
+	var typed *FailureError
+	if errors.As(err, &typed) {
+		name := typed.Harness
+		if len(harnessName) != 0 {
+			name = harnessName[0]
+		}
+		return &FailureError{Kind: typed.Kind, Harness: safeHarnessName(name)}
+	}
+	text := strings.ToLower(err.Error())
+	name := ""
+	if len(harnessName) != 0 {
+		name = harnessName[0]
+	}
+	switch {
+	case strings.Contains(text, "rate limit"), strings.Contains(text, "rate-limit"), strings.Contains(text, "too many requests"), strings.Contains(text, "status 429"), strings.Contains(text, "http 429"):
+		return NewRateLimitError(name)
+	case strings.Contains(text, "authentication expired"), strings.Contains(text, "auth expired"), strings.Contains(text, "token expired"), strings.Contains(text, "unauthorized"), strings.Contains(text, "not authenticated"), strings.Contains(text, "login required"), strings.Contains(text, "status 401"), strings.Contains(text, "http 401"):
+		return NewAuthenticationExpiredError(name)
+	case strings.Contains(text, "unexpected exit"), strings.Contains(text, "process exited unexpectedly"), strings.Contains(text, "harness exited"):
+		return NewUnexpectedExitError(name)
+	default:
+		return err
+	}
+}
+
+// IsUnexpectedExit reports whether err represents an unexpected harness exit.
+func IsUnexpectedExit(err error) bool {
+	return errors.Is(err, ErrUnexpectedExit)
+}
+
+// IsRateLimited reports whether err represents a temporary harness capacity
+// limit.
+func IsRateLimited(err error) bool {
+	return errors.Is(err, ErrRateLimited)
+}
+
+// IsAuthenticationExpired reports whether err represents expired harness
+// authentication.
+func IsAuthenticationExpired(err error) bool {
+	return errors.Is(err, ErrAuthenticationExpired)
+}
+
+// safeHarnessName keeps adapter labels bounded and free of control characters.
+func safeHarnessName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.ContainsAny(name, "\x00\r\n") || len(name) > 64 {
+		return ""
+	}
+	return name
+}

--- a/internal/harness/failure.go
+++ b/internal/harness/failure.go
@@ -82,18 +82,6 @@ func (e *FailureError) Unwrap() error {
 	}
 }
 
-// UnexpectedExitError names the typed unexpected-exit failure for callers
-// that prefer a semantic type assertion.
-type UnexpectedExitError = FailureError
-
-// RateLimitError names the typed rate-limit failure for callers that prefer a
-// semantic type assertion.
-type RateLimitError = FailureError
-
-// AuthenticationExpiredError names the typed authentication failure for
-// callers that prefer a semantic type assertion.
-type AuthenticationExpiredError = FailureError
-
 // NewUnexpectedExitError creates a redacted unexpected-exit failure.
 func NewUnexpectedExitError(harnessName string) error {
 	return &FailureError{Kind: FailureUnexpectedExit, Harness: safeHarnessName(harnessName)}

--- a/internal/harness/failure_test.go
+++ b/internal/harness/failure_test.go
@@ -1,0 +1,65 @@
+package harness
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestFailureErrorsAreTypedAndRedacted verifies coordinator-visible harness
+// failures expose recovery categories without copying adapter output.
+func TestFailureErrorsAreTypedAndRedacted(t *testing.T) {
+	secret := "token=super-secret"
+	for _, test := range []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "unexpected exit", err: NewUnexpectedExitError(NameCodex), want: ErrUnexpectedExit},
+		{name: "rate limit", err: NewRateLimitError(NameClaude), want: ErrRateLimited},
+		{name: "authentication", err: NewAuthenticationExpiredError(NameCodex), want: ErrAuthenticationExpired},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if !errors.Is(test.err, test.want) {
+				t.Fatalf("errors.Is(%v, %v) = false", test.err, test.want)
+			}
+			if strings.Contains(test.err.Error(), secret) {
+				t.Fatalf("typed error leaked adapter detail: %q", test.err)
+			}
+			var typed *FailureError
+			if !errors.As(test.err, &typed) {
+				t.Fatalf("error %T is not a FailureError", test.err)
+			}
+		})
+	}
+}
+
+// TestClassifyErrorRedactsKnownAdapterFailures verifies known transport text
+// becomes a stable typed category while unrelated errors remain unchanged.
+func TestClassifyErrorRedactsKnownAdapterFailures(t *testing.T) {
+	classified := ClassifyError(errors.New("HTTP 401: token=super-secret"), NameCodex)
+	if !IsAuthenticationExpired(classified) {
+		t.Fatalf("classified error = %v, want expired authentication", classified)
+	}
+	if strings.Contains(classified.Error(), "super-secret") {
+		t.Fatalf("classified error leaked credential: %v", classified)
+	}
+
+	original := errors.New("worker failed for an unrelated reason")
+	if got := ClassifyError(original, NameClaude); !errors.Is(got, original) {
+		t.Fatalf("unrelated error = %v, want original error", got)
+	}
+}
+
+// TestClassifyErrorRedactsWrappedTypedFailures verifies an adapter cannot
+// reintroduce credential-bearing context around an already typed failure.
+func TestClassifyErrorRedactsWrappedTypedFailures(t *testing.T) {
+	classified := ClassifyError(fmt.Errorf("provider token=super-secret: %w", NewAuthenticationExpiredError(NameCodex)))
+	if !IsAuthenticationExpired(classified) {
+		t.Fatalf("classified error = %v, want expired authentication", classified)
+	}
+	if strings.Contains(classified.Error(), "super-secret") || strings.Contains(classified.Error(), "token=") {
+		t.Fatalf("classified error leaked wrapped adapter detail: %v", classified)
+	}
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -91,6 +91,16 @@ type NativeSessionInspector interface {
 	NativeSessionID(context.Context, NativeSessionRequest) (string, error)
 }
 
+// NativeSessionLivenessInspector is an optional adapter capability for
+// detecting a native harness process that exited after launch. It deliberately
+// reports only liveness, leaving recovery policy and resume ceilings to the
+// coordinator.
+type NativeSessionLivenessInspector interface {
+	// NativeSessionRunning reports whether the persisted native session process
+	// is still running inside the worker.
+	NativeSessionRunning(context.Context, NativeSessionRequest) (bool, error)
+}
+
 // Runtime is the portable harness lifecycle seam used by the coordinator.
 type Runtime interface {
 	// Capabilities reports the adapter identity and supported lifecycle.

--- a/internal/harness/liveness.go
+++ b/internal/harness/liveness.go
@@ -1,0 +1,39 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// nativeSessionRunning checks the worker process table without reading the
+// visible terminal. The bracketed executable pattern prevents the ps/awk
+// inspection command from matching itself.
+func nativeSessionRunning(ctx context.Context, runtime worker.WorkerRuntime, request NativeSessionRequest, processPattern string) (bool, error) {
+	if runtime == nil {
+		return false, fmt.Errorf("%s worker runtime is required", request.Harness)
+	}
+	if strings.TrimSpace(processPattern) == "" {
+		return false, errors.New("native harness process pattern is required")
+	}
+	result, err := runtime.RunCommand(ctx, worker.CommandRequest{
+		RunID:             request.RunID,
+		Command:           fmt.Sprintf(`ps -eo pid=,args= | awk -v me="$$" '$1 != me && $0 ~ /%s/ { found = 1 } END { exit found ? 0 : 1 }'`, processPattern),
+		EnvironmentPolicy: worker.EnvironmentPolicyClean,
+		Role:              "coordinator",
+	})
+	if err != nil {
+		return false, err
+	}
+	switch result.ExitCode {
+	case 0:
+		return true, nil
+	case 1:
+		return false, nil
+	default:
+		return false, fmt.Errorf("native harness liveness command exited with code %d", result.ExitCode)
+	}
+}

--- a/internal/harness/liveness.go
+++ b/internal/harness/liveness.go
@@ -26,7 +26,7 @@ func nativeSessionRunning(ctx context.Context, runtime worker.WorkerRuntime, req
 		Role:              "coordinator",
 	})
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("run native session liveness command: %w", err)
 	}
 	switch result.ExitCode {
 	case 0:

--- a/internal/harness/liveness_test.go
+++ b/internal/harness/liveness_test.go
@@ -1,0 +1,87 @@
+package harness_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestNativeSessionLivenessIsPartOfTheHarnessContract verifies both adapters
+// use a worker-side process observation and map the command's presence result
+// to the coordinator-neutral liveness capability.
+func TestNativeSessionLivenessIsPartOfTheHarnessContract(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		harness string
+		marker  string
+	}{
+		{name: "codex", harness: harness.NameCodex, marker: "[c]odex"},
+		{name: "claude", harness: harness.NameClaude, marker: "[c]laude"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runtime, err := harness.New(test.harness, &livenessWorker{result: worker.CommandResult{ExitCode: 0}}, nil)
+			if err != nil {
+				t.Fatalf("harness.New() error = %v", err)
+			}
+			inspector, ok := runtime.(harness.NativeSessionLivenessInspector)
+			if !ok {
+				t.Fatalf("runtime %T does not implement NativeSessionLivenessInspector", runtime)
+			}
+			running, err := inspector.NativeSessionRunning(context.Background(), harness.NativeSessionRequest{RunID: "run-liveness", Harness: test.harness})
+			if err != nil {
+				t.Fatalf("NativeSessionRunning() error = %v", err)
+			}
+			if !running {
+				t.Fatal("NativeSessionRunning() = false, want a running process")
+			}
+
+			workerRuntime := &livenessWorker{result: worker.CommandResult{ExitCode: 1}}
+			deadRuntime, err := harness.New(test.harness, workerRuntime, nil)
+			if err != nil {
+				t.Fatalf("harness.New() for stopped process error = %v", err)
+			}
+			deadInspector := deadRuntime.(harness.NativeSessionLivenessInspector)
+			dead, err := deadInspector.NativeSessionRunning(context.Background(), harness.NativeSessionRequest{RunID: "run-liveness", Harness: test.harness})
+			if err != nil {
+				t.Fatalf("NativeSessionRunning() for stopped process error = %v", err)
+			}
+			if dead {
+				t.Fatal("NativeSessionRunning() = true, want an exited process")
+			}
+			if !strings.Contains(workerRuntime.lastRequest.Command, test.marker) || workerRuntime.lastRequest.EnvironmentPolicy != worker.EnvironmentPolicyClean || workerRuntime.lastRequest.Role != "coordinator" {
+				t.Fatalf("liveness command request = %#v, want clean coordinator command for %s", workerRuntime.lastRequest, test.harness)
+			}
+		})
+	}
+}
+
+// livenessWorker records the command used by a harness liveness inspection.
+type livenessWorker struct {
+	result      worker.CommandResult
+	lastRequest worker.CommandRequest
+}
+
+// Start satisfies the worker runtime for harness liveness tests.
+func (*livenessWorker) Start(context.Context, worker.StartRequest) error { return nil }
+
+// Resume satisfies the worker runtime for harness liveness tests.
+func (*livenessWorker) Resume(context.Context, worker.ResumeRequest) error { return nil }
+
+// RunCommand returns the configured process-table result.
+func (w *livenessWorker) RunCommand(_ context.Context, request worker.CommandRequest) (worker.CommandResult, error) {
+	w.lastRequest = request
+	return w.result, nil
+}
+
+// Stop satisfies the worker runtime for harness liveness tests.
+func (*livenessWorker) Stop(context.Context, string) error { return nil }
+
+// Inspect satisfies the worker runtime for harness liveness tests.
+func (*livenessWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+	return worker.Inspection{Exists: true, Running: true}, nil
+}
+
+var _ worker.WorkerRuntime = (*livenessWorker)(nil)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,7 +20,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 22
+const CurrentSchemaVersion = 23
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -423,6 +423,9 @@ type Invocation struct {
 	// RecoveryResumeCount records the number of coordinator-owned native resume
 	// attempts completed for this invocation. Reconciliation permits one.
 	RecoveryResumeCount int
+	// AttachRequired blocks workflow progression until an operator has attached
+	// the manually resumed native session through the factory attach command.
+	AttachRequired bool
 	// CreatedAt is the immutable invocation creation time.
 	CreatedAt time.Time
 	// UpdatedAt is the latest coordinator update time.
@@ -1393,8 +1396,8 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 			id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 			native_session_id, workspace_id, status_surface_id,
 				implementation_surface_id, checks_surface_id, invocation_directory,
-				result_directory, permitted_paths, prompt_version, status, recovery_resume_count, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				result_directory, permitted_paths, prompt_version, status, recovery_resume_count, attach_required, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			run_id = excluded.run_id,
 			harness = excluded.harness,
@@ -1414,6 +1417,7 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 				prompt_version = excluded.prompt_version,
 				status = excluded.status,
 				recovery_resume_count = excluded.recovery_resume_count,
+				attach_required = excluded.attach_required,
 				updated_at = excluded.updated_at`,
 		invocation.ID,
 		invocation.RunID,
@@ -1434,6 +1438,7 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 		invocation.PromptVersion,
 		invocation.Status,
 		invocation.RecoveryResumeCount,
+		invocation.AttachRequired,
 		invocation.CreatedAt.UTC().Format(runTimestampLayout),
 		invocation.UpdatedAt.UTC().Format(runTimestampLayout),
 	)
@@ -1530,7 +1535,7 @@ func (s *Store) Invocation(ctx context.Context, runID, invocationID string) (*In
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, attach_required, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ? AND id = ?`, runID, invocationID)
 	return scanInvocation(row)
@@ -1547,7 +1552,7 @@ func (s *Store) LatestInvocation(ctx context.Context, runID string) (*Invocation
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, attach_required, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ?
 		ORDER BY updated_at DESC, id DESC
@@ -1580,7 +1585,7 @@ func (s *Store) ActiveInvocation(ctx context.Context, runID string) (*Invocation
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, status, recovery_resume_count, attach_required, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ? AND status = ?
 		ORDER BY updated_at DESC
@@ -1612,6 +1617,7 @@ func scanInvocation(row *sql.Row) (*Invocation, error) {
 		&invocation.PromptVersion,
 		&invocation.Status,
 		&invocation.RecoveryResumeCount,
+		&invocation.AttachRequired,
 		&createdAt,
 		&updatedAt,
 	); err != nil {
@@ -2291,6 +2297,10 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 		case 22:
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE invocations ADD COLUMN recovery_resume_count INTEGER NOT NULL DEFAULT 0"); err != nil {
 				return fmt.Errorf("apply store migration 22: %w", err)
+			}
+		case 23:
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE invocations ADD COLUMN attach_required INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return fmt.Errorf("apply store migration 23: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)


### PR DESCRIPTION
## Summary

- recreate missing or stopped workers from the frozen image and invocation projection while preserving worktree and role state
- detect live harness exits, allow exactly one automatic native resume, and escalate subsequent failures for manual resume and attach
- pause and retry rate limits without workflow budget, surface redacted typed auth failures, and add factory resume, factory attach, and factory auth refresh
- add durable recovery tests, harness interruption contract coverage, and runtime documentation

## Verification

- go test ./...
- go vet ./...

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recovery commands to resume runs, reattach native sessions, and refresh harness authentication.
  - Runs can automatically recreate workers and resume once after recoverable interruptions.
  - Added waiting states for rate limits, expired authentication, and unavailable harness capacity.
  - Added liveness detection for native sessions.

- **Bug Fixes**
  - Improved recovery diagnostics and safely reconciled pending work.
  - Sensitive authentication and harness error details are now redacted.
  - Manual recovery now requires explicit session attachment when necessary.

- **Documentation**
  - Expanded recovery lifecycle and operational command documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->