### PR TITLE
fix: recover interrupted draft-pr checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,9 @@ factory auth refresh \
 
 - <code>resume</code> retries harness capacity or performs an explicit
   native-session recovery. It does not change the frozen packet.
+- When restart reconciliation has paused a coordinator-owned <code>check</code>
+  stage, <code>resume</code> re-enters check evaluation without launching a new
+  implementation agent; run <code>factory draft-pr</code> afterward.
 - A manually resumed native session sets an attach gate. <code>attach</code>
   restores the worker and visible terminal topology and clears that gate before
   report acceptance or workflow progression can continue.
@@ -1129,7 +1132,7 @@ supported by the installed binary.
 | <code>factory draft-pr</code> | Create the implementation checkpoint, push the branch, run gates, and create/update the draft PR. <code>--intervention</code> records a one-line operator marker. |
 | <code>factory poll</code> | Process one lifecycle and structured-command observation for the current run. |
 | <code>factory status</code> | Show the selected host configuration, repository, latest run, and recovery diagnosis. |
-| <code>factory resume</code> | Perform explicit native-session or harness-capacity recovery. |
+| <code>factory resume</code> | Perform explicit native-session or harness-capacity recovery, or re-enter a recovery-paused check stage. |
 | <code>factory attach</code> | Restore worker/terminal topology after a manual resume and clear the attach gate. |
 | <code>factory auth refresh</code> | Reseed a managed worker credential for the active invocation harness. |
 | <code>factory reconcile</code> | Run restart reconciliation, or abandon one inspected pending effect with <code>--abandon-effect</code> and <code>--reason</code>. |
@@ -1293,9 +1296,12 @@ terminal topology.
 
 The implementation invocation must have a terminal accepted report, the run
 must be <code>implementation/active</code> or in an allowed <code>check</code>
-wait, the worktree must be clean at the recorded checkpoint, and protected test
-paths must still match. Submit or correct the report first; do not create a
-manual checkpoint on the run branch.
+wait. A <code>check/waiting_for_human</code> run may continue only when its
+lifecycle reason begins with <code>restart reconciliation paused:</code>; use
+<code>factory reconcile</code> first, then <code>factory resume</code> or
+<code>factory draft-pr</code>. The worktree must be clean at the recorded
+checkpoint, and protected test paths must still match. Submit or correct the
+report first; do not create a manual checkpoint on the run branch.
 
 ### The worker image does not match
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -212,8 +212,9 @@ func runStop(ctx context.Context, args []string, defaultConfigPath string, outpu
 }
 
 // runResume performs one explicit native-session or harness-capacity recovery
