### PR TITLE
Issue 26 pilot P04 round 5

### DIFF
--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -109,15 +109,27 @@ type InvocationPacket struct {
 	ProtectedTestPaths []store.ProtectedTestPath `json:"protected_test_paths,omitempty"`
 	// TestExemption carries a provisional technical exemption to the reviewer.
 	TestExemption *store.TestExemption `json:"test_exemption,omitempty"`
+	// ReviewContext contains the exact diff and bounded handoffs for spec review.
+	ReviewContext *ReviewContext `json:"review_context,omitempty"`
 	// CheckRepair contains the complete failed-check context when this
 	// invocation is a native-resumed repair.
 	CheckRepair *CheckRepairPacket `json:"check_repair,omitempty"`
 }
 
+// ReviewContext is the immutable, coordinator-collected input to specification review.
+type ReviewContext struct {
+	CheckpointSHA         string                       `json:"checkpoint_sha"`
+	CurrentDiff           string                       `json:"current_diff"`
+	RelevantLogs          []string                     `json:"relevant_logs"`
+	ImplementationHandoff *store.ImplementationHandoff `json:"implementation_handoff,omitempty"`
+	TestHandoff           *store.TestHandoff           `json:"test_handoff,omitempty"`
+	TestExemption         *store.TestExemption         `json:"test_exemption,omitempty"`
+}
+
 const (
 	// invocationPacketVersion identifies the read-only invocation packet shape.
-	// Version three adds the test-stage handoff and protected-path projection.
-	invocationPacketVersion = 3
+	// Version four adds the exact-checkpoint specification-review projection.
+	invocationPacketVersion = 4
 	// invocationPacketFileName is the stable worker-visible packet filename.
 	invocationPacketFileName = "specification.json"
 )
@@ -206,6 +218,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		Harness:        invocation.Harness,
 		Role:           invocation.Role,
 		Stage:          string(invocation.Stage),
+		CheckpointSHA:  run.CheckpointSHA,
 		WorktreePath:   run.Worktree,
 		PermittedPaths: invocation.PermittedPaths,
 	}
@@ -335,6 +348,20 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	if invocation.Stage == store.StageTest {
 		return s.acceptTestStageReport(ctx, registration, runStore, run, invocation, value, state)
 	}
