### PR TITLE
Fix terminal lifecycle recovery after PR merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,8 +976,10 @@ command for that newly claimed state. Use the one-shot
 <code>factory issue</code> path for a complete manually driven run, and treat
 new claims made by <code>factory start</code> as an operational limitation that
 requires inspection rather than as unattended end-to-end execution. The
-supervisor does recover an existing persisted run on startup when its restart
-diagnosis is clean.
+supervisor observes a tracked issue or pull request before restart
+reconciliation when no effect is pending. This lets an already-merged or closed
+target enter its terminal state even after GitHub deletes the run branch. An
+unchanged non-terminal run still requires a clean restart diagnosis.
 
 Likewise, <code>factory poll</code> is the explicit one-shot command for
 issue/PR lifecycle observation and structured GitHub command handling. This

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -325,13 +325,17 @@ The coordinator then fetches `origin/<target_branch>`, records that fetched comm
 
 The GitHub adapter invokes the locally authenticated `gh` CLI. The coordinator receives issue and mutation results in memory; GitHub credentials are not read into or persisted by the factory. `factory status` reports the active run's stage, status, branch, and worktree, or the latest terminal run when no run is active.
 
-Before any later coordinator command can progress a persisted non-terminal run,
-the new process reconciles the durable effect journal and compares the run
-identifier, registered repository, worktree, branch, checkpoint SHA, issue
-number and factory state label, marked status-comment identity, and persisted
-pull-request identity when present. A missing or mismatched projection is
-reported alongside every other discovered discrepancy and pauses the run for
-human disposition. A remote run branch whose head is an ancestor of the
+When no effect is pending, the lifecycle and supervisor entry points first
+observe a tracked issue or pull request, so an already-merged or closed target
+can enter its terminal state even when GitHub has deleted the run branch or
+only historical invocation infrastructure remains. Before an unchanged
+non-terminal run or any other coordinator command can progress, the new process
+reconciles the durable effect journal and compares the run identifier,
+registered repository, worktree, branch, checkpoint SHA, issue number and
+factory state label, marked status-comment identity, and persisted pull-request
+identity when present. A missing or mismatched projection is reported alongside
+every other discovered discrepancy and pauses the run for human disposition. A
+remote run branch whose head is an ancestor of the
 persisted checkpoint is not a discrepancy: a checkpoint is committed before the
 gate suite runs and pushed only afterward, so an unpushed commit is an
 ordinary in-flight state rather than a diverged branch. A journaled effect is

--- a/internal/factory/lifecycle.go
+++ b/internal/factory/lifecycle.go
@@ -72,20 +72,20 @@ func (s *Service) PollLifecycle(ctx context.Context, request LifecycleRequest) (
 	return result, nil
 }
 
