### PR TITLE
fix: restore Codex credentials during worker recovery

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -63,7 +63,10 @@ of the selected harness is used. For a repository with a
 configured `test` role, `factory issue` leaves a healthy run in `test/active`,
 and this command starts the test agent. An implementation agent is started only
 after the test handoff is accepted, or after an authorized exemption. The
-command creates or reuses the control workspace and creates one run workspace
+agent auth flags must name the same sources registered for the repository;
+distinct one-off sources are refused because recovery never persists host
+credential paths. Change the registered source with `factory register` instead.
+The command creates or reuses the control workspace and creates one run workspace
 with role surfaces. Dormant status and checks layout
 definitions remain in the terminal adapter so they can return when they display
 live coordinator and gate output rather than duplicate the one-shot

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -52,9 +52,12 @@ type AgentRequest struct {
 	Model string
 	// ReasoningEffort is an optional policy-validated setting.
 	ReasoningEffort string
-	// CodexAuthPath overrides the registered narrow Codex auth source when set.
+	// CodexAuthPath selects the registered narrow Codex auth source when set;
+	// a distinct one-off source is refused because it cannot be restored after
+	// a coordinator restart without persisting the host path.
 	CodexAuthPath string
-	// ClaudeAuthPath overrides the registered narrow Claude auth source when set.
+	// ClaudeAuthPath selects the registered narrow Claude auth source when set;
+	// a distinct one-off source is refused for the same restart-safety reason.
 	ClaudeAuthPath string
 	// PermittedPaths constrains production paths in the accepted handoff.
 	PermittedPaths []string

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -277,7 +277,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	}
 	if seedCredentials != nil {
 		if err := seedCredentials(ctx, run.ID); err != nil {
-			return AgentLaunchResult{}, err
+			return AgentLaunchResult{}, newCredentialProjectionError(string(policy.Harness))
 		}
 	}
 	control, err := terminalRuntime.EnsureControlWorkspace(ctx, terminal.WorkspaceRequest{
@@ -454,7 +454,11 @@ func (s *Service) resumePersistedInvocationWithMode(ctx context.Context, registr
 	if err != nil {
 		return invocation, err
 	}
-	if _, err := s.ensureWorkerForInvocation(ctx, registration, runStore, run, invocation); err != nil {
+	_, invocation, err = s.ensureWorkerForInvocation(ctx, registration, runStore, run, invocation)
+	if err != nil {
+		return invocation, err
+	}
+	if err := s.restoreCredentialProjection(ctx, registration, run, invocation); err != nil {
 		return invocation, err
 	}
 	workspaceID, roleSurface, statusSurface, checksSurface, restored, err := s.restoreInvocationTerminal(ctx, terminalRuntime, run, invocation)
@@ -633,20 +637,26 @@ func reviewCheckpointSHA(review bool, checkpoint string) string {
 // no source is registered, leaving the credential the worker itself persisted
 // in its role volume in place.
 func (s *Service) credentialSeeding(registration config.RepositoryRegistration, request AgentRequest, harnessName config.Harness) (func(context.Context, string) error, string, error) {
-	var authPath string
+	var authPath, registeredAuthPath, overrideAuthPath string
 	var seed func(context.Context, worker.CredentialSeedRequest) error
 	switch harnessName {
 	case config.HarnessCodex:
-		authPath = defaultString(request.CodexAuthPath, registration.Authentication.CodexAuthPath)
+		registeredAuthPath = registration.Authentication.CodexAuthPath
+		overrideAuthPath = request.CodexAuthPath
 		if seeder, ok := s.deps.Worker.(worker.CredentialSeeder); ok {
 			seed = seeder.SeedCodexCredentials
 		}
 	case config.HarnessClaude:
-		authPath = defaultString(request.ClaudeAuthPath, registration.Authentication.ClaudeAuthPath)
+		registeredAuthPath = registration.Authentication.ClaudeAuthPath
+		overrideAuthPath = request.ClaudeAuthPath
 		if seeder, ok := s.deps.Worker.(worker.ClaudeCredentialSeeder); ok {
 			seed = seeder.SeedClaudeCredentials
 		}
 	}
+	if overrideAuthPath != "" && (registeredAuthPath == "" || filepath.Clean(overrideAuthPath) != filepath.Clean(registeredAuthPath)) {
+		return nil, "", fmt.Errorf("%s auth source override is not restart-safe; configure the source on the registered repository", harnessName)
+	}
+	authPath = defaultString(overrideAuthPath, registeredAuthPath)
 	if authPath == "" {
 		return nil, "", nil
 	}
@@ -656,4 +666,86 @@ func (s *Service) credentialSeeding(registration config.RepositoryRegistration, 
 	return func(ctx context.Context, runID string) error {
 		return seed(ctx, worker.CredentialSeedRequest{RunID: runID, AuthPath: authPath})
 	}, registration.Path, nil
+}
+
+// ensureCredentialStoreIdentity records the factory-managed credential store
+// identity when recovery discovers that a currently configured source belongs
+// to an older invocation that predates the persisted identity.
+func (s *Service) ensureCredentialStoreIdentity(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, invocation store.Invocation) (store.Invocation, error) {
+	_, credentialStoreID, err := s.credentialSeeding(registration, AgentRequest{}, config.Harness(invocation.Harness))
+	if err != nil {
+		return invocation, newCredentialProjectionError(invocation.Harness)
+	}
+	if strings.TrimSpace(credentialStoreID) == "" || strings.TrimSpace(invocation.CredentialStoreID) != "" {
+		return invocation, nil
+	}
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return invocation, errors.New("operational store does not support credential store persistence")
+	}
+	invocation.CredentialStoreID = credentialStoreID
+	invocation.UpdatedAt = s.deps.Now().UTC()
+	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
+		return invocation, fmt.Errorf("persist credential store identity during recovery: %w", err)
+	}
+	return invocation, nil
+}
+
+// restoreCredentialProjection reseeds the configured host source into the
+// already-mounted factory-managed volume. An absent source is intentionally a
+// no-op so harness-managed credentials in the role volume remain usable.
+func (s *Service) restoreCredentialProjection(ctx context.Context, registration config.RepositoryRegistration, run store.Run, invocation store.Invocation) error {
+	seed, _, err := s.credentialSeeding(registration, AgentRequest{}, config.Harness(invocation.Harness))
+	if err != nil || seed == nil {
+		if err == nil {
+			return nil
+		}
+		return newCredentialProjectionError(invocation.Harness)
+	}
+	if err := seed(ctx, run.ID); err != nil {
+		return newCredentialProjectionError(invocation.Harness)
+	}
+	return nil
+}
+
+// credentialProjectionError reports a credential restoration refusal without
+// retaining a host path, credential contents, or adapter output.
+type credentialProjectionError struct {
+	// Harness identifies the non-secret adapter whose projection is unavailable.
+	Harness string
+}
+
+// Error returns bounded operator guidance for restoring the managed projection.
+func (e *credentialProjectionError) Error() string {
+	if e == nil {
+		return "credential projection could not be restored; retry `factory auth refresh`"
+	}
+	return fmt.Sprintf("%s credential projection could not be restored; restore the configured source and retry `factory auth refresh`", credentialHarnessLabel(e.Harness))
+}
+
+// Unwrap lets the normal recovery policy pause the run in the auth state.
+func (e *credentialProjectionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return harness.NewAuthenticationExpiredError(credentialHarnessLabel(e.Harness))
+}
+
+// newCredentialProjectionError constructs the redacted credential recovery
+// error used at every host-source and worker-projection boundary.
+func newCredentialProjectionError(harnessName string) error {
+	return &credentialProjectionError{Harness: credentialHarnessLabel(harnessName)}
+}
+
+// credentialHarnessLabel bounds the adapter identity included in recovery
+// guidance so malformed persisted data cannot become an output channel.
+func credentialHarnessLabel(harnessName string) string {
+	switch config.Harness(harnessName) {
+	case config.HarnessCodex:
+		return string(config.HarnessCodex)
+	case config.HarnessClaude:
+		return string(config.HarnessClaude)
+	default:
+		return "harness"
+	}
 }

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -692,12 +692,12 @@ func (s *Service) ensureCredentialStoreIdentity(ctx context.Context, registratio
 }
 
 // restoreCredentialProjection reseeds the configured host source into the
-// already-mounted factory-managed volume. An absent source is intentionally a
-// no-op so harness-managed credentials in the role volume remain usable.
+// already-mounted factory-managed volume. An absent source is a no-op only
+// when the invocation has no persisted factory-managed credential store.
 func (s *Service) restoreCredentialProjection(ctx context.Context, registration config.RepositoryRegistration, run store.Run, invocation store.Invocation) error {
 	seed, _, err := s.credentialSeeding(registration, AgentRequest{}, config.Harness(invocation.Harness))
 	if err != nil || seed == nil {
-		if err == nil {
+		if err == nil && strings.TrimSpace(invocation.CredentialStoreID) == "" {
 			return nil
 		}
 		return newCredentialProjectionError(invocation.Harness)

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -1088,6 +1088,7 @@ type agentWorker struct {
 	claudeSeeds   []worker.CredentialSeedRequest
 	inspectResult *worker.Inspection
 	inspectErr    error
+	seedErr       error
 }
 
 // Start records one worker start.

--- a/internal/factory/harness_selection_test.go
+++ b/internal/factory/harness_selection_test.go
@@ -24,7 +24,8 @@ func (w *agentWorker) InteractiveCommand(_ context.Context, request worker.Inter
 	return worker.InteractiveCommand{Executable: "factory-worker-attach", Args: []string{"--run-id", request.RunID}}, nil
 }
 
-// SeedCodexCredentials records one narrowly scoped Codex credential seed.
+// SeedCodexCredentials records the requested Codex credential seed and returns
+// seedErr when configured.
 func (w *agentWorker) SeedCodexCredentials(_ context.Context, request worker.CredentialSeedRequest) error {
 	w.codexSeeds = append(w.codexSeeds, request)
 	if w.seedErr != nil {
@@ -159,6 +160,79 @@ func TestResumeRestoresConfiguredCodexCredentialsAfterWorkerRecovery(t *testing.
 	}
 }
 
+// TestAttachRestoresCredentialsOnceWhenItRecreatesTheTerminal verifies the
+// nested native resume owns credential restoration after topology recovery.
+func TestAttachRestoresCredentialsOnceWhenItRecreatesTheTerminal(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"access_token":"attach-secret"}`), 0o600); err != nil {
+		t.Fatalf("write credential source: %v", err)
+	}
+
+	service, runStore, runtime, _, launch := prepareAgentForWorkerRecovery(t, config.AuthenticationConfig{
+		CodexAuthPath: authPath,
+	})
+	persisted := runStore.invocations[launch.Invocation.ID]
+	persisted.WorkspaceID = ""
+	persisted.StatusSurfaceID = ""
+	persisted.RoleSurfaceID = ""
+	persisted.ImplementationSurfaceID = ""
+	persisted.ChecksSurfaceID = ""
+	if err := runStore.SaveInvocation(context.Background(), persisted); err != nil {
+		t.Fatalf("clear persisted terminal topology: %v", err)
+	}
+
+	attached, err := service.Attach(context.Background(), factory.AttachRequest{RunID: launch.Invocation.RunID})
+	if err != nil {
+		t.Fatalf("Attach() error = %v", err)
+	}
+	if attached.Run.Status != store.StatusActive {
+		t.Fatalf("Attach() run status = %q, want %q", attached.Run.Status, store.StatusActive)
+	}
+	if got := len(runtime.codexSeeds); got != 2 {
+		t.Fatalf("attach seeded Codex credentials %d times, want initial launch and one nested restore", got)
+	}
+	if got := len(runtime.interactive); got != 2 {
+		t.Fatalf("attach launched the native harness %d times, want initial launch and one nested resume", got)
+	}
+}
+
+// TestAttachPausesWhenNestedCredentialRestorationFails verifies a failed
+// projection after topology recovery stops the recreated worker.
+func TestAttachPausesWhenNestedCredentialRestorationFails(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"access_token":"attach-secret"}`), 0o600); err != nil {
+		t.Fatalf("write credential source: %v", err)
+	}
+
+	service, runStore, runtime, _, launch := prepareAgentForWorkerRecovery(t, config.AuthenticationConfig{
+		CodexAuthPath: authPath,
+	})
+	persisted := runStore.invocations[launch.Invocation.ID]
+	persisted.WorkspaceID = ""
+	persisted.StatusSurfaceID = ""
+	persisted.RoleSurfaceID = ""
+	persisted.ImplementationSurfaceID = ""
+	persisted.ChecksSurfaceID = ""
+	if err := runStore.SaveInvocation(context.Background(), persisted); err != nil {
+		t.Fatalf("clear persisted terminal topology: %v", err)
+	}
+	runtime.seedErr = errors.New("credential source unavailable")
+
+	attached, err := service.Attach(context.Background(), factory.AttachRequest{RunID: launch.Invocation.RunID})
+	if err == nil || !strings.Contains(err.Error(), "factory auth refresh") {
+		t.Fatalf("Attach() error = %v, want actionable auth refresh guidance", err)
+	}
+	if attached.Run.Status != store.StatusWaitingForHuman {
+		t.Fatalf("Attach() run status = %q, want %q", attached.Run.Status, store.StatusWaitingForHuman)
+	}
+	if len(runtime.starts) != 3 || runtime.stops != 2 {
+		t.Fatalf("attach worker lifecycle = %d starts/%d stops, want nested recreation followed by cleanup", len(runtime.starts), runtime.stops)
+	}
+	if got := len(runtime.codexSeeds); got != 2 {
+		t.Fatalf("failed attach seeded Codex credentials %d times, want initial launch and one nested restore", got)
+	}
+}
+
 // TestResumeAllowsRecoveryWithoutConfiguredCredentialSource verifies that an
 // optional host source is not required when the role-owned state is recoverable.
 func TestResumeAllowsRecoveryWithoutConfiguredCredentialSource(t *testing.T) {
@@ -174,6 +248,41 @@ func TestResumeAllowsRecoveryWithoutConfiguredCredentialSource(t *testing.T) {
 	}
 	if got := runStore.invocations[launch.Invocation.ID].CredentialStoreID; got != "" {
 		t.Fatalf("recovery without a credential source persisted credential store %q, want empty", got)
+	}
+}
+
+// TestResumeFailsClosedWhenPersistedCredentialSourceIsNotConfigured verifies
+// a managed store cannot silently fall back to stale role-volume credentials.
+func TestResumeFailsClosedWhenPersistedCredentialSourceIsNotConfigured(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	launchService := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, validRepositoryConfig(), config.AuthenticationConfig{
+		CodexAuthPath: authPath,
+	})
+	launch, err := launchService.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	persisted := runStore.invocations[launch.Invocation.ID]
+	persisted.NativeSessionID = "native-session-with-managed-credentials"
+	if err := runStore.SaveInvocation(context.Background(), persisted); err != nil {
+		t.Fatalf("persist native session: %v", err)
+	}
+	runtime.inspectResult = &worker.Inspection{}
+	recoveredService := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, validRepositoryConfig(), config.AuthenticationConfig{})
+
+	resumed, err := recoveredService.Resume(context.Background(), factory.ResumeRequest{RunID: launch.Invocation.RunID})
+	if err == nil || !strings.Contains(err.Error(), "factory auth refresh") {
+		t.Fatalf("Resume() error = %v, want actionable auth refresh guidance", err)
+	}
+	if resumed.Run.Status != store.StatusWaitingForHuman {
+		t.Fatalf("Resume() run status = %q, want %q", resumed.Run.Status, store.StatusWaitingForHuman)
+	}
+	if got := len(runtime.codexSeeds); got != 1 {
+		t.Fatalf("resume without configured source seeded Codex credentials %d times, want only initial launch", got)
+	}
+	if got := len(harnessRuntime.resumes); got != 0 {
+		t.Fatalf("resume without configured source resumed the native session %d times, want 0", got)
 	}
 }
 

--- a/internal/factory/harness_selection_test.go
+++ b/internal/factory/harness_selection_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/factory"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
@@ -25,12 +27,18 @@ func (w *agentWorker) InteractiveCommand(_ context.Context, request worker.Inter
 // SeedCodexCredentials records one narrowly scoped Codex credential seed.
 func (w *agentWorker) SeedCodexCredentials(_ context.Context, request worker.CredentialSeedRequest) error {
 	w.codexSeeds = append(w.codexSeeds, request)
+	if w.seedErr != nil {
+		return w.seedErr
+	}
 	return nil
 }
 
 // SeedClaudeCredentials records one narrowly scoped Claude credential seed.
 func (w *agentWorker) SeedClaudeCredentials(_ context.Context, request worker.CredentialSeedRequest) error {
 	w.claudeSeeds = append(w.claudeSeeds, request)
+	if w.seedErr != nil {
+		return w.seedErr
+	}
 	return nil
 }
 
@@ -108,6 +116,150 @@ func TestRefreshAuthReseedsTheRegisteredSourceWithoutChangingIt(t *testing.T) {
 	if string(unchanged) != string(source) {
 		t.Fatalf("registered auth source changed to %q", unchanged)
 	}
+}
+
+// TestResumeRestoresConfiguredCodexCredentialsAfterWorkerRecovery verifies a
+// recreated worker receives the same configured Codex projection before its
+// persisted native session is resumed.
+func TestResumeRestoresConfiguredCodexCredentialsAfterWorkerRecovery(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"access_token":"recovery-secret"}`), 0o600); err != nil {
+		t.Fatalf("write credential source: %v", err)
+	}
+
+	service, runStore, runtime, _, launch := prepareAgentForWorkerRecovery(t, config.AuthenticationConfig{
+		CodexAuthPath: authPath,
+	})
+	if got := len(runtime.codexSeeds); got != 1 {
+		t.Fatalf("initial launch seeded Codex credentials %d times, want 1", got)
+	}
+
+	_, err := service.Resume(context.Background(), factory.ResumeRequest{RunID: launch.Invocation.RunID})
+	var manualResumeErr *factory.ManualResumeRequiredError
+	if !errors.As(err, &manualResumeErr) {
+		t.Fatalf("Resume() error = %v, want manual resume handoff", err)
+	}
+	if got := len(runtime.codexSeeds); got != 2 {
+		t.Fatalf("recovery seeded Codex credentials %d times, want 2", got)
+	}
+	if got := runtime.codexSeeds[1].AuthPath; got != authPath {
+		t.Fatalf("recovery credential source = %q, want %q", got, authPath)
+	}
+	if got := runStore.invocations[launch.Invocation.ID].CredentialStoreID; got == "" {
+		t.Fatal("recovery removed the persisted credential store identity")
+	}
+	if len(runtime.starts) != 2 || runtime.starts[1].CredentialStoreID != launch.Invocation.CredentialStoreID {
+		t.Fatalf("recovery worker credential store = %#v, want persisted identity %q", runtime.starts, launch.Invocation.CredentialStoreID)
+	}
+	if got := len(runtime.interactive); got != 2 {
+		t.Fatalf("recovery launched the native harness %d times, want 2 total launches", got)
+	}
+	if !containsAdjacentArguments(runtime.interactive[1].Command, "resume", "native-session-recovery") {
+		t.Fatalf("recovery harness command = %#v, want the persisted native session", runtime.interactive[1].Command)
+	}
+}
+
+// TestResumeAllowsRecoveryWithoutConfiguredCredentialSource verifies that an
+// optional host source is not required when the role-owned state is recoverable.
+func TestResumeAllowsRecoveryWithoutConfiguredCredentialSource(t *testing.T) {
+	service, runStore, runtime, _, launch := prepareAgentForWorkerRecovery(t, config.AuthenticationConfig{})
+
+	_, err := service.Resume(context.Background(), factory.ResumeRequest{RunID: launch.Invocation.RunID})
+	var manualResumeErr *factory.ManualResumeRequiredError
+	if !errors.As(err, &manualResumeErr) {
+		t.Fatalf("Resume() error = %v, want manual resume handoff", err)
+	}
+	if got := len(runtime.codexSeeds); got != 0 {
+		t.Fatalf("recovery without a credential source seeded Codex credentials %d times, want 0", got)
+	}
+	if got := runStore.invocations[launch.Invocation.ID].CredentialStoreID; got != "" {
+		t.Fatalf("recovery without a credential source persisted credential store %q, want empty", got)
+	}
+}
+
+// TestResumeFailsClosedWhenConfiguredCodexCredentialsCannotBeRestored verifies
+// missing projection input pauses recovery with bounded operator guidance.
+func TestResumeFailsClosedWhenConfiguredCodexCredentialsCannotBeRestored(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"access_token":"recovery-secret"}`), 0o600); err != nil {
+		t.Fatalf("write credential source: %v", err)
+	}
+
+	service, runStore, runtime, _, launch := prepareAgentForWorkerRecovery(t, config.AuthenticationConfig{
+		CodexAuthPath: authPath,
+	})
+	if err := os.Remove(authPath); err != nil {
+		t.Fatalf("remove credential source: %v", err)
+	}
+	runtime.seedErr = errors.New(authPath + ": recovery-secret credential source disappeared")
+
+	_, err := service.Resume(context.Background(), factory.ResumeRequest{RunID: launch.Invocation.RunID})
+	if err == nil {
+		t.Fatal("Resume() succeeded without a restorable configured credential source")
+	}
+	if !strings.Contains(err.Error(), "factory auth refresh") {
+		t.Fatalf("Resume() error = %v, want actionable auth refresh guidance", err)
+	}
+	if strings.Contains(err.Error(), authPath) || strings.Contains(err.Error(), "recovery-secret") {
+		t.Fatalf("Resume() error leaked credential source details: %v", err)
+	}
+	if got := len(runtime.codexSeeds); got != 2 {
+		t.Fatalf("failed recovery attempted credential seed %d times, want the initial and failed restore", got)
+	}
+	if got := runStore.current.Status; got != store.StatusWaitingForHuman {
+		t.Fatalf("run status after failed credential recovery = %q, want %q", got, store.StatusWaitingForHuman)
+	}
+	// Attach follows the same boundary if an operator retries after the pause;
+	// a failed projection must not leave the newly started worker running.
+	_, attachErr := service.Attach(context.Background(), factory.AttachRequest{RunID: launch.Invocation.RunID})
+	if attachErr == nil || !strings.Contains(attachErr.Error(), "factory auth refresh") {
+		t.Fatalf("Attach() error = %v, want actionable auth refresh guidance", attachErr)
+	}
+	if got := runStore.current.Status; got != store.StatusWaitingForHuman {
+		t.Fatalf("run status after failed attach recovery = %q, want %q", got, store.StatusWaitingForHuman)
+	}
+}
+
+// TestStartAgentRefusesANonRestartSafeCredentialOverride verifies a one-off
+// host source cannot create an invocation that recovery could not restore.
+func TestStartAgentRefusesANonRestartSafeCredentialOverride(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, _ := newAgentService(t)
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, validRepositoryConfig(), config.AuthenticationConfig{})
+	overridePath := filepath.Join(t.TempDir(), "auth.json")
+
+	_, err := service.StartAgent(context.Background(), factory.AgentRequest{CodexAuthPath: overridePath})
+	if err == nil || !strings.Contains(err.Error(), "not restart-safe") {
+		t.Fatalf("StartAgent() error = %v, want non-restart-safe override refusal", err)
+	}
+	if strings.Contains(err.Error(), overridePath) {
+		t.Fatalf("override refusal leaked host credential path: %v", err)
+	}
+	if len(runtime.starts) != 0 || len(runtime.codexSeeds) != 0 {
+		t.Fatal("non-restart-safe credential override started a worker or seeded credentials")
+	}
+}
+
+// prepareAgentForWorkerRecovery launches an invocation, persists its native
+// session identity, and makes the worker appear missing to the next resume.
+func prepareAgentForWorkerRecovery(t *testing.T, authentication config.AuthenticationConfig) (*factory.Service, *agentRunStore, *agentWorker, *agentHarness, factory.AgentLaunchResult) {
+	t.Helper()
+
+	_, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	service := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, validRepositoryConfig(), authentication)
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+
+	persisted := runStore.invocations[launch.Invocation.ID]
+	persisted.NativeSessionID = "native-session-recovery"
+	if err := runStore.SaveInvocation(context.Background(), persisted); err != nil {
+		t.Fatalf("persist native session: %v", err)
+	}
+	runtime.inspectResult = &worker.Inspection{}
+
+	recoveredService := newDispatchingAgentService(t, runStore, runtime, terminalRuntime, validRepositoryConfig(), authentication)
+	return recoveredService, runStore, runtime, harnessRuntime, launch
 }
 
 // TestStartAgentRefusesAnIssueHarnessOverrideOutsidePolicy verifies an

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -156,6 +156,11 @@ func (s *Service) Resume(ctx context.Context, request ResumeRequest) (ResumeResu
 
 	updatedInvocation, resumeErr := s.resumePersistedInvocationManually(ctx, registration, runStore, *run, *active)
 	if resumeErr != nil {
+		var credentialErr *credentialProjectionError
+		if errors.As(resumeErr, &credentialErr) {
+			paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, active.Harness)
+			return ResumeResult{Run: paused, Invocation: updatedInvocation}, errors.Join(credentialErr, pauseErr)
+		}
 		classified := classifyHarnessRuntimeErrorForInvocation(*active, resumeErr)
 		if harness.IsRateLimited(classified) {
 			paused, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, *run, active.Harness)
@@ -233,8 +238,14 @@ func (s *Service) Attach(ctx context.Context, request AttachRequest) (AttachResu
 	if err != nil {
 		return AttachResult{}, fmt.Errorf("ensure agent runtime for attach: %w", err)
 	}
-	if _, err := s.ensureWorkerForInvocation(ctx, registration, runStore, *run, *active); err != nil {
+	_, recoveredInvocation, err := s.ensureWorkerForInvocation(ctx, registration, runStore, *run, *active)
+	if err != nil {
 		return AttachResult{}, err
+	}
+	active = &recoveredInvocation
+	if err := s.restoreCredentialProjection(ctx, registration, *run, *active); err != nil {
+		paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, active.Harness)
+		return AttachResult{Run: paused, Invocation: *active}, errors.Join(err, pauseErr)
 	}
 	workspaceID, implementationSurface, statusSurface, checksSurface, restored, err := s.restoreInvocationTerminal(ctx, terminalRuntime, *run, *active)
 	if err != nil {
@@ -340,11 +351,13 @@ func (s *Service) RefreshAuth(ctx context.Context, request AuthRefreshRequest) (
 			return AuthRefreshResult{}, fmt.Errorf("persist credential store identity: %w", err)
 		}
 	}
-	if _, err := s.ensureWorkerForInvocation(ctx, registration, runStore, *run, *invocation); err != nil {
+	_, recoveredInvocation, err := s.ensureWorkerForInvocation(ctx, registration, runStore, *run, *invocation)
+	if err != nil {
 		return AuthRefreshResult{}, err
 	}
+	*invocation = recoveredInvocation
 	if err := seed(ctx, run.ID); err != nil {
-		return AuthRefreshResult{}, fmt.Errorf("refresh %s credentials: %w", harnessName, classifyHarnessRuntimeError(nil, err))
+		return AuthRefreshResult{}, newCredentialProjectionError(string(harnessName))
 	}
 	return AuthRefreshResult{Run: *run, Invocation: *invocation, Harness: harnessName}, nil
 }
@@ -588,15 +601,20 @@ func (s *Service) pauseForManualRecovery(ctx context.Context, registration confi
 }
 
 // ensureWorkerForInvocation validates or recreates the pinned worker for an
-// invocation and returns the exact start request used for credential refresh.
-func (s *Service) ensureWorkerForInvocation(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, invocation store.Invocation) (worker.StartRequest, error) {
+// invocation and returns the exact start request plus any persisted credential
+// store identity added from the current registered source.
+func (s *Service) ensureWorkerForInvocation(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, invocation store.Invocation) (worker.StartRequest, store.Invocation, error) {
+	invocation, err := s.ensureCredentialStoreIdentity(ctx, registration, runStore, invocation)
+	if err != nil {
+		return worker.StartRequest{}, invocation, err
+	}
 	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
 	if err != nil {
-		return worker.StartRequest{}, fmt.Errorf("decode specification packet for worker recovery: %w", err)
+		return worker.StartRequest{}, invocation, fmt.Errorf("decode specification packet for worker recovery: %w", err)
 	}
 	gitMetadataPath, err := prepareGitMetadataProjection(run.ID, registration.Path, run.Worktree)
 	if err != nil {
-		return worker.StartRequest{}, fmt.Errorf("prepare recovery Git metadata: %w", err)
+		return worker.StartRequest{}, invocation, fmt.Errorf("prepare recovery Git metadata: %w", err)
 	}
 	request := worker.StartRequest{
 		RunID:             run.ID,
@@ -611,27 +629,27 @@ func (s *Service) ensureWorkerForInvocation(ctx context.Context, registration co
 		Role:              invocation.Role,
 	}
 	if s.deps.Worker == nil {
-		return worker.StartRequest{}, errors.New("worker runtime is required for invocation recovery")
+		return worker.StartRequest{}, invocation, errors.New("worker runtime is required for invocation recovery")
 	}
 	inspection, err := s.deps.Worker.Inspect(ctx, run.ID)
 	if err != nil {
-		return worker.StartRequest{}, fmt.Errorf("inspect worker for invocation recovery: %w", err)
+		return worker.StartRequest{}, invocation, fmt.Errorf("inspect worker for invocation recovery: %w", err)
 	}
 	if inspection.Exists {
 		if !workerImageMatches(inspection.Image, request.Image, request.ImageDigest) {
-			return worker.StartRequest{}, fmt.Errorf("persisted worker image %q does not match frozen image %q@%s", inspection.Image, request.Image, request.ImageDigest)
+			return worker.StartRequest{}, invocation, fmt.Errorf("persisted worker image %q does not match frozen image %q@%s", inspection.Image, request.Image, request.ImageDigest)
 		}
 		if inspection.Running {
 			known, matches := inspection.MountContractStatus(request)
 			if known && matches {
-				return request, nil
+				return request, invocation, nil
 			}
 		}
 	}
 	if err := s.startWorkerWithEffect(ctx, runStore, request); err != nil {
-		return worker.StartRequest{}, fmt.Errorf("start or recreate worker during invocation recovery: %w", err)
+		return worker.StartRequest{}, invocation, fmt.Errorf("start or recreate worker during invocation recovery: %w", err)
 	}
-	return request, nil
+	return request, invocation, nil
 }
 
 // restoreInvocationTerminal returns persisted handles when they still exist

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -243,10 +243,6 @@ func (s *Service) Attach(ctx context.Context, request AttachRequest) (AttachResu
 		return AttachResult{}, err
 	}
 	active = &recoveredInvocation
-	if err := s.restoreCredentialProjection(ctx, registration, *run, *active); err != nil {
-		paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, active.Harness)
-		return AttachResult{Run: paused, Invocation: *active}, errors.Join(err, pauseErr)
-	}
 	workspaceID, implementationSurface, statusSurface, checksSurface, restored, err := s.restoreInvocationTerminal(ctx, terminalRuntime, *run, *active)
 	if err != nil {
 		return AttachResult{}, err
@@ -256,17 +252,25 @@ func (s *Service) Attach(ctx context.Context, request AttachRequest) (AttachResu
 	setInvocationSurface(&updated, implementationSurface)
 	updated.StatusSurfaceID = string(statusSurface.ID)
 	updated.ChecksSurfaceID = string(checksSurface.ID)
-	if restored || updated.AttachRequired {
-		if restored {
-			// A recreated cmux topology needs a native resume to place the
-			// process into the newly created surface before the attach gate is
-			// cleared.
-			resumed, resumeErr := s.resumePersistedInvocationManually(ctx, registration, runStore, *run, updated)
-			if resumeErr != nil {
-				return AttachResult{Invocation: resumed}, resumeErr
+	if restored {
+		// A recreated cmux topology needs a native resume to place the process
+		// into the newly created surface. The nested resume restores credentials
+		// itself.
+		resumed, resumeErr := s.resumePersistedInvocationManually(ctx, registration, runStore, *run, updated)
+		if resumeErr != nil {
+			var credentialErr *credentialProjectionError
+			if errors.As(resumeErr, &credentialErr) {
+				paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, active.Harness)
+				return AttachResult{Run: paused, Invocation: resumed}, errors.Join(credentialErr, pauseErr)
 			}
-			updated = resumed
+			return AttachResult{Invocation: resumed}, resumeErr
 		}
+		updated = resumed
+	} else if err := s.restoreCredentialProjection(ctx, registration, *run, updated); err != nil {
+		paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, *run, active.Harness)
+		return AttachResult{Run: paused, Invocation: updated}, errors.Join(err, pauseErr)
+	}
+	if restored || updated.AttachRequired {
 		updated.AttachRequired = false
 		updated.UpdatedAt = s.deps.Now().UTC()
 		invocationStore, ok := runStore.(InvocationStore)

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -906,8 +906,17 @@ func (s *Service) reconcileInterruptedRunWithMode(ctx context.Context, registrat
 				})
 				diagnosis.SourcesAgree = false
 			} else if active != nil && (allowSameProcessRecovery || !s.invocationStartedHere(active.ID)) && active.Status == store.InvocationStatusActive && !active.AttachRequired && strings.TrimSpace(active.NativeSessionID) != "" {
+				if diagnosis.SourcesAgree && active.RecoveryResumeCount > 0 && !hasRecoverableInvocationLoss(diagnosis) {
+					if credentialErr := s.restoreCredentialProjection(ctx, registration, run, *active); credentialErr != nil {
+						return s.pauseForCredentialProjection(ctx, registration, runStore, run, &diagnosis, active.Harness, credentialErr)
+					}
+				}
 				if active.RecoveryResumeCount > 0 && hasRecoverableInvocationLoss(diagnosis) {
-					if _, repairErr := s.ensureWorkerForInvocation(ctx, registration, runStore, run, *active); repairErr != nil {
+					_, repairedInvocation, repairErr := s.ensureWorkerForInvocation(ctx, registration, runStore, run, *active)
+					if repairErr != nil {
+						if paused, pausedDiagnosis, outcome, credentialPauseErr, handled := s.pauseForCredentialProjectionError(ctx, registration, runStore, run, &diagnosis, active.Harness, repairErr); handled {
+							return paused, pausedDiagnosis, outcome, credentialPauseErr
+						}
 						addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
 							Kind:     RecoveryDiscrepancyInfrastructure,
 							Source:   "worker",
@@ -917,6 +926,9 @@ func (s *Service) reconcileInterruptedRunWithMode(ctx context.Context, registrat
 						})
 						diagnosis.SourcesAgree = false
 					} else {
+						if credentialErr := s.restoreCredentialProjection(ctx, registration, run, repairedInvocation); credentialErr != nil {
+							return s.pauseForCredentialProjection(ctx, registration, runStore, run, &diagnosis, active.Harness, credentialErr)
+						}
 						paused, pauseErr := s.pauseForManualRecovery(ctx, registration, runStore, run, active.Harness, harness.NewUnexpectedExitError(active.Harness))
 						if pauseErr != nil {
 							return paused, diagnosis, RecoveryOutcomeWaitingForHuman, pauseErr
@@ -927,6 +939,9 @@ func (s *Service) reconcileInterruptedRunWithMode(ctx context.Context, registrat
 				if diagnosis.SourcesAgree && active.RecoveryResumeCount == 0 {
 					_, resumeErr := s.resumePersistedInvocation(ctx, registration, runStore, run, *active)
 					if resumeErr != nil {
+						if paused, pausedDiagnosis, outcome, credentialPauseErr, handled := s.pauseForCredentialProjectionError(ctx, registration, runStore, run, &diagnosis, active.Harness, resumeErr); handled {
+							return paused, pausedDiagnosis, outcome, credentialPauseErr
+						}
 						classified := harness.ClassifyError(resumeErr, active.Harness)
 						if harness.IsRateLimited(classified) {
 							paused, waitErr := s.pauseForHarnessCapacity(ctx, registration, runStore, run, active.Harness)
@@ -997,6 +1012,50 @@ func (s *Service) reconcileInterruptedRunWithMode(ctx context.Context, registrat
 		return paused, diagnosis, RecoveryOutcomeWaitingForHuman, &InfrastructureDiscrepancyError{Diagnosis: diagnosis}
 	}
 	return run, diagnosis, RecoveryOutcomeReconciled, nil
+}
+
+// pauseForCredentialProjection records a bounded credential discrepancy and
+// transitions the run through the same stopped-worker authentication boundary
+// used for an expired harness credential.
+func (s *Service) pauseForCredentialProjection(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, diagnosis *RecoveryDiagnosis, harnessName string, cause error) (store.Run, RecoveryDiagnosis, RecoveryOutcome, error) {
+	recordCredentialProjectionDiscrepancy(diagnosis)
+	paused, pauseErr := s.pauseForAuthentication(ctx, registration, runStore, run, harnessName)
+	if diagnosis == nil {
+		return paused, RecoveryDiagnosis{}, RecoveryOutcomeWaitingForHuman, errors.Join(cause, pauseErr)
+	}
+	return paused, *diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(cause, pauseErr)
+}
+
+// pauseForCredentialProjectionError handles a credential failure from either
+// worker preparation or native resume and reports whether it recognized one.
+func (s *Service) pauseForCredentialProjectionError(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, diagnosis *RecoveryDiagnosis, harnessName string, cause error) (store.Run, RecoveryDiagnosis, RecoveryOutcome, error, bool) {
+	var credentialErr *credentialProjectionError
+	if !errors.As(cause, &credentialErr) {
+		if diagnosis == nil {
+			return run, RecoveryDiagnosis{}, "", nil, false
+		}
+		return run, *diagnosis, "", nil, false
+	}
+	paused, pausedDiagnosis, outcome, pauseErr := s.pauseForCredentialProjection(ctx, registration, runStore, run, diagnosis, harnessName, credentialErr)
+	return paused, pausedDiagnosis, outcome, pauseErr, true
+}
+
+// recordCredentialProjectionDiscrepancy adds only a bounded credential-store
+// observation to recovery diagnosis; source paths and adapter output stay out
+// of persisted or operator-visible recovery metadata.
+func recordCredentialProjectionDiscrepancy(diagnosis *RecoveryDiagnosis) {
+	if diagnosis == nil {
+		return
+	}
+	addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+		Kind:        RecoveryDiscrepancyInfrastructure,
+		Source:      "credential store",
+		Field:       "projection",
+		Expected:    "configured credentials projected into the factory-managed store",
+		Observed:    "credential projection unavailable",
+		Recoverable: false,
+	})
+	diagnosis.SourcesAgree = false
 }
 
 // harnessResumeWasAlreadyReserved reports whether a pending native-resume

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -41,6 +41,10 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-journaled-recovery\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	authPath := filepath.Join(root, "codex-auth.json")
+	if err := os.WriteFile(authPath, []byte(`{"access_token":"journaled-recovery-secret"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	packet := SpecificationPacket{
 		Version: specificationPacketVersion,
@@ -86,6 +90,7 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 		Role:                    "implementation",
 		Stage:                   store.StageImplementation,
 		Model:                   "gpt-5",
+		CredentialStoreID:       root,
 		NativeSessionID:         "session-journaled-recovery",
 		WorkspaceID:             "workspace-journaled-recovery",
 		StatusSurfaceID:         "surface-status-journaled-recovery",
@@ -126,6 +131,7 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 		Path:                root,
 		OperationalDataPath: databasePath,
 		GitHub:              config.GitHubConfig{Owner: "example", Repository: "project"},
+		Authentication:      config.AuthenticationConfig{CodexAuthPath: authPath},
 	}
 	githubRuntime := &effectMatrixGitHub{
 		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{factoryLabelForStatus(run.Status)}},
@@ -168,6 +174,9 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 	if workerRuntime.startRequests[0].ImageDigest != run.ImageDigest || workerRuntime.startRequests[0].InvocationPath != invocation.InvocationDirectory || workerRuntime.startRequests[0].ResultPath != invocation.ResultDirectory {
 		t.Fatalf("recreated worker request = %#v, want frozen image and invocation mounts", workerRuntime.startRequests[0])
 	}
+	if len(workerRuntime.codexSeeds) != 1 || workerRuntime.codexSeeds[0].AuthPath != authPath {
+		t.Fatalf("recovery credential seeds = %#v, want one seed from the registered source", workerRuntime.codexSeeds)
+	}
 	if harnessRuntime.resumeCalls != 1 {
 		t.Fatalf("native resumes after first startup = %d, want one", harnessRuntime.resumeCalls)
 	}
@@ -194,8 +203,14 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 	if freshRun == nil {
 		t.Fatal("fresh coordinator fixture lost its run")
 	}
+	// Model a restart after the managed volume contents were lost while its
+	// mount identity still matched the persisted worker contract.
+	workerRuntime.codexSeeds = nil
 	if err := fresh.reconcileRegisteredRun(ctx, registration); err != nil {
 		t.Fatalf("second journaled startup = %v", err)
+	}
+	if len(workerRuntime.codexSeeds) != 1 || workerRuntime.codexSeeds[0].AuthPath != authPath {
+		t.Fatalf("credential restoration after matching-worker restart = %#v, want one registered-source seed", workerRuntime.codexSeeds)
 	}
 	if harnessRuntime.resumeCalls != 1 {
 		t.Fatalf("native resumes after second startup = %d, want no duplicate", harnessRuntime.resumeCalls)
@@ -297,6 +312,45 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 	liveRecovered, err := opened.CurrentRun(ctx)
 	if err != nil || liveRecovered == nil || liveRecovered.Status != store.StatusActive {
 		t.Fatalf("run after live harness recovery = %#v, error = %v; want active run", liveRecovered, err)
+	}
+
+	// A configured source that disappears before the next restart must pause
+	// before native resume and keep its path and contents out of the error.
+	if err := os.Remove(authPath); err != nil {
+		t.Fatal(err)
+	}
+	persisted, err = opened.Invocation(ctx, run.ID, invocation.ID)
+	if err != nil || persisted == nil {
+		t.Fatalf("read invocation before missing-source recovery = %#v, error = %v", persisted, err)
+	}
+	persisted.RecoveryResumeCount = 0
+	persisted.UpdatedAt = now.Add(4 * time.Minute)
+	if err := opened.SaveInvocation(ctx, *persisted); err != nil {
+		t.Fatal(err)
+	}
+	activeRun = *liveRecovered
+	activeRun.Status = store.StatusActive
+	activeRun.LifecycleReason = "worker recovered with a missing credential source"
+	activeRun.UpdatedAt = now.Add(4 * time.Minute)
+	if err := opened.SaveRun(ctx, activeRun); err != nil {
+		t.Fatal(err)
+	}
+	githubRuntime.issue.Labels = []string{factoryLabelForStatus(activeRun.Status)}
+	githubRuntime.statusComment.Body = statusCommentBody(activeRun)
+	workerRuntime.inspection = worker.Inspection{}
+	workerRuntime.seedErr = errors.New(authPath + ": journaled-recovery-secret")
+	harnessRuntime.nativeSessionExited = false
+	missingSourceService := &Service{deps: service.deps}
+	missingSourceErr := missingSourceService.reconcileRegisteredRun(ctx, registration)
+	if missingSourceErr == nil || !strings.Contains(missingSourceErr.Error(), "factory auth refresh") {
+		t.Fatalf("missing-source recovery error = %v, want actionable auth refresh guidance", missingSourceErr)
+	}
+	if strings.Contains(missingSourceErr.Error(), authPath) || strings.Contains(missingSourceErr.Error(), "journaled-recovery-secret") {
+		t.Fatalf("missing-source recovery leaked credential details: %v", missingSourceErr)
+	}
+	paused, err := opened.CurrentRun(ctx)
+	if err != nil || paused == nil || paused.Status != store.StatusWaitingForHuman || !strings.HasPrefix(paused.LifecycleReason, "harness authentication expired") {
+		t.Fatalf("run after missing-source recovery = %#v, error = %v; want authentication pause", paused, err)
 	}
 }
 
@@ -438,6 +492,8 @@ type journalRecoveryWorker struct {
 	inspectCalls  int
 	startCalls    int
 	startRequests []worker.StartRequest
+	codexSeeds    []worker.CredentialSeedRequest
+	seedErr       error
 }
 
 // Start recreates the worker from the coordinator's frozen request and updates
@@ -471,7 +527,14 @@ func (w *journalRecoveryWorker) Inspect(context.Context, string) (worker.Inspect
 	return w.inspection, w.inspectErr
 }
 
+// SeedCodexCredentials records restoration of the configured factory source.
+func (w *journalRecoveryWorker) SeedCodexCredentials(_ context.Context, request worker.CredentialSeedRequest) error {
+	w.codexSeeds = append(w.codexSeeds, request)
+	return w.seedErr
+}
+
 var _ worker.WorkerRuntime = (*journalRecoveryWorker)(nil)
+var _ worker.CredentialSeeder = (*journalRecoveryWorker)(nil)
 
 // journalRecoveryTerminal supplies the persisted cmux workspace projection.
 type journalRecoveryTerminal struct {

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -501,6 +501,10 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 	if capabilities.Name != previous.Harness {
 		return store.Invocation{}, run, fmt.Errorf("%w: harness %q cannot resume a %q session", ErrCheckRepairSessionUnavailable, capabilities.Name, previous.Harness)
 	}
+	seedCredentials, configuredCredentialStoreID, credentialErr := s.credentialSeeding(registration, AgentRequest{}, config.Harness(previous.Harness))
+	if credentialErr != nil {
+		return store.Invocation{}, run, newCredentialProjectionError(previous.Harness)
+	}
 	identifier, err := s.deps.NewRunID()
 	if err != nil {
 		return store.Invocation{}, run, fmt.Errorf("generate check-repair invocation identifier: %w", err)
@@ -543,8 +547,8 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		return store.Invocation{}, run, err
 	}
 	credentialStoreID := previous.CredentialStoreID
-	if credentialStoreID == "" && registration.Authentication.CodexAuthPath != "" {
-		credentialStoreID = registration.Path
+	if credentialStoreID == "" {
+		credentialStoreID = configuredCredentialStoreID
 	}
 	invocation = store.Invocation{
 		ID:                      invocationID,
@@ -665,6 +669,11 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		return store.Invocation{}, run, fmt.Errorf("start worker for check repair: %w", err)
 	}
 	workerStarted = true
+	if seedCredentials != nil {
+		if err := seedCredentials(ctx, run.ID); err != nil {
+			return store.Invocation{}, run, newCredentialProjectionError(previous.Harness)
+		}
+	}
 	next := run
 	next.Stage = store.StageImplementation
 	next.Status = store.StatusActive

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -502,7 +502,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		return store.Invocation{}, run, fmt.Errorf("%w: harness %q cannot resume a %q session", ErrCheckRepairSessionUnavailable, capabilities.Name, previous.Harness)
 	}
 	seedCredentials, configuredCredentialStoreID, credentialErr := s.credentialSeeding(registration, AgentRequest{}, config.Harness(previous.Harness))
-	if credentialErr != nil {
+	if credentialErr != nil || (strings.TrimSpace(previous.CredentialStoreID) != "" && seedCredentials == nil) {
 		return store.Invocation{}, run, newCredentialProjectionError(previous.Harness)
 	}
 	identifier, err := s.deps.NewRunID()

--- a/internal/factory/repair_test.go
+++ b/internal/factory/repair_test.go
@@ -704,3 +704,30 @@ func TestCheckRepairRefusesMidSessionHarnessMigration(t *testing.T) {
 		t.Fatalf("resume calls = %d, want no cross-harness resume attempt", harnessRuntime.resumes)
 	}
 }
+
+// TestCheckRepairFailsClosedWithoutThePersistedCredentialSource verifies a
+// repair cannot resume a managed credential store after its source is removed.
+func TestCheckRepairFailsClosedWithoutThePersistedCredentialSource(t *testing.T) {
+	service, registration, runStore, harnessRuntime := newRepairLaunchService(t, nil, 0, 0)
+	previous := runStore.invocations["inv-initial"]
+	previous.CredentialStoreID = registration.Path
+	runStore.invocations["inv-initial"] = previous
+	run := runStore.run
+
+	_, _, err := service.startCheckRepair(context.Background(), registration, runStore, run, SpecificationPacket{
+		Issue: github.Issue{Body: "repair guidance"},
+	}, CheckRepairPacket{
+		Version:       checkRepairPacketVersion,
+		RunID:         run.ID,
+		CheckpointSHA: run.CheckpointSHA,
+		Attempt:       1,
+		Budget:        3,
+	})
+	var credentialErr *credentialProjectionError
+	if !errors.As(err, &credentialErr) {
+		t.Fatalf("startCheckRepair() error = %v, want credential projection failure", err)
+	}
+	if harnessRuntime.resumes != 0 || len(runStore.invocations) != 1 {
+		t.Fatalf("check repair effects = %d resumes/%d invocations, want no launch side effects", harnessRuntime.resumes, len(runStore.invocations))
+	}
+}

--- a/internal/worker/interactive_contract_test.go
+++ b/internal/worker/interactive_contract_test.go
@@ -87,12 +87,13 @@ func TestDockerRuntimeRecreatesAnExistingWorkerForInvocationMounts(t *testing.T)
 	gitMetadata := makeDirectory(t, "git-metadata")
 	runtime := &worker.DockerRuntime{DockerBinary: stub}
 	base := worker.StartRequest{
-		RunID:           "run-reconfigure",
-		WorktreePath:    worktree,
-		GitMetadataPath: gitMetadata,
-		Role:            "gate",
-		Image:           "ghcr.io/example/factory-worker",
-		ImageDigest:     interactiveWorkerDigest,
+		RunID:             "run-reconfigure",
+		WorktreePath:      worktree,
+		GitMetadataPath:   gitMetadata,
+		CredentialStoreID: "registration",
+		Role:              "gate",
+		Image:             "ghcr.io/example/factory-worker",
+		ImageDigest:       interactiveWorkerDigest,
 	}
 	if err := runtime.Start(context.Background(), base); err != nil {
 		t.Fatalf("base Start() error = %v", err)
@@ -115,20 +116,30 @@ func TestDockerRuntimeRecreatesAnExistingWorkerForInvocationMounts(t *testing.T)
 	}
 	t.Setenv("WORKER_DOCKER_INSPECT_JSON_FILE", inspectionPath)
 	if err := runtime.Start(context.Background(), worker.StartRequest{
-		RunID:           base.RunID,
-		WorktreePath:    worktree,
-		GitMetadataPath: gitMetadata,
-		InvocationPath:  makeDirectory(t, "invocation"),
-		ResultPath:      makeDirectory(t, "results"),
-		Role:            "implementation",
-		Image:           base.Image,
-		ImageDigest:     base.ImageDigest,
+		RunID:             base.RunID,
+		WorktreePath:      worktree,
+		GitMetadataPath:   gitMetadata,
+		InvocationPath:    makeDirectory(t, "invocation"),
+		ResultPath:        makeDirectory(t, "results"),
+		CredentialStoreID: base.CredentialStoreID,
+		Role:              "implementation",
+		Image:             base.Image,
+		ImageDigest:       base.ImageDigest,
 	}); err != nil {
 		t.Fatalf("visible Start() error = %v", err)
 	}
 	lines := readStubLog(t, logPath)
 	if countLogLines(lines, " run ") != 2 || countLogLines(lines, " rm ") != 1 {
 		t.Fatalf("Docker reconfiguration calls = %#v, want stop/rm and replacement run", lines)
+	}
+	for _, line := range findLogLines(lines, " rm ") {
+		if strings.Contains(line, " -v ") {
+			t.Fatalf("worker recreation removed named volumes: %q", line)
+		}
+	}
+	replacement := findLogLines(lines, " run ")[1]
+	if !strings.Contains(replacement, "dst="+worker.CredentialPath) {
+		t.Fatalf("replacement worker mounts = %q, want the factory credential projection", replacement)
 	}
 }
 
@@ -325,5 +336,40 @@ func TestDockerRuntimeRefusesAnUnsafeClaudeCredentialSource(t *testing.T) {
 				t.Fatalf("SeedClaudeCredentials() error = %v, want %q refusal", err, test.problem)
 			}
 		})
+	}
+}
+
+// TestDockerRuntimeRedactsCredentialSourceAndDockerErrors verifies that a
+// missing source or Docker-side failure cannot expose the host auth path or
+// credential bytes through the worker seam.
+func TestDockerRuntimeRedactsCredentialSourceAndDockerErrors(t *testing.T) {
+	stub, _, _ := writeDockerStub(t)
+	runtime := &worker.DockerRuntime{DockerBinary: stub}
+	authRoot := t.TempDir()
+	authPath := filepath.Join(authRoot, "auth.json")
+	missingErr := runtime.SeedCodexCredentials(context.Background(), worker.CredentialSeedRequest{
+		RunID:    "run-redacted-source",
+		AuthPath: authPath,
+	})
+	if missingErr == nil {
+		t.Fatal("SeedCodexCredentials() accepted a missing credential source")
+	}
+	if strings.Contains(missingErr.Error(), authPath) {
+		t.Fatalf("missing-source error leaked host credential path: %v", missingErr)
+	}
+
+	if err := os.WriteFile(authPath, []byte("credential-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WORKER_DOCKER_EXEC_ERROR", authPath+": credential-secret")
+	dockerErr := runtime.SeedCodexCredentials(context.Background(), worker.CredentialSeedRequest{
+		RunID:    "run-redacted-docker",
+		AuthPath: authPath,
+	})
+	if dockerErr == nil {
+		t.Fatal("SeedCodexCredentials() accepted a Docker projection failure")
+	}
+	if strings.Contains(dockerErr.Error(), authPath) || strings.Contains(dockerErr.Error(), "credential-secret") {
+		t.Fatalf("Docker projection error leaked credential details: %v", dockerErr)
 	}
 }

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -543,7 +543,7 @@ func (r *DockerRuntime) seedCredentialFile(ctx context.Context, request Credenti
 	}
 	info, err := os.Lstat(request.AuthPath)
 	if err != nil {
-		return fmt.Errorf("inspect %s auth file: %w", credential.Harness, err)
+		return fmt.Errorf("inspect %s auth file: credential source is unavailable", credential.Harness)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("%s auth path must not be a symbolic link", credential.Harness)
@@ -553,7 +553,7 @@ func (r *DockerRuntime) seedCredentialFile(ctx context.Context, request Credenti
 	}
 	data, err := os.ReadFile(request.AuthPath)
 	if err != nil {
-		return fmt.Errorf("read %s auth file: %w", credential.Harness, err)
+		return fmt.Errorf("read %s auth file: credential source is unavailable", credential.Harness)
 	}
 	if len(data) == 0 {
 		return fmt.Errorf("%s auth file is empty", credential.Harness)
@@ -570,14 +570,14 @@ func (r *DockerRuntime) seedCredentialFile(ctx context.Context, request Credenti
 		name, "/bin/sh", "-c",
 		"umask 077; rm -f \"" + credentialPath + "\"; cat > \"" + credentialPath + "\"; chmod 0444 \"" + credentialPath + "\"",
 	}, data); err != nil {
-		return fmt.Errorf("seed %s credentials: %w", credential.Harness, dockerStderrDetail(err))
+		return fmt.Errorf("seed %s credentials: credential projection failed", credential.Harness)
 	}
 	if _, err := r.runDocker(ctx, []string{
 		"exec", "--user", WorkerUser, "--workdir", WorktreePath,
 		name, "/bin/sh", "-c",
 		"mkdir -p \"" + credential.RoleHome + "\"; rm -f \"" + linkPath + "\"; ln -s \"" + credentialPath + "\" \"" + linkPath + "\"",
 	}); err != nil {
-		return fmt.Errorf("link %s credentials into the role home: %w", credential.Harness, dockerStderrDetail(err))
+		return fmt.Errorf("link %s credentials into the role home: credential projection failed", credential.Harness)
 	}
 	return nil
 }
@@ -1249,10 +1249,14 @@ func workerMountsPresent(request StartRequest, inspection Inspection) bool {
 	return true
 }
 
-// requiredInvocationMounts returns the mounts introduced by the visible
-// invocation seam; older adapters cannot safely compare the base mount sources.
+// requiredInvocationMounts returns the mounts that older inspections can
+// safely compare by destination, including the managed credential projection
+// when the invocation requires one.
 func requiredInvocationMounts(request StartRequest) []string {
-	required := make([]string, 0, 2)
+	required := make([]string, 0, 3)
+	if request.CredentialStoreID != "" {
+		required = append(required, CredentialPath)
+	}
 	if request.InvocationPath != "" {
 		required = append(required, InvocationPath)
 	}

--- a/internal/worker/runtime_contract_test.go
+++ b/internal/worker/runtime_contract_test.go
@@ -438,6 +438,10 @@ case "$command_name" in
     fi
     ;;
   exec)
+    if [ -n "${WORKER_DOCKER_EXEC_ERROR:-}" ]; then
+      printf '%s\n' "$WORKER_DOCKER_EXEC_ERROR" >&2
+      exit "${WORKER_DOCKER_EXEC_EXIT:-1}"
+    fi
     case "$*" in
       *fail-126*)
         printf 'command-failed-126\n' >&2


### PR DESCRIPTION
Restores factory-managed harness credential projections during persisted worker recovery, fails closed with redacted factory auth refresh guidance, rejects non-restart-safe auth overrides, and adds recovery and credential-redaction regression coverage. Closes #79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication now uses registered repository credential sources.
  * Invocation recovery restores credentials before resuming interrupted work.
  * Missing or invalid credentials pause runs for authentication instead of continuing unsafely.

* **Bug Fixes**
  * Rejects unsupported one-off credential overrides.
  * Prevents orphaned workers when credential restoration fails.
  * Sensitive credential paths, contents, and infrastructure details are redacted from errors.
  * Improved recovery when workers restart or are recreated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->