+	if invocation.Role == "spec_review" && invocation.Stage == store.StageReview {
+		return s.acceptSpecificationReviewReport(ctx, registration, runStore, run, invocation, value)
+	}
+	if value.Handoff != nil {
+		run.ImplementationHandoff = &store.ImplementationHandoff{
+			ChangeSummary:          value.Handoff.ChangeSummary,
+			ProductionFilesChanged: append([]string(nil), value.Handoff.ProductionFilesChanged...),
+			FocusedCommands:        append([]string(nil), value.Handoff.FocusedCommands...),
+			KnownLimitations:       append([]string(nil), value.Handoff.KnownLimitations...),
+		}
+		for _, mapping := range value.Handoff.AcceptanceMapping {
+			run.ImplementationHandoff.AcceptanceMapping = append(run.ImplementationHandoff.AcceptanceMapping, store.HandoffAcceptance{Criterion: mapping.Criterion, Evidence: mapping.Evidence})
+		}
+	}
 	run.Stage = store.StageImplementation
 	switch value.Outcome {
 	case report.OutcomeNeedsClarification:
@@ -389,10 +416,10 @@ func normalizeAgentRequest(request AgentRequest) AgentRequest {
 // validateAgentRequest rejects roles and stages outside the supported visible
 // role seams before external side effects occur.
 func validateAgentRequest(request AgentRequest) error {
-	if request.Role != "" && request.Role != "implementation" && request.Role != "test" {
+	if request.Role != "" && request.Role != "implementation" && request.Role != "test" && request.Role != "spec_review" {
 		return fmt.Errorf("agent role %q is not supported", request.Role)
 	}
-	if request.Stage != "" && request.Stage != store.StageTest && request.Stage != store.StageImplementation {
+	if request.Stage != "" && request.Stage != store.StageTest && request.Stage != store.StageImplementation && request.Stage != store.StageReview {
 		return fmt.Errorf("agent stage %q is not supported", request.Stage)
 	}
 	if (request.Role == "test") != (request.Stage == store.StageTest) && request.Role != "" && request.Stage != "" {
@@ -403,6 +430,12 @@ func validateAgentRequest(request AgentRequest) error {
 	}
 	if request.Role == "test" && request.Stage == store.StageImplementation {
 		return errors.New("test role cannot run in implementation stage")
+	}
+	if request.Role == "spec_review" && request.Stage != store.StageReview {
+		return errors.New("spec_review role requires review stage")
+	}
+	if request.Stage == store.StageReview && request.Role != "spec_review" {
+		return errors.New("review stage requires spec_review role")
 	}
 	if request.Model != "" && strings.ContainsAny(request.Model, "\x00\r\n ") {
 		return errors.New("agent model contains unsafe characters")
@@ -488,7 +521,7 @@ func validateAgentRunState(run store.Run) error {
 		return fmt.Errorf("cannot start implementation agent from run status %q", run.Status)
 	}
 	switch run.Stage {
-	case store.StageClaim, store.StageTest, store.StageImplementation:
+	case store.StageClaim, store.StageTest, store.StageImplementation, store.StageDraftPR, store.StageReview:
 		return nil
 	default:
 		return fmt.Errorf("cannot start implementation agent from run stage %q", run.Stage)
@@ -501,6 +534,12 @@ func selectAgentRole(run store.Run, request AgentRequest) (AgentRequest, error) 
 		if run.Stage == store.StageTest {
 			request.Role = "test"
 			request.Stage = store.StageTest
+		} else if run.Stage == store.StageReview {
+			request.Role = "spec_review"
+			request.Stage = store.StageReview
+		} else if run.Stage == store.StageDraftPR {
+			request.Role = "spec_review"
+			request.Stage = store.StageReview
 		} else {
 			request.Role = "implementation"
 			request.Stage = store.StageImplementation
@@ -509,6 +548,8 @@ func selectAgentRole(run store.Run, request AgentRequest) (AgentRequest, error) 
 	if request.Role == "" {
 		if request.Stage == store.StageTest {
 			request.Role = "test"
+		} else if request.Stage == store.StageReview {
+			request.Role = "spec_review"
 		} else {
 			request.Role = "implementation"
 		}
@@ -528,6 +569,12 @@ func selectAgentRole(run store.Run, request AgentRequest) (AgentRequest, error) 
 	}
 	if request.Role == "implementation" && run.Stage == store.StageTest {
 		return AgentRequest{}, errors.New("implementation agent cannot bypass the test stage")
+	}
+	if request.Stage == store.StageReview && run.Stage != store.StageReview && run.Stage != store.StageDraftPR {
+		return AgentRequest{}, fmt.Errorf("specification review requires active review stage, not %q", run.Stage)
+	}
+	if request.Role == "spec_review" && run.Stage != store.StageReview && run.Stage != store.StageDraftPR {
+		return AgentRequest{}, fmt.Errorf("specification review requires active review stage, not %q", run.Stage)
 	}
 	return request, nil
 }

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/prompt"
 	"github.com/Stevie1704/sw-factory/internal/report"
@@ -114,6 +115,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	}
 	role := request.Role
 	stage := request.Stage
+	var reviewContext *ReviewContext
 	promptText, err := prompt.Build(prompt.Request{
 		InvocationID:            invocationID,
 		RunID:                   run.ID,
@@ -126,6 +128,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		TestExemption:           run.TestExemption,
 		TestPaths:               packet.RepositoryConfig.TestPolicy.TestPaths,
 		TestInfrastructurePaths: packet.RepositoryConfig.TestPolicy.InfrastructurePaths,
+		ReviewContext:           nil,
 	})
 	if err != nil {
 		return AgentLaunchResult{}, err
@@ -142,6 +145,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		TestHandoff:         run.TestHandoff,
 		ProtectedTestPaths:  append([]store.ProtectedTestPath(nil), run.ProtectedTestPaths...),
 		TestExemption:       run.TestExemption,
+		ReviewContext:       reviewContext,
 	}); err != nil {
 		return AgentLaunchResult{}, err
 	}
@@ -212,6 +216,39 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		return AgentLaunchResult{}, fmt.Errorf("start worker for visible agent: %w", err)
 	}
 	workerStarted = true
+	if role == "spec_review" && stage == store.StageReview {
+		reviewContext, err = collectReviewContext(ctx, s.deps.Worker, run.ID, run.CheckpointSHA, *run)
+		if err != nil {
+			return AgentLaunchResult{}, err
+		}
+		promptText, err = prompt.Build(prompt.Request{
+			InvocationID: invocationID, RunID: run.ID, Role: role, Stage: string(stage),
+			SpecificationPacket: run.SpecificationPacket, RepositoryGuidance: packet.Issue.Body,
+			TestHandoff: run.TestHandoff, ProtectedTestPaths: run.ProtectedTestPaths,
+			TestExemption: run.TestExemption, TestPaths: packet.RepositoryConfig.TestPolicy.TestPaths,
+			TestInfrastructurePaths: packet.RepositoryConfig.TestPolicy.InfrastructurePaths,
+			ReviewContext: &prompt.ReviewContext{
+				CheckpointSHA: reviewContext.CheckpointSHA, CurrentDiff: reviewContext.CurrentDiff,
+				RelevantLogs: reviewContext.RelevantLogs, ImplementationHandoff: reviewContext.ImplementationHandoff,
+				TestHandoff: reviewContext.TestHandoff, TestExemption: reviewContext.TestExemption,
+			},
+		})
+		if err != nil {
+			return AgentLaunchResult{}, err
+		}
+		if err := writeInvocationPacket(packetDirectory, InvocationPacket{
+			SchemaVersion: invocationPacketVersion, InvocationID: invocationID, RunID: run.ID,
+			Role: role, Stage: stage, SpecificationPacket: run.SpecificationPacket,
+			PromptVersion: prompt.VersionFor(role, string(stage)), PermittedPaths: append([]string(nil), request.PermittedPaths...),
+			TestHandoff: run.TestHandoff, ProtectedTestPaths: append([]store.ProtectedTestPath(nil), run.ProtectedTestPaths...),
+			TestExemption: run.TestExemption, ReviewContext: reviewContext,
+		}); err != nil {
+			return AgentLaunchResult{}, err
+		}
+		if err := s.publishSpecificationReviewStatus(ctx, registration, run.CheckpointSHA, github.CommitStatusPending, "specification review in progress"); err != nil {
+			return AgentLaunchResult{}, err
+		}
+	}
 	if authPath != "" {
 		if err := seeder.SeedCodexCredentials(ctx, worker.CredentialSeedRequest{RunID: run.ID, AuthPath: authPath}); err != nil {
 			return AgentLaunchResult{}, err
@@ -259,6 +296,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		Prompt:          promptText,
 		Model:           model,
 		ReasoningEffort: request.ReasoningEffort,
+		CheckpointSHA:   run.CheckpointSHA,
 	})
 	if err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("launch Codex implementation agent: %w", err)

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -619,7 +619,8 @@ func statusCommentBody(run store.Run) string {
 			questions += fmt.Sprintf("- `%s`: %s\n", safeStatusCommentValue(question.ID), safeStatusCommentValue(question.Prompt))
 		}
 	}
-	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, checkRepair, pullRequest, lifecycle, harness, questions, commandFeedback)
+	review := renderSpecificationReviewStatus(run.SpecificationReview)
+	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, checkRepair, pullRequest, lifecycle, harness, questions, review, commandFeedback)
 }
 
 // safeStatusCommentValue keeps command feedback single-line and prevents

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -367,6 +367,8 @@ func packetResumeStageForPacket(run store.Run, packet SpecificationPacket) store
 // resetTestProjectionForPacketChange removes downstream test evidence that was
 // produced for an older specification packet before a new role starts.
 func resetTestProjectionForPacketChange(run *store.Run, packet SpecificationPacket) {
+	run.ImplementationHandoff = nil
+	run.SpecificationReview = nil
 	run.TestHandoff = nil
 	run.ProtectedTestPaths = nil
 	run.TestCheckpointSHA = ""

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -383,7 +383,12 @@ func generatedPullRequestBody(run store.Run, packet SpecificationPacket, gates [
 	if run.TestExemption != nil {
 		testStageDisposition = fmt.Sprintf("- test-stage disposition: `%s` (provisional): %s", safeStatusCommentValue(run.TestExemption.Kind), safeStatusCommentValue(run.TestExemption.Justification))
 	}
-	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `draft_pr`\n- intervention: `%s`\n%s\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, intervention, testStageDisposition, issueBody, strings.Join(gateLines, "\n"), run.ID, generatedPullRequestEnd)
+	reviewProjection := renderSpecificationReview(run.SpecificationReview)
+	prStage := run.Stage
+	if prStage == store.StageImplementation || prStage == store.StageCheck {
+		prStage = store.StageDraftPR
+	}
+	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- intervention: `%s`\n%s\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n%s\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, prStage, intervention, testStageDisposition, issueBody, strings.Join(gateLines, "\n"), reviewProjection, run.ID, generatedPullRequestEnd)
 }
 
 // mergeGeneratedPullRequestBody replaces only the marked factory section and

--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -1,0 +1,143 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// SpecificationReviewStatusContext is the stable exact-SHA status context for
+// the independent specification reviewer.
+const SpecificationReviewStatusContext = "factory/specification-review"
+
+// collectReviewContext obtains the immutable diff through the worker boundary
+// and carries only bounded handoffs and content-free checkpoint evidence.
+func collectReviewContext(ctx context.Context, runtime worker.WorkerRuntime, runID, checkpoint string, run store.Run) (*ReviewContext, error) {
+	if runtime == nil {
+		return nil, errors.New("worker runtime is required for specification review")
+	}
+	if !github.ValidCommitSHA(checkpoint) {
+		return nil, errors.New("specification review requires a valid checkpoint SHA")
+	}
+	commandRuntime, ok := runtime.(interface {
+		RunCommand(context.Context, worker.CommandRequest) (worker.CommandResult, error)
+	})
+	if !ok {
+		return nil, errors.New("worker runtime does not support specification-review context collection")
+	}
+	result, err := commandRuntime.RunCommand(ctx, worker.CommandRequest{
+		RunID:             runID,
+		Command:           fmt.Sprintf("git diff --no-ext-diff %s^ %s --", checkpoint, checkpoint),
+		EnvironmentPolicy: worker.EnvironmentPolicyClean,
+		Role:              "spec_review",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("collect exact checkpoint diff: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return nil, fmt.Errorf("collect exact checkpoint diff exited with code %d", result.ExitCode)
+	}
+	return &ReviewContext{
+		CheckpointSHA:         checkpoint,
+		CurrentDiff:           result.Stdout,
+		RelevantLogs:          []string{"review context collected for exact checkpoint " + checkpoint},
+		ImplementationHandoff: run.ImplementationHandoff,
+		TestHandoff:           run.TestHandoff,
+		TestExemption:         run.TestExemption,
+	}, nil
+}
+
+// publishSpecificationReviewStatus publishes a status attached to the exact
+// checkpoint and fails closed when the configured publisher is unavailable.
+func (s *Service) publishSpecificationReviewStatus(ctx context.Context, registration config.RepositoryRegistration, sha string, state github.CommitStatusState, description string) error {
+	if s.deps.CommitStatuses == nil {
+		return errors.New("commit status publisher is required for specification review")
+	}
+	return s.deps.CommitStatuses.CreateCommitStatus(ctx, github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}, github.CommitStatus{
+		SHA: sha, State: state, Context: SpecificationReviewStatusContext, Description: description,
+	})
+}
+
+// acceptSpecificationReviewReport stores the exact-checkpoint review and
+// routes concrete violations to human review while keeping advisories visible.
+func (s *Service) acceptSpecificationReviewReport(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, invocation *store.Invocation, value report.Report) (AgentResult, error) {
+	if value.ReviewHandoff == nil {
+		return AgentResult{}, errors.New("completed specification review requires a review handoff")
+	}
+	projection := &store.SpecificationReview{CheckpointSHA: value.ReviewHandoff.ReviewedSHA}
+	blocking := false
+	for _, finding := range value.ReviewHandoff.Findings {
+		projection.Findings = append(projection.Findings, store.ReviewFinding{
+			Location: finding.Location, Claim: finding.Claim, Evidence: finding.Evidence,
+			Severity: string(finding.Severity), Category: string(finding.Category),
+			SuggestedResolution: finding.SuggestedResolution, SuggestedOwner: finding.SuggestedOwner,
+		})
+		if report.ReviewFindingBlocks(finding) {
+			blocking = true
+		}
+	}
+	previous := *run
+	run.SpecificationReview = projection
+	run.Stage = store.StageReview
+	run.PendingQuestions = nil
+	run.ClarificationCommentID = ""
+	run.ClarificationNotificationSent = false
+	if blocking {
+		run.Status = store.StatusWaitingForHuman
+		run.LifecycleReason = "specification review found a concrete violation"
+	} else {
+		run.Status = store.StatusActive
+		run.Stage = store.StageReady
+		run.LifecycleReason = "specification review accepted; advisories remain visible"
+	}
+	run.UpdatedAt = s.deps.Now().UTC()
+	if err := s.persistAgentRunState(ctx, registration, runStore, previous, *run); err != nil {
+		return AgentResult{}, fmt.Errorf("persist specification review state: %w", err)
+	}
+	status := github.CommitStatusSuccess
+	description := "specification review accepted"
+	if blocking {
+		status = github.CommitStatusFailure
+		description = "specification review requires human disposition"
+	}
+	if err := s.publishSpecificationReviewStatus(ctx, registration, value.ReviewHandoff.ReviewedSHA, status, description); err != nil {
+		return AgentResult{}, err
+	}
+	if run.PullRequestNumber > 0 {
+		packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+		if err != nil {
+			return AgentResult{}, err
+		}
+		if _, err := s.regenerateDraftPullRequest(ctx, registration, *run, packet, ""); err != nil {
+			return AgentResult{}, fmt.Errorf("project specification review on pull request: %w", err)
+		}
+	}
+	return AgentResult{Invocation: *invocation, Report: value}, nil
+}
+
+// reviewFindingLine renders a complete finding without exposing a transcript.
+func reviewFindingLine(finding store.ReviewFinding) string {
+	return fmt.Sprintf("- `%s` `%s` at `%s`: %s — evidence: %s; suggested resolution: %s; suggested owner: %s", finding.Severity, finding.Category, finding.Location, finding.Claim, finding.Evidence, finding.SuggestedResolution, finding.SuggestedOwner)
+}
+
+// renderSpecificationReview projects review findings into the generated PR section.
+func renderSpecificationReview(review *store.SpecificationReview) string {
+	if review == nil {
+		return ""
+	}
+	lines := make([]string, 0, len(review.Findings))
+	for _, finding := range review.Findings {
+		lines = append(lines, reviewFindingLine(finding))
+	}
+	if len(lines) == 0 {
+		lines = append(lines, "- no findings")
+	}
+	return fmt.Sprintf("\n### Specification review\n\n- reviewed checkpoint: `%s`\n%s\n", review.CheckpointSHA, strings.Join(lines, "\n"))
+}

--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -141,3 +141,22 @@ func renderSpecificationReview(review *store.SpecificationReview) string {
 	}
 	return fmt.Sprintf("\n### Specification review\n\n- reviewed checkpoint: `%s`\n%s\n", review.CheckpointSHA, strings.Join(lines, "\n"))
 }
+
+// renderSpecificationReviewStatus projects findings into the editable status
+// comment while keeping every untrusted field on one safe Markdown line.
+func renderSpecificationReviewStatus(review *store.SpecificationReview) string {
+	if review == nil {
+		return ""
+	}
+	lines := []string{"\n### Specification review", "", "- reviewed checkpoint: `" + safeStatusCommentValue(review.CheckpointSHA) + "`"}
+	if len(review.Findings) == 0 {
+		lines = append(lines, "- no findings")
+	} else {
+		for _, finding := range review.Findings {
+			lines = append(lines, fmt.Sprintf("- `%s` `%s` at `%s`: %s — evidence: %s; suggested resolution: %s; suggested owner: %s",
+				safeStatusCommentValue(finding.Severity), safeStatusCommentValue(finding.Category), safeStatusCommentValue(finding.Location),
+				safeStatusCommentValue(finding.Claim), safeStatusCommentValue(finding.Evidence), safeStatusCommentValue(finding.SuggestedResolution), safeStatusCommentValue(finding.SuggestedOwner)))
+		}
+	}
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/internal/factory/review_test.go
+++ b/internal/factory/review_test.go
@@ -1,0 +1,212 @@
+package factory_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+const reviewCheckpoint = "fedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedc"
+
+// TestSpecificationReviewUsesAnImmutablePacketAndRoutesAdvisories verifies
+// the independent reviewer receives the exact diff and structured handoffs,
+// while taste/scope findings remain visible without blocking readiness.
+func TestSpecificationReviewUsesAnImmutablePacketAndRoutesAdvisories(t *testing.T) {
+	fixture := newReviewFixture(t)
+	launch, err := fixture.service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	if launch.Invocation.Role != "spec_review" || launch.Invocation.Stage != store.StageReview {
+		t.Fatalf("review invocation = %#v, want spec_review/review", launch.Invocation)
+	}
+	if len(fixture.statuses.values) != 1 || fixture.statuses.values[0].State != github.CommitStatusPending || fixture.statuses.values[0].SHA != reviewCheckpoint || fixture.statuses.values[0].Context != factory.SpecificationReviewStatusContext {
+		t.Fatalf("review statuses after launch = %#v, want pending exact-checkpoint status", fixture.statuses.values)
+	}
+	if len(fixture.worker.starts) != 1 || len(fixture.worker.commands) != 1 || len(fixture.harness.starts) != 1 || !strings.Contains(fixture.worker.commands[0].Command, reviewCheckpoint) {
+		t.Fatalf("review worker effects = starts %#v commands %#v, want one exact-diff command", fixture.worker.starts, fixture.worker.commands)
+	}
+	packetData, err := os.ReadFile(filepath.Join(launch.Invocation.InvocationDirectory, "specification.json"))
+	if err != nil {
+		t.Fatalf("read review packet: %v", err)
+	}
+	var packet factory.InvocationPacket
+	if err := json.Unmarshal(packetData, &packet); err != nil {
+		t.Fatalf("decode review packet: %v", err)
+	}
+	if packet.ReviewContext == nil || packet.ReviewContext.CheckpointSHA != reviewCheckpoint || packet.ReviewContext.CurrentDiff != "diff --git a/internal/factory/review.go b/internal/factory/review.go\n" || packet.ReviewContext.ImplementationHandoff == nil || packet.ReviewContext.TestExemption == nil || len(packet.ReviewContext.RelevantLogs) == 0 {
+		t.Fatalf("review context = %#v, want exact checkpoint, diff, and implementation handoff", packet.ReviewContext)
+	}
+	for _, marker := range []string{"specification-review-v1", "exact checkpoint", "--finding", "no upstream harness transcript"} {
+		if !strings.Contains(strings.ToLower(launch.Prompt), strings.ToLower(marker)) {
+			t.Errorf("review prompt missing %q:\n%s", marker, launch.Prompt)
+		}
+	}
+
+	reportValue := reviewReport(launch, []report.ReviewFinding{
+		{Location: "internal/factory/review.go:20", Claim: "scope could be narrower", Evidence: "the helper is reusable", Severity: report.ReviewSeverityBlocker, Category: report.ReviewCategoryScope, SuggestedResolution: "keep the helper", SuggestedOwner: "implementation"},
+		{Location: "internal/factory/review.go:21", Claim: "name is subjective", Evidence: "no behavior changes", Severity: report.ReviewSeverityAdvisory, Category: report.ReviewCategoryTaste, SuggestedResolution: "consider a shorter name", SuggestedOwner: "implementation"},
+	})
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, reportValue); err != nil {
+		t.Fatalf("write review report: %v", err)
+	}
+	accepted, err := fixture.service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: launch.Invocation.RunID, InvocationID: launch.Invocation.ID})
+	if err != nil {
+		t.Fatalf("AcceptAgentReport() error = %v", err)
+	}
+	if accepted.Report.ReviewHandoff == nil || fixture.runStore.current.Stage != store.StageReady || fixture.runStore.current.Status != store.StatusActive {
+		t.Fatalf("accepted review = %#v run=%#v, want ready/active", accepted.Report, fixture.runStore.current)
+	}
+	if len(fixture.statuses.values) != 2 || fixture.statuses.values[1].State != github.CommitStatusSuccess {
+		t.Fatalf("review statuses after acceptance = %#v, want pending then success", fixture.statuses.values)
+	}
+	body := fixture.pullRequests.updatedRequests[len(fixture.pullRequests.updatedRequests)-1].Body
+	for _, marker := range []string{"Specification review", "scope", "taste", "suggested owner", "keep the helper"} {
+		if !strings.Contains(body, marker) {
+			t.Errorf("PR review projection missing %q: %s", marker, body)
+		}
+	}
+}
+
+// TestSpecificationReviewBlocksOnlyConcreteViolations verifies a correctness
+// blocker moves the run to human review and publishes failure for the exact SHA.
+func TestSpecificationReviewBlocksOnlyConcreteViolations(t *testing.T) {
+	fixture := newReviewFixture(t)
+	launch, err := fixture.service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	reportValue := reviewReport(launch, []report.ReviewFinding{{
+		Location: "internal/factory/review.go:1", Claim: "checkpoint is not immutable", Evidence: "worktree can be changed", Severity: report.ReviewSeverityBlocker, Category: report.ReviewCategoryCorrectness, SuggestedResolution: "reject changed paths", SuggestedOwner: "implementation",
+	}})
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, reportValue); err != nil {
+		t.Fatalf("write review report: %v", err)
+	}
+	if _, err := fixture.service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: launch.Invocation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() error = %v", err)
+	}
+	if fixture.runStore.current.Stage != store.StageReview || fixture.runStore.current.Status != store.StatusWaitingForHuman {
+		t.Fatalf("blocked run = %#v, want review/waiting_for_human", fixture.runStore.current)
+	}
+	if got := fixture.statuses.values[len(fixture.statuses.values)-1].State; got != github.CommitStatusFailure {
+		t.Fatalf("final review status = %q, want failure", got)
+	}
+}
+
+// reviewFixture bundles the Factory seam and all isolated review projections.
+type reviewFixture struct {
+	service      *factory.Service
+	runStore     *agentRunStore
+	worker       *agentWorker
+	harness      *agentHarness
+	statuses     *gateStatuses
+	pullRequests *fakePullRequests
+}
+
+// newReviewFixture creates a draft-PR run with a valid baseline and checkpoint.
+func newReviewFixture(t *testing.T) reviewFixture {
+	t.Helper()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-review\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy := validRepositoryConfig()
+	policy.RoleHarnessDefaults["spec_review"] = config.HarnessCodex
+	policy.ModelOptions["spec_review"] = []string{"gpt-5"}
+	issue := github.Issue{Number: 42, Title: "Review the checkpoint", Body: "Review the exact implementation checkpoint.", State: "open", Labels: []string{github.LabelAgentReady}}
+	githubAdapter := &fakeGitHub{issueValue: issue}
+	statuses := &gateStatuses{}
+	pullRequests := &fakePullRequests{existing: github.PullRequest{Number: 17, URL: "https://github.com/example/project/pull/17", Body: "<!-- factory-generated:start -->\nold\n<!-- factory-generated:end -->", State: "open", Draft: true, HeadBranch: "factory/run-review", BaseBranch: "main"}}
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-review", Worktree: worktreePath}},
+		state:        gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-review", HeadSHA: factoryGateCheckpoint},
+	}
+	runStore := &agentRunStore{runs: map[string]store.Run{}, invocations: map[string]store.Invocation{}, gateResults: map[string][]store.GateResult{}, worktree: worktree}
+	runtime := &agentWorker{results: []worker.CommandResult{{ExitCode: 0, Stdout: "diff --git a/internal/factory/review.go b/internal/factory/review.go\n"}}}
+	terminalRuntime := &agentTerminal{}
+	harnessRuntime := &agentHarness{}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: repositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		Cmux: config.CmuxConfig{ControlWorkspace: "factory-control"}, OperationalDataPath: filepath.Join(root, "state", "factory.db"), RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+	}}}
+	ids := []string{"run-review", "review-session"}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		GitHub:         &fakeGitHubWithPullRequests{fakeGitHub: githubAdapter},
+		PullRequests:   pullRequests,
+		Worktree:       worktree,
+		Worker:         runtime,
+		Terminal:       terminalRuntime,
+		Harness:        harnessRuntime,
+		CommitStatuses: statuses,
+		Now:            func() time.Time { return time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC) },
+		NewRunID: func() (string, error) {
+			id := ids[0]
+			ids = ids[1:]
+			return id, nil
+		},
+	})
+	claimed, err := service.ClaimIssue(context.Background(), issue.Number)
+	if err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	run := claimed.Run
+	run.TestStageSkipped = true
+	run.TestExemption = &store.TestExemption{Kind: "human", Justification: "review fixture"}
+	run.ImplementationHandoff = &store.ImplementationHandoff{
+		ChangeSummary:          "implemented review behavior",
+		AcceptanceMapping:      []store.HandoffAcceptance{{Criterion: "review behavior", Evidence: "focused test"}},
+		ProductionFilesChanged: []string{"internal/factory/review.go"},
+		FocusedCommands:        []string{"go test ./internal/factory"},
+	}
+	run.Stage = store.StageDraftPR
+	run.Status = store.StatusActive
+	run.BaseCheckpointSHA = factoryGateCheckpoint
+	run.CheckpointSHA = reviewCheckpoint
+	run.PullRequestNumber = pullRequests.existing.Number
+	run.PullRequestURL = pullRequests.existing.URL
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun() review fixture error = %v", err)
+	}
+	githubAdapter.statusComment = github.Comment{ID: run.StatusCommentID, Body: "<!-- factory-status: " + run.ID + " -->"}
+	worktree.state.HeadSHA = reviewCheckpoint
+	worktree.state.ChangedPaths = nil
+	runStore.gateResults[run.ID] = []store.GateResult{
+		{RunID: run.ID, CheckpointSHA: factoryGateCheckpoint, Phase: store.GatePhaseBaseline, Ordinal: 0, GateName: policy.Gates[0].Name, Outcome: store.GateOutcomePassed, Status: string(github.CommitStatusSuccess), Blocking: policy.Gates[0].Blocking},
+		{RunID: run.ID, CheckpointSHA: reviewCheckpoint, Phase: store.GatePhaseCheckpoint, Ordinal: 0, GateName: policy.Gates[0].Name, Outcome: store.GateOutcomePassed, Status: string(github.CommitStatusSuccess), Blocking: policy.Gates[0].Blocking},
+	}
+	return reviewFixture{service: service, runStore: runStore, worker: runtime, harness: harnessRuntime, statuses: statuses, pullRequests: pullRequests}
+}
+
+// reviewReport creates a valid completed review report for a launched session.
+func reviewReport(launch factory.AgentLaunchResult, findings []report.ReviewFinding) report.Report {
+	return report.Report{
+		SchemaVersion: report.SchemaVersion, InvocationID: launch.Invocation.ID, RunID: launch.Invocation.RunID,
+		Harness: launch.Invocation.Harness, Role: launch.Invocation.Role, Stage: string(launch.Invocation.Stage),
+		Outcome: report.OutcomeCompleted, Summary: "review complete", ReviewHandoff: &report.ReviewHandoff{
+			ReviewedSHA: reviewCheckpoint, Findings: findings,
+		}, NativeSessionID: "session-review", ReportedAt: time.Now().UTC(),
+	}
+}

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -23,6 +23,8 @@ type StartRequest struct {
 	Role string
 	// Stage identifies the workflow stage.
 	Stage string
+	// CheckpointSHA binds a specification review to the immutable commit under review.
+	CheckpointSHA string
 	// WorkspaceID identifies the terminal workspace receiving the surface.
 	WorkspaceID terminal.WorkspaceID
 	// Surface is an existing role surface in the run workspace. When empty, the
@@ -136,6 +138,9 @@ func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, erro
 		"FACTORY_HARNESS":       "codex",
 		"FACTORY_INVOCATION_ID": request.InvocationID,
 		"FACTORY_STAGE":         request.Stage,
+	}
+	if request.CheckpointSHA != "" {
+		environment["FACTORY_CHECKPOINT_SHA"] = request.CheckpointSHA
 	}
 	if request.Model != "" {
 		environment["FACTORY_MODEL"] = request.Model

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -57,6 +57,29 @@ func TestCodexStartsAnInteractiveSessionThroughThePortableSeams(t *testing.T) {
 	}
 }
 
