### PR TITLE
Make persisted invocation packet recovery backward compatible

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -98,6 +98,11 @@ same invocation twice. Gates, reports, transitions, draft pull requests, and
 other progression paths reconcile the durable effect journal and external
 identities before they resume an interrupted run.
 
+Invocation packets use append-only schemas. Restart recovery accepts the current
+and retained historical packet versions when their required identities and
+role-specific context are present; missing optional fields remain absent. Future
+or unsupported versions pause recovery rather than guessing at their semantics.
+
 When automatic recovery is exhausted, an operator can use the explicit
 recovery commands:
 

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -121,6 +121,9 @@ type InvocationPacket struct {
 }
 
 const (
+	// invocationPacketMinimumSupportedVersion identifies the oldest append-only
+	// packet shape retained for restart recovery.
+	invocationPacketMinimumSupportedVersion = 1
 	// invocationPacketVersion identifies the read-only invocation packet shape.
 	// Version four adds the independent-review context projection.
 	invocationPacketVersion = 4

--- a/internal/factory/agent_internal_test.go
+++ b/internal/factory/agent_internal_test.go
@@ -1,21 +1,135 @@
 package factory
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/workflow"
 )
 
+// TestPromptForPersistedInvocationAcceptsSupportedSchemaVersions verifies
+// recovery can rebuild prompts from the current and historical append-only
+// packet shapes.
+func TestPromptForPersistedInvocationAcceptsSupportedSchemaVersions(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		packet     string
+		want       string
+		wantAbsent string
+	}{
+		{
+			name: "version one",
+			packet: `{
+  "schema_version": 1,
+  "invocation_id": "inv-prompt",
+  "run_id": "run-prompt",
+  "role": "implementation",
+  "stage": "implementation",
+  "specification_packet": "{}",
+  "prompt_version": "implementation-v1",
+  "permitted_paths": ["."]
+}`,
+			want:       "factory prompt version implementation-v1",
+			wantAbsent: "Check-repair context:",
+		},
+		{
+			name: "version two",
+			packet: `{
+  "schema_version": 2,
+  "invocation_id": "inv-prompt",
+  "run_id": "run-prompt",
+  "role": "implementation",
+  "stage": "implementation",
+  "specification_packet": "{}",
+  "prompt_version": "implementation-v1",
+  "permitted_paths": ["."],
+  "check_repair": {
+    "version": 1,
+    "run_id": "run-prompt",
+    "checkpoint_sha": "checkpoint",
+    "attempt": 2,
+    "budget": 3,
+    "setup": {"exit_code": 0},
+    "gates": []
+  }
+}`,
+			want:       "This is repair attempt 2 of 3",
+			wantAbsent: "Protected test-stage handoff (coordinator-owned):",
+		},
+		{
+			name: "version three",
+			packet: `{
+  "schema_version": 3,
+  "invocation_id": "inv-prompt",
+  "run_id": "run-prompt",
+  "role": "implementation",
+  "stage": "implementation",
+  "specification_packet": "{}",
+  "prompt_version": "implementation-v1",
+  "permitted_paths": ["."],
+  "test_handoff": {
+    "acceptance_coverage": [{"criterion": "criterion", "evidence": "red test"}],
+    "changed_files": ["internal/example_test.go"],
+    "focused_test_command": "go test ./internal/example",
+    "expected_failure_reason": "expected assertion",
+    "observed_failure_evidence": [{"kind": "exit_code", "detail": "1"}]
+  },
+  "protected_test_paths": [{"path": "internal/example_test.go", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]
+}`,
+			want:       "Protected test-stage handoff (coordinator-owned):",
+			wantAbsent: "Check-repair context:",
+		},
+		{
+			name: "version four",
+			packet: `{
+  "schema_version": 4,
+  "invocation_id": "inv-prompt",
+  "run_id": "run-prompt",
+  "role": "implementation",
+  "stage": "implementation",
+  "specification_packet": "{}",
+  "prompt_version": "implementation-v1",
+  "permitted_paths": ["."]
+}`,
+			want: "factory prompt version implementation-v1",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			run := store.Run{ID: "run-prompt", SpecificationPacket: "{}"}
+			invocation := store.Invocation{
+				ID: "inv-prompt", RunID: run.ID, Role: "implementation", Stage: store.StageImplementation,
+				InvocationDirectory: directory, PromptVersion: "implementation-v1",
+			}
+			if err := os.WriteFile(filepath.Join(directory, invocationPacketFileName), []byte(test.packet), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			promptText, err := promptForPersistedInvocation(run, invocation, SpecificationPacket{})
+			if err != nil {
+				t.Fatalf("promptForPersistedInvocation() error = %v, want supported historical packet", err)
+			}
+			if !strings.Contains(promptText, test.want) {
+				t.Fatalf("promptForPersistedInvocation() prompt does not contain %q:\n%s", test.want, promptText)
+			}
+			if test.wantAbsent != "" && strings.Contains(promptText, test.wantAbsent) {
+				t.Fatalf("promptForPersistedInvocation() prompt contains unexpected %q:\n%s", test.wantAbsent, promptText)
+			}
+		})
+	}
+}
+
 // TestPromptForPersistedInvocationRejectsUnsupportedSchemaVersion verifies