-// for the active run. A successful native resume remains behind the attach
-// gate until the operator acknowledges the visible terminal session.
+// for the active run, or re-enters a coordinator-owned check after restart
+// reconciliation. A successful native resume remains behind the attach gate
+// until the operator acknowledges the visible terminal session.
 func runResume(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
 	flags := flag.NewFlagSet("resume", flag.ContinueOnError)
 	flags.SetOutput(errorsOutput)
@@ -238,6 +239,10 @@ func runResume(ctx context.Context, args []string, defaultConfigPath string, out
 			status = "waiting for human"
 		}
 		if !writeOutput(output, errorsOutput, "agent %s\nrun: %s\ninvocation: %s\nstatus: %s\n", status, result.Run.ID, result.Invocation.ID, status) {
+			return 1
+		}
+	} else if result.Run.ID != "" {
+		if !writeOutput(output, errorsOutput, "check evaluation resumed\nrun: %s\nstage: %s\nstatus: %s\n", result.Run.ID, result.Run.Stage, result.Run.Status) {
 			return 1
 		}
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -241,7 +241,7 @@ func runResume(ctx context.Context, args []string, defaultConfigPath string, out
 		if !writeOutput(output, errorsOutput, "agent %s\nrun: %s\ninvocation: %s\nstatus: %s\n", status, result.Run.ID, result.Invocation.ID, status) {
 			return 1
 		}
-	} else if result.Run.ID != "" {
+	} else if err == nil && result.Run.ID != "" {
 		if !writeOutput(output, errorsOutput, "check evaluation resumed\nrun: %s\nstage: %s\nstatus: %s\n", result.Run.ID, result.Run.Stage, result.Run.Status) {
 			return 1
 		}

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -87,7 +87,7 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 	if run.Stage == store.StageImplementation && run.Status != store.StatusActive {
 		return DraftPullRequestResult{}, fmt.Errorf("run %q is %s; implementation must be active", run.ID, run.Status)
 	}
-	if run.Stage == store.StageCheck && run.Status != store.StatusActive && run.Status != store.StatusWaitingForHarness {
+	if run.Stage == store.StageCheck && run.Status != store.StatusActive && run.Status != store.StatusWaitingForHarness && !isRestartReconciliationPause(*run) {
 		return DraftPullRequestResult{}, fmt.Errorf("run %q is %s; check evaluation must be active or waiting for harness", run.ID, run.Status)
 	}
 	if run.CheckRepairPendingAttempt != 0 {
@@ -101,6 +101,13 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 		if active != nil {
 			return DraftPullRequestResult{}, fmt.Errorf("run %q still has active implementation invocation %q", run.ID, active.ID)
 		}
+	}
+	if run.Stage == store.StageCheck && isRestartReconciliationPause(*run) {
+		resumed, resumeErr := s.resumeRecoveredCheck(ctx, registration, runStore, *run)
+		if resumeErr != nil {
+			return DraftPullRequestResult{Run: resumed}, resumeErr
+		}
+		*run = resumed
 	}
 	workspace := s.gitWorkspace()
 	if workspace == nil {

--- a/internal/factory/draft_pr_test.go
+++ b/internal/factory/draft_pr_test.go
@@ -206,6 +206,89 @@ func TestCreateDraftPullRequestPublishesGateStatusesForAPushedCheckpoint(t *test
 	}
 }
 
+// TestCreateDraftPullRequestReentersRecoveryPausedCheck verifies that a
+// reconciled check-stage pause can continue through the normal draft-PR
+// command without starting a replacement implementation agent.
+func TestCreateDraftPullRequestReentersRecoveryPausedCheck(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repo")
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-recovered-check\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy := validRepositoryConfig()
+	policy.Gates = []config.GateConfig{{Name: "format", Command: "format", Timeout: "5m", Blocking: true, EnvironmentPolicy: config.EnvironmentPolicyClean}}
+	runStore := &fakeRunStore{}
+	githubAdapter := &fakeGitHub{issueValue: github.Issue{
+		Number: 42, Title: "Recover the check stage", Body: "Continue gate evaluation after recovery.", State: "open",
+		Labels: []string{github.LabelAgentReady},
+	}}
+	workspace := &draftGitWorkspace{
+		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-recovered-check", Worktree: worktreePath},
+		state:     gitadapter.WorktreeState{Branch: "factory/run-recovered-check", HeadSHA: factoryGateCheckpoint},
+	}
+	workerRuntime := &gateWorker{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}}}
+	statuses := &gateStatuses{}
+	pullRequests := &fakePullRequests{created: github.PullRequest{
+		Number: 20, URL: "https://github.com/example/project/pull/20", State: "open", Draft: true,
+		HeadBranch: "factory/run-recovered-check", BaseBranch: "main",
+	}}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: repositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		OperationalDataPath: filepath.Join(root, "state", "factory.db"), RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+	}}}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		GitHub:         &fakeGitHubWithPullRequests{fakeGitHub: githubAdapter},
+		PullRequests:   pullRequests,
+		Worktree:       workspace,
+		GitWorkspace:   workspace,
+		Worker:         workerRuntime,
+		CommitStatuses: statuses,
+		Now:            func() time.Time { return time.Date(2026, 8, 28, 13, 0, 0, 0, time.UTC) },
+		NewRunID:       func() (string, error) { return "run-recovered-check", nil },
+	})
+	claimed, err := service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	claimed.Run.Stage = store.StageCheck
+	claimed.Run.Status = store.StatusWaitingForHuman
+	claimed.Run.LifecycleReason = "restart reconciliation paused: stale GitHub projection"
+	if err := runStore.SaveRun(context.Background(), claimed.Run); err != nil {
+		t.Fatalf("SaveRun() fixture setup error = %v", err)
+	}
+	githubAdapter.issueValue.Labels = []string{github.LabelAgentNeedsInput}
+	githubAdapter.statusComment = github.Comment{ID: claimed.Run.StatusCommentID, Body: factory.StatusCommentBody(claimed.Run)}
+
+	result, err := service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: claimed.Run.ID})
+	if err != nil {
+		t.Fatalf("CreateDraftPullRequest() error = %v", err)
+	}
+	if result.Run.Stage != store.StageDraftPR || result.PullRequest.Number != 20 {
+		t.Fatalf("result = %#v, want draft PR after recovered check", result)
+	}
+	if len(workspace.checkpoints) != 0 || len(workspace.pushes) != 1 || len(statuses.values) != 1 || statuses.values[0].SHA != factoryGateCheckpoint {
+		t.Fatalf("check effects = pushes %#v statuses %#v, want one evaluated checkpoint", workspace.pushes, statuses.values)
+	}
+	if len(workerRuntime.commands) != 2 || workerRuntime.commands[0].Command != policy.Setup || workerRuntime.commands[1].Command != "format" {
+		t.Fatalf("check commands = %#v, want setup and format only", workerRuntime.commands)
+	}
+	if got := githubAdapter.issueValue.Labels; len(got) != 1 || got[0] != github.LabelAgentRunning {
+		t.Fatalf("final issue labels = %#v, want agent-running", got)
+	}
+}
+
 // unpushedCheckpointStatuses answers a status for an unpushed commit the way
 // GitHub does, so a test proves the checkpoint reaches the remote first.
 type unpushedCheckpointStatuses struct {

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -45,7 +45,8 @@ type Factory interface {
 	AcceptAgentReport(context.Context, AgentReportRequest) (AgentResult, error)
 	// RunAgent launches a visible agent and accepts its already-written report.
 	RunAgent(context.Context, AgentRequest) (AgentResult, error)
-	// Resume performs an explicit native-session or harness-capacity recovery.
+	// Resume performs an explicit native-session or harness-capacity recovery,
+	// or re-enters a coordinator-owned check paused by restart reconciliation.
 	Resume(context.Context, ResumeRequest) (ResumeResult, error)
 	// Attach acknowledges and reattaches a manually resumed visible session.
 	Attach(context.Context, AttachRequest) (AttachResult, error)

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -81,9 +81,10 @@ func (e *ManualResumeRequiredError) Error() string {
 	return fmt.Sprintf("manual harness resume for run %q requires `factory attach` before progression", e.RunID)
 }
 
-// Resume explicitly restores one persisted native session or retries a run
-// that is waiting for harness capacity. It never consumes the automatic
-// recovery ceiling.
+// Resume explicitly restores one persisted native session, retries a run that
+// is waiting for harness capacity, or re-enters a coordinator-owned check
+// paused by restart reconciliation. It never consumes the automatic recovery
+// ceiling.
 func (s *Service) Resume(ctx context.Context, request ResumeRequest) (ResumeResult, error) {
 	if err := validateOptionalRunID(request.RunID); err != nil {
 		return ResumeResult{}, err
@@ -142,6 +143,13 @@ func (s *Service) Resume(ctx context.Context, request ResumeRequest) (ResumeResu
 		}
 	}
 	if active == nil {
+		if run.Stage == store.StageCheck && isRestartReconciliationPause(*run) {
+			resumed, resumeErr := s.resumeRecoveredCheck(ctx, registration, runStore, *run)
+			if resumeErr != nil {
+				return ResumeResult{Run: resumed}, resumeErr
+			}
+			return ResumeResult{Run: resumed}, nil
+		}
 		requestForRun := normalizeAgentRequest(agentRequestForRun(*run))
 		launchRun := *run
 		if launchRun.Status != store.StatusActive {

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -22,6 +22,11 @@ import (
 // boundary. Issue #21 supersedes this refusal with complete reconciliation.
 const RecoveryRequiredCode = "recovery-required"
 
+// restartReconciliationPausePrefix identifies a pause created by recovery
+// itself, which is the only waiting-for-human state eligible for check-stage
+// re-entry without a new agent invocation.
+const restartReconciliationPausePrefix = "restart reconciliation paused:"
+
 // RecoveryDiscrepancyKind identifies whether a restart disagreement is an
 // infrastructure observation or a workflow-owned failure.
 type RecoveryDiscrepancyKind string
@@ -412,6 +417,7 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 		})
 		return
 	}
+	expectedStopped := workerProjectionExpectedStopped(run, *active)
 	workerProjectionLost := false
 	workerInspection, inspectErr := s.deps.Worker.Inspect(ctx, run.ID)
 	if inspectErr != nil {
@@ -447,6 +453,14 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 					Recoverable: workerProjectionLost,
 				})
 			}
+		} else if expectedStopped {
+			addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
+				Kind:     RecoveryDiscrepancyInfrastructure,
+				Source:   "worker",
+				Field:    "lifecycle",
+				Expected: "stopped",
+				Observed: "running",
+			})
 		} else {
 			packet, packetErr := decodeSpecificationPacket(run.SpecificationPacket)
 			if packetErr != nil {
@@ -499,6 +513,14 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 				}
 			}
 		}
