### PR TITLE
Implement cleanup and retention policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,3 +125,10 @@ The versioned, host-local SQLite store for current run state. Its current-state
 tables are separate from repository configuration, disposable run artifacts,
 and the isolated local evaluation-summary projection.
 _Avoid_: Event journal, telemetry, transcript archive
+
+**Cleanup**:
+The explicit, seven-day retention operation that previews and removes one or
+more terminal runs' local worktrees, local branches, workers, role sessions,
+generated outputs, and operational rows while retaining remote branches,
+credential stores, and local evaluation summaries.
+_Avoid_: Remote branch deletion, automatic summary deletion

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -403,7 +403,7 @@ prints the run, invocation, workspace, and surface handles. The role receives a
 read-only invocation packet and reports through `factory-report`; use
 `factory agent-report --invocation-id <id>` to ask the coordinator to validate
 and accept the structured report. Terminal output is never treated as a stage
-result. The operational store schema is version 22 and persists invocation
+result. The operational store schema is version 24 and persists invocation
 identity, opaque surface handles, prompt version, result directory, native
 session identifier, and permitted handoff paths in addition to run state. It
 also persists the draft pull-request number and URL so a restarted command can
@@ -486,8 +486,8 @@ Record the command output and verify the demonstration at each boundary:
 - `factory status` and the issue's status comment report `draft_pr`.
 
 Keep the resulting pull-request URL and the status-comment URL as the
-demonstration evidence. Close the disposable pull request and issue, then
-remove the run's local worktree and operational database after inspection.
+demonstration evidence. Close the disposable pull request and issue, then use
+`factory cleanup` after inspection to remove the eligible local run artifacts.
 
 ## Operational SQLite store
 
@@ -508,5 +508,36 @@ attach a human classification, and the separately confirmed
 `factory evaluation-delete --before <RFC3339> --confirm` command to remove only
 selected terminal summaries. Ordinary run-artifact cleanup does not touch this
 projection.
+
+## Run-artifact cleanup
+
+Ordinary run data becomes eligible seven days after a run enters its current
+terminal state: merged, closed, failed, or cancelled. The coordinator retains
+the current baseline and latest output projections while a run is active, and
+keeps worktrees and implementation session state while its pull request is
+open. It does not select active or waiting runs for cleanup.
+
+`factory cleanup` first prints every exact local worktree, local factory branch,
+logical worker target, and generated stored-output directory selected for
+removal. For a run with a tracked pull request it also reads the current GitHub
+lifecycle and keeps the run when that pull request is still open. It requires
+an explicit `--confirm` flag; the command never deletes a remote branch. A
+pending external-effect reservation, a malformed run identity, or a path that
+cannot be proven run-scoped blocks that run from cleanup. The second
+confirmation pass reuses the displayed cutoff and refuses a changed plan, so
+the printed targets are the targets being authorized.
+
+```sh
+factory cleanup --config /Users/me/.config/factory/config.yaml
+factory cleanup --config /Users/me/.config/factory/config.yaml --confirm
+factory cleanup --config /Users/me/.config/factory/config.yaml --run-id <run-id> --confirm
+```
+
+Cleanup removes operational run rows, invocation history, deterministic gate
+results, worker containers, run-scoped role-home volumes, generated invocation
+packets/results, and Git metadata projections through the WorkerRuntime and
+GitWorkspace adapters. Factory-managed credential volumes and local evaluation
+summaries are retained; `factory evaluation-delete` remains the only summary
+deletion command.
 
 The high-level `Factory` seam injects configuration, repository checking, GitHub, pull requests, `GitWorkspace`, worker, terminal, harness, clock, run-identity, and operational-store adapters. Foundation tests use a real temporary SQLite store and fake the external repository/configuration boundary; issue #4 adds focused fake-adapter tests for the claim seam and a real temporary Git repository test for worktree isolation. Issue #5 owns the `WorkerRuntime` adapter and coordinator worker ownership; issue #6 adds the portable `TerminalRuntime`, Codex harness, invocation packet, and structured report boundary; issue #7 adds host checkpoint, push, and draft-PR orchestration.

--- a/docs/worker-runtime.md
+++ b/docs/worker-runtime.md
@@ -67,6 +67,14 @@ host-side `GitWorkspace` validates the accepted worktree, creates the immutable
 checkpoint, synchronizes a base branch when policy requires it, pushes the run
 branch, and removes the worktree during cleanup.
 
+After the Factory cleanup policy confirms that a terminal run is older than
+seven days, the optional `CleanupRuntime` extension removes the run's private
+worker container, role-home volumes, and the exact invocation packet/result
+directories supplied for that run. It never removes the separate
+factory-managed credential volume; the coordinator supplies only the selected
+run roles, run identity, and validated output directories to this destructive
+adapter operation.
+
 Setup and the selected repository-declared gate run with `env -i` plus an
 explicit worker baseline. Role-policy commands additionally receive the
 coordinator-defined role identity; clean-policy commands do not. The gate

