### PR TITLE
fix: push checkpoint before publishing gate statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cannot add arbitrary roles or redefine the transition graph in
 | <code>architecture</code> | <code>architecture</code> role, optional | The agent writes a design document under the permitted architecture path, then hands off to implementation. |
 | <code>implementation</code> | <code>implementation</code> role | The agent edits production code and submits a structured implementation handoff. |
 | <code>check</code> | Coordinator | The accepted implementation is checkpointed and every configured gate runs against that exact checkpoint. |
-| <code>draft_pr</code> | Coordinator | After successful gates, the host pushes the run branch and creates or updates one draft pull request. |
+| <code>draft_pr</code> | Coordinator | The host pushes the run branch before the gate statuses, then creates or updates one draft pull request after successful gates. |
 | <code>review</code> | <code>spec_review</code> role | An independent reviewer receives the exact checkpoint and reports blocking findings or advisories. |
 | <code>ready</code> | Coordinator | The run is ready for a human to review and merge. Factory leaves the pull request as a draft and does not merge it. |
 
@@ -651,10 +651,11 @@ The host coordinator:
    that protected test paths are unchanged;
 2. creates an implementation checkpoint commit with a message containing
    <code>factory: implementation checkpoint &lt;run-id&gt;</code>;
-3. runs every configured gate against that exact checkpoint;
-4. pushes <code>factory/&lt;run-id&gt;</code> only if the required gates pass; and
+3. pushes <code>factory/&lt;run-id&gt;</code> so GitHub can resolve the checkpoint
+   commit named by every gate status;
+4. runs every configured gate against that exact checkpoint; and
 5. creates or updates one draft pull request targeting the configured base
-   branch.
+   branch only if the required gates pass.
 
 Workers never commit, push, access a GitHub API, or receive a GitHub token.
 Repeating <code>factory draft-pr</code> after the first PR exists regenerates
@@ -1125,7 +1126,7 @@ supported by the installed binary.
 | <code>factory issue [--issue N] N</code> | Claim one issue and run its baseline. The number may be positional or supplied with <code>--issue</code>, but not both. |
 | <code>factory agent</code> | Start the active stage's visible role, or select a validated role/stage/harness/model/reasoning override. |
 | <code>factory agent-report</code> | Validate and accept a report already written by one invocation. Requires <code>--run-id</code> and <code>--invocation-id</code>. |
-| <code>factory draft-pr</code> | Create the implementation checkpoint, run gates, push the branch, and create/update the draft PR. <code>--intervention</code> records a one-line operator marker. |
+| <code>factory draft-pr</code> | Create the implementation checkpoint, push the branch, run gates, and create/update the draft PR. <code>--intervention</code> records a one-line operator marker. |
 | <code>factory poll</code> | Process one lifecycle and structured-command observation for the current run. |
 | <code>factory status</code> | Show the selected host configuration, repository, latest run, and recovery diagnosis. |
 | <code>factory resume</code> | Perform explicit native-session or harness-capacity recovery. |

--- a/README.md
+++ b/README.md
@@ -670,12 +670,13 @@ Human-authored text outside those markers is preserved. The PR body includes
 the issue, packet version, checkpoint, gate results, test disposition, review
 projection, intervention marker, and control commands.
 
-If a gate fails, <code>draft-pr</code> returns the bounded check-repair
-decision instead of pushing the branch. The next implementation invocation
-reuses the worker role volume and implementation surface, subject to the frozen
-repair budget. After an accepted repair report, run <code>factory draft-pr</code>
-again. Infrastructure waits do not spend the check-repair budget; the hard
-ceiling is three attempts.
+If a gate fails, the checkpoint remains pushed on the run branch and
+<code>draft-pr</code> returns the bounded check-repair decision without creating
+or updating the draft pull request. The next implementation invocation reuses
+the worker role volume and implementation surface, subject to the frozen repair
+budget. After an accepted repair report, run <code>factory draft-pr</code> again.
+Infrastructure waits do not spend the check-repair budget; the hard ceiling is
+three attempts.
 
 ### 6. Run the independent specification review
 

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -179,6 +179,10 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 		}
 	}
 