-// recovery refuses invocation packets it cannot interpret without building a
+// recovery refuses missing and future packet versions without building a
 // degraded role prompt.
 func TestPromptForPersistedInvocationRejectsUnsupportedSchemaVersion(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		version int
 	}{
-		{name: "legacy", version: invocationPacketVersion - 1},
+		{name: "missing", version: 0},
 		{name: "future", version: invocationPacketVersion + 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -36,5 +150,32 @@ func TestPromptForPersistedInvocationRejectsUnsupportedSchemaVersion(t *testing.
 				t.Fatalf("promptForPersistedInvocation() error = %v, want schema-version refusal", err)
 			}
 		})
+	}
+}
+
+// TestPromptForPersistedInvocationRejectsReviewWithoutContext verifies an old
+// or incomplete reviewer packet cannot resume without the exact checkpoint
+// review input required by the role contract.
+func TestPromptForPersistedInvocationRejectsReviewWithoutContext(t *testing.T) {
+	directory := t.TempDir()
+	run := store.Run{ID: "run-review", SpecificationPacket: "{}"}
+	invocation := store.Invocation{
+		ID: "inv-review", RunID: run.ID, Role: workflow.RoleSpecificationReview, Stage: store.StageReview,
+		InvocationDirectory: directory, PromptVersion: workflow.PromptVersionSpecificationReview,
+	}
+	if err := writeInvocationPacket(directory, InvocationPacket{
+		SchemaVersion:       invocationPacketVersion,
+		InvocationID:        invocation.ID,
+		RunID:               run.ID,
+		Role:                invocation.Role,
+		Stage:               invocation.Stage,
+		SpecificationPacket: run.SpecificationPacket,
+		PromptVersion:       invocation.PromptVersion,
+		PermittedPaths:      []string{"."},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := promptForPersistedInvocation(run, invocation, SpecificationPacket{}); err == nil || !strings.Contains(err.Error(), "has no review context") {
+		t.Fatalf("promptForPersistedInvocation() error = %v, want missing-review-context refusal", err)
 	}
 }

--- a/internal/factory/agent_internal_test.go
+++ b/internal/factory/agent_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Stevie1704/sw-factory/internal/prompt"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/workflow"
 )
@@ -153,29 +154,41 @@ func TestPromptForPersistedInvocationRejectsUnsupportedSchemaVersion(t *testing.
 	}
 }
 