+	}
+	if terminalInvocationProjectionExpectedStopped(run, *active) {
+		// A completed implementation invocation intentionally leaves its worker
+		// and native process stopped while the coordinator evaluates the check
+		// stage (and readiness similarly has no live agent). The worker adapter
+		// may be unable to inspect a stopped process, so its historical terminal
+		// identities are not a live projection here.
+		return
 	}
 
 	terminalRuntime := s.deps.Terminal
@@ -594,7 +616,20 @@ func workerProjectionExpectedStopped(run store.Run, invocation store.Invocation)
 	if invocation.Status == store.InvocationStatusActive {
 		return false
 	}
-	return run.Stage == store.StageReady || run.Status == store.StatusWaitingForHuman
+	return run.Stage == store.StageReady || run.Stage == store.StageCheck || run.Status == store.StatusWaitingForHuman
+}
+
+// terminalInvocationProjectionExpectedStopped reports the coordinator-owned
+// boundaries where a completed invocation is historical rather than live. A
+// human pause in another stage still inspects its terminal runtime identities.
+func terminalInvocationProjectionExpectedStopped(run store.Run, invocation store.Invocation) bool {
+	if invocation.Status == store.InvocationStatusActive {
+		return false
+	}
+	if run.Stage == store.StageCheck && invocation.Stage == store.StageImplementation {
+		return true
+	}
+	return run.Stage == store.StageReady
 }
 
 // hasRecoverableInvocationLoss reports whether a previously consumed automatic