+	if err := s.publishCheckpointBranch(ctx, runStore, workspace, next); err != nil {
+		return DraftPullRequestResult{Run: next}, err
+	}
+
 	gates, gateErr := s.runConfiguredGates(ctx, registration, runStore, next, packet)
 	result := DraftPullRequestResult{Run: next, Gates: gates}
 	if gateErr != nil {
@@ -196,16 +200,6 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 	}
 	if len(state.ChangedPaths) != 0 {
 		return result, errors.New("worktree has uncommitted changes after deterministic gates")
-	}
-	pushRequest := gitadapter.PushRequest{WorktreePath: next.Worktree, Branch: next.Branch}
-	var pushErr error
-	if _, journaled := runStore.(PendingEffectStore); journaled {
-		pushErr = s.pushWithEffect(ctx, runStore, next.ID, workspace, pushRequest, next.CheckpointSHA)
-	} else {
-		pushErr = workspace.Push(ctx, pushRequest)
-	}
-	if pushErr != nil {
-		return result, pushErr
 	}
 	draftTransition, transitionErr := workflow.DefaultRegistry().ResolveEventTransition(next.Stage, workflow.StageEventDraftPullRequest)
 	if transitionErr != nil {
@@ -245,6 +239,19 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 		return DraftPullRequestResult{Run: next, Gates: gates, PullRequest: pullRequest}, err
 	}
 	return DraftPullRequestResult{Run: next, Gates: gates, PullRequest: pullRequest}, nil
+}
+
+// publishCheckpointBranch pushes the run branch so GitHub can resolve the
+// checkpoint commit. Every gate status names that exact SHA, and GitHub
+// rejects a status for a commit it has never seen, so the branch must reach
+// the remote before the first status is published. The push observes the
+// remote head first and is therefore safe to repeat.
+func (s *Service) publishCheckpointBranch(ctx context.Context, runStore RunStore, workspace gitadapter.GitWorkspace, run store.Run) error {
+	request := gitadapter.PushRequest{WorktreePath: run.Worktree, Branch: run.Branch}
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		return s.pushWithEffect(ctx, runStore, run.ID, workspace, request, run.CheckpointSHA)
+	}
+	return workspace.Push(ctx, request)
 }
 
 // runConfiguredGates executes the frozen gate suite once and joins blocking