-// openLifecycleRunStore opens the latest run without requiring non-terminal
-// projections to agree before GitHub can report an already-terminal outcome.
-// A pending effect still crosses the ordinary reconciliation boundary first,
-// because lifecycle terminalization must not replace an unresolved mutation.
+// openLifecycleRunStore opens the active run first, falling back to the latest
+// terminal projection only when no run is active. A pending effect still crosses
+// the ordinary reconciliation boundary first, because lifecycle terminalization
+// must not replace an unresolved mutation.
 func (s *Service) openLifecycleRunStore(ctx context.Context) (config.RepositoryRegistration, RunStore, *store.Run, error) {
 	registration, runStore, err := s.openRunStore(ctx)
 	if err != nil {
 		return config.RepositoryRegistration{}, nil, nil, err
 	}
-	var run *store.Run
-	if latestStore, ok := runStore.(LatestRunStore); ok {
-		run, err = latestStore.LatestRun(ctx)
-	} else {
-		run, err = runStore.CurrentRun(ctx)
+	run, err := runStore.CurrentRun(ctx)
+	if err == nil && run == nil {
+		if latestStore, ok := runStore.(LatestRunStore); ok {
+			run, err = latestStore.LatestRun(ctx)
+		}
 	}
 	if err != nil {
 		_ = runStore.Close()

--- a/internal/factory/lifecycle.go
+++ b/internal/factory/lifecycle.go
@@ -50,7 +50,7 @@ func (s *Service) PollLifecycle(ctx context.Context, request LifecycleRequest) (
 	s.commandMu.Lock()
 	defer s.commandMu.Unlock()
 
-	registration, runStore, run, err := s.openCommandRunStore(ctx)
+	registration, runStore, run, err := s.openLifecycleRunStore(ctx)
 	if err != nil {
 		return LifecycleResult{}, err
 	}
@@ -61,7 +61,53 @@ func (s *Service) PollLifecycle(ctx context.Context, request LifecycleRequest) (
 	if request.RunID != "" && request.RunID != run.ID {
 		return LifecycleResult{}, fmt.Errorf("latest run is %s, not %s", run.ID, request.RunID)
 	}
-	return s.observeLifecycle(ctx, registration, runStore, run)
+	result, err := s.observeLifecycle(ctx, registration, runStore, run)
+	if err != nil || result.Outcome != LifecycleUnchanged || store.IsTerminalStatus(result.Run.Status) {
+		return result, err
+	}
+	if err := s.ensureProgressionStartup(ctx, registration, runStore, run); err != nil {
+		return LifecycleResult{}, err
+	}
+	result.Run = *run
+	return result, nil
+}
+
+// openLifecycleRunStore opens the latest run without requiring non-terminal
+// projections to agree before GitHub can report an already-terminal outcome.
+// A pending effect still crosses the ordinary reconciliation boundary first,
+// because lifecycle terminalization must not replace an unresolved mutation.
+func (s *Service) openLifecycleRunStore(ctx context.Context) (config.RepositoryRegistration, RunStore, *store.Run, error) {
+	registration, runStore, err := s.openRunStore(ctx)
+	if err != nil {
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	var run *store.Run
+	if latestStore, ok := runStore.(LatestRunStore); ok {
+		run, err = latestStore.LatestRun(ctx)
+	} else {
+		run, err = runStore.CurrentRun(ctx)
+	}
+	if err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	journal, journaled := runStore.(PendingEffectStore)
+	if !journaled || run == nil {
+		return registration, runStore, run, nil
+	}
+	pending, err := journal.PendingEffect(ctx, run.ID)
+	if err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, fmt.Errorf("read pending effect before lifecycle observation: %w", err)
+	}
+	if pending == nil {
+		return registration, runStore, run, nil
+	}
+	if err := s.ensureProgressionStartup(ctx, registration, runStore, run); err != nil {
+		_ = runStore.Close()
+		return config.RepositoryRegistration{}, nil, nil, err
+	}
+	return registration, runStore, run, nil
 }
 
 // observeLifecycle applies one lifecycle decision against an already-open

--- a/internal/factory/lifecycle_test.go
+++ b/internal/factory/lifecycle_test.go
@@ -120,6 +120,39 @@ func TestPollLifecycleRetriesAFailedTerminalNotification(t *testing.T) {
 	}
 }
 
+// TestPollLifecyclePrefersAnActiveRunAfterTerminalNotificationRetry verifies
+// that a terminal notification retry cannot make its older run supersede an
+// active run selected by an explicit ID.
+func TestPollLifecyclePrefersAnActiveRunAfterTerminalNotificationRetry(t *testing.T) {
+	t.Parallel()
+
+	active := commandRun(t, store.StatusActive)
+	active.ID = "run-active"
+	terminal := commandRun(t, store.StatusComplete)
+	terminal.ID = "run-terminal"
+	terminal.LifecycleReason = "pull request #17 merged"
+	terminal.LifecycleNotificationSent = true
+	// A notification retry persists the older terminal run after the active run,
+	// so it is the latest projection while the active run remains current.
+	runStore := &commandRunStore{current: &active, latest: &terminal}
+	githubAdapter := &lifecycleGitHub{
+		commandGitHub: commandGitHub{issue: github.Issue{Number: active.IssueNumber, State: "closed", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: active.StatusCommentID}},
+	}
+	terminalRuntime := &lifecycleTerminal{}
+	service := newLifecycleService(runStore, githubAdapter, &lifecycleWorker{}, terminalRuntime)
+
+	result, err := service.PollLifecycle(context.Background(), factoryLifecycleRequest(active.ID))
+	if err != nil {
+		t.Fatalf("PollLifecycle() error = %v", err)
+	}
+	if result.Outcome != factory.LifecycleCancelled || result.Run.ID != active.ID || result.Run.Status != store.StatusCancelled {
+		t.Fatalf("lifecycle result = %#v, want cancelled active run %q", result, active.ID)
+	}
+	if len(terminalRuntime.notifications) != 1 || !strings.Contains(terminalRuntime.notifications[0].Body, active.ID) {
+		t.Fatalf("notifications = %#v, want one notification for active run %q", terminalRuntime.notifications, active.ID)
+	}
+}
+
 // TestPollLifecycleDoesNotResendAfterNotifySucceedsPersistFails verifies that
 // when notification delivery succeeds but the subsequent run save fails, a retry
 // does not send the notification again (the durable claim prevents duplicate delivery).

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -194,6 +194,21 @@ func (s *Service) reconcileRegisteredRun(ctx context.Context, registration confi
 	if err != nil {
 		return fmt.Errorf("read persisted run for startup reconciliation: %w", err)
 	}
+	if journal, journaled := runStore.(PendingEffectStore); journaled && run != nil {
+		pending, pendingErr := journal.PendingEffect(ctx, run.ID)
+		if pendingErr != nil {
+			return fmt.Errorf("read pending effect before startup lifecycle observation: %w", pendingErr)
+		}
+		if pending == nil {
+			lifecycle, lifecycleErr := s.observeLifecycle(ctx, registration, runStore, run)
+			if lifecycleErr != nil {
+				return fmt.Errorf("observe lifecycle before startup reconciliation: %w", lifecycleErr)
+			}
+			if lifecycle.Outcome != LifecycleUnchanged || store.IsTerminalStatus(lifecycle.Run.Status) {
+				return nil
+			}
+		}
+	}
 	return s.ensureAgentStartup(ctx, registration, runStore, run, AgentRequest{})
 }
 

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -620,12 +620,13 @@ func workerProjectionExpectedStopped(run store.Run, invocation store.Invocation)
 
 // terminalInvocationProjectionExpectedStopped reports the coordinator-owned
 // boundaries where a completed invocation is historical rather than live. A
-// human pause in another stage still inspects its terminal runtime identities.
+// draft pull request may retain a gate worker whose contract deliberately
+// differs from the earlier implementation invocation.
 func terminalInvocationProjectionExpectedStopped(run store.Run, invocation store.Invocation) bool {
 	if invocation.Status == store.InvocationStatusActive {
 		return false
 	}
-	if run.Stage == store.StageCheck && invocation.Stage == store.StageImplementation {
+	if (run.Stage == store.StageCheck || run.Stage == store.StageDraftPR) && invocation.Stage == store.StageImplementation {
 		return true
 	}
 	return run.Stage == store.StageReady

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -359,10 +360,10 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 // its newest persisted invocation is already terminal.
 func TestRecoveryInspectsTheLatestTerminalInvocation(t *testing.T) {
 	now := time.Unix(1, 0).UTC()
-	run := store.Run{ID: "run-terminal-projection", Stage: store.StageDraftPR, Status: store.StatusActive}
+	run := store.Run{ID: "run-terminal-projection", Stage: store.StageReview, Status: store.StatusActive}
 	invocation := store.Invocation{
 		ID: "inv-terminal-projection", RunID: run.ID, Harness: harness.NameCodex,
-		Role: "implementation", Stage: store.StageImplementation,
+		Role: "spec_review", Stage: store.StageReview,
 		NativeSessionID: "session-terminal-projection", WorkspaceID: "workspace-terminal-projection",
 		ImplementationSurfaceID: "surface-terminal-projection",
 		Status:                  store.InvocationStatusCompleted, CreatedAt: now, UpdatedAt: now,
@@ -430,6 +431,308 @@ func TestRecoveryAcceptsAStoppedWorkerAfterReadiness(t *testing.T) {
 	if len(diagnosis.Discrepancies) != 0 {
 		t.Fatalf("recovery discrepancies = %#v, want stopped worker accepted after readiness", diagnosis.Discrepancies)
 	}
+}
+
+// TestPollLifecycleCompletesAMergedRunBeforeRecovery verifies that a deleted
+// remote branch and historical worker projection cannot block the public
+// lifecycle seam from recording an already-merged pull request.
+func TestPollLifecycleCompletesAMergedRunBeforeRecovery(t *testing.T) {
+	fixture := newDraftPRRecoveryFixture(t, "run-poll-merged-before-recovery", 17, true, "")
+
+	result, err := fixture.lifecycleService().PollLifecycle(context.Background(), LifecycleRequest{RunID: fixture.run.ID})
+	if err != nil {
+		t.Fatalf("PollLifecycle() error = %v, want merged completion before recovery", err)
+	}
+	if result.Outcome != LifecycleCompleted || result.Run.Status != store.StatusComplete || result.Run.MergeCommitSHA != fixture.mergedSHA {
+		t.Fatalf("PollLifecycle() result = %#v, want completed run at merge %s", result, fixture.mergedSHA)
+	}
+	if fixture.worker.inspectCalls != 0 {
+		t.Fatalf("worker recovery inspections = %d, want lifecycle observation first", fixture.worker.inspectCalls)
+	}
+}
+
+// TestStartCompletesAMergedRunBeforeRecovery verifies the persistent
+// supervisor records an already-merged pull request before startup
+// reconciliation can reject its deleted remote branch.
+func TestStartCompletesAMergedRunBeforeRecovery(t *testing.T) {
+	fixture := newDraftPRRecoveryFixture(t, "run-start-merged-before-recovery", 18, true, "")
+	pollContext, cancel := context.WithCancel(context.Background())
+
+	if err := fixture.supervisorService(cancel).Start(pollContext); err != nil {
+		t.Fatalf("Start() error = %v, want merged completion before recovery", err)
+	}
+	latest := fixture.latestRun(t)
+	if latest.Status != store.StatusComplete || latest.MergeCommitSHA != fixture.mergedSHA {
+		t.Fatalf("latest run = %#v, want completed run at merge %s", latest, fixture.mergedSHA)
+	}
+	if fixture.workspace.remoteInspections != 0 {
+		t.Fatalf("remote recovery inspections = %d, want lifecycle observation first", fixture.workspace.remoteInspections)
+	}
+}
+
+// TestStartTreatsACompletedImplementationAsHistoricalAtDraftPR verifies an
+// open pull request can survive coordinator restart after its gate worker has
+// replaced the completed implementation worker projection.
+func TestStartTreatsACompletedImplementationAsHistoricalAtDraftPR(t *testing.T) {
+	fixture := newDraftPRRecoveryFixture(
+		t,
+		"run-start-open-draft-pr",
+		19,
+		false,
+		strings.Repeat("c", 40),
+	)
+	pollContext, cancel := context.WithCancel(context.Background())
+
+	if err := fixture.supervisorService(cancel).Start(pollContext); err != nil {
+		t.Fatalf("Start() error = %v, want open draft PR supervision", err)
+	}
+	if fixture.worker.inspectCalls != 0 {
+		t.Fatalf("historical implementation inspections = %d, want none at draft PR", fixture.worker.inspectCalls)
+	}
+}
+
+// draftPRRecoveryFixture contains one journaled draft-PR run and its external
+// projections for lifecycle-before-recovery tests.
+type draftPRRecoveryFixture struct {
+	databasePath string
+	run          store.Run
+	mergedSHA    string
+	github       *mergedRecoveryGitHub
+	workspace    *mergedRecoveryWorkspace
+	worker       *journalRecoveryWorker
+	host         config.HostConfig
+	now          time.Time
+}
+
+// newDraftPRRecoveryFixture persists one draft-PR run whose current worker has
+// gate mounts while its latest invocation is the completed implementation.
+func newDraftPRRecoveryFixture(t *testing.T, runID string, pullRequestNumber int, merged bool, remoteHead string) *draftPRRecoveryFixture {
+	t.Helper()
+	ctx := context.Background()
+	root := t.TempDir()
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(worktreePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	packetData, err := json.Marshal(SpecificationPacket{
+		Version: specificationPacketVersion,
+		Issue:   github.Issue{Number: 42, Title: "Draft PR recovery", Body: "observe lifecycle before recovery"},
+		RepositoryConfig: config.RepositoryConfig{
+			TargetBranch: "main",
+			WorkerBuild:  config.WorkerBuildConfig{Image: "ghcr.io/example/factory-worker"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 28, 13, pullRequestNumber, 0, 0, time.UTC)
+	checkpointSHA := strings.Repeat("c", 40)
+	run := store.Run{
+		ID: runID, RepositoryPath: root, IssueNumber: 42,
+		Stage: store.StageDraftPR, Status: store.StatusActive,
+		Branch: "factory/" + runID, Worktree: worktreePath,
+		CheckpointSHA: checkpointSHA, ImageDigest: journalRecoveryImageDigest,
+		StatusCommentID: "status-" + runID, PullRequestNumber: pullRequestNumber,
+		PullRequestURL:      fmt.Sprintf("https://github.com/example/project/pull/%d", pullRequestNumber),
+		SpecificationPacket: string(packetData), CreatedAt: now, UpdatedAt: now,
+	}
+	invocation := store.Invocation{
+		ID: "inv-" + runID, RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-" + runID, WorkspaceID: "workspace-" + runID,
+		StatusSurfaceID: "surface-status-" + runID, ImplementationSurfaceID: "surface-implementation-" + runID,
+		ChecksSurfaceID: "surface-checks-" + runID, Status: store.InvocationStatusCompleted,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	databasePath := filepath.Join(root, "state", "factory.db")
+	opened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SaveRun(ctx, run); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	mergedSHA := ""
+	pullRequestState := "open"
+	if merged {
+		mergedSHA = strings.Repeat("d", 40)
+		pullRequestState = "closed"
+	}
+	githubRuntime := &mergedRecoveryGitHub{
+		effectMatrixGitHub: &effectMatrixGitHub{
+			issue:         github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+			statusComment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(run)},
+		},
+		pullRequest: github.PullRequest{
+			Number: run.PullRequestNumber, URL: run.PullRequestURL, State: pullRequestState, Merged: merged,
+			MergeCommitSHA: mergedSHA, HeadBranch: run.Branch, BaseBranch: "main",
+		},
+	}
+	workspace := &mergedRecoveryWorkspace{
+		state:      gitadapter.WorktreeState{RepositoryPath: root, Branch: run.Branch, HeadSHA: checkpointSHA},
+		remoteHead: remoteHead,
+	}
+	workerRuntime := &journalRecoveryWorker{inspection: worker.Inspection{
+		Exists: true, Running: true, MountFingerprint: "gate-worker-mounts",
+	}}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path: root, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		Polling:             config.PollingConfig{Interval: "1ms", Backoff: "1ms"},
+		OperationalDataPath: databasePath, RepositoryConfigPath: filepath.Join(root, "factory.yaml"),
+	}}}
+	return &draftPRRecoveryFixture{
+		databasePath: databasePath, run: run, mergedSHA: mergedSHA,
+		github: githubRuntime, workspace: workspace, worker: workerRuntime,
+		host: host, now: now,
+	}
+}
+
+// lifecycleService constructs the public lifecycle seam for the fixture.
+func (f *draftPRRecoveryFixture) lifecycleService() *Service {
+	return NewWithDependencies("/host/config.yaml", f.dependencies())
+}
+
+// supervisorService constructs the persistent supervisor seam and cancels it
+// after the first lease renewal.
+func (f *draftPRRecoveryFixture) supervisorService(cancel context.CancelFunc) *Service {
+	dependencies := f.dependencies()
+	dependencies.LoadRepository = func(string) (config.RepositoryConfig, error) {
+		return config.RepositoryConfig{TargetBranch: "main"}, nil
+	}
+	dependencies.IssuePoller = &mergedRecoveryIssuePoller{}
+	dependencies.Lease = &mergedRecoveryLease{onRenew: cancel}
+	dependencies.StartupDiagnosis = func(context.Context) (DoctorResult, error) { return DoctorResult{}, nil }
+	return NewWithDependencies("/host/config.yaml", dependencies)
+}
+
+// dependencies returns the common real-store and external-boundary adapters.
+func (f *draftPRRecoveryFixture) dependencies() Dependencies {
+	return Dependencies{
+		Config: effectMatrixConfig{host: f.host},
+		OpenStore: func(ctx context.Context, path string) (OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		GitHub: f.github, PullRequests: f.github,
+		GitWorkspace: f.workspace, Worktree: f.workspace,
+		Worker: f.worker, Terminal: &journalRecoveryTerminal{},
+		Harness: &journalRecoveryHarness{}, Now: func() time.Time { return f.now.Add(time.Minute) },
+	}
+}
+
+// latestRun reads the public persisted run projection after supervisor exit.
+func (f *draftPRRecoveryFixture) latestRun(t *testing.T) store.Run {
+	t.Helper()
+	opened, err := store.Open(context.Background(), f.databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	latest, err := opened.LatestRun(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if latest == nil {
+		t.Fatal("LatestRun() = nil, want persisted run")
+	}
+	return *latest
+}
+
+// mergedRecoveryGitHub combines exact persisted issue state with a merged pull
+// request so public lifecycle tests exercise only external system boundaries.
+type mergedRecoveryGitHub struct {
+	*effectMatrixGitHub
+	pullRequest github.PullRequest
+}
+
+// FindPullRequest returns the tracked merged pull request.
+func (g *mergedRecoveryGitHub) FindPullRequest(context.Context, github.Repository, string, string) (github.PullRequest, error) {
+	return g.pullRequest, nil
+}
+
+// CreatePullRequest satisfies the lifecycle pull-request boundary.
+func (g *mergedRecoveryGitHub) CreatePullRequest(context.Context, github.Repository, github.PullRequestRequest) (github.PullRequest, error) {
+	return g.pullRequest, nil
+}
+
+// UpdatePullRequest satisfies the lifecycle pull-request boundary.
+func (g *mergedRecoveryGitHub) UpdatePullRequest(context.Context, github.Repository, int, github.PullRequestRequest) (github.PullRequest, error) {
+	return g.pullRequest, nil
+}
+
+// mergedRecoveryWorkspace exposes a valid local worktree and a deleted remote
+// run branch, matching GitHub's post-merge branch cleanup.
+type mergedRecoveryWorkspace struct {
+	state             gitadapter.WorktreeState
+	remoteHead        string
+	remoteInspections int
+}
+
+// Create satisfies the Git workspace seam.
+func (*mergedRecoveryWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	return gitadapter.Workspace{}, nil
+}
+
+// Remove satisfies the Git workspace seam.
+func (*mergedRecoveryWorkspace) Remove(context.Context, string, gitadapter.Workspace) error {
+	return nil
+}
+
+// Inspect returns the persisted local worktree projection.
+func (w *mergedRecoveryWorkspace) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	return w.state, nil
+}
+
+// CreateCheckpoint satisfies the Git workspace seam.
+func (*mergedRecoveryWorkspace) CreateCheckpoint(context.Context, gitadapter.CheckpointRequest) (gitadapter.CheckpointResult, error) {
+	return gitadapter.CheckpointResult{}, nil
+}
+
+// Push satisfies the Git workspace seam.
+func (*mergedRecoveryWorkspace) Push(context.Context, gitadapter.PushRequest) error { return nil }
+
+// SynchronizeBase satisfies the Git workspace seam.
+func (*mergedRecoveryWorkspace) SynchronizeBase(context.Context, gitadapter.BaseSyncRequest) error {
+	return nil
+}
+
+// RemoteBranchHead reports a deleted remote run branch.
+func (w *mergedRecoveryWorkspace) RemoteBranchHead(context.Context, gitadapter.PushRequest) (string, error) {
+	w.remoteInspections++
+	return w.remoteHead, nil
+}
+
+var _ gitadapter.GitWorkspace = (*mergedRecoveryWorkspace)(nil)
+var _ gitadapter.RemoteBranchInspector = (*mergedRecoveryWorkspace)(nil)
+
+// mergedRecoveryIssuePoller returns an empty eligible queue after terminal
+// lifecycle observation releases the completed run's active slot.
+type mergedRecoveryIssuePoller struct{}
+
+// ListEligibleIssues reports no queued work.
+func (*mergedRecoveryIssuePoller) ListEligibleIssues(context.Context, github.Repository) ([]github.Issue, error) {
+	return nil, nil
+}
+
+// mergedRecoveryLease cancels the supervisor after its first visible renewal.
+type mergedRecoveryLease struct {
+	onRenew context.CancelFunc
+}
+
+// RenewLease records no external state and stops the focused supervisor test.
+func (l *mergedRecoveryLease) RenewLease(context.Context, github.Repository, github.Lease) error {
+	if l.onRenew != nil {
+		l.onRenew()
+	}
+	return nil
 }
 
 // terminalProjectionStore exposes a latest terminal invocation while reporting


### PR DESCRIPTION
## Summary

- observe merged or closed tracked targets before non-terminal reconciliation when no effect is pending
- treat completed implementation invocations as historical in draft PR stage, where the retained worker may be gate-scoped
- preserve fail-closed pending-effect reconciliation and document the terminal-first exception

## Regression coverage

- `PollLifecycle` completes a merged run despite a deleted remote branch and historical worker/session projections
- `Start` completes the same merged run before startup reconciliation
- `Start` accepts an open draft PR with a retained gate worker instead of comparing it to the completed implementation invocation

## Verification

- `go test ./internal/factory -count=1`
- `go test ./... -count=1`
- `scripts/worker-go.sh vet ./...`
- `scripts/worker-go.sh build -o /tmp/factory-pr-terminal-lifecycle ./cmd/factory`
- `gofmt -l .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup and polling now recognize merged or closed issues and pull requests as terminal before attempting recovery.
  * Runs can complete correctly even when their branches or historical worker infrastructure are no longer available.
  * Completed implementation steps are handled correctly during draft pull-request recovery.
  * Pending changes continue to be reconciled before lifecycle status is evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->