-// TestPromptForPersistedInvocationRejectsReviewWithoutContext verifies an old
-// or incomplete reviewer packet cannot resume without the exact checkpoint
-// review input required by the role contract.
-func TestPromptForPersistedInvocationRejectsReviewWithoutContext(t *testing.T) {
-	directory := t.TempDir()
-	run := store.Run{ID: "run-review", SpecificationPacket: "{}"}
-	invocation := store.Invocation{
-		ID: "inv-review", RunID: run.ID, Role: workflow.RoleSpecificationReview, Stage: store.StageReview,
-		InvocationDirectory: directory, PromptVersion: workflow.PromptVersionSpecificationReview,
-	}
-	if err := writeInvocationPacket(directory, InvocationPacket{
-		SchemaVersion:       invocationPacketVersion,
-		InvocationID:        invocation.ID,
-		RunID:               run.ID,
-		Role:                invocation.Role,
-		Stage:               invocation.Stage,
-		SpecificationPacket: run.SpecificationPacket,
-		PromptVersion:       invocation.PromptVersion,
-		PermittedPaths:      []string{"."},
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := promptForPersistedInvocation(run, invocation, SpecificationPacket{}); err == nil || !strings.Contains(err.Error(), "has no review context") {
-		t.Fatalf("promptForPersistedInvocation() error = %v, want missing-review-context refusal", err)
+// TestPromptForPersistedInvocationRejectsInvalidReviewContext verifies recovery
+// cannot resume a reviewer without a context tied to the run's checkpoint.
+func TestPromptForPersistedInvocationRejectsInvalidReviewContext(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		context *prompt.ReviewContext
+		want    string
+	}{
+		{name: "missing context", want: "has no review context"},
+		{name: "empty checkpoint", context: &prompt.ReviewContext{}, want: "has no review checkpoint"},
+		{name: "mismatched checkpoint", context: &prompt.ReviewContext{CheckpointSHA: "different-checkpoint"}, want: "review checkpoint does not match the run"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			run := store.Run{ID: "run-review", CheckpointSHA: "review-checkpoint", SpecificationPacket: "{}"}
+			invocation := store.Invocation{
+				ID: "inv-review", RunID: run.ID, Role: workflow.RoleSpecificationReview, Stage: store.StageReview,
+				InvocationDirectory: directory, PromptVersion: workflow.PromptVersionSpecificationReview,
+			}
+			if err := writeInvocationPacket(directory, InvocationPacket{
+				SchemaVersion:       invocationPacketVersion,
+				InvocationID:        invocation.ID,
+				RunID:               run.ID,
+				Role:                invocation.Role,
+				Stage:               invocation.Stage,
+				SpecificationPacket: run.SpecificationPacket,
+				PromptVersion:       invocation.PromptVersion,
+				PermittedPaths:      []string{"."},
+				ReviewContext:       test.context,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := promptForPersistedInvocation(run, invocation, SpecificationPacket{}); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("promptForPersistedInvocation() error = %v, want %q refusal", err, test.want)
+			}
+		})
 	}
 }

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -572,8 +572,16 @@ func validatePersistedInvocationPacket(run store.Run, invocation store.Invocatio
 	if invocation.PromptVersion != "" && persisted.PromptVersion != invocation.PromptVersion {
 		return errors.New("persisted invocation packet prompt version does not match the invocation")
 	}
-	if invocation.Role == workflow.RoleSpecificationReview && persisted.ReviewContext == nil {
-		return errors.New("persisted specification-review invocation packet has no review context")
+	if invocation.Role == workflow.RoleSpecificationReview {
+		if persisted.ReviewContext == nil {
+			return errors.New("persisted specification-review invocation packet has no review context")
+		}
+		if strings.TrimSpace(persisted.ReviewContext.CheckpointSHA) == "" {
+			return errors.New("persisted specification-review invocation packet has no review checkpoint")
+		}
+		if persisted.ReviewContext.CheckpointSHA != run.CheckpointSHA {
+			return errors.New("persisted specification-review invocation packet review checkpoint does not match the run")
+		}
 	}
 	return nil
 }

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -498,19 +498,16 @@ func (s *Service) resumePersistedInvocationWithMode(ctx context.Context, registr
 // promptForPersistedInvocation rebuilds the same role prompt from the frozen
 // packet and invocation packet after a process restart.
 func promptForPersistedInvocation(run store.Run, invocation store.Invocation, packet SpecificationPacket) (string, error) {
-	var persisted InvocationPacket
 	data, err := os.ReadFile(filepath.Join(invocation.InvocationDirectory, invocationPacketFileName))
 	if err != nil {
 		return "", fmt.Errorf("read persisted invocation packet: %w", err)
 	}
-	if err := json.Unmarshal(data, &persisted); err != nil {
+	persisted, err := decodePersistedInvocationPacket(data)
+	if err != nil {
 		return "", fmt.Errorf("decode persisted invocation packet: %w", err)
 	}
-	if persisted.SchemaVersion != invocationPacketVersion {
-		return "", fmt.Errorf("unsupported persisted invocation packet schema version %d", persisted.SchemaVersion)
-	}
-	if persisted.InvocationID != invocation.ID || persisted.RunID != run.ID {
-		return "", errors.New("persisted invocation packet identity does not match the run")
+	if err := validatePersistedInvocationPacket(run, invocation, persisted); err != nil {
+		return "", err
 	}
 	return prompt.Build(prompt.Request{
 		InvocationID:            invocation.ID,
@@ -528,6 +525,57 @@ func promptForPersistedInvocation(run store.Run, invocation store.Invocation, pa
 		CheckRepairBudget:       checkRepairBudget(persisted.CheckRepair),
 		ReviewContext:           persisted.ReviewContext,
 	})
+}
+
+// decodePersistedInvocationPacket accepts the current and retained historical
+// append-only packet shapes. Fields introduced after an older version remain at
+// their zero value, while missing, future, and unsupported versions fail closed.
+func decodePersistedInvocationPacket(data []byte) (InvocationPacket, error) {
+	var persisted InvocationPacket
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		return InvocationPacket{}, err
+	}
+	if !supportedInvocationPacketVersion(persisted.SchemaVersion) {
+		return InvocationPacket{}, fmt.Errorf("unsupported persisted invocation packet schema version %d", persisted.SchemaVersion)
+	}
+	return persisted, nil
+}
+
+// supportedInvocationPacketVersion reports whether a packet belongs to the
+// contiguous compatibility range maintained by the current factory.
+func supportedInvocationPacketVersion(version int) bool {
+	return version >= invocationPacketMinimumSupportedVersion && version <= invocationPacketVersion
+}
+
+// validatePersistedInvocationPacket verifies that a decoded packet still
+// describes the durable invocation and frozen run being resumed. Review
+// invocations additionally require their exact review context to be present.
+func validatePersistedInvocationPacket(run store.Run, invocation store.Invocation, persisted InvocationPacket) error {
+	if persisted.InvocationID != invocation.ID || persisted.RunID != run.ID {
+		return errors.New("persisted invocation packet identity does not match the run")
+	}
+	if strings.TrimSpace(persisted.Role) == "" || strings.TrimSpace(string(persisted.Stage)) == "" {
+		return errors.New("persisted invocation packet role and stage are required")
+	}
+	if persisted.Role != invocation.Role || persisted.Stage != invocation.Stage {
+		return errors.New("persisted invocation packet role and stage do not match the invocation")
+	}
+	if strings.TrimSpace(persisted.SpecificationPacket) == "" {
+		return errors.New("persisted invocation packet specification is required")
+	}
+	if persisted.SpecificationPacket != run.SpecificationPacket {
+		return errors.New("persisted invocation packet specification does not match the run")
+	}
+	if strings.TrimSpace(persisted.PromptVersion) == "" {
+		return errors.New("persisted invocation packet prompt version is required")
+	}
+	if invocation.PromptVersion != "" && persisted.PromptVersion != invocation.PromptVersion {
+		return errors.New("persisted invocation packet prompt version does not match the invocation")
+	}
+	if invocation.Role == workflow.RoleSpecificationReview && persisted.ReviewContext == nil {
+		return errors.New("persisted specification-review invocation packet has no review context")
+	}
+	return nil
 }
 
 // checkRepairAttempt extracts the bounded repair attempt from a persisted


### PR DESCRIPTION
## Summary

- Accept invocation packet schema versions 1 through 4 during restart recovery because the packet evolution is append-only.
- Validate packet identity, role/stage, frozen specification, prompt identity, and required review context while continuing to reject missing or future versions.
- Add historical packet-shape regression tests and document the compatibility contract.

## Verification

- ?   	github.com/Stevie1704/sw-factory/cmd/factory	[no test files]
?   	github.com/Stevie1704/sw-factory/cmd/factory-report	[no test files]
?   	github.com/Stevie1704/sw-factory/cmd/factory-worker-attach	[no test files]
ok  	github.com/Stevie1704/sw-factory/internal/cli	0.907s
ok  	github.com/Stevie1704/sw-factory/internal/command	0.198s
ok  	github.com/Stevie1704/sw-factory/internal/config	0.617s
ok  	github.com/Stevie1704/sw-factory/internal/doctor	0.369s
ok  	github.com/Stevie1704/sw-factory/internal/factory	1.823s
ok  	github.com/Stevie1704/sw-factory/internal/gate	0.308s
ok  	github.com/Stevie1704/sw-factory/internal/git	1.250s
ok  	github.com/Stevie1704/sw-factory/internal/github	0.879s
ok  	github.com/Stevie1704/sw-factory/internal/harness	3.073s
ok  	github.com/Stevie1704/sw-factory/internal/prompt	1.298s
?   	github.com/Stevie1704/sw-factory/internal/ref	[no test files]
ok  	github.com/Stevie1704/sw-factory/internal/report	1.507s
ok  	github.com/Stevie1704/sw-factory/internal/reportcli	1.668s
ok  	github.com/Stevie1704/sw-factory/internal/store	2.168s
ok  	github.com/Stevie1704/sw-factory/internal/terminal	1.722s
ok  	github.com/Stevie1704/sw-factory/internal/worker	5.509s
ok  	github.com/Stevie1704/sw-factory/internal/workflow	1.345s
- 
- 
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart recovery for persisted agent tasks across supported historical packet versions.
  * Preserved available prompt information while allowing optional fields to be absent.
  * Added validation for required task identity, role, stage, specification, prompt version, and review context.
  * Unsupported, future, malformed, or incomplete recovery data now pauses safely instead of being misinterpreted.
* **Documentation**
  * Documented compatibility behavior for invocation packet versions during restart recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->