--- a/internal/factory/draft_pr_test.go
+++ b/internal/factory/draft_pr_test.go
@@ -3,6 +3,7 @@ package factory_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,10 +21,10 @@ import (
 const implementationCheckpoint = "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
 const repairedImplementationCheckpoint = "1234561234561234561234561234561234561234561234561234561234561234"
 
-// TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft
+// TestCreateDraftPullRequestPushesTheCheckpointBeforeGatesAndCreatesOneDraft
 // verifies the complete host-owned implementation boundary at the Factory
 // seam.
-func TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft(t *testing.T) {
+func TestCreateDraftPullRequestPushesTheCheckpointBeforeGatesAndCreatesOneDraft(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -127,6 +128,104 @@ func TestCreateDraftPullRequestRunsGatesBeforeTheFirstPushAndCreatesOneDraft(t *
 		t.Fatalf("updated PR body = %q, want preserved human text and one regenerated section", updatedBody)
 	}
 }
+
+// TestCreateDraftPullRequestPublishesGateStatusesForAPushedCheckpoint
+// verifies the coordinator never asks GitHub for a status on a commit the
+// remote cannot resolve. GitHub rejects such a status with an unknown-SHA
+// error, which previously left the run's journaled status effect pending and
+// the run stuck in recovery.
+func TestCreateDraftPullRequestPublishesGateStatusesForAPushedCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repo")
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-unpushed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy := validRepositoryConfig()
+	policy.Gates = []config.GateConfig{{Name: "format", Command: "format", Timeout: "5m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean}}
+	runStore := &fakeRunStore{}
+	githubAdapter := &fakeGitHub{issueValue: github.Issue{Number: 42, Title: "Publish the checkpoint first", Body: "Attach gate statuses to a resolvable commit.", State: "open", Labels: []string{github.LabelAgentReady}}}
+	workspace := &draftGitWorkspace{
+		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-unpushed", Worktree: worktreePath},
+		state:     gitadapter.WorktreeState{Branch: "factory/run-unpushed", HeadSHA: factoryGateCheckpoint, ChangedPaths: []string{"internal/factory.go"}},
+	}
+	workerRuntime := &gateWorker{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}}}
+	statuses := &unpushedCheckpointStatuses{workspace: workspace}
+	pullRequests := &fakePullRequests{created: github.PullRequest{Number: 19, URL: "https://github.com/example/project/pull/19", State: "open", Draft: true, HeadBranch: "factory/run-unpushed", BaseBranch: "main"}}
+
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: repositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		OperationalDataPath: filepath.Join(root, "state", "factory.db"), RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+	}}}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		GitHub:         &fakeGitHubWithPullRequests{fakeGitHub: githubAdapter},
+		PullRequests:   pullRequests,
+		Worktree:       workspace,
+		GitWorkspace:   workspace,
+		Worker:         workerRuntime,
+		CommitStatuses: statuses,
+		Now:            func() time.Time { return time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC) },
+		NewRunID:       func() (string, error) { return "run-unpushed", nil },
+	})
+	claimed, err := service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	claimed.Run.Stage = store.StageImplementation
+	claimed.Run.Status = store.StatusActive
+	if err := runStore.SaveRun(context.Background(), claimed.Run); err != nil {
+		t.Fatalf("SaveRun() fixture setup error = %v", err)
+	}
+
+	result, err := service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: claimed.Run.ID})
+	if err != nil {
+		t.Fatalf("CreateDraftPullRequest() error = %v", err)
+	}
+	if result.Run.Stage != store.StageDraftPR || result.PullRequest.Number != 19 {
+		t.Fatalf("result = %#v, want a draft PR at the published checkpoint", result)
+	}
+	if len(workspace.pushedSHAs) != 1 || workspace.pushedSHAs[0] != implementationCheckpoint {
+		t.Fatalf("pushed checkpoints = %#v, want the evaluated checkpoint", workspace.pushedSHAs)
+	}
+	if len(statuses.values) != 1 || statuses.values[0].SHA != implementationCheckpoint {
+		t.Fatalf("published gate statuses = %#v, want one status on the pushed checkpoint", statuses.values)
+	}
+	if statuses.rejected != 0 {
+		t.Fatalf("statuses published for an unresolvable commit = %d, want zero", statuses.rejected)
+	}
+}
+
+// unpushedCheckpointStatuses answers a status for an unpushed commit the way
+// GitHub does, so a test proves the checkpoint reaches the remote first.
+type unpushedCheckpointStatuses struct {
+	workspace *draftGitWorkspace
+	values    []github.CommitStatus
+	rejected  int
+}
+
+// CreateCommitStatus records one status and rejects any SHA the remote cannot
+// resolve yet.
+func (s *unpushedCheckpointStatuses) CreateCommitStatus(_ context.Context, _ github.Repository, status github.CommitStatus) error {
+	if !s.workspace.remoteHasCheckpoint(status.SHA) {
+		s.rejected++
+		return fmt.Errorf("No commit found for SHA: %s (HTTP 422)", status.SHA)
+	}
+	s.values = append(s.values, status)
+	return nil
+}
+
+var _ github.CommitStatusPublisher = (*unpushedCheckpointStatuses)(nil)
 
 // TestCreateDraftPullRequestRoutesDeterministicFailuresThroughNativeRepair
 // verifies the full failed-check to resumed-session to fresh-checkpoint loop.