+// TestCodexPassesTheReviewCheckpointToTheWorker verifies the exact SHA is
+// available to the review report command without using terminal text.
+func TestCodexPassesTheReviewCheckpointToTheWorker(t *testing.T) {
+	workerRuntime := &fakeWorker{}
+	terminalRuntime := &fakeTerminal{surface: terminal.Surface{ID: "surface-review", WorkspaceID: "workspace-run", Name: "spec-review"}}
+	_, err := harness.NewCodex(workerRuntime, terminalRuntime).Start(context.Background(), harness.StartRequest{
+		InvocationID:  "inv-review",
+		RunID:         "run-review",
+		Role:          "spec_review",
+		Stage:         "review",
+		CheckpointSHA: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		WorkspaceID:   "workspace-run",
+		Surface:       terminalRuntime.surface,
+		Prompt:        "Review the immutable checkpoint.",
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if got := workerRuntime.requests[0].Environment["FACTORY_CHECKPOINT_SHA"]; got != "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" {
+		t.Fatalf("checkpoint environment = %q, want exact review SHA", got)
+	}
+}
+
 // TestCodexResumesWithNativeSessionIdentifier verifies the resume command's
 // global flags precede the resume subcommand as required by the spike.
 func TestCodexResumesWithNativeSessionIdentifier(t *testing.T) {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -15,6 +15,9 @@ const Version = "implementation-v1"
 // TestVersion identifies the factory-owned test-stage prompt.
 const TestVersion = "test-v1"
 
+// ReviewVersion identifies the factory-owned independent specification-review prompt.
+const ReviewVersion = "specification-review-v1"
+
 // fenceMarkers are the delimiters that untrusted prompt content must not contain.
 var fenceMarkers = []string{
 	"--- BEGIN SPECIFICATION PACKET ---",
@@ -55,6 +58,19 @@ type Request struct {
 	TestPaths []string
 	// TestInfrastructurePaths lists frozen essential test-infrastructure prefixes.
 	TestInfrastructurePaths []string
+	// ReviewContext contains the exact checkpoint and bounded handoffs supplied
+	// to an independent specification reviewer.
+	ReviewContext *ReviewContext
+}
+
+// ReviewContext is the packet projection used by the independent reviewer.
+type ReviewContext struct {
+	CheckpointSHA         string
+	CurrentDiff           string
+	RelevantLogs          []string
+	ImplementationHandoff *store.ImplementationHandoff
+	TestHandoff           *store.TestHandoff
+	TestExemption         *store.TestExemption
 }
 
 // Build constructs one role prompt with repository guidance bounded before the
@@ -84,7 +100,25 @@ Check-repair context:
 	}
 	version := VersionFor(request.Role, request.Stage)
 	testContext := ""
-	if request.Role == "test" && request.Stage == "test" {
+	if request.Role == "spec_review" && request.Stage == "review" {
+		data, err := json.Marshal(request.ReviewContext)
+		if err != nil {
+			return "", fmt.Errorf("encode specification-review context: %w", err)
+		}
+		testContext = fmt.Sprintf(`
+Independent specification-review ownership:
+- Review only the exact checkpoint identified in the coordinator packet; do not inspect or infer a moving latest state.
+- Read the immutable review packet from /invocation/specification.json.
+- The packet contains bounded implementation/test handoffs, the exact diff, and relevant logs.
+- Do not request, reproduce, or include any upstream harness transcript; no upstream harness transcript is part of this review.
+- Taste and scope concerns are visible advisory findings and do not block readiness.
+- Report complete findings with: --finding location|claim|evidence|severity|category|resolution|owner.
+- An exact checkpoint finding is a blocker only for a concrete correctness, security, specification, or standards violation.
+
+Review context:
+%s
+`, string(data))
+	} else if request.Role == "test" && request.Stage == "test" {
 		scope, err := json.Marshal(struct {
 			TestPaths           []string `json:"test_paths"`
 			InfrastructurePaths []string `json:"infrastructure_paths"`
@@ -147,6 +181,9 @@ Factory-owned rules:
 
 // VersionFor returns the factory-owned prompt version for one role and stage.
 func VersionFor(role, stage string) string {
+	if role == "spec_review" && stage == "review" {
+		return ReviewVersion
+	}
 	if role == "test" && stage == "test" {
 		return TestVersion
 	}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -100,3 +100,33 @@ func TestBuildIncludesCheckRepairContext(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildIncludesIndependentReviewRules verifies the reviewer is directed to
+// the immutable packet and the complete finding contract without transcripts.
+func TestBuildIncludesIndependentReviewRules(t *testing.T) {
+	value, err := prompt.Build(prompt.Request{
+		InvocationID:        "inv-review",
+		RunID:               "run-review",
+		Role:                "spec_review",
+		Stage:               "review",
+		SpecificationPacket: `{"issue":{"title":"Review"}}`,
+		ReviewContext: &prompt.ReviewContext{
+			CheckpointSHA: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	for _, marker := range []string{
+		"factory prompt version " + prompt.ReviewVersion,
+		"exact checkpoint",
+		"/invocation/specification.json",
+		"no upstream harness transcript",
+		"--finding location|claim|evidence|severity|category|resolution|owner",
+		"Taste and scope concerns are visible advisory findings",
+	} {
+		if !strings.Contains(value, marker) {
+			t.Fatalf("review prompt missing %q:\n%s", marker, value)
+		}
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -98,13 +98,13 @@ const (
 type ReviewCategory string
 
 const (
-	ReviewCategoryCorrectness   ReviewCategory = "correctness"
-	ReviewCategorySecurity      ReviewCategory = "security"
-	ReviewCategorySpecification ReviewCategory = "specification"
-	ReviewCategoryStandards     ReviewCategory = "standards"
+	ReviewCategoryCorrectness         ReviewCategory = "correctness"
+	ReviewCategorySecurity            ReviewCategory = "security"
+	ReviewCategorySpecification       ReviewCategory = "specification"
+	ReviewCategoryStandards           ReviewCategory = "standards"
 	ReviewCategoryDocumentedStandards ReviewCategory = "documented_standards"
-	ReviewCategoryTaste         ReviewCategory = "taste"
-	ReviewCategoryScope         ReviewCategory = "scope"
+	ReviewCategoryTaste               ReviewCategory = "taste"
+	ReviewCategoryScope               ReviewCategory = "scope"
 )
 
 // ReviewFinding is a complete, content-limited observation from the independent reviewer.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -43,6 +43,7 @@ const (
 	maxTestFiles = 256
 	// maxUncoveredCriteria bounds criteria the test role explicitly leaves open.
 	maxUncoveredCriteria = 64
+	maxReviewFindings    = 128
 )
 
 // ReportFileName is the only accepted report filename in an invocation result
@@ -81,6 +82,46 @@ type Handoff struct {
 	FocusedCommands []string `json:"focused_commands"`
 	// KnownLimitations records limitations that remain visible to later stages.
 	KnownLimitations []string `json:"known_limitations,omitempty"`
+}
+
+// ReviewSeverity classifies the urgency of one specification-review finding.
+type ReviewSeverity string
+
+const (
+	// ReviewSeverityBlocker identifies a concrete violation that prevents readiness.
+	ReviewSeverityBlocker ReviewSeverity = "blocker"
+	// ReviewSeverityAdvisory identifies a visible, non-gating observation.
+	ReviewSeverityAdvisory ReviewSeverity = "advisory"
+)
+
+// ReviewCategory identifies the bounded class of a review observation.
+type ReviewCategory string
+
+const (
+	ReviewCategoryCorrectness   ReviewCategory = "correctness"
+	ReviewCategorySecurity      ReviewCategory = "security"
+	ReviewCategorySpecification ReviewCategory = "specification"
+	ReviewCategoryStandards     ReviewCategory = "standards"
+	ReviewCategoryDocumentedStandards ReviewCategory = "documented_standards"
+	ReviewCategoryTaste         ReviewCategory = "taste"
+	ReviewCategoryScope         ReviewCategory = "scope"
+)
+
+// ReviewFinding is a complete, content-limited observation from the independent reviewer.
+type ReviewFinding struct {
+	Location            string         `json:"location"`
+	Claim               string         `json:"claim"`
+	Evidence            string         `json:"evidence"`
+	Severity            ReviewSeverity `json:"severity"`
+	Category            ReviewCategory `json:"category"`
+	SuggestedResolution string         `json:"suggested_resolution"`
+	SuggestedOwner      string         `json:"suggested_owner"`
+}
+
+// ReviewHandoff binds all findings to the immutable checkpoint they inspected.
+type ReviewHandoff struct {
+	ReviewedSHA string          `json:"reviewed_sha"`
+	Findings    []ReviewFinding `json:"findings"`
 }
 
 // TestHandoff contains the bounded evidence needed to transfer a test-stage
@@ -203,6 +244,8 @@ type Report struct {
 	Summary string `json:"summary"`
 	// Handoff is required only for a completed outcome.
 	Handoff *Handoff `json:"handoff,omitempty"`
+	// ReviewHandoff is required only for a completed specification-review report.
+	ReviewHandoff *ReviewHandoff `json:"review_handoff,omitempty"`
 	// TestHandoff is required for a completed test-stage outcome unless a
 	// technical exemption is explicitly reported.
 	TestHandoff *TestHandoff `json:"test_handoff,omitempty"`
@@ -239,6 +282,8 @@ type ValidationContext struct {
 	Role string
 	// Stage is the expected workflow stage.
 	Stage string
+	// CheckpointSHA is the exact commit a review report must have inspected.
+	CheckpointSHA string
 	// WorktreePath is the host checkout root, when filesystem containment is checked.
 	WorktreePath string
 	// PermittedPaths contains repository-relative prefixes the role may report.
@@ -448,7 +493,17 @@ func Validate(value Report, context ValidationContext) error {
 	}
 	switch value.Outcome {
 	case OutcomeCompleted:
-		if isTestReport(value) {
+		if isReviewReport(value) {
+			if value.Handoff != nil || value.TestHandoff != nil {
+				return errors.New("specification review report must contain only a review handoff")
+			}
+			if value.ReviewHandoff == nil {
+				return errors.New("completed specification review requires a review handoff")
+			}
+			if err := validateReviewHandoff(*value.ReviewHandoff, context); err != nil {
+				return err
+			}
+		} else if isTestReport(value) {
 			if value.Handoff != nil {
 				return errors.New("test completed report must contain only a test handoff")
 			}
@@ -460,6 +515,9 @@ func Validate(value Report, context ValidationContext) error {
 				return err
 			}
 		} else {
+			if value.ReviewHandoff != nil {
+				return errors.New("implementation completed report must not contain a review handoff")
+			}
 			if value.Handoff == nil {
 				return errors.New("completed report requires a handoff")
 			}
@@ -477,7 +535,7 @@ func Validate(value Report, context ValidationContext) error {
 		if len(value.Questions) == 0 {
 			return errors.New("needs_clarification report requires at least one question")
 		}
-		if value.Handoff != nil || value.TestHandoff != nil || len(value.Evidence) != 0 {
+		if value.Handoff != nil || value.TestHandoff != nil || value.ReviewHandoff != nil || len(value.Evidence) != 0 {
 			return errors.New("needs_clarification report must contain only questions")
 		}
 		if err := validateQuestions(value.Questions); err != nil {
@@ -487,7 +545,7 @@ func Validate(value Report, context ValidationContext) error {
 		if len(value.Evidence) == 0 {
 			return errors.New("cannot_proceed report requires evidence")
 		}
-		if value.Handoff != nil || value.TestHandoff != nil || len(value.Questions) != 0 {
+		if value.Handoff != nil || value.TestHandoff != nil || value.ReviewHandoff != nil || len(value.Questions) != 0 {
 			return errors.New("cannot_proceed report must contain only evidence")
 		}
 		if err := validateEvidence(value.Evidence); err != nil {
@@ -660,6 +718,81 @@ func validateHandoff(value Handoff, context ValidationContext) error {
 // isTestReport identifies the coordinator-owned test-stage envelope.
 func isTestReport(value Report) bool {
 	return value.Role == "test" && value.Stage == "test"
+}
+
+// isReviewReport identifies the coordinator-owned independent review envelope.
+func isReviewReport(value Report) bool {
+	return value.Role == "spec_review" && value.Stage == "review"
+}
+
+// ReviewFindingBlocks reports whether a finding is a concrete readiness blocker.
+// Taste and scope observations remain visible advisories even when mislabeled
+// with blocker severity, because they do not identify a correctness violation.
+func ReviewFindingBlocks(value ReviewFinding) bool {
+	if value.Severity != ReviewSeverityBlocker {
+		return false
+	}
+	switch value.Category {
+	case ReviewCategoryCorrectness, ReviewCategorySecurity, ReviewCategorySpecification, ReviewCategoryStandards, ReviewCategoryDocumentedStandards:
+		return true
+	default:
+		return false
+	}
+}
+
+// validateReviewHandoff validates the exact checkpoint binding and complete
+// finding contract before a review can influence coordinator readiness.
+func validateReviewHandoff(value ReviewHandoff, context ValidationContext) error {
+	if err := validateSHA("review handoff reviewed_sha", value.ReviewedSHA); err != nil {
+		return err
+	}
+	if context.CheckpointSHA != "" && value.ReviewedSHA != context.CheckpointSHA {
+		return fmt.Errorf("reviewed SHA %q does not match checkpoint %q", value.ReviewedSHA, context.CheckpointSHA)
+	}
+	if len(value.Findings) > maxReviewFindings {
+		return fmt.Errorf("review handoff findings exceeds %d entries", maxReviewFindings)
+	}
+	for index, finding := range value.Findings {
+		fields := []struct {
+			name  string
+			value string
+		}{
+			{fmt.Sprintf("review finding[%d].location", index), finding.Location},
+			{fmt.Sprintf("review finding[%d].claim", index), finding.Claim},
+			{fmt.Sprintf("review finding[%d].evidence", index), finding.Evidence},
+			{fmt.Sprintf("review finding[%d].suggested_resolution", index), finding.SuggestedResolution},
+			{fmt.Sprintf("review finding[%d].suggested_owner", index), finding.SuggestedOwner},
+		}
+		for _, field := range fields {
+			if err := validateText(field.name, field.value, maxTextRunes, true); err != nil {
+				return err
+			}
+		}
+		switch finding.Severity {
+		case ReviewSeverityBlocker, ReviewSeverityAdvisory:
+		default:
+			return fmt.Errorf("review finding[%d].severity %q is unsupported", index, finding.Severity)
+		}
+		switch finding.Category {
+		case ReviewCategoryCorrectness, ReviewCategorySecurity, ReviewCategorySpecification, ReviewCategoryStandards, ReviewCategoryDocumentedStandards, ReviewCategoryTaste, ReviewCategoryScope:
+		default:
+			return fmt.Errorf("review finding[%d].category %q is unsupported", index, finding.Category)
+		}
+	}
+	return nil
+}
+
+// validateSHA accepts the full hexadecimal commit identities used by GitHub.
+func validateSHA(field, value string) error {
+	if len(value) != 40 && len(value) != 64 {
+		return fmt.Errorf("%s must contain exactly 40 or 64 lowercase hexadecimal characters", field)
+	}
+	for _, character := range value {
+		if !((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f')) {
+			return fmt.Errorf("%s must contain exactly 40 or 64 lowercase hexadecimal characters", field)
+		}
+	}
+	return nil
 }
 
 // hasExemption reports whether one fixed exemption category is present.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -299,6 +299,54 @@ func TestValidateRequiresTheTestHandoffForTestCompletion(t *testing.T) {
 	}
 }
 
+// TestValidateAcceptsACompleteSpecificationReview verifies a review binds its
+// findings to the exact immutable checkpoint and preserves advisory findings.
+func TestValidateAcceptsACompleteSpecificationReview(t *testing.T) {
+	value := specificationReviewReport()
+	if err := report.Validate(value, report.ValidationContext{
+		InvocationID:  "inv-review",
+		RunID:         "run-review",
+		Harness:       "codex",
+		Role:          "spec_review",
+		Stage:         "review",
+		CheckpointSHA: value.ReviewHandoff.ReviewedSHA,
+	}); err != nil {
+		t.Fatalf("Validate() error = %v, want accepted specification review", err)
+	}
+	if !report.ReviewFindingBlocks(value.ReviewHandoff.Findings[0]) {
+		t.Fatal("concrete blocker was classified as advisory")
+	}
+	if report.ReviewFindingBlocks(value.ReviewHandoff.Findings[1]) {
+		t.Fatal("scope finding blocked readiness")
+	}
+}
+
+// TestValidateRejectsAnIncompleteReviewFinding verifies every finding field is
+// required before a reviewer can influence readiness.
+func TestValidateRejectsAnIncompleteReviewFinding(t *testing.T) {
+	value := specificationReviewReport()
+	value.ReviewHandoff.Findings[0].SuggestedOwner = ""
+	err := report.Validate(value, report.ValidationContext{
+		InvocationID: "inv-review", RunID: "run-review", Harness: "codex", Role: "spec_review", Stage: "review",
+	})
+	if err == nil || !strings.Contains(err.Error(), "suggested_owner") {
+		t.Fatalf("Validate() error = %v, want missing-owner rejection", err)
+	}
+}
+
+// TestValidateRejectsAReviewForAStaleCheckpoint verifies review output cannot
+// be reused after the reviewed commit changes.
+func TestValidateRejectsAReviewForAStaleCheckpoint(t *testing.T) {
+	value := specificationReviewReport()
+	err := report.Validate(value, report.ValidationContext{
+		InvocationID: "inv-review", RunID: "run-review", Harness: "codex", Role: "spec_review", Stage: "review",
+		CheckpointSHA: strings.Repeat("b", 40),
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not match checkpoint") {
+		t.Fatalf("Validate() error = %v, want stale-checkpoint rejection", err)
+	}
+}
+
 // TestValidateChecksPermittedFilesAgainstTheObservedWorktree verifies that a
 // handoff cannot claim a path outside the coordinator-approved worktree state.
 func TestValidateChecksPermittedFilesAgainstTheObservedWorktree(t *testing.T) {
@@ -447,5 +495,44 @@ func testStageReport() report.Report {
 			InfrastructureChanges: []string{"test-support/fixtures.go"},
 		},
 		ReportedAt: time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC),
+	}
+}
+
+// specificationReviewReport returns a valid review report with one blocker
+// and one advisory scope observation.
+func specificationReviewReport() report.Report {
+	return report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  "inv-review",
+		RunID:         "run-review",
+		Harness:       "codex",
+		Role:          "spec_review",
+		Stage:         "review",
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "review complete",
+		ReviewHandoff: &report.ReviewHandoff{
+			ReviewedSHA: strings.Repeat("a", 40),
+			Findings: []report.ReviewFinding{
+				{
+					Location:            "internal/factory/agent.go:42",
+					Claim:               "the implementation accepts stale review output",
+					Evidence:            "checkpoint identity is not compared",
+					Severity:            report.ReviewSeverityBlocker,
+					Category:            report.ReviewCategoryCorrectness,
+					SuggestedResolution: "compare the reviewed SHA before acceptance",
+					SuggestedOwner:      "implementation",
+				},
+				{
+					Location:            "internal/factory/review.go",
+					Claim:               "the review packet could explain the scope boundary more clearly",
+					Evidence:            "the packet already contains the frozen issue",
+					Severity:            report.ReviewSeverityAdvisory,
+					Category:            report.ReviewCategoryScope,
+					SuggestedResolution: "clarify the prompt if later scope remains ambiguous",
+					SuggestedOwner:      "human",
+				},
+			},
+		},
+		ReportedAt: time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC),
 	}
 }

--- a/internal/reportcli/reportcli.go
+++ b/internal/reportcli/reportcli.go
@@ -68,6 +68,8 @@ func Run(request Request) int {
 	expectedFailureReason := flags.String("expected-failure-reason", "", "failure identifier expected in the coordinator rerun output")
 	observedFailures := pairList{}
 	flags.Var(&observedFailures, "observed-failure", "red-test evidence kind=detail; may be repeated")
+	findings := stringList{}
+	flags.Var(&findings, "finding", "review finding location|claim|evidence|severity|category|resolution|owner; may be repeated")
 	uncoveredCriteria := stringList{}
 	flags.Var(&uncoveredCriteria, "uncovered-criterion", "acceptance criterion not covered by this test handoff; may be repeated")
 	questions := pairList{}
@@ -101,6 +103,7 @@ func Run(request Request) int {
 		"role":          lookup("FACTORY_ROLE"),
 		"stage":         lookup("FACTORY_STAGE"),
 	}
+	checkpointSHA := lookup("FACTORY_CHECKPOINT_SHA")
 	for field, value := range identity {
 		if strings.TrimSpace(value) == "" {
 			writeError(request.ErrorsOutput, fmt.Errorf("%s environment value is required", field))
@@ -166,6 +169,31 @@ func Run(request Request) int {
 				value.TestHandoff.ObservedFailureEvidence = append(value.TestHandoff.ObservedFailureEvidence, report.Evidence{Kind: pair.Key, Detail: pair.Value})
 			}
 		}
+	} else if identity["role"] == "spec_review" && identity["stage"] == "review" {
+		if strings.TrimSpace(checkpointSHA) == "" {
+			writeError(request.ErrorsOutput, errors.New("FACTORY_CHECKPOINT_SHA environment value is required for specification review"))
+			return 1
+		}
+		handoff := &report.ReviewHandoff{ReviewedSHA: checkpointSHA}
+		for index, encoded := range findings {
+			parts := strings.Split(encoded, "|")
+			if len(parts) != 7 {
+				writeError(request.ErrorsOutput, fmt.Errorf("finding %d must use location|claim|evidence|severity|category|resolution|owner", index+1))
+				return 2
+			}
+			for partIndex, part := range parts {
+				if strings.TrimSpace(part) == "" {
+					writeError(request.ErrorsOutput, fmt.Errorf("finding %d field %d must not be empty", index+1, partIndex+1))
+					return 2
+				}
+			}
+			handoff.Findings = append(handoff.Findings, report.ReviewFinding{
+				Location: parts[0], Claim: parts[1], Evidence: parts[2],
+				Severity: report.ReviewSeverity(parts[3]), Category: report.ReviewCategory(parts[4]),
+				SuggestedResolution: parts[5], SuggestedOwner: parts[6],
+			})
+		}
+		value.ReviewHandoff = handoff
 	} else {
 		for _, pair := range acceptance {
 			value.Handoff = ensureHandoff(value.Handoff)

--- a/internal/reportcli/reportcli_test.go
+++ b/internal/reportcli/reportcli_test.go
@@ -144,3 +144,38 @@ func TestRunWritesTheTestStageHandoff(t *testing.T) {
 		t.Fatalf("test handoff = %#v, want focused command and red evidence", value.TestHandoff)
 	}
 }
+
+// TestRunWritesTheSpecificationReviewFindingContract verifies repeated review
+// flags bind complete findings to the coordinator-provided checkpoint.
+func TestRunWritesTheSpecificationReviewFindingContract(t *testing.T) {
+	resultDirectory := t.TempDir()
+	var errorsOutput bytes.Buffer
+	status := reportcli.Run(reportcli.Request{
+		Args: []string{
+			"--outcome", "completed", "--summary", "review complete",
+			"--finding", "internal/factory/review.go:1|behavior is incorrect|focused assertion|blocker|correctness|reject the behavior|implementation",
+			"--finding", "internal/factory/review.go:2|name is subjective|style preference|advisory|taste|consider renaming|implementation",
+		},
+		Environment: map[string]string{
+			"FACTORY_INVOCATION_ID":  "inv-review",
+			"FACTORY_RUN_ID":         "run-review",
+			"FACTORY_HARNESS":        "codex",
+			"FACTORY_ROLE":           "spec_review",
+			"FACTORY_STAGE":          "review",
+			"FACTORY_CHECKPOINT_SHA": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			"FACTORY_RESULT_DIR":     resultDirectory,
+		},
+		Output:       &bytes.Buffer{},
+		ErrorsOutput: &errorsOutput,
+	})
+	if status != 0 {
+		t.Fatalf("Run() status = %d, stderr = %s", status, errorsOutput.String())
+	}
+	value, err := report.Read(resultDirectory + "/report.json")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if value.ReviewHandoff == nil || value.ReviewHandoff.ReviewedSHA != "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" || len(value.ReviewHandoff.Findings) != 2 {
+		t.Fatalf("review handoff = %#v, want exact SHA and two findings", value.ReviewHandoff)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,7 @@ import (
 
 // CurrentSchemaVersion is the latest operational-store schema understood by
 // this binary.
-const CurrentSchemaVersion = 19
+const CurrentSchemaVersion = 20
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -189,6 +189,39 @@ type ProtectedTestPath struct {
 	SHA256 string `json:"sha256"`
 }
 
+// HandoffAcceptance maps one acceptance criterion to implementation evidence.
+type HandoffAcceptance struct {
+	Criterion string `json:"criterion"`
+	Evidence  string `json:"evidence"`
+}
+
+// ImplementationHandoff is the durable implementation-stage projection sent
+// to the independent reviewer.
+type ImplementationHandoff struct {
+	ChangeSummary          string              `json:"change_summary"`
+	AcceptanceMapping      []HandoffAcceptance `json:"acceptance_mapping"`
+	ProductionFilesChanged []string            `json:"production_files_changed"`
+	FocusedCommands        []string            `json:"focused_commands"`
+	KnownLimitations       []string            `json:"known_limitations,omitempty"`
+}
+
+// ReviewFinding is the durable copy of one complete specification-review observation.
+type ReviewFinding struct {
+	Location            string `json:"location"`
+	Claim               string `json:"claim"`
+	Evidence            string `json:"evidence"`
+	Severity            string `json:"severity"`
+	Category            string `json:"category"`
+	SuggestedResolution string `json:"suggested_resolution"`
+	SuggestedOwner      string `json:"suggested_owner"`
+}
+
+// SpecificationReview is the durable review projection bound to one checkpoint.
+type SpecificationReview struct {
+	CheckpointSHA string          `json:"checkpoint_sha"`
+	Findings      []ReviewFinding `json:"findings"`
+}
+
 // Run is the persisted operational identity and current state of one run.
 type Run struct {
 	ID             string
@@ -212,9 +245,13 @@ type Run struct {
 	ProtectedTestPaths []ProtectedTestPath
 	// TestStageSkipped records an authorized skip before implementation.
 	TestStageSkipped bool
-	ImageDigest      string
-	Coordinator      string
-	StatusCommentID  string
+	// ImplementationHandoff is the accepted implementation evidence for review.
+	ImplementationHandoff *ImplementationHandoff
+	// SpecificationReview is the accepted review result for the current checkpoint.
+	SpecificationReview *SpecificationReview
+	ImageDigest         string
+	Coordinator         string
+	StatusCommentID     string
 	// PullRequestNumber is the persisted idempotency identity of the draft PR.
 	PullRequestNumber int
 	// PullRequestURL is the operator-facing URL of the draft PR.
@@ -447,6 +484,7 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
 		       test_handoff, test_exemption, protected_test_paths, test_stage_skipped,
+		       implementation_handoff, specification_review,
 		       image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent,
@@ -470,6 +508,7 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
 		       test_handoff, test_exemption, protected_test_paths, test_stage_skipped,
+		       implementation_handoff, specification_review,
 		       image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent,
@@ -490,6 +529,7 @@ func scanRun(row *sql.Row) (*Run, error) {
 	var run Run
 	var baseCheckpointSHA, testCheckpointSHA string
 	var testHandoffJSON, testExemptionJSON, protectedTestPathsJSON string
+	var implementationHandoffJSON, specificationReviewJSON string
 	var pendingQuestionsJSON, clarificationCommentID, createdAt, updatedAt string
 	var clarificationNotificationSent bool
 	if err := row.Scan(
@@ -507,6 +547,8 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&testExemptionJSON,
 		&protectedTestPathsJSON,
 		&run.TestStageSkipped,
+		&implementationHandoffJSON,
+		&specificationReviewJSON,
 		&run.ImageDigest,
 		&run.Coordinator,
 		&run.StatusCommentID,
@@ -562,6 +604,18 @@ func scanRun(row *sql.Row) (*Run, error) {
 	if protectedTestPathsJSON != "" {
 		if err := json.Unmarshal([]byte(protectedTestPathsJSON), &run.ProtectedTestPaths); err != nil {
 			return nil, fmt.Errorf("decode protected test paths: %w", err)
+		}
+	}
+	if implementationHandoffJSON != "" {
+		run.ImplementationHandoff = &ImplementationHandoff{}
+		if err := json.Unmarshal([]byte(implementationHandoffJSON), run.ImplementationHandoff); err != nil {
+			return nil, fmt.Errorf("decode implementation handoff: %w", err)
+		}
+	}
+	if specificationReviewJSON != "" {
+		run.SpecificationReview = &SpecificationReview{}
+		if err := json.Unmarshal([]byte(specificationReviewJSON), run.SpecificationReview); err != nil {
+			return nil, fmt.Errorf("decode specification review: %w", err)
 		}
 	}
 	run.ClarificationCommentID = clarificationCommentID
@@ -635,6 +689,9 @@ func normalizeRun(run Run) (Run, error) {
 	if err := validateTestProjection(run); err != nil {
 		return Run{}, err
 	}
+	if err := validateReviewProjection(run); err != nil {
+		return Run{}, err
+	}
 	if run.CheckRepairAttempts < 0 {
 		return Run{}, errors.New("run check-repair attempts must not be negative")
 	}
@@ -666,6 +723,26 @@ func normalizeRun(run Run) (Run, error) {
 		run.UpdatedAt = run.CreatedAt
 	}
 	return run, nil
+}
+
+// validateReviewProjection keeps durable review findings complete and tied to
+// the run's current immutable checkpoint.
+func validateReviewProjection(run Run) error {
+	if run.SpecificationReview == nil {
+		return nil
+	}
+	if run.SpecificationReview.CheckpointSHA == "" || run.SpecificationReview.CheckpointSHA != run.CheckpointSHA {
+		return errors.New("specification review checkpoint must match the run checkpoint")
+	}
+	if len(run.SpecificationReview.Findings) > 128 {
+		return errors.New("specification review findings exceed 128 entries")
+	}
+	for index, finding := range run.SpecificationReview.Findings {
+		if strings.TrimSpace(finding.Location) == "" || strings.TrimSpace(finding.Claim) == "" || strings.TrimSpace(finding.Evidence) == "" || strings.TrimSpace(finding.Severity) == "" || strings.TrimSpace(finding.Category) == "" || strings.TrimSpace(finding.SuggestedResolution) == "" || strings.TrimSpace(finding.SuggestedOwner) == "" {
+			return fmt.Errorf("specification review finding %d is incomplete", index)
+		}
+	}
+	return nil
 }
 
 // validateTestProjection checks the bounded durable test-stage state before it
@@ -825,6 +902,30 @@ func protectedTestPathsJSON(values []ProtectedTestPath) string {
 	return string(data)
 }
 
+// implementationHandoffJSON serializes a nullable implementation handoff.
+func implementationHandoffJSON(value *ImplementationHandoff) string {
+	if value == nil {
+		return ""
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// specificationReviewJSON serializes a nullable exact-checkpoint review.
+func specificationReviewJSON(value *SpecificationReview) string {
+	if value == nil {
+		return ""
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 // runValues returns the ordered SQL values shared by normal and revision-safe
 // run persistence.
 func runValues(run Run) []any {
@@ -843,6 +944,8 @@ func runValues(run Run) []any {
 		testExemptionJSON(run.TestExemption),
 		protectedTestPathsJSON(run.ProtectedTestPaths),
 		run.TestStageSkipped,
+		implementationHandoffJSON(run.ImplementationHandoff),
+		specificationReviewJSON(run.SpecificationReview),
 		run.ImageDigest,
 		run.Coordinator,
 		run.StatusCommentID,
@@ -875,6 +978,7 @@ const saveRunStatement = `
 			id, repository_path, issue_number, stage, status, branch, worktree,
 			checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
 			test_handoff, test_exemption, protected_test_paths, test_stage_skipped,
+			implementation_handoff, specification_review,
 			image_digest, coordinator, status_comment_id,
 			pull_request_number, pull_request_url, merge_commit_sha, lifecycle_reason,
 			lifecycle_notification_sent,
@@ -888,7 +992,7 @@ const saveRunStatement = `
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
@@ -904,6 +1008,8 @@ const saveRunStatement = `
 			test_exemption = excluded.test_exemption,
 			protected_test_paths = excluded.protected_test_paths,
 			test_stage_skipped = excluded.test_stage_skipped,
+			implementation_handoff = excluded.implementation_handoff,
+			specification_review = excluded.specification_review,
 			image_digest = excluded.image_digest,
 			coordinator = excluded.coordinator,
 			status_comment_id = excluded.status_comment_id,
@@ -933,6 +1039,7 @@ const saveRunIfRevisionStatement = `
 			repository_path = ?, issue_number = ?, stage = ?, status = ?, branch = ?, worktree = ?,
 			checkpoint_sha = ?, base_checkpoint_sha = ?, test_checkpoint_sha = ?,
 			test_handoff = ?, test_exemption = ?, protected_test_paths = ?, test_stage_skipped = ?,
+			implementation_handoff = ?, specification_review = ?,
 			image_digest = ?, coordinator = ?, status_comment_id = ?,
 			pull_request_number = ?, pull_request_url = ?, merge_commit_sha = ?, lifecycle_reason = ?,
 			lifecycle_notification_sent = ?,
@@ -1835,6 +1942,15 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 			} {
 				if _, err := tx.ExecContext(ctx, statement); err != nil {
 					return fmt.Errorf("apply store migration 19: %w", err)
+				}
+			}
+		case 20:
+			for _, statement := range []string{
+				"ALTER TABLE operational_runs ADD COLUMN implementation_handoff TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN specification_review TEXT NOT NULL DEFAULT ''",
+			} {
+				if _, err := tx.ExecContext(ctx, statement); err != nil {
+					return fmt.Errorf("apply store migration 20: %w", err)
 				}
 			}
 		default:

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -515,6 +515,75 @@ func TestRunPersistsTheProtectedTestHandoffProjection(t *testing.T) {
 	}
 }
 
+// TestRunPersistsImplementationAndSpecificationReviewProjections verifies the
+// reviewer packet's durable handoffs survive the schema-20 restart boundary.
+func TestRunPersistsImplementationAndSpecificationReviewProjections(t *testing.T) {
+	t.Parallel()
+
+	opened, err := store.Open(context.Background(), filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	checkpoint := strings.Repeat("b", 64)
+	want := store.Run{
+		ID:             "run-review-projection",
+		RepositoryPath: "/work/repository",
+		Stage:          store.StageReview,
+		Status:         store.StatusWaitingForHuman,
+		CheckpointSHA:  checkpoint,
+		ImplementationHandoff: &store.ImplementationHandoff{
+			ChangeSummary:          "implemented the requested review behavior",
+			AcceptanceMapping:      []store.HandoffAcceptance{{Criterion: "criterion", Evidence: "focused test"}},
+			ProductionFilesChanged: []string{"internal/factory/review.go"},
+			FocusedCommands:        []string{"go test ./internal/factory"},
+			KnownLimitations:       []string{"advisory naming note"},
+		},
+		SpecificationReview: &store.SpecificationReview{
+			CheckpointSHA: checkpoint,
+			Findings: []store.ReviewFinding{{
+				Location: "internal/factory/review.go:1", Claim: "claim", Evidence: "evidence", Severity: "advisory", Category: "scope",
+				SuggestedResolution: "resolution", SuggestedOwner: "implementation",
+			}},
+		},
+	}
+	if err := opened.SaveRun(context.Background(), want); err != nil {
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	got, err := opened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentRun() error = %v", err)
+	}
+	if got == nil || got.ImplementationHandoff == nil || got.SpecificationReview == nil || got.SpecificationReview.CheckpointSHA != checkpoint || got.SpecificationReview.Findings[0].SuggestedOwner != "implementation" {
+		t.Fatalf("CurrentRun() = %#v, want implementation and review projections", got)
+	}
+}
+
+// TestRunRejectsAReviewProjectionForAnOlderCheckpoint verifies stale findings
+// cannot be persisted or reused after a new immutable checkpoint is selected.
+func TestRunRejectsAReviewProjectionForAnOlderCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	opened, err := store.Open(context.Background(), filepath.Join(t.TempDir(), "data", "factory.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	run := store.Run{
+		ID:             "run-stale-review",
+		RepositoryPath: "/work/repository",
+		Stage:          store.StageReview,
+		Status:         store.StatusWaitingForHuman,
+		CheckpointSHA:  strings.Repeat("b", 64),
+		SpecificationReview: &store.SpecificationReview{
+			CheckpointSHA: strings.Repeat("a", 64),
+		},
+	}
+	if err := opened.SaveRun(context.Background(), run); err == nil || !strings.Contains(err.Error(), "match the run checkpoint") {
+		t.Fatalf("SaveRun() error = %v, want stale-review rejection", err)
+	}
+}
+
 // TestStorePersistsCheckRepairBudget verifies the retry ceiling, consumed
 // attempt count, and in-flight reservation survive the restart boundary.
 func TestStorePersistsCheckRepairBudget(t *testing.T) {


### PR DESCRIPTION
<!-- factory-generated:start -->
## Factory run

- run: `run-b97e47ec-bf3e-4d2f-a3aa-7e030c1bf2fb`
- issue: #70 — Issue 26 pilot P04 round 5
- specification packet: version 1, target branch `pilot-issue26-v2-p04-base`
- checkpoint: `d03213d2b00b8f56a35520b9cde54b532858f5a8`
- stage: `draft_pr`
- intervention: `none`
- test-stage disposition: none

<!-- factory-generated:review:start -->
### Specification review

- reviewed checkpoint: `d03213d2b00b8f56a35520b9cde54b532858f5a8`
- outcome: 3 blocking findings, 0 advisory findings

#### Finding 1 — blocker/specification
- location: `internal/factory/review.go:35-50`
- claim: The reviewer is not given the frozen current diff.
- evidence: collectReviewContext executes git diff --no-ext-diff checkpoint^ checkpoint, which covers only the tip commit instead of the accumulated diff from the frozen base to the reviewed checkpoint.
- suggested resolution: Collect or pass the immutable base-to-checkpoint diff used by the coordinator and bind it to the reviewed SHA.
- suggested owner: `implementation`

#### Finding 2 — blocker/specification
- location: `internal/factory/review.go:47-54`
- claim: The review context omits the relevant logs required by the frozen packet.
- evidence: RelevantLogs is hard-coded to a synthetic collection message; it does not carry the packet gate outcomes for format, vet, test, and build or other bounded coordinator logs.
- suggested resolution: Pass bounded coordinator-collected relevant logs into ReviewContext instead of replacing them with a synthetic marker.
- suggested owner: `implementation`

#### Finding 3 — blocker/specification
- location: `internal/report/report.go:100-107,731-740`
- claim: A generic standards finding can block readiness even when it is not a documented-standards violation.
- evidence: ReviewCategoryStandards is accepted alongside ReviewCategoryDocumentedStandards, and ReviewFindingBlocks returns true for both categories whenever severity is blocker; this permits an undocumented standards preference to gate the run.
- suggested resolution: Remove the generic standards blocker category or require documented_standards with evidence of a named documented requirement; keep generic standards observations advisory.
- suggested owner: `implementation`
<!-- factory-generated:review:end -->

### Issue summary

## Parent

#1 — Spec: Build a supervised GitHub-to-PR software factory

## What to build

Introduce the first independent reviewer and, with it, the finding contract the second reviewer will reuse.

The specification reviewer runs in a fresh session against an exact immutable commit SHA and receives the frozen specification packet with its accepted clarifications. It receives structured handoffs, the current diff, relevant logs, and findings — never upstream transcripts.

Every finding carries location, claim, evidence, severity, suggested resolution, and suggested owner, so repair is actionable and routable. A finding missing any of these is rejected rather than half-accepted.

Severity semantics are the point of this ticket. A finding blocks only when it is a concrete correctness, security, specification, or documented-standards violation. Taste and scope expansion are advisory: visible, useful, and non-gating, so a reviewer cannot silently expand the issue's required scope.

The result is published as a Commit Status with a stable context tied to the reviewed SHA, and is invalidated the moment the SHA changes.

For the measured pilot this reviewer may use the existing Codex adapter from the tracer bullet. Interchangeable per-role harness selection in #14 is not a prerequisite for learning whether one independent reviewer adds value.

## User stories covered

Stories 44, 47, 48, 53 of #1.

## Acceptance criteria

- [ ] The specification reviewer runs in a fresh session against an exact immutable commit SHA.
- [ ] It receives the frozen specification packet with accepted clarifications, structured handoffs, the current diff, and relevant logs — not upstream transcripts.
- [ ] Each finding carries location, claim, evidence, severity, suggested resolution, and suggested owner. A finding missing any of these is rejected.
- [ ] A finding blocks only when it names a concrete correctness, security, specification, or documented-standards violation.
- [ ] Taste and scope-expansion findings are advisory: recorded and visible, but gating nothing.
- [ ] Advisory findings appear in the status comment and the pull-request factory section.
- [ ] The review result is published as a Commit Status with a stable context tied to the reviewed SHA.
- [ ] The review result is invalidated when the SHA changes and is never reused against a different commit.
- [ ] A provisional test exemption carried forward from the test stage is presented to the reviewer for evaluation.

## Blocked by

- #7 — Checkpoint commit, push, and draft pull request
- #9 — Full gate model: ordering, baseline health, and dependencies
- #25 — Local evaluation summaries and run cost report

## Terminology

`agent-ready` is the **product's** issue-trigger label, created by `factory bootstrap-labels` in whichever repository the factory operates on. `ready-for-agent` is **this tracker's** triage label, applied to this ticket. They serve different purposes and must never be conflated in code, configuration, prompts, or tests.

### Gates

- `format`: passed
- `vet`: passed
- `test`: passed
- `build`: passed

### Control commands

- `factory status`
- `factory draft-pr --run-id run-b97e47ec-bf3e-4d2f-a3aa-7e030c1bf2fb`

<!-- factory-generated:end -->