@@ -1006,6 +1041,33 @@ func (s *Service) reconcileInterruptedRunWithMode(ctx context.Context, registrat
 			}
 			return paused, diagnosis, RecoveryOutcomeWaitingForHuman, errors.Join(&InfrastructureDiscrepancyError{Diagnosis: diagnosis}, pauseErr)
 		}
+		if recoveryProjectionOnly(diagnosis) {
+			finalDiagnosis := s.diagnoseInterruptedRunWithStore(ctx, registration, runStore, paused)
+			if pending, pendingErr := journal.PendingEffect(ctx, paused.ID); pendingErr != nil {
+				addRecoveryDiscrepancy(&finalDiagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyInfrastructure,
+					Source:   "operational store",
+					Field:    "pending effect",
+					Expected: "no pending effect after recovery pause",
+					Observed: pendingErr.Error(),
+				})
+				finalDiagnosis.SourcesAgree = false
+			} else if pending != nil {
+				finalDiagnosis.PendingEffect = pending
+				addRecoveryDiscrepancy(&finalDiagnosis, RecoveryDiscrepancy{
+					Kind:     RecoveryDiscrepancyInfrastructure,
+					Source:   "pending effect",
+					Field:    string(pending.Kind),
+					Expected: "no pending effect after recovery pause",
+					Observed: "still pending",
+				})
+				finalDiagnosis.SourcesAgree = false
+			}
+			if finalDiagnosis.SourcesAgree {
+				return paused, finalDiagnosis, RecoveryOutcomeReconciled, nil
+			}
+			diagnosis = finalDiagnosis
+		}
 		if hasWorkflowDiscrepancy(diagnosis) {
 			return paused, diagnosis, RecoveryOutcomeWaitingForHuman, &WorkflowFailureError{RunID: run.ID, Cause: errors.New(recoveryDiscrepancyReason(diagnosis))}
 		}