@@ -242,8 +341,11 @@ func TestCreateDraftPullRequestRoutesDeterministicFailuresThroughNativeRepair(t 
 	if second.Repair != nil || second.Run.Stage != store.StageDraftPR || second.Run.CheckpointSHA != repairedImplementationCheckpoint || second.PullRequest.Number != 18 {
 		t.Fatalf("second result = %#v, want a draft PR at a fresh checkpoint", second)
 	}
-	if len(workspace.checkpoints) != 2 || workspace.checkpoints[1].ParentSHA != implementationCheckpoint || len(workspace.pushes) != 1 {
-		t.Fatalf("checkpoint/push effects = %#v/%#v, want repair checkpoint parent and one push", workspace.checkpoints, workspace.pushes)
+	if len(workspace.checkpoints) != 2 || workspace.checkpoints[1].ParentSHA != implementationCheckpoint || len(workspace.pushedSHAs) != 2 {
+		t.Fatalf("checkpoint/push effects = %#v/%#v, want repair checkpoint parent and one push per evaluated checkpoint", workspace.checkpoints, workspace.pushedSHAs)
+	}
+	if workspace.pushedSHAs[0] != implementationCheckpoint || workspace.pushedSHAs[1] != repairedImplementationCheckpoint {
+		t.Fatalf("pushed checkpoints = %#v, want each evaluated checkpoint published before its statuses", workspace.pushedSHAs)
 	}
 	if len(statuses.values) != 2 || statuses.values[0].SHA != implementationCheckpoint || statuses.values[1].SHA != repairedImplementationCheckpoint {
 		t.Fatalf("published gate statuses = %#v, want one status per exact checkpoint", statuses.values)
@@ -292,6 +394,7 @@ type draftGitWorkspace struct {
 	checkpoints    []gitadapter.CheckpointRequest
 	checkpointSHAs []string
 	pushes         []gitadapter.PushRequest
+	pushedSHAs     []string
 }
 
 // activeInvocationRunStore adds the real-store invocation guard to the small
@@ -335,10 +438,23 @@ func (w *draftGitWorkspace) CreateCheckpoint(_ context.Context, request gitadapt
 	return gitadapter.CheckpointResult{SHA: checkpoint, Created: true}, nil
 }
 
-// Push records the host-side branch push.
+// Push records the host-side branch push and the checkpoint it publishes.
 func (w *draftGitWorkspace) Push(_ context.Context, request gitadapter.PushRequest) error {
 	w.pushes = append(w.pushes, request)
+	w.pushedSHAs = append(w.pushedSHAs, w.state.HeadSHA)
 	return nil
+}
+
+// remoteHasCheckpoint reports whether the branch push already published one
+// exact commit, so a status publisher fake can reject an unknown SHA the way
+// GitHub does.
+func (w *draftGitWorkspace) remoteHasCheckpoint(sha string) bool {
+	for _, pushed := range w.pushedSHAs {
+		if pushed == sha {
+			return true
+		}
+	}
+	return false
 }
 
 // SynchronizeBase implements GitWorkspace for the coordinator test.

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -1006,6 +1006,16 @@ func (s *Service) replayPendingCommitStatus(ctx context.Context, runStore RunSto
 	if !ok {
 		return store.Run{}, errors.New("commit-status reader is required to replay status safely")
 	}
+	run, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("read run during commit status replay: %w", err)
+	}
+	if run == nil {
+		return store.Run{}, fmt.Errorf("run %q disappeared during commit status replay", effect.RunID)
+	}
+	if err := s.publishStatusCheckpoint(ctx, *run, payload.Status.SHA); err != nil {
+		return store.Run{}, err
+	}
 	statuses, err := reader.ListCommitStatuses(ctx, payload.Repository, payload.Status.SHA)
 	if err != nil {
 		return store.Run{}, fmt.Errorf("inspect commit status during replay: %w", err)
@@ -1027,14 +1037,33 @@ func (s *Service) replayPendingCommitStatus(ctx context.Context, runStore RunSto
 			return store.Run{}, fmt.Errorf("clear replayed commit status: %w", err)
 		}
 	}
-	run, err := readReconciliationRun(ctx, runStore)
+	current, err := readReconciliationRun(ctx, runStore)
 	if err != nil {
 		return store.Run{}, fmt.Errorf("read run after commit status replay: %w", err)
 	}
-	if run == nil {
+	if current == nil {
 		return store.Run{}, fmt.Errorf("run %q disappeared during commit status replay", effect.RunID)
 	}
-	return *run, nil
+	return *current, nil
+}
+
+// publishStatusCheckpoint makes the remote resolve the commit a journaled
+// status names before the status is inspected or republished. An interrupted
+// attempt can journal a status for a checkpoint that never reached GitHub, and
+// GitHub answers every later attempt with an unknown-SHA rejection, so the
+// reservation could otherwise never be completed. Only the run's own
+// checkpoint is published this way, and the push observes the remote head
+// first, so it adds no unobserved second mutation.
+func (s *Service) publishStatusCheckpoint(ctx context.Context, run store.Run, sha string) error {
+	workspace := s.gitWorkspace()
+	if workspace == nil || sha == "" || sha != run.CheckpointSHA || strings.TrimSpace(run.Branch) == "" {
+		return nil
+	}
+	request := gitadapter.PushRequest{WorktreePath: run.Worktree, Branch: run.Branch}
+	if err := s.pushOnce(ctx, workspace, request, sha); err != nil {
+		return fmt.Errorf("publish checkpoint %s before commit status replay: %w", sha, err)
+	}
+	return nil
 }
 
 // acceptResultWithEffect journals harness finalization, invocation state, and

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -313,6 +313,88 @@ func TestCommitStatusEffectReplaysTheActualStatusMutation(t *testing.T) {
 	}
 }
 
+// TestCommitStatusEffectReplayPublishesAnUnpushedCheckpoint verifies a status
+// journaled for a commit GitHub cannot resolve is completed by publishing the
+// checkpoint branch first. Without that repair the reservation never clears
+// and the run stays in recovery with a stale GitHub projection.
+func TestCommitStatusEffectReplayPublishesAnUnpushedCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	opened, databasePath, run := openEffectMatrixStore(t, ctx)
+	checkpoint := strings.Repeat("b", 40)
+	run.CheckpointSHA = checkpoint
+	if err := opened.SaveRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	workspace := &effectMatrixGitWorkspace{expectedRemoteHead: checkpoint, checkpointSHA: checkpoint}
+	statusRuntime := &unresolvableCommitStatus{workspace: workspace}
+	service := newEffectMatrixService(nil, statusRuntime, workspace, nil)
+	publisher := commitStatusPublisher{service: service, runStore: opened, runID: run.ID, delegate: statusRuntime}
+	status := github.CommitStatus{SHA: checkpoint, State: github.CommitStatusSuccess, Context: "factory/gate/format", Description: "factory gate passed"}
+	if err := publisher.CreateCommitStatus(ctx, github.Repository{Owner: "example", Name: "project"}, status); err == nil {
+		t.Fatal("CreateCommitStatus() = nil, want an unresolved-commit rejection")
+	}
+	if len(statusRuntime.statuses) != 0 {
+		t.Fatalf("published statuses = %#v, want none before the checkpoint is pushed", statusRuntime.statuses)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	pending, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil || pending == nil {
+		t.Fatalf("pending commit status = %#v, error = %v", pending, err)
+	}
+	restarted := newEffectMatrixService(nil, statusRuntime, workspace, nil)
+	if _, err := restarted.replayPendingEffect(ctx, reopened, *pending); err != nil {
+		t.Fatalf("replayPendingEffect() = %v", err)
+	}
+	if workspace.pushMutations != 1 {
+		t.Fatalf("push mutations during replay = %d, want the checkpoint published once", workspace.pushMutations)
+	}
+	if len(statusRuntime.statuses) != 1 || statusRuntime.statuses[0].SHA != checkpoint {
+		t.Fatalf("published statuses = %#v, want one status on the published checkpoint", statusRuntime.statuses)
+	}
+	cleared, err := reopened.PendingEffect(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleared != nil {
+		t.Fatalf("pending effect after replay = %#v, want a cleared reservation", cleared)
+	}
+}
+
+// unresolvableCommitStatus answers every request for a commit the remote does
+// not have the way GitHub does, so a test can prove the replay publishes the
+// checkpoint before it inspects or attaches a status.
+type unresolvableCommitStatus struct {
+	workspace *effectMatrixGitWorkspace
+	statuses  []github.CommitStatus
+}
+
+// ListCommitStatuses rejects a SHA the remote cannot resolve.
+func (s *unresolvableCommitStatus) ListCommitStatuses(_ context.Context, _ github.Repository, sha string) ([]github.CommitStatus, error) {
+	if s.workspace.remoteHead != sha {
+		return nil, fmt.Errorf("No commit found for SHA: %s (HTTP 422)", sha)
+	}
+	return append([]github.CommitStatus(nil), s.statuses...), nil
+}
+
+// CreateCommitStatus rejects a SHA the remote cannot resolve.
+func (s *unresolvableCommitStatus) CreateCommitStatus(_ context.Context, _ github.Repository, status github.CommitStatus) error {
+	if s.workspace.remoteHead != status.SHA {
+		return fmt.Errorf("No commit found for SHA: %s (HTTP 422)", status.SHA)
+	}
+	s.statuses = append(s.statuses, status)
+	return nil
+}
+
+var _ github.CommitStatusPublisher = (*unresolvableCommitStatus)(nil)
+var _ github.CommitStatusReader = (*unresolvableCommitStatus)(nil)
+
 // TestPushEffectReplaysTheActualRemoteMutation verifies remote-head
 // observation suppresses a second push after a transport response is lost.
 func TestPushEffectReplaysTheActualRemoteMutation(t *testing.T) {


### PR DESCRIPTION
## Summary

- `factory draft-pr` published `factory/gate/<name>` commit statuses for a checkpoint that existed only in the local worktree. GitHub cannot attach a status to a commit it has never seen, so it answered `No commit found for SHA … (HTTP 422)`.
- The status was already reserved in the pending-effect journal. Because a reservation blocks any *different* effect, every later `draft-pr` failed with `pending effect conflict`.
- Reconciliation replayed the status, hit the same rejection, and fell into `pauseRunLocally`, which sets `waiting_for_human` locally without touching the GitHub label or status comment — leaving the run stopped with divergent projections.
- The branch is now pushed before the gate suite runs, so every status names a commit GitHub can resolve.
- Commit-status replay performs the same repair, so a run already interrupted by this bug can be reconciled without hand-editing SQLite.

Reported against run `run-921b1f27-7878-4cbb-bea6-d417b260f808` (checkpoint `f7e955a…`). No tracking issue exists for it.

## Changes

**Coordinator — `internal/factory/draft_pr.go`**
- `CreateDraftPullRequest` calls the new `publishCheckpointBranch` before `runConfiguredGates`; the old post-gate push block is removed. Both entry paths are covered: a fresh implementation checkpoint and a check-stage resume.
- The post-gate assertions (worktree HEAD unchanged, no uncommitted changes) stay where they were, so nothing new is pushed after gates.
- Journaled stores still route through `pushWithEffect`, keeping the push itself replayable.

**Recovery — `internal/factory/effects.go`**
- `replayPendingCommitStatus` reads the run first, then calls the new `publishStatusCheckpoint`, which pushes the run branch when the journaled status names the run's own checkpoint. It reuses `pushOnce`, so the remote head is observed before any mutation and the push adds no unobserved second effect.

**Docs — `README.md`**
- Stage table, coordinator step list, and command table now describe push-then-gates.

## Contract Impact

None. No schema, API, or persisted-format change. The observable behaviour change is ordering: a gate failure now leaves its checkpoint on the run branch, where previously nothing reached the remote until gates passed. The check-repair loop pushes each new checkpoint on top, so no force-push is involved.

## Test Plan

- [x] `TestCreateDraftPullRequestPublishesGateStatusesForAPushedCheckpoint` (new) — a status publisher that rejects any SHA the workspace has not pushed, mirroring the 422. Verified failing against the old ordering, where it reproduces the reported symptom exactly: the run lands at `check` / `waiting_for_harness` with a check-repair result.
- [x] `TestCommitStatusEffectReplayPublishesAnUnpushedCheckpoint` (new) — journals a status for an unpushed checkpoint, restarts the service, and asserts the replay pushes once, publishes the status, and clears the reservation. Verified failing without `publishStatusCheckpoint`.
- [x] `TestCreateDraftPullRequestRoutesDeterministicFailuresThroughNativeRepair` — updated: two evaluated checkpoints now mean two pushes, each asserted against the checkpoint whose statuses follow.
- [x] `go test ./...` — 604 passed across 20 packages; `go vet ./...` clean.

## Known gap

After `factory reconcile` repairs a run stuck by this bug, the run sits at `check` / `waiting_for_human` and nothing carries it forward: `draft_pr.go` accepts a check-stage run only when `active` or `waiting_for_harness`, `retry` is gated to failed/cancelled runs, and `factory resume` finds no role for `StageCheck` so it launches a fresh agent instead of continuing the coordinator step. The conflicting projections and the unclearable reservation are fixed here; returning such a run to `active` changes pause semantics and is left for a separate decision.

## Checklist

- [x] Tests pass
- [x] No breaking changes (ordering change documented above)
- [ ] CLAUDE.md updated if architecture changed — not needed; README carries the stage-order description

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured checkpoint branches are published before gate statuses are reported.
  * Improved draft pull request workflows when status updates reference commits not yet available remotely.
  * Added reliable replay handling for pending status updates, including checkpoint publication and duplicate prevention.

* **Documentation**
  * Updated the draft pull request workflow and command reference to reflect the checkpoint-first process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->