--- a/internal/cli/cleanup_test.go
+++ b/internal/cli/cleanup_test.go
@@ -1,0 +1,102 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/cli"
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestCleanupCommandPrintsTargetsBeforeConfirmation verifies that the CLI
+// exposes every local target and leaves the run untouched without --confirm.
+func TestCleanupCommandPrintsTargetsBeforeConfirmation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	configPath := filepath.Join(root, "host", "config.yaml")
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktrees", "run-cli-cleanup")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	for _, path := range []string{repositoryPath, worktreePath, filepath.Join(root, "worktrees", ".factory-agents", "run-cli-cleanup"), filepath.Join(root, "worktrees", ".factory-git", "run-cli-cleanup")} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := config.SaveHost(configPath, config.HostConfig{
+		SchemaVersion: 1,
+		Repositories: []config.RepositoryRegistration{{
+			Path:                 repositoryPath,
+			GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+			AuthorizedUsers:      []string{"alice"},
+			Polling:              config.PollingConfig{Interval: "30s", Backoff: "5m"},
+			OperationalDataPath:  operationalPath,
+			RepositoryConfigPath: filepath.Join(repositoryPath, config.RepositoryConfigFileName),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+	opened, err := store.Open(context.Background(), operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SaveRun(context.Background(), store.Run{
+		ID:             "run-cli-cleanup",
+		RepositoryPath: repositoryPath,
+		IssueNumber:    23,
+		Stage:          store.StageReady,
+		Status:         store.StatusComplete,
+		Branch:         "factory/run-cli-cleanup",
+		Worktree:       worktreePath,
+		TerminalAt:     now.Add(-8 * 24 * time.Hour),
+		CreatedAt:      now.Add(-9 * 24 * time.Hour),
+		UpdatedAt:      now.Add(-8 * 24 * time.Hour),
+	}); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	code := cli.Run(context.Background(), []string{"cleanup", "--config", configPath}, &output, &output)
+	if code != 2 {
+		t.Fatalf("cleanup exit code = %d, want 2; output = %s", code, output.String())
+	}
+	for _, fragment := range []string{
+		"cleanup worktree: " + worktreePath,
+		"cleanup branch: factory/run-cli-cleanup (local only; remote retained)",
+		"cleanup container: run=run-cli-cleanup",
+		"cleanup stored output:",
+		"cleanup requires --confirm; no resources removed",
+	} {
+		if !strings.Contains(output.String(), fragment) {
+			t.Fatalf("cleanup output = %q, missing %q", output.String(), fragment)
+		}
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("worktree after preview: %v", err)
+	}
+	reopened, err := store.Open(context.Background(), operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if run, err := reopened.LatestRun(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if run == nil || run.ID != "run-cli-cleanup" {
+		t.Fatalf("LatestRun() = %#v, want retained run", run)
+	}
+	if _, err := os.Stat(filepath.Join(root, "worktrees", ".factory-agents", "run-cli-cleanup")); errors.Is(err, os.ErrNotExist) {
+		t.Fatal("preview removed stored outputs")
+	}
+}

--- a/internal/cli/cleanup_test.go
+++ b/internal/cli/cleanup_test.go
@@ -43,7 +43,7 @@ func TestCleanupCommandPrintsTargetsBeforeConfirmation(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	opened, err := store.Open(context.Background(), operationalPath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,6 +47,7 @@ var commandTable = []commandDefinition{
 	{name: "evaluation", handler: runEvaluation},
 	{name: "evaluation-delete", handler: runEvaluationDelete},
 	{name: "evaluation-disposition", handler: runEvaluationDisposition},
+	{name: "cleanup", handler: runCleanup},
 }
 
 // Run dispatches the requested CLI command and returns its exit status.
@@ -887,6 +888,84 @@ func runEvaluationDisposition(ctx context.Context, args []string, defaultConfigP
 		return 1
 	}
 	return 0
+}
+
+// runCleanup displays the exact local cleanup plan and requires --confirm
+// before asking the Factory service to remove any run resources.
+func runCleanup(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
+	flags := flag.NewFlagSet("cleanup", flag.ContinueOnError)
+	flags.SetOutput(errorsOutput)
+	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	runID := flags.String("run-id", "", "terminal factory run identifier")
+	confirm := flags.Bool("confirm", false, "confirm cleanup of the displayed local targets")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		writeError(errorsOutput, errors.New("cleanup does not accept positional arguments"))
+		return 2
+	}
+
+	service := factory.New(*configPath)
+	preview, err := service.Cleanup(ctx, factory.CleanupRequest{RunID: *runID})
+	var confirmationErr *factory.CleanupConfirmationRequiredError
+	if err != nil && !errors.As(err, &confirmationErr) {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeCleanupPlan(output, errorsOutput, preview.Plan) {
+		return 1
+	}
+	if !*confirm {
+		if !writeOutput(output, errorsOutput, "cleanup requires --confirm; no resources removed\n") {
+			return 1
+		}
+		return 2
+	}
+
+	result, err := service.Cleanup(ctx, factory.CleanupRequest{
+		RunID:        *runID,
+		Confirm:      true,
+		Before:       preview.Plan.Before,
+		ExpectedPlan: &preview.Plan,
+	})
+	if err != nil {
+		writeError(errorsOutput, err)
+		return 1
+	}
+	if !writeOutput(output, errorsOutput, "cleanup complete: runs=%d\n", len(result.Deleted)) {
+		return 1
+	}
+	return 0
+}
+
+// writeCleanupPlan renders every exact target before any confirmed mutation.
+func writeCleanupPlan(output, errorsOutput io.Writer, plan factory.CleanupPlan) bool {
+	if !writeOutput(output, errorsOutput, "cleanup cutoff: %s\ncleanup runs: %d\n", plan.Before.Format(time.RFC3339Nano), len(plan.Runs)) {
+		return false
+	}
+	for _, run := range plan.Runs {
+		if !writeOutput(output, errorsOutput, "cleanup run: %s status=%s eligible_at=%s\ncleanup worktree: %s\ncleanup branch: %s (local only; remote retained)\ncleanup container: run=%s\n", run.RunID, run.Status, run.EligibleAt.Format(time.RFC3339Nano), run.Worktree, run.Branch, run.WorkerRunID) {
+			return false
+		}
+		if len(run.Roles) > 0 && !writeOutput(output, errorsOutput, "cleanup worker roles: %s\n", strings.Join(run.Roles, ", ")) {
+			return false
+		}
+		for _, outputPath := range run.StoredOutputs {
+			if !writeOutput(output, errorsOutput, "cleanup stored output: %s\n", outputPath) {
+				return false
+			}
+		}
+		if len(run.StoredOutputs) == 0 && !writeOutput(output, errorsOutput, "cleanup stored output: none\n") {
+			return false
+		}
+	}
+	for _, skipped := range plan.Skipped {
+		if !writeOutput(output, errorsOutput, "cleanup skipped run: %s reason=%s\n", skipped.RunID, skipped.Reason) {
+			return false
+		}
+	}
+	return true
 }
 
 // writeOutput writes one successful command response and reports writer errors

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -332,6 +332,15 @@ func (s *Service) applyStateTransition(ctx context.Context, runStore RunStore, t
 	if next.Revision <= transition.Previous.Revision {
 		next.Revision = transition.Previous.Revision + 1
 	}
+	if store.IsTerminalStatus(next.Status) && !store.IsTerminalStatus(transition.Previous.Status) && next.TerminalAt.IsZero() {
+		next.TerminalAt = next.UpdatedAt
+		if next.TerminalAt.IsZero() {
+			next.TerminalAt = s.deps.Now().UTC()
+		}
+	}
+	if !store.IsTerminalStatus(next.Status) {
+		next.TerminalAt = time.Time{}
+	}
 	if _, journaled := runStore.(PendingEffectStore); journaled {
 		return s.applyJournaledStateTransition(ctx, runStore, transition, next)
 	}

--- a/internal/factory/cleanup.go
+++ b/internal/factory/cleanup.go
@@ -1,0 +1,426 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+const (
+	// CleanupRetention is the minimum age of a terminal run before ordinary
+	// local run artifacts may be removed.
+	CleanupRetention = 7 * 24 * time.Hour
+)
+
+// cleanupWorkerRoles covers every coordinator-owned role that can create a
+// run-scoped worker home, including deterministic gate execution.
+var cleanupWorkerRoles = []string{"gate", "implementation", "spec_review", "test"}
+
+// CleanupStore is the operational-store seam needed to list and delete local
+// run artifacts while keeping evaluation-summary deletion separate.
+type CleanupStore interface {
+	OperationalStore
+	ListCleanupCandidates(context.Context, time.Time, string) ([]store.CleanupCandidate, error)
+	BeginCleanup(context.Context, string, time.Time) (store.CleanupTransaction, error)
+}
+
+// CleanupRequest selects a run and whether the destructive operation is
+// explicitly confirmed. An empty RunID considers all eligible runs.
+type CleanupRequest struct {
+	// RunID narrows cleanup to one run when set.
+	RunID string
+	// Confirm authorizes removal after the caller has displayed the plan.
+	Confirm bool
+	// Before reuses a previously displayed cutoff during confirmation. Zero
+	// selects the current clock minus CleanupRetention.
+	Before time.Time
+	// ExpectedPlan makes confirmation fail closed if the plan changed between
+	// preview and mutation.
+	ExpectedPlan *CleanupPlan
+}
+
+// CleanupRun describes every local target selected for one cleanup operation.
+type CleanupRun struct {
+	// RunID identifies the run and its private worker resources.
+	RunID string
+	// Status is the terminal status observed when the plan was built.
+	Status store.Status
+	// EligibleAt is the terminal time used for the seven-day cutoff.
+	EligibleAt time.Time
+	// RepositoryPath is the registered repository owning the local branch.
+	RepositoryPath string
+	// Branch is the local factory branch to remove. Remote branches are never
+	// addressed by this target.
+	Branch string
+	// Worktree is the exact local worktree path to remove.
+	Worktree string
+	// WorkerRunID is the logical worker identity passed to the runtime adapter;
+	// Docker names remain private to that adapter.
+	WorkerRunID string
+	// StoredOutputs contains the exact generated output directories to remove.
+	StoredOutputs []string
+	// Roles selects run-scoped role-home volumes for the worker adapter.
+	Roles []string
+}
+
+// CleanupSkippedRun explains why an otherwise old terminal run was withheld
+// from the destructive plan.
+type CleanupSkippedRun struct {
+	// RunID identifies the withheld run.
+	RunID string
+	// Reason is a bounded operator-facing safety explanation.
+	Reason string
+}
+
+// CleanupPlan is the complete operator-visible cleanup preview.
+type CleanupPlan struct {
+	// Before is the inclusive upper bound for terminal eligibility.
+	Before time.Time
+	// Runs contains exact resources that would be removed.
+	Runs []CleanupRun
+	// Skipped contains terminal runs withheld because their identity or state
+	// could not be validated safely.
+	Skipped []CleanupSkippedRun
+}
+
+// CleanupResult contains the preview and any operational rows removed after
+// confirmation.
+type CleanupResult struct {
+	// Plan is returned for both preview and confirmed cleanup.
+	Plan CleanupPlan
+	// Deleted contains one row-count projection for each removed run.
+	Deleted []store.CleanupDeletionResult
+}
+
+// CleanupConfirmationRequiredError tells a CLI or embedder to display the
+// returned plan and repeat with explicit confirmation.
+type CleanupConfirmationRequiredError struct{}
+
+// Error describes the required cleanup confirmation.
+func (*CleanupConfirmationRequiredError) Error() string {
+	return "cleanup requires explicit confirmation"
+}
+
+// CleanupBlockedError reports that at least one candidate was withheld and no
+// destructive cleanup was attempted for the plan.
+type CleanupBlockedError struct {
+	// Runs contains every skipped candidate that blocked the operation.
+	Runs []CleanupSkippedRun
+}
+
+// Error describes why confirmed cleanup was refused before any mutation.
+func (e *CleanupBlockedError) Error() string {
+	return fmt.Sprintf("cleanup blocked for %d run(s)", len(e.Runs))
+}
+
+// CleanupPlanChangedError tells the caller to display a fresh plan because
+// persisted state changed after the previous preview.
+type CleanupPlanChangedError struct{}
+
+// Error describes the stale-plan refusal.
+func (*CleanupPlanChangedError) Error() string { return "cleanup plan changed; preview it again" }
+
+// Cleanup previews eligible local artifacts and removes them only when the
+// caller explicitly confirms the complete plan. It reads the lifecycle of a
+// tracked pull request but never mutates GitHub, deletes remote branches, or
+// removes local evaluation summaries.
+func (s *Service) Cleanup(ctx context.Context, request CleanupRequest) (CleanupResult, error) {
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+
+	registration, cleanupStore, closeStore, err := s.openCleanupStore(ctx)
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	defer func() { _ = closeStore() }()
+
+	minimumBefore := s.deps.Now().UTC().Add(-CleanupRetention)
+	before := request.Before.UTC()
+	if request.Before.IsZero() {
+		before = minimumBefore
+	}
+	if before.After(minimumBefore) {
+		return CleanupResult{}, fmt.Errorf("cleanup cutoff %s is newer than the required seven-day cutoff %s", before.Format(time.RFC3339Nano), minimumBefore.Format(time.RFC3339Nano))
+	}
+	before = before.UTC()
+	candidates, err := cleanupStore.ListCleanupCandidates(ctx, before, request.RunID)
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	plan := s.buildCleanupPlan(ctx, registration, candidates, before)
+	result := CleanupResult{Plan: plan}
+	if request.Confirm && request.ExpectedPlan != nil && !cleanupPlansEqual(plan, *request.ExpectedPlan) {
+		return result, &CleanupPlanChangedError{}
+	}
+	if !request.Confirm {
+		return result, &CleanupConfirmationRequiredError{}
+	}
+	if len(plan.Skipped) > 0 {
+		return result, &CleanupBlockedError{Runs: append([]CleanupSkippedRun(nil), plan.Skipped...)}
+	}
+	if len(plan.Runs) == 0 {
+		return result, nil
+	}
+
+	runtime, ok := s.deps.Worker.(worker.CleanupRuntime)
+	if !ok {
+		return result, errors.New("worker runtime does not support cleanup")
+	}
+	workspace := s.gitWorkspace()
+	if workspace == nil {
+		return result, errors.New("GitWorkspace is required for cleanup")
+	}
+	for _, target := range plan.Runs {
+		cleanupTransaction, err := cleanupStore.BeginCleanup(ctx, target.RunID, plan.Before)
+		if err != nil {
+			return result, fmt.Errorf("reserve cleanup for run %q: %w", target.RunID, err)
+		}
+		rollback := func() { _ = cleanupTransaction.Rollback() }
+		if err := runtime.Cleanup(ctx, worker.CleanupRequest{RunID: target.RunID, Roles: target.Roles, StoredOutputs: target.StoredOutputs}); err != nil {
+			rollback()
+			return result, fmt.Errorf("clean worker for run %q: %w", target.RunID, err)
+		}
+		if err := workspace.Remove(ctx, registration.Path, gitadapter.Workspace{RunID: target.RunID, Branch: target.Branch, Worktree: target.Worktree}); err != nil {
+			rollback()
+			return result, fmt.Errorf("remove Git workspace for run %q: %w", target.RunID, err)
+		}
+		deleted, err := cleanupTransaction.Delete(ctx)
+		if err != nil {
+			rollback()
+			return result, fmt.Errorf("delete operational state for run %q: %w", target.RunID, err)
+		}
+		if err := cleanupTransaction.Commit(); err != nil {
+			rollback()
+			return result, fmt.Errorf("commit cleanup for run %q: %w", target.RunID, err)
+		}
+		if deleted.Runs > 0 {
+			result.Deleted = append(result.Deleted, deleted)
+		}
+	}
+	return result, nil
+}
+
+// openCleanupStore loads the registered repository and opens its cleanup-capable
+// local store without invoking terminal or harness adapters.
+func (s *Service) openCleanupStore(ctx context.Context) (config.RepositoryRegistration, CleanupStore, func() error, error) {
+	registration, err := s.registration()
+	if err != nil {
+		return config.RepositoryRegistration{}, nil, func() error { return nil }, err
+	}
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return config.RepositoryRegistration{}, nil, func() error { return nil }, err
+	}
+	cleanupStore, ok := opened.(CleanupStore)
+	if !ok {
+		_ = opened.Close()
+		return config.RepositoryRegistration{}, nil, func() error { return nil }, errors.New("operational store does not support cleanup")
+	}
+	return registration, cleanupStore, opened.Close, nil
+}
+
+// buildCleanupPlan validates persisted identity and derives only exact,
+// run-scoped resources from each store candidate. It observes tracked pull
+// requests so an open PR keeps its worktree and session state.
+func (s *Service) buildCleanupPlan(ctx context.Context, registration config.RepositoryRegistration, candidates []store.CleanupCandidate, before time.Time) CleanupPlan {
+	plan := CleanupPlan{Before: before.UTC()}
+	for _, candidate := range candidates {
+		target, reason := s.cleanupTarget(ctx, registration, candidate)
+		if reason != "" {
+			plan.Skipped = append(plan.Skipped, CleanupSkippedRun{RunID: candidate.Run.ID, Reason: reason})
+			continue
+		}
+		plan.Runs = append(plan.Runs, target)
+	}
+	return plan
+}
+
+// cleanupTarget validates one candidate before it can enter a destructive
+// plan. Every rejection is fail-closed so a malformed row cannot widen cleanup.
+func (s *Service) cleanupTarget(ctx context.Context, registration config.RepositoryRegistration, candidate store.CleanupCandidate) (CleanupRun, string) {
+	run := candidate.Run
+	if !safeCleanupIdentifier(run.ID) {
+		return CleanupRun{}, "run identifier is not a safe local identifier"
+	}
+	if candidate.PendingEffect != nil {
+		return CleanupRun{}, fmt.Sprintf("pending external effect %q requires reconciliation", candidate.PendingEffect.ID)
+	}
+	if resolvePath(run.RepositoryPath) != resolvePath(registration.Path) {
+		return CleanupRun{}, "run repository does not match the registered repository"
+	}
+	if !store.IsTerminalStatus(run.Status) {
+		return CleanupRun{}, "run is no longer terminal"
+	}
+	if run.PullRequestNumber < 0 {
+		return CleanupRun{}, "pull-request number is invalid"
+	}
+	if run.PullRequestNumber > 0 {
+		pullRequest, found, err := s.trackedPullRequest(ctx, registration, run)
+		if err != nil {
+			return CleanupRun{}, fmt.Sprintf("cannot verify tracked pull request: %v", err)
+		}
+		if !found {
+			return CleanupRun{}, "tracked pull request could not be observed"
+		}
+		if pullRequest.Merged {
+			// A merged pull request is terminal and its local resources are
+			// eligible once the seven-day retention cutoff is reached.
+		} else if strings.EqualFold(strings.TrimSpace(pullRequest.State), "open") {
+			return CleanupRun{}, "pull request is still open"
+		} else if !strings.EqualFold(strings.TrimSpace(pullRequest.State), "closed") {
+			return CleanupRun{}, "pull request lifecycle is not conclusively terminal"
+		}
+	}
+	expectedBranch := "factory/" + run.ID
+	if run.Branch != expectedBranch {
+		return CleanupRun{}, fmt.Sprintf("branch %q is not the run-owned branch %q", run.Branch, expectedBranch)
+	}
+	if !filepath.IsAbs(run.Worktree) || filepath.Base(filepath.Clean(run.Worktree)) != run.ID {
+		return CleanupRun{}, "worktree is not an absolute run-scoped path"
+	}
+	worktree := filepath.Clean(run.Worktree)
+	if pathWithin(registration.Path, worktree) || pathWithin(worktree, registration.Path) {
+		return CleanupRun{}, "worktree overlaps the registered repository"
+	}
+	if reason := cleanupDirectoryTarget(worktree, "worktree"); reason != "" {
+		return CleanupRun{}, reason
+	}
+
+	storedOutputs := make([]string, 0, len(candidate.Invocations)*2)
+	seenOutputs := make(map[string]struct{}, len(candidate.Invocations)*2)
+	for _, invocation := range candidate.Invocations {
+		for _, path := range []string{invocation.InvocationDirectory, invocation.ResultDirectory} {
+			if path == "" {
+				continue
+			}
+			clean := filepath.Clean(path)
+			if pathWithin(registration.Path, clean) {
+				return CleanupRun{}, "stored output overlaps the registered repository"
+			}
+			if _, exists := seenOutputs[clean]; !exists {
+				seenOutputs[clean] = struct{}{}
+				storedOutputs = append(storedOutputs, clean)
+			}
+		}
+	}
+	if err := worker.ValidateCleanupStoredOutputs(run.ID, storedOutputs); err != nil {
+		return CleanupRun{}, err.Error()
+	}
+	sort.Strings(storedOutputs)
+
+	roles := append([]string(nil), cleanupWorkerRoles...)
+	roleSet := make(map[string]struct{}, len(roles))
+	for _, role := range roles {
+		roleSet[role] = struct{}{}
+	}
+	for _, invocation := range candidate.Invocations {
+		if !safeCleanupIdentifier(invocation.Role) {
+			return CleanupRun{}, fmt.Sprintf("invocation %q has an unsafe worker role", invocation.ID)
+		}
+		if _, exists := roleSet[invocation.Role]; !exists {
+			roleSet[invocation.Role] = struct{}{}
+			roles = append(roles, invocation.Role)
+		}
+	}
+	sort.Strings(roles)
+	eligibleAt := run.TerminalAt
+	if eligibleAt.IsZero() {
+		eligibleAt = run.UpdatedAt
+	}
+	if eligibleAt.IsZero() {
+		return CleanupRun{}, "run has no terminal timestamp"
+	}
+	return CleanupRun{
+		RunID:          run.ID,
+		Status:         run.Status,
+		EligibleAt:     eligibleAt.UTC(),
+		RepositoryPath: registration.Path,
+		Branch:         run.Branch,
+		Worktree:       worktree,
+		WorkerRunID:    run.ID,
+		StoredOutputs:  storedOutputs,
+		Roles:          roles,
+	}, ""
+}
+
+// cleanupDirectoryTarget verifies that an exact planned directory is safe to
+// remove. Missing directories are valid because a prior partial cleanup may
+// already have removed them.
+func cleanupDirectoryTarget(path, label string) string {
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) == string(filepath.Separator) {
+		return label + " is not a safe absolute directory"
+	}
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	if err != nil {
+		return fmt.Sprintf("inspect %s: %v", label, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return label + " must not be a symbolic link"
+	}
+	if !info.IsDir() {
+		return label + " is not a directory"
+	}
+	return ""
+}
+
+// safeCleanupIdentifier accepts only one path component suitable for both
+// generated directory names and the worker runtime's run identity.
+func safeCleanupIdentifier(value string) bool {
+	if value == "" || value == "." || value == ".." || strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || character == '-' || character == '_' || character == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// cleanupPlansEqual compares the operator-visible target identity used to
+// protect a two-step preview-and-confirm command from a stale plan.
+func cleanupPlansEqual(left, right CleanupPlan) bool {
+	if !left.Before.Equal(right.Before) || len(left.Runs) != len(right.Runs) || len(left.Skipped) != len(right.Skipped) {
+		return false
+	}
+	for index := range left.Runs {
+		leftRun, rightRun := left.Runs[index], right.Runs[index]
+		if leftRun.RunID != rightRun.RunID || leftRun.Status != rightRun.Status || !leftRun.EligibleAt.Equal(rightRun.EligibleAt) || leftRun.RepositoryPath != rightRun.RepositoryPath || leftRun.Branch != rightRun.Branch || leftRun.Worktree != rightRun.Worktree || leftRun.WorkerRunID != rightRun.WorkerRunID || !stringSlicesEqual(leftRun.StoredOutputs, rightRun.StoredOutputs) || !stringSlicesEqual(leftRun.Roles, rightRun.Roles) {
+			return false
+		}
+	}
+	for index := range left.Skipped {
+		if left.Skipped[index] != right.Skipped[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// stringSlicesEqual compares ordered cleanup target fields without exposing a
+// mutable alias through the plan comparison.
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/factory/cleanup_test.go
+++ b/internal/factory/cleanup_test.go
@@ -1,0 +1,384 @@
+package factory_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun fixes the
+// public cleanup preview contract before cleanup effects are implemented.
+func TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	worktreePath := filepath.Join(root, "worktrees", "run-eligible")
+	invocationRoot := filepath.Join(root, "worktrees", ".factory-agents", "run-eligible", "invocation-1")
+	invocationPath := filepath.Join(invocationRoot, "packet")
+	resultPath := filepath.Join(invocationRoot, "results")
+	for _, path := range []string{worktreePath, invocationPath, resultPath, filepath.Join(root, "worktrees", ".factory-git", "run-eligible")} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+	terminalAt := now.Add(-8 * 24 * time.Hour)
+	opened, err := store.Open(ctx, operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := store.Run{
+		ID:             "run-eligible",
+		RepositoryPath: repositoryPath,
+		IssueNumber:    23,
+		Stage:          store.StageReady,
+		Status:         store.StatusComplete,
+		Branch:         "factory/run-eligible",
+		Worktree:       worktreePath,
+		TerminalAt:     terminalAt,
+		CreatedAt:      terminalAt.Add(-time.Hour),
+		UpdatedAt:      terminalAt,
+	}
+	if err := opened.SaveRun(ctx, run); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.EnsureEvaluationSummary(ctx, run); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.FinalizeEvaluation(ctx, run.ID, store.EvaluationOutcomeComplete, terminalAt); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.SaveInvocation(ctx, store.Invocation{
+		ID:                  "invocation-1",
+		RunID:               "run-eligible",
+		Harness:             "codex",
+		Role:                "implementation",
+		Stage:               store.StageImplementation,
+		Status:              store.InvocationStatusCompleted,
+		InvocationDirectory: invocationPath,
+		ResultDirectory:     resultPath,
+		CreatedAt:           terminalAt,
+		UpdatedAt:           terminalAt,
+	}); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	workspace := &cleanupTestWorkspace{}
+	runtime := &cleanupTestWorker{}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfigRepository{value: config.HostConfig{
+			SchemaVersion: 1,
+			Repositories: []config.RepositoryRegistration{{
+				Path:                repositoryPath,
+				OperationalDataPath: operationalPath,
+			}},
+		}},
+		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		GitWorkspace: workspace,
+		Worker:       runtime,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	result, err := service.Cleanup(ctx, factory.CleanupRequest{})
+	var confirmationErr *factory.CleanupConfirmationRequiredError
+	if !errors.As(err, &confirmationErr) {
+		t.Fatalf("Cleanup() error = %v, want CleanupConfirmationRequiredError", err)
+	}
+	if len(result.Plan.Runs) != 1 {
+		t.Fatalf("cleanup plan runs = %d, want 1", len(result.Plan.Runs))
+	}
+	if result.Plan.Runs[0].RunID != "run-eligible" {
+		t.Fatalf("planned run = %q, want run-eligible", result.Plan.Runs[0].RunID)
+	}
+	if len(workspace.removed) != 0 {
+		t.Fatalf("workspace removals = %d, want preview to be side-effect free", len(workspace.removed))
+	}
+	if len(runtime.cleaned) != 0 {
+		t.Fatalf("worker cleanups = %d, want preview to be side-effect free", len(runtime.cleaned))
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("worktree after preview: %v", err)
+	}
+	if _, err := os.Stat(operationalPath); err != nil {
+		t.Fatalf("operational store after preview: %v", err)
+	}
+
+	confirmed, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
+	if err != nil {
+		t.Fatalf("confirmed Cleanup() error = %v", err)
+	}
+	if len(confirmed.Deleted) != 1 || confirmed.Deleted[0].RunID != "run-eligible" {
+		t.Fatalf("confirmed deletions = %#v, want run-eligible", confirmed.Deleted)
+	}
+	if len(workspace.removed) != 1 || workspace.removed[0].Branch != "factory/run-eligible" {
+		t.Fatalf("workspace removals = %#v, want the run-owned branch", workspace.removed)
+	}
+	if len(runtime.cleaned) != 1 || runtime.cleaned[0].RunID != "run-eligible" {
+		t.Fatalf("worker cleanups = %#v, want run-eligible", runtime.cleaned)
+	}
+	for _, path := range []string{worktreePath, invocationPath, resultPath, filepath.Join(root, "worktrees", ".factory-git", "run-eligible")} {
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("cleanup path %q still exists or returned unexpected error: %v", path, err)
+		}
+	}
+	reopened, err := store.Open(ctx, operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if latest, err := reopened.LatestRun(ctx); err != nil {
+		t.Fatal(err)
+	} else if latest != nil {
+		t.Fatalf("LatestRun() = %#v, want operational run deleted", latest)
+	}
+	if summary, err := reopened.EvaluationSummary(ctx, run.ID); err != nil {
+		t.Fatal(err)
+	} else if summary == nil || summary.Outcome != store.EvaluationOutcomeComplete {
+		t.Fatalf("EvaluationSummary() = %#v, want retained completed summary", summary)
+	}
+	pendingWorktree := filepath.Join(root, "worktrees", "run-pending")
+	if err := os.MkdirAll(pendingWorktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pendingRun := store.Run{
+		ID:             "run-pending",
+		RepositoryPath: repositoryPath,
+		IssueNumber:    24,
+		Stage:          store.StageReady,
+		Status:         store.StatusComplete,
+		Branch:         "factory/run-pending",
+		Worktree:       pendingWorktree,
+		TerminalAt:     terminalAt,
+		CreatedAt:      terminalAt.Add(-time.Hour),
+		UpdatedAt:      terminalAt,
+	}
+	if err := reopened.SaveRun(ctx, pendingRun); err != nil {
+		t.Fatal(err)
+	}
+	if err := reopened.SavePendingEffect(ctx, store.PendingEffect{
+		RunID:     pendingRun.ID,
+		ID:        "effect-pending",
+		Kind:      store.PendingEffectKindWorkerLaunch,
+		Payload:   `{"run_id":"run-pending"}`,
+		CreatedAt: terminalAt,
+		UpdatedAt: terminalAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reopened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
+	var blockedErr *factory.CleanupBlockedError
+	if !errors.As(err, &blockedErr) {
+		t.Fatalf("Cleanup() with pending effect error = %v, want CleanupBlockedError", err)
+	}
+	if len(blocked.Plan.Runs) != 0 || len(blocked.Plan.Skipped) != 1 || blocked.Plan.Skipped[0].RunID != pendingRun.ID {
+		t.Fatalf("blocked cleanup plan = %#v, want only pending run skipped", blocked.Plan)
+	}
+	if len(workspace.removed) != 1 || len(runtime.cleaned) != 1 {
+		t.Fatalf("blocked cleanup performed effects: workspaces=%#v workers=%#v", workspace.removed, runtime.cleaned)
+	}
+	if _, err := os.Stat(pendingWorktree); err != nil {
+		t.Fatalf("pending run worktree after blocked cleanup: %v", err)
+	}
+}
+
+// TestCleanupKeepsAnOpenPullRequestRun verifies that terminal age alone does
+// not remove local state while the tracked pull request remains open.
+func TestCleanupKeepsAnOpenPullRequestRun(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktrees", "run-open-pr")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	for _, path := range []string{repositoryPath, worktreePath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+	opened, err := store.Open(ctx, operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := store.Run{
+		ID:                  "run-open-pr",
+		RepositoryPath:      repositoryPath,
+		IssueNumber:         23,
+		Stage:               store.StageReady,
+		Status:              store.StatusCancelled,
+		Branch:              "factory/run-open-pr",
+		Worktree:            worktreePath,
+		PullRequestNumber:   42,
+		SpecificationPacket: `{"version":1,"repository_config":{"target_branch":"main"}}`,
+		TerminalAt:          now.Add(-8 * 24 * time.Hour),
+		CreatedAt:           now.Add(-9 * 24 * time.Hour),
+		UpdatedAt:           now.Add(-8 * 24 * time.Hour),
+	}
+	if err := opened.SaveRun(ctx, run); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	workspace := &cleanupTestWorkspace{}
+	runtime := &cleanupTestWorker{}
+	pullRequests := &fakePullRequests{existing: github.PullRequest{
+		Number:     run.PullRequestNumber,
+		State:      "open",
+		HeadBranch: run.Branch,
+		BaseBranch: "main",
+	}}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfigRepository{value: config.HostConfig{
+			SchemaVersion: 1,
+			Repositories: []config.RepositoryRegistration{{
+				Path:                repositoryPath,
+				GitHub:              config.GitHubConfig{Owner: "example", Repository: "project"},
+				OperationalDataPath: operationalPath,
+			}},
+		}},
+		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		GitWorkspace: workspace,
+		Worker:       runtime,
+		PullRequests: pullRequests,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	if _, err := service.Cleanup(ctx, factory.CleanupRequest{Before: now.Add(-6 * 24 * time.Hour)}); err == nil {
+		t.Fatal("Cleanup() accepted a cutoff newer than the seven-day retention boundary")
+	}
+	result, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
+	var blockedErr *factory.CleanupBlockedError
+	if !errors.As(err, &blockedErr) {
+		t.Fatalf("Cleanup() error = %v, want CleanupBlockedError", err)
+	}
+	if len(result.Plan.Runs) != 0 || len(result.Plan.Skipped) != 1 || result.Plan.Skipped[0].RunID != run.ID {
+		t.Fatalf("cleanup plan = %#v, want the open-PR run skipped", result.Plan)
+	}
+	if len(workspace.removed) != 0 || len(runtime.cleaned) != 0 {
+		t.Fatalf("cleanup effects = workspaces=%#v workers=%#v, want none", workspace.removed, runtime.cleaned)
+	}
+	reopened, err := store.Open(ctx, operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if retained, err := reopened.LatestRun(ctx); err != nil {
+		t.Fatal(err)
+	} else if retained == nil || retained.ID != run.ID {
+		t.Fatalf("LatestRun() = %#v, want open-PR run retained", retained)
+	}
+}
+
+// cleanupTestWorkspace records host cleanup effects for the Factory seam.
+type cleanupTestWorkspace struct {
+	removed []gitadapter.Workspace
+}
+
+// Create returns an unused workspace because preview cleanup never creates one.
+func (*cleanupTestWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	return gitadapter.Workspace{}, errors.New("unexpected workspace creation")
+}
+
+// Remove records the exact workspace selected for deletion.
+func (w *cleanupTestWorkspace) Remove(_ context.Context, _ string, workspace gitadapter.Workspace) error {
+	w.removed = append(w.removed, workspace)
+	if err := os.RemoveAll(workspace.Worktree); err != nil {
+		return err
+	}
+	if workspace.RunID != "" {
+		return os.RemoveAll(filepath.Join(filepath.Dir(workspace.Worktree), ".factory-git", workspace.RunID))
+	}
+	return nil
+}
+
+// Inspect satisfies the GitWorkspace contract for cleanup tests.
+func (*cleanupTestWorkspace) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	return gitadapter.WorktreeState{}, nil
+}
+
+// CreateCheckpoint satisfies the GitWorkspace contract for cleanup tests.
+func (*cleanupTestWorkspace) CreateCheckpoint(context.Context, gitadapter.CheckpointRequest) (gitadapter.CheckpointResult, error) {
+	return gitadapter.CheckpointResult{}, nil
+}
+
+// Push satisfies the GitWorkspace contract for cleanup tests.
+func (*cleanupTestWorkspace) Push(context.Context, gitadapter.PushRequest) error { return nil }
+
+// SynchronizeBase satisfies the GitWorkspace contract for cleanup tests.
+func (*cleanupTestWorkspace) SynchronizeBase(context.Context, gitadapter.BaseSyncRequest) error {
+	return nil
+}
+
+// cleanupTestWorker records worker cleanup effects for the Factory seam.
+type cleanupTestWorker struct {
+	cleaned []worker.CleanupRequest
+}
+
+// Start satisfies WorkerRuntime for cleanup tests.
+func (*cleanupTestWorker) Start(context.Context, worker.StartRequest) error { return nil }
+
+// Resume satisfies WorkerRuntime for cleanup tests.
+func (*cleanupTestWorker) Resume(context.Context, worker.ResumeRequest) error { return nil }
+
+// RunCommand satisfies WorkerRuntime for cleanup tests.
+func (*cleanupTestWorker) RunCommand(context.Context, worker.CommandRequest) (worker.CommandResult, error) {
+	return worker.CommandResult{}, nil
+}
+
+// Stop satisfies WorkerRuntime for cleanup tests.
+func (*cleanupTestWorker) Stop(context.Context, string) error { return nil }
+
+// Inspect satisfies WorkerRuntime for cleanup tests.
+func (*cleanupTestWorker) Inspect(context.Context, string) (worker.Inspection, error) {
+	return worker.Inspection{}, nil
+}
+
+// Cleanup records the exact worker cleanup request.
+func (w *cleanupTestWorker) Cleanup(_ context.Context, request worker.CleanupRequest) error {
+	w.cleaned = append(w.cleaned, request)
+	for _, path := range request.StoredOutputs {
+		if err := os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	commandlanguage "github.com/Stevie1704/sw-factory/internal/command"
 	"github.com/Stevie1704/sw-factory/internal/config"
@@ -675,6 +676,7 @@ func (s *Service) handleRetryCommand(ctx context.Context, registration config.Re
 	next.MergeCommitSHA = ""
 	next.LifecycleReason = ""
 	next.LifecycleNotificationSent = false
+	next.TerminalAt = time.Time{}
 	updated, err := s.applyStateTransition(ctx, runStore, stateTransition{
 		Repository:           repository,
 		Issue:                issue,

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -73,6 +73,9 @@ type Factory interface {
 	DeleteEvaluation(context.Context, EvaluationDeleteRequest) (EvaluationDeleteResult, error)
 	// AttachEvaluationDisposition records an explicit human escalation disposition.
 	AttachEvaluationDisposition(context.Context, EvaluationDispositionRequest) (EvaluationDispositionResult, error)
+	// Cleanup previews and, when explicitly confirmed, removes eligible local
+	// run artifacts without deleting remote branches or evaluation summaries.
+	Cleanup(context.Context, CleanupRequest) (CleanupResult, error)
 }
 
 // RunCoordinator is the single claim/state-transition seam used by the

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -20,6 +20,9 @@ const DefaultRemoteName = "origin"
 // Workspace identifies the fetched base commit and isolated checkout created
 // for one run.
 type Workspace struct {
+	// RunID identifies the run-owned metadata projection adjacent to Worktree.
+	// It is optional for compatibility with callers that only manage Git state.
+	RunID    string
 	BaseSHA  string
 	Branch   string
 	Worktree string
@@ -266,7 +269,7 @@ func (m *LocalWorktreeManager) Create(ctx context.Context, repositoryPath, targe
 	if _, err := m.runner().Run(ctx, repositoryPath, []string{"worktree", "add", "-b", branch, worktree, baseSHA}); err != nil {
 		return Workspace{}, fmt.Errorf("create worktree %q: %w", worktree, err)
 	}
-	return Workspace{BaseSHA: baseSHA, Branch: branch, Worktree: worktree}, nil
+	return Workspace{RunID: runID, BaseSHA: baseSHA, Branch: branch, Worktree: worktree}, nil
 }
 
 // CreateCheckpoint validates the run worktree and creates one host-side
@@ -482,8 +485,9 @@ func (m *LocalWorktreeManager) hasCheckpointMarker(ctx context.Context, worktree
 	return firstLine == marker
 }
 
-// Remove deletes a run worktree and its factory branch after a claim failure.
-// It attempts both operations so a partial cleanup still reports every error.
+// Remove deletes a run worktree, its factory branch, and its exact run-owned
+// Git metadata projection. It attempts every operation so a partial cleanup
+// still reports every error. It never addresses a remote branch.
 func (m *LocalWorktreeManager) Remove(ctx context.Context, repositoryPath string, workspace Workspace) error {
 	if strings.TrimSpace(repositoryPath) == "" {
 		return errors.New("repository path is required")
@@ -500,6 +504,14 @@ func (m *LocalWorktreeManager) Remove(ctx context.Context, repositoryPath string
 	if err := validateRefPart(workspace.Branch); err != nil {
 		return fmt.Errorf("workspace branch: %w", err)
 	}
+	if workspace.RunID != "" {
+		if err := validateRefPart(workspace.RunID); err != nil {
+			return fmt.Errorf("workspace run id: %w", err)
+		}
+		if filepath.Base(filepath.Clean(workspace.Worktree)) != workspace.RunID {
+			return errors.New("workspace path does not end in its run id")
+		}
+	}
 
 	var cleanupErrors []error
 	if _, err := m.runner().Run(ctx, repositoryPath, []string{"worktree", "remove", "--force", workspace.Worktree}); err != nil {
@@ -508,7 +520,36 @@ func (m *LocalWorktreeManager) Remove(ctx context.Context, repositoryPath string
 	if _, err := m.runner().Run(ctx, repositoryPath, []string{"branch", "-D", workspace.Branch}); err != nil {
 		cleanupErrors = append(cleanupErrors, fmt.Errorf("remove branch %q: %w", workspace.Branch, err))
 	}
+	if workspace.RunID != "" {
+		if err := removeRunGitMetadata(workspace); err != nil {
+			cleanupErrors = append(cleanupErrors, err)
+		}
+	}
 	return errors.Join(cleanupErrors...)
+}
+
+// removeRunGitMetadata removes one exact run directory under the sibling
+// .factory-git projection. Symlinks and non-directories are rejected so a
+// persisted path cannot widen Git cleanup beyond the run's own metadata.
+func removeRunGitMetadata(workspace Workspace) error {
+	metadataPath := filepath.Join(filepath.Dir(filepath.Clean(workspace.Worktree)), ".factory-git", workspace.RunID)
+	info, err := os.Lstat(metadataPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect Git metadata %q: %w", metadataPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("Git metadata %q must not be a symbolic link", metadataPath)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("Git metadata %q is not a directory", metadataPath)
+	}
+	if err := os.RemoveAll(metadataPath); err != nil {
+		return fmt.Errorf("remove Git metadata %q: %w", metadataPath, err)
+	}
+	return nil
 }
 
 // worktreePath returns the configured or default sibling worktree location.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -50,6 +50,9 @@ func TestLocalWorktreeManagerCreatesFromFetchedTargetWithoutChangingOrdinaryChec
 	if workspace.Branch != "factory/run-fixed" {
 		t.Fatalf("Branch = %q, want factory/run-fixed", workspace.Branch)
 	}
+	if workspace.RunID != "run-fixed" {
+		t.Fatalf("RunID = %q, want run-fixed", workspace.RunID)
+	}
 	wantWorktree := filepath.Join(root, "worktrees", "run-fixed")
 	if workspace.Worktree != wantWorktree {
 		t.Fatalf("Worktree = %q, want %q", workspace.Worktree, wantWorktree)
@@ -70,11 +73,18 @@ func TestLocalWorktreeManagerCreatesFromFetchedTargetWithoutChangingOrdinaryChec
 	if string(contents) != "base\n" {
 		t.Fatalf("worktree README = %q, want target branch contents", contents)
 	}
+	gitMetadataProjection := filepath.Join(root, "worktrees", ".factory-git", "run-fixed")
+	if err := os.MkdirAll(gitMetadataProjection, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := manager.Remove(context.Background(), repository, workspace); err != nil {
 		t.Fatalf("Remove() error = %v", err)
 	}
 	if _, err := os.Stat(workspace.Worktree); !os.IsNotExist(err) {
 		t.Fatalf("worktree path still exists after Remove(): err = %v", err)
+	}
+	if _, err := os.Stat(gitMetadataProjection); !os.IsNotExist(err) {
+		t.Fatalf("Git metadata projection still exists after Remove(): err = %v", err)
 	}
 	if got := strings.TrimSpace(runGit(t, repository, "branch", "--list", workspace.Branch)); got != "" {
 		t.Fatalf("run branch = %q, want branch removed", got)

--- a/internal/store/cleanup.go
+++ b/internal/store/cleanup.go
@@ -1,0 +1,345 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ErrCleanupNotEligible identifies a run that changed state or is newer than
+// the cleanup cutoff after a plan was created.
+var ErrCleanupNotEligible = errors.New("run is not cleanup eligible")
+
+// CleanupCandidate is one terminal run and the operational records needed by
+// the coordinator to plan safe external cleanup.
+type CleanupCandidate struct {
+	// Run is the current persisted run projection.
+	Run Run
+	// Invocations contains every persisted invocation for the run.
+	Invocations []Invocation
+	// PendingEffect is the unresolved external mutation, when present.
+	PendingEffect *PendingEffect
+}
+
+// CleanupDeletionResult reports operational rows deleted for one run. Local
+// evaluation-summary rows are intentionally absent because cleanup never
+// removes that separately retained projection.
+type CleanupDeletionResult struct {
+	// RunID identifies the deleted run.
+	RunID string
+	// Runs is one when the operational run row was deleted.
+	Runs int
+	// Invocations counts deleted harness invocation rows.
+	Invocations int
+	// GateResults counts deleted deterministic gate-result rows.
+	GateResults int
+	// PendingEffects counts deleted resolved-effect reservations.
+	PendingEffects int
+	// LifecycleNotifications counts deleted terminal-notification rows.
+	LifecycleNotifications int
+}
+
+// CleanupTransaction reserves one terminal run for external artifact cleanup
+// and then deletes its operational rows. The reservation holds the SQLite
+// write transaction open while the Git and worker adapters remove resources,
+// preventing the run from being reopened between planning and deletion.
+type CleanupTransaction interface {
+	// Delete removes the reserved run's operational rows and leaves separately
+	// retained evaluation summaries untouched.
+	Delete(context.Context) (CleanupDeletionResult, error)
+	// Commit makes the operational deletion durable.
+	Commit() error
+	// Rollback releases the reservation and preserves operational rows.
+	Rollback() error
+}
+
+// cleanupTransaction is the SQLite implementation of CleanupTransaction.
+type cleanupTransaction struct {
+	tx      *sql.Tx
+	runID   string
+	exists  bool
+	deleted bool
+}
+
+// CleanupNotEligibleError carries the run identity that failed the final
+// eligibility guard during deletion.
+type CleanupNotEligibleError struct {
+	// RunID identifies the run that was no longer eligible.
+	RunID string
+}
+
+// Error describes why one cleanup deletion was refused.
+func (e *CleanupNotEligibleError) Error() string {
+	return fmt.Sprintf("run %q is not cleanup eligible", e.RunID)
+}
+
+// Unwrap lets callers classify cleanup races with ErrCleanupNotEligible.
+func (*CleanupNotEligibleError) Unwrap() error { return ErrCleanupNotEligible }
+
+// BeginCleanup reserves one terminal run after checking its current status and
+// terminal timestamp. A no-op transaction is returned for an already absent
+// run so repeated cleanup remains idempotent.
+func (s *Store) BeginCleanup(ctx context.Context, runID string, before time.Time) (CleanupTransaction, error) {
+	if strings.TrimSpace(runID) == "" {
+		return nil, errors.New("cleanup run id is required")
+	}
+	if strings.ContainsAny(runID, "\x00\r\n") {
+		return nil, errors.New("cleanup run id contains a control character")
+	}
+	if before.IsZero() {
+		return nil, errors.New("cleanup cutoff is required")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin cleanup for run %q: %w", runID, err)
+	}
+	transaction := &cleanupTransaction{tx: tx, runID: runID}
+	// This deliberately no-op update acquires SQLite's write reservation
+	// before external cleanup begins. No coordinator state is changed.
+	if _, err := tx.ExecContext(ctx, "UPDATE operational_runs SET id = id WHERE id = ?", runID); err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("reserve cleanup for run %q: %w", runID, err)
+	}
+	var status Status
+	var terminalAt, updatedAt string
+	err = tx.QueryRowContext(ctx, `
+		SELECT status, terminal_at, updated_at
+		FROM operational_runs
+		WHERE id = ?`, runID).Scan(&status, &terminalAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return transaction, nil
+	}
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("read cleanup run %q: %w", runID, err)
+	}
+	transaction.exists = true
+	if !IsTerminalStatus(status) {
+		_ = tx.Rollback()
+		return nil, &CleanupNotEligibleError{RunID: runID}
+	}
+	eligibleAt, err := parseCleanupTimestamp(terminalAt, updatedAt)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("parse cleanup timestamp for run %q: %w", runID, err)
+	}
+	if eligibleAt.After(before.UTC()) {
+		_ = tx.Rollback()
+		return nil, &CleanupNotEligibleError{RunID: runID}
+	}
+	return transaction, nil
+}
+
+// ListCleanupCandidates returns terminal runs whose terminal time is at or
+// before before. An empty runID lists every candidate; a non-empty runID
+// narrows the result without changing the same eligibility rules.
+func (s *Store) ListCleanupCandidates(ctx context.Context, before time.Time, runID string) ([]CleanupCandidate, error) {
+	if before.IsZero() {
+		return nil, errors.New("cleanup cutoff is required")
+	}
+	if strings.ContainsAny(runID, "\x00\r\n") {
+		return nil, errors.New("cleanup run id contains a control character")
+	}
+	cutoff := before.UTC().Format(runTimestampLayout)
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id
+		FROM operational_runs
+		WHERE status IN (?, ?, ?)
+		  AND COALESCE(NULLIF(terminal_at, ''), updated_at) <= ?
+		  AND (? = '' OR id = ?)
+		ORDER BY COALESCE(NULLIF(terminal_at, ''), updated_at), id`,
+		StatusComplete, StatusCancelled, StatusFailed, cutoff, runID, runID)
+	if err != nil {
+		return nil, fmt.Errorf("list cleanup candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	ids := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan cleanup candidate: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read cleanup candidates: %w", err)
+	}
+
+	candidates := make([]CleanupCandidate, 0, len(ids))
+	for _, id := range ids {
+		run, err := s.cleanupRun(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if run == nil {
+			continue
+		}
+		invocations, err := s.cleanupInvocations(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		pendingEffect, err := s.PendingEffect(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("read cleanup pending effect for run %q: %w", id, err)
+		}
+		candidates = append(candidates, CleanupCandidate{
+			Run:           *run,
+			Invocations:   invocations,
+			PendingEffect: pendingEffect,
+		})
+	}
+	return candidates, nil
+}
+
+// DeleteCleanupRun reserves and atomically removes one already-planned run and
+// its operational children. It never deletes evaluation summaries, usage, or
+// dispositions.
+func (s *Store) DeleteCleanupRun(ctx context.Context, runID string, before time.Time) (CleanupDeletionResult, error) {
+	transaction, err := s.BeginCleanup(ctx, runID, before)
+	if err != nil {
+		return CleanupDeletionResult{RunID: runID}, err
+	}
+	defer func() { _ = transaction.Rollback() }()
+	result, err := transaction.Delete(ctx)
+	if err != nil {
+		return result, err
+	}
+	if err := transaction.Commit(); err != nil {
+		return result, fmt.Errorf("commit cleanup for run %q: %w", runID, err)
+	}
+	return result, nil
+}
+
+// Delete removes the reserved run's operational children and parent row. It
+// may be called once; absent runs return an idempotent zero-count result.
+func (t *cleanupTransaction) Delete(ctx context.Context) (CleanupDeletionResult, error) {
+	result := CleanupDeletionResult{RunID: t.runID}
+	if !t.exists || t.deleted {
+		return result, nil
+	}
+	var err error
+	if result.PendingEffects, err = deleteCleanupRows(ctx, t.tx, "pending_effects", t.runID); err != nil {
+		return result, fmt.Errorf("delete pending effects for run %q: %w", t.runID, err)
+	}
+	if result.LifecycleNotifications, err = deleteCleanupRows(ctx, t.tx, "lifecycle_notifications", t.runID); err != nil {
+		return result, fmt.Errorf("delete lifecycle notifications for run %q: %w", t.runID, err)
+	}
+	if result.GateResults, err = deleteCleanupRows(ctx, t.tx, "gate_results", t.runID); err != nil {
+		return result, fmt.Errorf("delete gate results for run %q: %w", t.runID, err)
+	}
+	if result.Invocations, err = deleteCleanupRows(ctx, t.tx, "invocations", t.runID); err != nil {
+		return result, fmt.Errorf("delete invocations for run %q: %w", t.runID, err)
+	}
+	if result.Runs, err = deleteCleanupRunRow(ctx, t.tx, t.runID); err != nil {
+		return result, fmt.Errorf("delete operational run %q: %w", t.runID, err)
+	}
+	t.deleted = true
+	return result, nil
+}
+
+// Commit makes the reserved deletion durable and releases the SQLite lock.
+func (t *cleanupTransaction) Commit() error { return t.tx.Commit() }
+
+// Rollback releases the reservation and preserves rows not yet committed.
+func (t *cleanupTransaction) Rollback() error { return t.tx.Rollback() }
+
+// cleanupRun loads one run using the complete operational projection needed
+// by cleanup planning.
+func (s *Store) cleanupRun(ctx context.Context, runID string) (*Run, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
+		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
+		       test_handoff, implementation_handoff, specification_review,
+		       test_exemption, protected_test_paths, test_stage_skipped,
+		       image_digest, coordinator, status_comment_id,
+		       pull_request_number, pull_request_url, merge_commit_sha,
+		       lifecycle_reason, lifecycle_notification_sent,
+		       revision, processed_comment_id, processed_comment_revision,
+		       last_command_name, last_command_outcome, last_command_message,
+		       harness_override, check_repair_attempts, check_repair_budget,
+		       check_repair_pending_attempt,
+		       specification_packet, pending_questions, clarification_comment_id,
+		       clarification_notification_sent, terminal_at, created_at, updated_at
+		FROM operational_runs
+		WHERE id = ?`, runID)
+	return scanRun(row)
+}
+
+// cleanupInvocations loads every invocation directory associated with one
+// candidate so the Factory can display and validate stored-output targets.
+func (s *Store) cleanupInvocations(ctx context.Context, runID string) ([]Invocation, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id
+		FROM invocations
+		WHERE run_id = ?
+		ORDER BY updated_at, id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("list invocations for cleanup run %q: %w", runID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	ids := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan invocation for cleanup run %q: %w", runID, err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read invocations for cleanup run %q: %w", runID, err)
+	}
+
+	invocations := make([]Invocation, 0, len(ids))
+	for _, id := range ids {
+		invocation, err := s.Invocation(ctx, runID, id)
+		if err != nil {
+			return nil, fmt.Errorf("read invocation %q for cleanup run %q: %w", id, runID, err)
+		}
+		if invocation != nil {
+			invocations = append(invocations, *invocation)
+		}
+	}
+	return invocations, nil
+}
+
+// parseCleanupTimestamp selects the stable terminal timestamp and falls back
+// to updated_at for databases created before terminal_at was introduced.
+func parseCleanupTimestamp(terminalAt, updatedAt string) (time.Time, error) {
+	value := terminalAt
+	if value == "" {
+		value = updatedAt
+	}
+	return time.Parse(time.RFC3339Nano, value)
+}
+
+// deleteCleanupRows deletes one run-scoped table and reports affected rows.
+// Table names are fixed internal constants at every call site.
+func deleteCleanupRows(ctx context.Context, tx *sql.Tx, table, runID string) (int, error) {
+	result, err := tx.ExecContext(ctx, "DELETE FROM "+table+" WHERE run_id = ?", runID)
+	if err != nil {
+		return 0, err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(changed), nil
+}
+
+// deleteCleanupRunRow deletes the parent row whose identity column is named
+// id rather than run_id.
+func deleteCleanupRunRow(ctx context.Context, tx *sql.Tx, runID string) (int, error) {
+	result, err := tx.ExecContext(ctx, "DELETE FROM operational_runs WHERE id = ?", runID)
+	if err != nil {
+		return 0, err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(changed), nil
+}

--- a/internal/store/cleanup_test.go
+++ b/internal/store/cleanup_test.go
@@ -1,0 +1,153 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestStoreCleanupUsesTerminalRetentionAndPreservesEvaluationSummaries
+// verifies the seven-day boundary and the separation between operational and
+// content-free evaluation projections.
+func TestStoreCleanupUsesTerminalRetentionAndPreservesEvaluationSummaries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+	cutoff := now.Add(-7 * 24 * time.Hour)
+	opened, err := store.Open(ctx, filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+
+	boundary := store.Run{
+		ID:             "run-boundary",
+		RepositoryPath: "/repo/boundary",
+		Stage:          store.StageReady,
+		Status:         store.StatusComplete,
+		Branch:         "factory/run-boundary",
+		Worktree:       "/worktrees/run-boundary",
+		TerminalAt:     cutoff,
+		CreatedAt:      cutoff.Add(-time.Hour),
+		UpdatedAt:      cutoff,
+	}
+	recent := store.Run{
+		ID:             "run-recent",
+		RepositoryPath: "/repo/recent",
+		Stage:          store.StageReady,
+		Status:         store.StatusFailed,
+		Branch:         "factory/run-recent",
+		Worktree:       "/worktrees/run-recent",
+		TerminalAt:     cutoff.Add(time.Minute),
+		CreatedAt:      cutoff,
+		UpdatedAt:      cutoff.Add(time.Minute),
+	}
+	active := store.Run{
+		ID:             "run-active",
+		RepositoryPath: "/repo/active",
+		Stage:          store.StageImplementation,
+		Status:         store.StatusActive,
+		Branch:         "factory/run-active",
+		Worktree:       "/worktrees/run-active",
+		CreatedAt:      cutoff.Add(-time.Hour),
+		UpdatedAt:      cutoff.Add(-time.Hour),
+	}
+	for _, run := range []store.Run{boundary, recent, active} {
+		if err := opened.SaveRun(ctx, run); err != nil {
+			t.Fatalf("SaveRun(%s) error = %v", run.ID, err)
+		}
+	}
+	if err := opened.SaveInvocation(ctx, store.Invocation{
+		ID:                  "inv-boundary",
+		RunID:               boundary.ID,
+		Harness:             "codex",
+		Role:                "implementation",
+		Stage:               store.StageImplementation,
+		Status:              store.InvocationStatusCompleted,
+		InvocationDirectory: "/worktrees/.factory-agents/run-boundary/inv-boundary/packet",
+		ResultDirectory:     "/worktrees/.factory-agents/run-boundary/inv-boundary/results",
+		CreatedAt:           cutoff,
+		UpdatedAt:           cutoff,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SavePendingEffect(ctx, store.PendingEffect{
+		RunID:     boundary.ID,
+		ID:        "effect-boundary",
+		Kind:      store.PendingEffectKindCheckpoint,
+		Payload:   `{"run_id":"run-boundary"}`,
+		CreatedAt: cutoff,
+		UpdatedAt: cutoff,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SaveGateResults(ctx, []store.GateResult{{
+		RunID:         boundary.ID,
+		CheckpointSHA: strings.Repeat("a", 40),
+		Phase:         store.GatePhaseCheckpoint,
+		Ordinal:       0,
+		GateName:      "test",
+		Outcome:       store.GateOutcomePassed,
+		Status:        "success",
+		Blocking:      true,
+		CreatedAt:     cutoff,
+		UpdatedAt:     cutoff,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.EnsureEvaluationSummary(ctx, boundary); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.FinalizeEvaluation(ctx, boundary.ID, store.EvaluationOutcomeComplete, cutoff); err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := opened.ListCleanupCandidates(ctx, now.Add(-7*24*time.Hour), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 || candidates[0].Run.ID != boundary.ID {
+		t.Fatalf("ListCleanupCandidates() = %#v, want only boundary run", candidates)
+	}
+	if candidates[0].PendingEffect == nil || len(candidates[0].Invocations) != 1 {
+		t.Fatalf("cleanup candidate = %#v, want pending effect and invocation history", candidates[0])
+	}
+
+	deleted, err := opened.DeleteCleanupRun(ctx, boundary.ID, now.Add(-7*24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted.Runs != 1 || deleted.Invocations != 1 || deleted.GateResults != 1 || deleted.PendingEffects != 1 {
+		t.Fatalf("DeleteCleanupRun() = %#v, want all operational rows removed", deleted)
+	}
+	if summary, err := opened.EvaluationSummary(ctx, boundary.ID); err != nil {
+		t.Fatal(err)
+	} else if summary == nil || summary.Outcome != store.EvaluationOutcomeComplete {
+		t.Fatalf("EvaluationSummary() = %#v, want retained summary", summary)
+	}
+	if invocation, err := opened.Invocation(ctx, boundary.ID, "inv-boundary"); err != nil {
+		t.Fatal(err)
+	} else if invocation != nil {
+		t.Fatalf("Invocation() = %#v, want deleted invocation", invocation)
+	}
+
+	if _, err := opened.DeleteCleanupRun(ctx, recent.ID, now.Add(-7*24*time.Hour)); err == nil {
+		t.Fatal("DeleteCleanupRun() removed a recent terminal run")
+	} else {
+		var notEligible *store.CleanupNotEligibleError
+		if !errors.As(err, &notEligible) {
+			t.Fatalf("DeleteCleanupRun() error = %v, want CleanupNotEligibleError", err)
+		}
+	}
+	if repeated, err := opened.DeleteCleanupRun(ctx, boundary.ID, now.Add(-7*24*time.Hour)); err != nil {
+		t.Fatal(err)
+	} else if repeated.Runs != 0 {
+		t.Fatalf("repeated DeleteCleanupRun() = %#v, want idempotent no-op", repeated)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,7 +20,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 23
+const CurrentSchemaVersion = 24
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -336,6 +336,10 @@ type Run struct {
 	MergeCommitSHA string
 	// LifecycleReason explains an automatic or authorized terminal transition.
 	LifecycleReason string
+	// TerminalAt records when the run first entered its current terminal state.
+	// It remains stable while terminal notifications or status projections are
+	// retried, and is cleared when a terminal run is explicitly reopened.
+	TerminalAt time.Time
 	// LifecycleNotificationSent records successful cmux notification delivery.
 	LifecycleNotificationSent bool
 	// Revision is the monotonic coordinator revision used by command replay
@@ -631,7 +635,7 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 		       harness_override, check_repair_attempts, check_repair_budget,
 		       check_repair_pending_attempt,
 		       specification_packet, pending_questions, clarification_comment_id,
-		       clarification_notification_sent, created_at, updated_at
+		       clarification_notification_sent, terminal_at, created_at, updated_at
 		FROM operational_runs
 		WHERE status NOT IN (?, ?, ?)
 		ORDER BY updated_at DESC
@@ -655,7 +659,7 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 		       harness_override, check_repair_attempts, check_repair_budget,
 		       check_repair_pending_attempt,
 		       specification_packet, pending_questions, clarification_comment_id,
-		       clarification_notification_sent, created_at, updated_at
+		       clarification_notification_sent, terminal_at, created_at, updated_at
 		FROM operational_runs
 		ORDER BY updated_at DESC
 		LIMIT 1`)
@@ -668,8 +672,9 @@ func scanRun(row *sql.Row) (*Run, error) {
 	var baseCheckpointSHA, testCheckpointSHA string
 	var testHandoffJSON, implementationHandoffJSON, specificationReviewJSON string
 	var testExemptionJSON, protectedTestPathsJSON string
-	var pendingQuestionsJSON, clarificationCommentID, createdAt, updatedAt string
+	var pendingQuestionsJSON, clarificationCommentID, terminalAt, createdAt, updatedAt string
 	var clarificationNotificationSent bool
+	var err error
 	if err := row.Scan(
 		&run.ID,
 		&run.RepositoryPath,
@@ -709,6 +714,7 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&pendingQuestionsJSON,
 		&clarificationCommentID,
 		&clarificationNotificationSent,
+		&terminalAt,
 		&createdAt,
 		&updatedAt,
 	); err != nil {
@@ -758,7 +764,12 @@ func scanRun(row *sql.Row) (*Run, error) {
 	}
 	run.ClarificationCommentID = clarificationCommentID
 	run.ClarificationNotificationSent = clarificationNotificationSent
-	var err error
+	if terminalAt != "" {
+		run.TerminalAt, err = time.Parse(time.RFC3339Nano, terminalAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse run terminal_at: %w", err)
+		}
+	}
 	run.CreatedAt, err = time.Parse(time.RFC3339Nano, createdAt)
 	if err != nil {
 		return nil, fmt.Errorf("parse run created_at: %w", err)
@@ -996,6 +1007,13 @@ func normalizeRun(run Run) (Run, error) {
 	}
 	if run.UpdatedAt.IsZero() {
 		run.UpdatedAt = run.CreatedAt
+	}
+	if IsTerminalStatus(run.Status) {
+		if run.TerminalAt.IsZero() {
+			run.TerminalAt = run.UpdatedAt
+		}
+	} else {
+		run.TerminalAt = time.Time{}
 	}
 	return run, nil
 }
@@ -1272,9 +1290,19 @@ func runValues(run Run) []any {
 		pendingQuestionsJSON(run.PendingQuestions),
 		run.ClarificationCommentID,
 		run.ClarificationNotificationSent,
+		terminalAtValue(run.TerminalAt),
 		run.CreatedAt.UTC().Format(runTimestampLayout),
 		run.UpdatedAt.UTC().Format(runTimestampLayout),
 	}
+}
+
+// terminalAtValue serializes an absent terminal timestamp as the empty
+// projection used by migrated and active runs.
+func terminalAtValue(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(runTimestampLayout)
 }
 
 const saveRunStatement = `
@@ -1291,12 +1319,12 @@ const saveRunStatement = `
 			last_command_message, harness_override, check_repair_attempts,
 			check_repair_budget, check_repair_pending_attempt, specification_packet,
 			pending_questions, clarification_comment_id,
-			clarification_notification_sent, created_at, updated_at
+			clarification_notification_sent, terminal_at, created_at, updated_at
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
@@ -1336,6 +1364,7 @@ const saveRunStatement = `
 			pending_questions = excluded.pending_questions,
 			clarification_comment_id = excluded.clarification_comment_id,
 			clarification_notification_sent = excluded.clarification_notification_sent,
+			terminal_at = excluded.terminal_at,
 			updated_at = excluded.updated_at`
 
 const saveRunIfRevisionStatement = `
@@ -1352,7 +1381,7 @@ const saveRunIfRevisionStatement = `
 			last_command_message = ?, harness_override = ?, check_repair_attempts = ?,
 			check_repair_budget = ?, check_repair_pending_attempt = ?, specification_packet = ?,
 			pending_questions = ?, clarification_comment_id = ?,
-			clarification_notification_sent = ?, created_at = ?, updated_at = ?
+			clarification_notification_sent = ?, terminal_at = ?, created_at = ?, updated_at = ?
 		WHERE id = ? AND revision = ?`
 
 // SaveInvocation validates and upserts one recoverable harness invocation.
@@ -2301,6 +2330,10 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 		case 23:
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE invocations ADD COLUMN attach_required INTEGER NOT NULL DEFAULT 0"); err != nil {
 				return fmt.Errorf("apply store migration 23: %w", err)
+			}
+		case 24:
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN terminal_at TEXT NOT NULL DEFAULT ''"); err != nil {
+				return fmt.Errorf("apply store migration 24: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -287,6 +287,29 @@ type WorkerRuntime interface {
 	Inspect(context.Context, string) (Inspection, error)
 }
 
+// CleanupRequest selects the run-scoped worker resources that may be removed
+// after the coordinator has confirmed the run is no longer recoverable.
+type CleanupRequest struct {
+	// RunID identifies the worker container and role volumes.
+	RunID string
+	// Roles identifies the role-home volumes to remove. Credential storage is
+	// deliberately not addressable through this request.
+	Roles []string
+	// StoredOutputs contains exact invocation packet and result directories
+	// owned by this worker runtime.
+	StoredOutputs []string
+}
+
+// CleanupRuntime is the optional destructive extension for a WorkerRuntime.
+// Keeping it separate lets existing embedders provide run execution without
+// gaining an implicit authority to delete worker state.
+type CleanupRuntime interface {
+	WorkerRuntime
+	// Cleanup removes the selected run container and role-home volumes while
+	// preserving factory-managed credential volumes.
+	Cleanup(context.Context, CleanupRequest) error
+}
+
 // DockerRuntime implements WorkerRuntime with the host Docker executable.
 // Docker container names are derived privately from RunID and never appear in
 // the WorkerRuntime interface or its results.
@@ -685,6 +708,205 @@ func (r *DockerRuntime) Stop(ctx context.Context, runID string) error {
 		return fmt.Errorf("stop worker %q: %w", runID, err)
 	}
 	return nil
+}
+
+// Cleanup removes one stopped or running worker and its run-scoped role-home
+// volumes. It is idempotent for absent Docker resources and never removes the
+// credential volume shared by harnesses.
+func (r *DockerRuntime) Cleanup(ctx context.Context, request CleanupRequest) error {
+	if err := validateRunID(request.RunID); err != nil {
+		return err
+	}
+	if err := ValidateCleanupStoredOutputs(request.RunID, request.StoredOutputs); err != nil {
+		return err
+	}
+	seenRoles := make(map[string]struct{}, len(request.Roles))
+	for _, role := range request.Roles {
+		if !validName(role) {
+			return fmt.Errorf("worker cleanup role %q contains unsafe characters", role)
+		}
+		if _, exists := seenRoles[role]; exists {
+			return fmt.Errorf("worker cleanup role %q is duplicated", role)
+		}
+		seenRoles[role] = struct{}{}
+	}
+
+	name := containerName(request.RunID)
+	if _, err := r.runDocker(ctx, []string{"rm", "--force", name}); err != nil && !isDockerResourceNotFound(err) {
+		return fmt.Errorf("remove worker %q: %w", request.RunID, dockerStderrDetail(err))
+	}
+	for _, role := range request.Roles {
+		volume := roleVolumeName(request.RunID, role)
+		if _, err := r.runDocker(ctx, []string{"volume", "rm", volume}); err != nil && !isDockerResourceNotFound(err) {
+			return fmt.Errorf("remove worker role storage for %q: %w", role, dockerStderrDetail(err))
+		}
+	}
+	if err := removeCleanupStoredOutputs(request.StoredOutputs); err != nil {
+		return fmt.Errorf("remove stored worker outputs: %w", err)
+	}
+	return nil
+}
+
+// ValidateCleanupStoredOutputs validates the exact invocation packet and
+// result directories accepted by Cleanup. It prevents a persisted path from
+// widening a worker cleanup into an arbitrary host deletion.
+func ValidateCleanupStoredOutputs(runID string, paths []string) error {
+	if err := validateRunID(runID); err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		if err := validateCleanupStoredOutputPath(runID, path); err != nil {
+			return err
+		}
+		if _, exists := seen[path]; exists {
+			return fmt.Errorf("stored output %q is duplicated", path)
+		}
+		seen[path] = struct{}{}
+	}
+	return nil
+}
+
+// validateCleanupStoredOutputPath accepts only the packet or result directory
+// shape generated beneath one run's private .factory-agents root.
+func validateCleanupStoredOutputPath(runID, path string) error {
+	if !filepath.IsAbs(path) || strings.ContainsAny(path, "\x00\r\n,") {
+		return fmt.Errorf("stored output %q must be an absolute safe path", path)
+	}
+	clean := filepath.Clean(path)
+	parts := strings.Split(filepath.ToSlash(strings.TrimPrefix(clean, string(filepath.Separator))), "/")
+	for index := 0; index+3 < len(parts); index++ {
+		if parts[index] != ".factory-agents" || parts[index+1] != runID || !validName(parts[index+2]) {
+			continue
+		}
+		if index+3 != len(parts)-1 || (parts[index+3] != "packet" && parts[index+3] != "results") {
+			break
+		}
+		return nil
+	}
+	return fmt.Errorf("stored output %q is outside the run invocation roots", path)
+}
+
+// removeCleanupStoredOutputs removes exact worker-owned output directories and
+// treats missing paths as successful for retry after a partial cleanup.
+func removeCleanupStoredOutputs(paths []string) error {
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("stored output %q must not be a symbolic link", path)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("stored output %q is not a directory", path)
+		}
+		root, err := cleanupStoredOutputRoot(path)
+		if err != nil {
+			return err
+		}
+		if err := validateCleanupStoredOutputTree(root, path); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("remove stored output %q: %w", path, err)
+		}
+		if err := removeEmptyCleanupParents(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanupStoredOutputRoot returns the run's lexical .factory-agents root for
+// one validated output path. It allows normal system-level symlinks such as
+// macOS /var while keeping the run-owned portion of the path symlink-free.
+func cleanupStoredOutputRoot(path string) (string, error) {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	marker := "/.factory-agents/"
+	index := strings.Index(clean, marker)
+	if index < 0 {
+		return "", fmt.Errorf("stored output %q is outside the run invocation roots", path)
+	}
+	return filepath.FromSlash(clean[:index+len("/.factory-agents")]), nil
+}
+
+// validateCleanupStoredOutputTree rejects symlinks and non-directories from
+// the private .factory-agents root through the exact output directory.
+func validateCleanupStoredOutputTree(root, path string) error {
+	rootInfo, err := os.Lstat(root)
+	if err != nil {
+		return fmt.Errorf("inspect stored output root %q: %w", root, err)
+	}
+	if rootInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("stored output root %q must not be a symbolic link", root)
+	}
+	if !rootInfo.IsDir() {
+		return fmt.Errorf("stored output root %q is not a directory", root)
+	}
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("stored output %q is outside its run invocation root", path)
+	}
+	current := root
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return fmt.Errorf("inspect stored output component %q: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("stored output component %q must not be a symbolic link", current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("stored output component %q is not a directory", current)
+		}
+	}
+	return nil
+}
+
+// removeEmptyCleanupParents removes only empty invocation and run directories
+// beneath the private .factory-agents root, never the shared root itself.
+func removeEmptyCleanupParents(path string) error {
+	root, err := cleanupStoredOutputRoot(path)
+	if err != nil {
+		return err
+	}
+	runRoot := filepath.Dir(filepath.Dir(filepath.Clean(path)))
+	for current := filepath.Dir(filepath.Clean(path)); current != root; current = filepath.Dir(current) {
+		if !pathWithinCleanupRoot(root, current) || current == root {
+			return fmt.Errorf("stored output parent %q is outside its private root", current)
+		}
+		if _, err := os.Stat(current); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("inspect stored output parent %q: %w", current, err)
+		}
+		if err := os.Remove(current); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if errors.Is(err, syscall.ENOTEMPTY) {
+			break
+		} else if err != nil {
+			return fmt.Errorf("remove empty stored output parent %q: %w", current, err)
+		}
+		if current == runRoot {
+			break
+		}
+	}
+	return nil
+}
+
+// pathWithinCleanupRoot reports lexical containment for already validated
+// paths without resolving ordinary system-level symlinks.
+func pathWithinCleanupRoot(root, target string) bool {
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
 }
 
 // Inspect reports a run worker's state and returns an empty inspection when
@@ -1657,6 +1879,20 @@ func isContainerNotFound(err error) bool {
 	}
 	message := strings.ToLower(commandErr.Stderr)
 	return strings.Contains(message, "no such object") || strings.Contains(message, "no such container")
+}
+
+// isDockerResourceNotFound reports whether Docker rejected removal because a
+// container or volume was already absent.
+func isDockerResourceNotFound(err error) bool {
+	var commandErr *dockerCommandError
+	if !errors.As(err, &commandErr) || commandErr.ExitCode != 1 {
+		return false
+	}
+	message := strings.ToLower(commandErr.Stderr)
+	return strings.Contains(message, "no such object") ||
+		strings.Contains(message, "no such container") ||
+		strings.Contains(message, "no such volume") ||
+		strings.Contains(message, "volume not found")
 }
 
 // isDockerRuntimeFailure identifies Docker command errors that indicate a

--- a/internal/worker/runtime_contract_test.go
+++ b/internal/worker/runtime_contract_test.go
@@ -184,6 +184,55 @@ func TestDockerRuntimeResumesThePinnedWorker(t *testing.T) {
 	}
 }
 
+// TestDockerRuntimeCleansRunResourcesWithoutCredentialStorage verifies that
+// destructive worker cleanup targets only the container and role-home volumes.
+func TestDockerRuntimeCleansRunResourcesWithoutCredentialStorage(t *testing.T) {
+	stub, logPath, _ := writeDockerStub(t)
+	runtime := &worker.DockerRuntime{DockerBinary: stub}
+	root := t.TempDir()
+	invocationRoot := filepath.Join(root, ".factory-agents", "run-cleanup-contract", "invocation-1")
+	packetPath := filepath.Join(invocationRoot, "packet")
+	resultPath := filepath.Join(invocationRoot, "results")
+	for _, path := range []string{packetPath, resultPath} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := runtime.Cleanup(context.Background(), worker.CleanupRequest{
+		RunID:         "run-cleanup-contract",
+		Roles:         []string{"implementation", "spec_review"},
+		StoredOutputs: []string{packetPath, resultPath},
+	}); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	for _, path := range []string{packetPath, resultPath, invocationRoot, filepath.Dir(invocationRoot)} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("cleanup path %q still exists after Cleanup(): err = %v", path, err)
+		}
+	}
+	lines := readStubLog(t, logPath)
+	if len(lines) != 3 {
+		t.Fatalf("Docker cleanup calls = %d, want container plus two role volumes; calls = %#v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "rm --force factory-worker-") {
+		t.Fatalf("container cleanup call = %q, want private worker removal", lines[0])
+	}
+	if !strings.Contains(lines[1], "volume rm factory-role-implementation-") || !strings.Contains(lines[2], "volume rm factory-role-spec_review-") {
+		t.Fatalf("role cleanup calls = %#v, want implementation and spec_review role volumes", lines[1:])
+	}
+	for _, line := range lines {
+		if strings.Contains(line, "factory-auth") {
+			t.Fatalf("cleanup touched credential storage: %q", line)
+		}
+	}
+	if err := runtime.Cleanup(context.Background(), worker.CleanupRequest{RunID: "../unsafe"}); err == nil {
+		t.Fatal("Cleanup() accepted an unsafe run identifier")
+	}
+	if got := len(readStubLog(t, logPath)); got != len(lines) {
+		t.Fatalf("Docker calls after unsafe cleanup request = %d, want %d", got, len(lines))
+	}
+}
+
 // TestDockerRuntimeRejectsMutableImagesAndCredentialEnvironment verifies the
 // worker cannot start from a mutable image or execute with a host credential.
 func TestDockerRuntimeRejectsMutableImagesAndCredentialEnvironment(t *testing.T) {
@@ -379,6 +428,14 @@ case "$command_name" in
   rm)
     rm -f "$WORKER_DOCKER_STATE"
     printf 'stub-container\n'
+    ;;
+  volume)
+    if [ "${2:-}" = "rm" ]; then
+      printf 'stub-volume\n'
+    else
+      echo "unsupported docker volume command: $*" >&2
+      exit 2
+    fi
     ;;
   exec)
     case "$*" in


### PR DESCRIPTION
Closes #23

## Summary
- add seven-day terminal-run retention with stable terminal timestamps
- add preview-and-confirmed factory cleanup for worktrees, local branches, worker resources, invocation outputs, and operational rows
- preserve remote branches, credential volumes, and local evaluation summaries
- block cleanup for pending effects, malformed paths, and open tracked pull requests
- add adapter-owned cleanup and SQLite reservation to prevent unsafe concurrent reopening

## Verification
- go test ./... -count=1
- go vet ./...
- go test -race ./internal/factory ./internal/store ./internal/worker ./internal/cli -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `factory cleanup` command for previewing and removing eligible local resources from terminal runs older than seven days.
  * Cleanup requires explicit confirmation and reports eligible, skipped, or blocked runs.
  * Preserves remote branches, credential storage, and evaluation summaries.
  * Safely removes local worktrees, worker resources, stored outputs, and operational records.
* **Bug Fixes**
  * Improved terminal-run timestamp tracking and reset behavior when runs are reopened.
* **Documentation**
  * Added cleanup terminology, configuration guidance, and runtime cleanup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->