@@ -1163,7 +1225,7 @@ func (s *Service) pauseRunLocally(ctx context.Context, runStore RunStore, run st
 	if err := s.stopRunWorker(ctx, run.ID); err != nil {
 		return run, err
 	}
-	if run.Status == store.StatusWaitingForHuman && strings.HasPrefix(run.LifecycleReason, "restart reconciliation paused:") {
+	if isRestartReconciliationPause(run) {
 		return run, nil
 	}
 	next := run
@@ -1178,11 +1240,11 @@ func (s *Service) pauseRunLocally(ctx context.Context, runStore RunStore, run st
 }
 
 // pauseForRecovery records a discrepancy in the durable workflow projection
-// and uses the ordinary state-transition effect journal to publish the waiting
-// label and status comment when those projections are available.
+// and uses the ordinary state-transition effect journal to publish or repair
+// the waiting label and status comment when those projections are available.
 func (s *Service) pauseForRecovery(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, diagnosis RecoveryDiagnosis) (store.Run, error) {
 	reason := recoveryDiscrepancyReason(diagnosis)
-	if run.Status == store.StatusWaitingForHuman && strings.HasPrefix(run.LifecycleReason, "restart reconciliation paused:") {
+	if isRestartReconciliationPause(run) && !hasGitHubStateProjectionDiscrepancy(diagnosis) {
 		if err := s.stopRunWorker(ctx, run.ID); err != nil {
 			return run, err
 		}
@@ -1231,6 +1293,79 @@ func (s *Service) pauseForRecovery(ctx context.Context, registration config.Repo
 		return updated, fmt.Errorf("publish restart reconciliation pause: %w", err)
 	}
 	return updated, nil
+}
+
+// isRestartReconciliationPause reports whether recovery, rather than a human
+// command or harness policy, created the current waiting state.
+func isRestartReconciliationPause(run store.Run) bool {
+	return run.Status == store.StatusWaitingForHuman && strings.HasPrefix(run.LifecycleReason, restartReconciliationPausePrefix)
+}
+
+// hasGitHubStateProjectionDiscrepancy identifies label or status-comment drift
+// that the ordinary state-transition effect can repair idempotently.
+func hasGitHubStateProjectionDiscrepancy(diagnosis RecoveryDiagnosis) bool {
+	for _, discrepancy := range diagnosis.Discrepancies {
+		if discrepancy.Source != "github" {
+			continue
+		}
+		switch discrepancy.Field {
+		case "state label", "status comment", "status comment marker":
+			return true
+		}
+	}
+	return false
+}
+
+// recoveryProjectionOnly reports the bounded stale-projection case that can
+// be rechecked after pausing. Other discrepancies remain human-owned even if
+// the label or status comment was also stale.
+func recoveryProjectionOnly(diagnosis RecoveryDiagnosis) bool {
+	if len(diagnosis.Discrepancies) == 0 {
+		return false
+	}
+	for _, discrepancy := range diagnosis.Discrepancies {
+		if discrepancy.Source != "github" {
+			return false
+		}
+		switch discrepancy.Field {
+		case "state label", "status comment", "status comment marker":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// resumeRecoveredCheck re-enters a coordinator-owned check after recovery has
+// repaired its projections. It never starts an implementation agent and keeps
+// ordinary human, clarification, and check-repair pauses fail-closed.
+func (s *Service) resumeRecoveredCheck(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, error) {
+	if !isRestartReconciliationPause(run) || run.Stage != store.StageCheck {
+		return run, nil
+	}
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		updated, _, _, reconcileErr := s.reconcileInterruptedRun(ctx, registration, runStore, run)
+		if reconcileErr != nil {
+			return updated, reconcileErr
+		}
+		run = updated
+	}
+	if len(run.PendingQuestions) != 0 {
+		return run, errors.New("recovery-paused check has pending clarification questions")
+	}
+	if run.CheckRepairPendingAttempt != 0 {
+		return run, fmt.Errorf("check-repair attempt %d is pending reconciliation", run.CheckRepairPendingAttempt)
+	}
+	next := run
+	next.Status = store.StatusActive
+	next.LifecycleReason = "resuming check evaluation after restart reconciliation"
+	next.Revision = run.Revision + 1
+	next.UpdatedAt = s.deps.Now().UTC()
+	if err := s.persistAgentRunState(ctx, registration, runStore, run, next); err != nil {
+		return run, fmt.Errorf("resume check evaluation after restart reconciliation: %w", err)
+	}
+	s.resetStartupState()
+	return next, nil
 }
 
 // recoveryDiscrepancyReason renders a bounded single-line workflow reason so

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -407,6 +407,14 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 			Observed: "empty",
 		})
 	}
+	if terminalInvocationProjectionExpectedStopped(run, *active) {
+		// A completed implementation invocation intentionally leaves its worker
+		// and native process stopped while the coordinator evaluates the check
+		// stage (and readiness similarly has no live agent). The worker adapter
+		// may be unable to inspect a stopped process, so its historical terminal
+		// identities are not a live projection here.
+		return
+	}
 	if s.deps.Worker == nil {
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
 			Kind:     RecoveryDiscrepancyInfrastructure,
@@ -514,15 +522,6 @@ func (s *Service) inspectInvocationProjection(ctx context.Context, diagnosis *Re
 			}
 		}
 	}
-	if terminalInvocationProjectionExpectedStopped(run, *active) {
-		// A completed implementation invocation intentionally leaves its worker
-		// and native process stopped while the coordinator evaluates the check
-		// stage (and readiness similarly has no live agent). The worker adapter
-		// may be unable to inspect a stopped process, so its historical terminal
-		// identities are not a live projection here.
-		return
-	}
-
 	terminalRuntime := s.deps.Terminal
 	if terminalRuntime == nil {
 		terminalRuntime = terminal.NewCmuxRuntime(nil, registration.Cmux.SocketPath)

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -788,7 +788,7 @@ func TestReconcileRepairsStaleProjectionAfterInterruptedCheck(t *testing.T) {
 	workspace := &journalRecoveryWorkspace{state: gitadapter.WorktreeState{
 		RepositoryPath: root, Branch: run.Branch, HeadSHA: run.CheckpointSHA,
 	}}
-	workerRuntime := &journalRecoveryWorker{inspection: worker.Inspection{Exists: true, Running: false}}
+	workerRuntime := &journalRecoveryWorker{inspectErr: errors.New("stopped worker cannot be inspected")}
 	terminalRuntime := &journalRecoveryTerminal{inspection: terminal.WorkspaceInspection{
 		Exists: true, WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID),
 		Surfaces: []terminal.Surface{
@@ -819,6 +819,9 @@ func TestReconcileRepairsStaleProjectionAfterInterruptedCheck(t *testing.T) {
 	}
 	if result.Outcome != RecoveryOutcomeReconciled || !result.Diagnosis.SourcesAgree || len(result.Diagnosis.Discrepancies) != 0 {
 		t.Fatalf("Reconcile() result = %#v, want reconciled projections", result)
+	}
+	if workerRuntime.inspectCalls != 0 {
+		t.Fatalf("worker inspections = %d, want none for completed implementation at check boundary", workerRuntime.inspectCalls)
 	}
 	if got := githubRuntime.issue.Labels; len(got) != 1 || got[0] != github.LabelAgentNeedsInput {
 		t.Fatalf("repaired issue labels = %#v, want agent-needs-input", got)

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -721,3 +721,209 @@ func TestRemoteBranchBehindCheckpointIsNotADiscrepancy(t *testing.T) {
 		t.Fatalf("diverged discrepancy field = %q, want %q", divergedDiagnosis.Discrepancies[0].Field, "head")
 	}
 }
+
+// TestReconcileRepairsStaleProjectionAfterInterruptedCheck verifies that a
+// status-effect recovery can repair the GitHub projection after an earlier
+// local pause, while treating the completed implementation runtime as stopped
+// during the coordinator-owned check stage.
+func TestReconcileRepairsStaleProjectionAfterInterruptedCheck(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(worktreePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	databasePath := filepath.Join(root, "state", "factory.db")
+	now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	packetData, err := json.Marshal(SpecificationPacket{
+		Version: specificationPacketVersion,
+		Issue:   github.Issue{Number: 42, Title: "Recover check", Body: "recover the check stage"},
+		RepositoryConfig: config.RepositoryConfig{
+			TargetBranch: "main",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := store.Run{
+		ID: "run-stale-check-projection", RepositoryPath: root, IssueNumber: 42,
+		Stage: store.StageCheck, Status: store.StatusWaitingForHuman,
+		Branch: "factory/run-stale-check-projection", Worktree: worktreePath,
+		CheckpointSHA: strings.Repeat("a", 40), StatusCommentID: "status-stale-check-projection",
+		LifecycleReason:     "restart reconciliation paused: pending commit status could not be published",
+		SpecificationPacket: string(packetData), CreatedAt: now, UpdatedAt: now,
+	}
+	activeProjection := run
+	activeProjection.Status = store.StatusActive
+	activeProjection.LifecycleReason = "evaluating implementation checkpoint"
+	invocation := store.Invocation{
+		ID: "inv-stale-check-projection", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-stale-check-projection", WorkspaceID: "workspace-stale-check-projection",
+		StatusSurfaceID:         "surface-status-stale-check-projection",
+		ImplementationSurfaceID: "surface-implementation-stale-check-projection",
+		ChecksSurfaceID:         "surface-checks-stale-check-projection",
+		Status:                  store.InvocationStatusCompleted, CreatedAt: now, UpdatedAt: now,
+	}
+	opened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SaveRun(ctx, run); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(activeProjection)},
+	}
+	workspace := &journalRecoveryWorkspace{state: gitadapter.WorktreeState{
+		RepositoryPath: root, Branch: run.Branch, HeadSHA: run.CheckpointSHA,
+	}}
+	workerRuntime := &journalRecoveryWorker{inspection: worker.Inspection{Exists: true, Running: false}}
+	terminalRuntime := &journalRecoveryTerminal{inspection: terminal.WorkspaceInspection{
+		Exists: true, WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID),
+		Surfaces: []terminal.Surface{
+			{ID: terminal.SurfaceID(invocation.StatusSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+			{ID: terminal.SurfaceID(invocation.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+			{ID: terminal.SurfaceID(invocation.ChecksSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+		},
+	}}
+	// An implementation session cannot be inspected through Docker after its
+	// worker has been stopped. Check-stage recovery must not turn that expected
+	// condition into a second discrepancy.
+	harnessRuntime := &journalRecoveryHarness{}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: root, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		OperationalDataPath: databasePath, RepositoryConfigPath: filepath.Join(root, "factory.yaml"),
+	}}}
+	service := &Service{configPath: "/host/config.yaml", deps: Dependencies{
+		Config:    effectMatrixConfig{host: host},
+		OpenStore: func(ctx context.Context, path string) (OperationalStore, error) { return store.Open(ctx, path) },
+		GitHub:    githubRuntime, GitWorkspace: workspace, Worktree: workspace,
+		Worker: workerRuntime, Terminal: terminalRuntime, Harness: harnessRuntime,
+		Now: func() time.Time { return now },
+	}}
+
+	result, err := service.Reconcile(ctx)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v, want stale projection repair", err)
+	}
+	if result.Outcome != RecoveryOutcomeReconciled || !result.Diagnosis.SourcesAgree || len(result.Diagnosis.Discrepancies) != 0 {
+		t.Fatalf("Reconcile() result = %#v, want reconciled projections", result)
+	}
+	if got := githubRuntime.issue.Labels; len(got) != 1 || got[0] != github.LabelAgentNeedsInput {
+		t.Fatalf("repaired issue labels = %#v, want agent-needs-input", got)
+	}
+	reopened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	persisted, err := reopened.CurrentRun(ctx)
+	if err != nil || persisted == nil {
+		t.Fatalf("persisted recovered run = %#v, error = %v", persisted, err)
+	}
+	if persisted.Status != store.StatusWaitingForHuman || persisted.Revision <= run.Revision {
+		t.Fatalf("persisted recovered run = %#v, want waiting state with repaired revision", persisted)
+	}
+	if githubRuntime.statusComment.Body != statusCommentBody(*persisted) {
+		t.Fatalf("repaired status comment = %q, want %q", githubRuntime.statusComment.Body, statusCommentBody(*persisted))
+	}
+}
+
+// TestResumeReentersARecoveryPausedCheck verifies that explicit resume clears
+// only the restart-reconciliation pause and does not launch a new agent for a
+// coordinator-owned check stage.
+func TestResumeReentersARecoveryPausedCheck(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 8, 28, 12, 30, 0, 0, time.UTC)
+	run := store.Run{
+		ID: "run-resume-check", RepositoryPath: "/repo", IssueNumber: 42,
+		Stage: store.StageCheck, Status: store.StatusWaitingForHuman,
+		Branch: "factory/run-resume-check", Worktree: "/worktree/run-resume-check",
+		CheckpointSHA: strings.Repeat("b", 40), StatusCommentID: "status-resume-check",
+		LifecycleReason: "restart reconciliation paused: stale GitHub projection",
+		CreatedAt:       now, UpdatedAt: now,
+	}
+	runStore := &recoveryResumeStore{run: run}
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentNeedsInput}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(run)},
+	}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: run.RepositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		OperationalDataPath: "/state/factory.db", RepositoryConfigPath: "/repo/factory.yaml",
+	}}}
+	service := &Service{configPath: "/host/config.yaml", deps: Dependencies{
+		Config:    effectMatrixConfig{host: host},
+		OpenStore: func(context.Context, string) (OperationalStore, error) { return runStore, nil },
+		GitHub:    githubRuntime, Now: func() time.Time { return now },
+	}}
+
+	result, err := service.Resume(ctx, ResumeRequest{RunID: run.ID})
+	if err != nil {
+		t.Fatalf("Resume() error = %v, want check re-entry", err)
+	}
+	if result.Run.Status != store.StatusActive || runStore.run.Status != store.StatusActive {
+		t.Fatalf("resumed run = %#v, want active check", result.Run)
+	}
+	if len(runStore.saved) != 1 {
+		t.Fatalf("resume persistence count = %d, want one state transition", len(runStore.saved))
+	}
+	if got := githubRuntime.issue.Labels; len(got) != 1 || got[0] != github.LabelAgentRunning {
+		t.Fatalf("resumed issue labels = %#v, want agent-running", got)
+	}
+	if githubRuntime.statusComment.Body != statusCommentBody(runStore.run) {
+		t.Fatalf("resumed status comment = %q, want %q", githubRuntime.statusComment.Body, statusCommentBody(runStore.run))
+	}
+}
+
+// recoveryResumeStore supplies the small public resume seam without exposing
+// a visible invocation, allowing the test to detect an accidental fresh launch.
+type recoveryResumeStore struct {
+	run   store.Run
+	saved []store.Run
+}
+
+// CurrentRun returns the one recovery-paused run.
+func (s *recoveryResumeStore) CurrentRun(context.Context) (*store.Run, error) {
+	run := s.run
+	return &run, nil
+}
+
+// SaveRun records and persists the resumed run projection.
+func (s *recoveryResumeStore) SaveRun(_ context.Context, run store.Run) error {
+	s.run = run
+	s.saved = append(s.saved, run)
+	return nil
+}
+
+// ClaimLifecycleNotification satisfies the run-store notification seam.
+func (*recoveryResumeStore) ClaimLifecycleNotification(context.Context, string, store.Status) (bool, error) {
+	return true, nil
+}
+
+// ReleaseLifecycleNotification satisfies the run-store notification seam.
+func (*recoveryResumeStore) ReleaseLifecycleNotification(context.Context, string, store.Status) error {
+	return nil
+}
+
+// ActiveInvocation reports that check re-entry has no visible agent to launch.
+func (*recoveryResumeStore) ActiveInvocation(context.Context, string) (*store.Invocation, error) {
+	return nil, nil
+}
+
+// Close satisfies the operational-store seam.
+func (*recoveryResumeStore) Close() error { return nil }
+
+var _ RunStore = (*recoveryResumeStore)(nil)
+var _ ActiveInvocationStore = (*recoveryResumeStore)(nil)


### PR DESCRIPTION
Closes #82

## Summary

- Treats a completed implementation invocation as historical at the coordinator-owned `check` boundary, so a stopped worker or unavailable native-session inspection does not block gate recovery.
- Repairs the GitHub state label and status comment after a pending effect has been cleared, then re-runs the read-only diagnosis so the result reflects the repaired projections.
- Adds a guarded `factory resume` and `factory draft-pr` path for recovery-created `check/waiting_for_human` states. It re-enters coordinator-owned check evaluation and never launches a replacement implementation agent.
- Updates the operator documentation and adds regression coverage for stale projections, check re-entry, and eventual draft-PR publication.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

Unrelated pre-existing `docs/research/*` changes were left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery support for check stages paused during restart reconciliation.
  * `factory resume` can continue coordinator-owned checks without starting a replacement implementation agent.
  * Draft pull request processing can resume after eligible reconciliation pauses.

* **Bug Fixes**
  * Improved recovery of stale GitHub status projections after interrupted check transitions.
  * Added safeguards to keep unexpected pauses from resuming automatically.

* **Documentation**
  * Expanded recovery and command-reference guidance, including the required reconciliation/resume flow and lifecycle restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->