### PR TITLE
Make implementation-owned TDD the fast default path

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,7 +22,7 @@ An immutable commit representing accepted work at a stage boundary and identifyi
 _Avoid_: Snapshot, latest code
 
 **Test-stage handoff**:
-The bounded acceptance coverage, changed test paths, focused red-test command, expected failure reason, observed failure evidence, infrastructure changes, uncovered criteria, and exemption state transferred from test to implementation.
+The required-mode transfer of bounded acceptance coverage, changed test paths, focused red-test command, expected failure reason, observed failure evidence, infrastructure changes, uncovered criteria, and exemption state from the independent test role to implementation. Advisory mode has no test-stage handoff.
 _Avoid_: Agent claim, transcript, implementation handoff
 
 **Protected test path**:
@@ -30,7 +30,7 @@ A repository-relative test or authorized test-infrastructure path recorded at th
 _Avoid_: Mutable test file, permitted production path
 
 **Baseline**:
-The repository-declared setup and gate suite evaluated against the claimed run's base checkpoint before any agent edit; a blocking failure moves the run to failed preflight unless the frozen issue explicitly targets it. A healthy configured run enters test stage before implementation.
+The repository-declared setup and gate suite evaluated against the claimed run's base checkpoint before any agent edit; a blocking failure moves the run to failed preflight unless the frozen issue explicitly targets it. A healthy required-mode run enters the independent test stage; a healthy advisory run enters implementation-owned TDD directly.
 _Avoid_: Preflight assumption, agent diagnosis
 
 **Setup fingerprint**:
@@ -117,7 +117,7 @@ An evidence-gathering delivery phase that compares the supervised factory with a
 _Avoid_: Production readiness, tracer bullet
 
 **Host configuration**:
-Host-local YAML that registers the one repository, its GitHub identity, authorized users, polling and cmux settings, and the external operational-data location.
+Host-local YAML that registers the one repository, its GitHub identity, authorized users, polling and terminal settings, and the external operational-data location.
 _Avoid_: Repository policy
 
 **Repository configuration**:

--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ frozen specification packet
         |
         | isolated branch/worktree + baseline gates
         v
-test -> implementation -> checkpoint gates -> draft PR -> specification review
-  |          |                 |                  |                |
-  |          |                 |                  |                +--> ready
-  |          |                 |                  +--> human review/merge
-  |          |                 +--> bounded check repair loop
-  |          +--> clarification, retry, or failure
-  +--> verified red-test handoff or authorized exemption
+required: test -> implementation -> checkpoint gates -> draft PR -> review
+             |          |                 |                  |          |
+             |          |                 |                  |          +--> ready
+             |          |                 |                  +--> human review/merge
+             |          |                 +--> bounded check repair loop
+             |          +--> clarification, retry, or failure
+             +--> verified red-test handoff or authorized exemption
+
+advisory: implementation-owned red/green/refactor -> checkpoint gates -> ...
 ~~~
 
 The coordinator owns workflow state, GitHub projections, worktrees, worker
@@ -90,9 +92,11 @@ operational store, GitHub comments, and the documentation.
 | **Reconciliation** | A deliberate restart pass that replays an exact pending effect or pauses for human inspection when external state is ambiguous. |
 
 There is only one active non-terminal run per registered repository. Stage and
-status are separate values. For example, <code>test/active</code> means the
-test stage is running, while <code>implementation/waiting_for_human</code>
-means implementation is paused for an operator.
+status are separate values. In required mode, <code>test/active</code> means the
+independent test stage is running; in advisory mode a healthy baseline enters
+<code>implementation/active</code> directly. In either mode,
+<code>implementation/waiting_for_human</code> means implementation is paused for
+an operator.
 
 ## Run lifecycle
 
@@ -105,7 +109,7 @@ cannot add arbitrary roles or redefine the transition graph in
 | --- | --- | --- |
 | <code>claim</code> | Coordinator | The issue, repository policy, target branch, run branch, worktree, and status projection are frozen. |
 | <code>preflight</code> | Coordinator | Setup and baseline gates run before an agent edits anything. |
-| <code>test</code> | <code>test</code> role | The agent adds a focused test or test infrastructure change. The coordinator reruns the focused command and accepts only verified red evidence. |
+| <code>test</code> (required mode) | <code>test</code> role | The independent agent adds a focused test or test infrastructure change. The coordinator reruns the focused command and accepts only verified red evidence. |
 | <code>architecture</code> | <code>architecture</code> role, optional | The agent writes a design document under the permitted architecture path, then hands off to implementation. |
 | <code>implementation</code> | <code>implementation</code> role | The agent edits production code and submits a structured implementation handoff. |
 | <code>check</code> | Coordinator | The accepted implementation is checkpointed and every configured gate runs against that exact checkpoint. |
@@ -113,18 +117,25 @@ cannot add arbitrary roles or redefine the transition graph in
 | <code>review</code> | <code>spec_review</code> role | An independent reviewer receives the exact checkpoint and reports blocking findings or advisories. |
 | <code>ready</code> | Coordinator | The run is ready for a human to review and merge. Factory leaves the pull request as a draft and does not merge it. |
 
-The test stage is required by the checked-in policy in this repository. It can
-be skipped only through an explicitly permitted human or technical exemption.
-The human exemption marker must be present in the frozen issue before claim:
+The checked-in policy uses advisory mode: after a healthy baseline, the
+implementation role owns the complete red/green/refactor loop. It may add or
+revise focused behavioral tests and essential test infrastructure within its
+permitted scope. There is no separate test invocation, handoff, checkpoint,
+protected-test path, exemption, or test-stage dispute in advisory mode.
+
+Repositories using required mode enter the independent test stage. That stage
+can be skipped only through an explicitly permitted human or technical
+exemption. The human exemption marker must be present in the frozen issue before
+claim:
 
 ~~~text
 <!-- factory-test-exemption: human | documentation-only change -->
 ~~~
 
-The test policy must allow that exemption. A test handoff never owns
-production files. Once accepted, its test checkpoint and protected test paths
-are carried into implementation, and an implementation report that changes a
-protected test path is rejected.
+The test policy must allow that exemption. In required mode, a test handoff never
+owns production files. Once accepted, its test checkpoint and protected test
+paths are carried into implementation, and an implementation report that changes
+a protected test path is rejected.
 
 Every stage also has an orthogonal status:
 
@@ -346,10 +357,13 @@ Its important current characteristics are:
 - blocking gates in dependency order: <code>format</code>,
   <code>vet</code>, <code>test</code>, <code>build</code>;
 - <code>clean</code> environment policy for setup and gates;
+- advisory <code>test_policy.mode</code>, so <code>implementation</code> owns
+  TDD by default (the independent <code>test</code> role remains available when
+  policy is switched to required);
 - configured <code>test</code>, <code>implementation</code>,
   <code>architecture</code>, <code>spec_review</code>, and
   <code>standards_review</code> role policy;
-- required test stage with human and technical exemptions enabled;
+- human and technical exemption settings retained for required-mode repositories;
 - a pinned worker image and digest; and
 - no automatic base synchronization
   (<code>base_synchronization.mode: never</code>).
@@ -455,8 +469,10 @@ Important policy rules:
   Claude Code use different native argument names and accepted effort values,
   so declare the values intended for the selected harness.
 - <code>test_policy.mode</code> is <code>required</code> or
-  <code>advisory</code>; the test role is still factory-owned and the
-  coordinator independently verifies a required red test before implementation.
+  <code>advisory</code>. Required mode uses the factory-owned test role and
+  independently verifies red evidence before implementation. Advisory mode
+  starts implementation after baseline and makes its complete TDD loop part of
+  the implementation handoff; it is not an exemption.
 - <code>allowed_overrides</code> can contain <code>model</code>,
   <code>reasoning_effort</code>, and <code>harness</code>. Keep this list narrow
   because it widens the frozen run policy at invocation time.
@@ -526,11 +542,12 @@ The command:
 6. creates one editable factory status comment; and
 7. runs the baseline setup and gates automatically.
 
-The output includes the run ID, branch, worktree, stage, status, and baseline
-gate count. Save the <code>run</code> value. A healthy run using this
-repository's policy normally becomes <code>test/active</code>. If a human
-exemption was frozen in the issue, it can become
-<code>implementation/active</code> instead.
+The output includes the run ID, branch, worktree, stage, status, test policy,
+and baseline gate count. Save the <code>run</code> value. With this repository's
+advisory policy, a healthy run normally becomes
+<code>implementation/active</code>. A required-mode repository normally becomes
+<code>test/active</code>; an authorized human exemption can move that run
+directly to <code>implementation/active</code>.
 
 The claim refuses closed issues, pull requests, issues without the exact
 <code>agent-ready</code> label, conflicting factory state, and a repository that
@@ -563,27 +580,29 @@ The invocation receives a read-only specification packet at
 at <code>/results</code>. The prompt and terminal content are not printed by
 the coordinator.
 
-With the current repository policy, the first invocation is the
-<code>test</code> role. Use the visible checks surface to add the focused test
-or test infrastructure, then submit a test report from inside that worker (see
-[Structured agent reports](#structured-agent-reports)). Accept it from the
+With this repository's advisory policy, the first invocation is the
+<code>implementation</code> role. Use the visible implementation surface to own
+the complete red/green/refactor loop, including a focused behavioral test when
+practical, then submit the common implementation report from inside that worker
+(see [Structured agent reports](#structured-agent-reports)). Accept it from the
 host:
 
 ~~~sh
 factory agent-report \
   --config /Users/me/.config/factory/config.yaml \
   --run-id <run-id> \
-  --invocation-id <test-invocation-id>
+  --invocation-id <implementation-invocation-id>
 ~~~
 
-For a completed test handoff, the coordinator independently reruns the focused
-test command. It requires a nonzero result and the expected failure reason in
-the command output. Once verified, it creates the test checkpoint, protects the
-reported test paths, and automatically starts a fresh implementation
-invocation. The accepted command output identifies the test invocation that was
-submitted; record the new implementation invocation ID from the newly created
-visible surface or its coordinator output before accepting the implementation
-report. Do not submit an implementation report using the test invocation ID.
+For a required-mode completed test handoff, the coordinator independently reruns
+the focused test command. It requires a nonzero result and the expected failure
+reason in the command output. Once verified, it creates the test checkpoint,
+protects the reported test paths, and automatically starts a fresh
+implementation invocation. The accepted command output identifies the test
+invocation that was submitted; record the new implementation invocation ID from
+the newly created visible surface or its coordinator output before accepting the
+implementation report. Do not submit an implementation report using the test
+invocation ID.
 
 If the test report requests clarification or cannot be verified, the run is
 paused for a human. Factory does not silently turn an unverifiable red test
@@ -647,8 +666,8 @@ factory draft-pr \
 
 The host coordinator:
 
-1. verifies that the worktree is still at the expected parent checkpoint and
-   that protected test paths are unchanged;
+1. verifies that the worktree is still at the expected parent checkpoint and,
+   for required-mode runs, that protected test paths are unchanged;
 2. creates an implementation checkpoint commit with a message containing
    <code>factory: implementation checkpoint &lt;run-id&gt;</code>;
 3. pushes <code>factory/&lt;run-id&gt;</code> so GitHub can resolve the checkpoint
@@ -773,7 +792,7 @@ Repeat <code>--acceptance</code>, <code>--production-file</code>,
 Keep evidence observable and concise. Do not put a transcript, chain of
 thought, or credentials in a report.
 
-### Test handoff
+### Required-mode test handoff
 
 Test reports use test-specific fields and must not report production paths:
 
@@ -1282,10 +1301,10 @@ baseline target is appropriate.
 
 Inspect the issue or PR status comment and run <code>factory status</code>. For
 a pending question, answer with the authorized
-<code>/factory answer ...</code> command. For a test dispute or review blocker,
-inspect the evidence and record an evaluation disposition if appropriate. For a
-recovery discrepancy, use <code>factory reconcile</code> and resolve the
-external state before continuing.
+<code>/factory answer ...</code> command. For a required-mode test dispute or
+review blocker, inspect the evidence and record an evaluation disposition if
+appropriate. For a recovery discrepancy, use <code>factory reconcile</code> and
+resolve the external state before continuing.
 
 ### The run is waiting for harness capacity or authentication
 
@@ -1303,8 +1322,8 @@ wait. A <code>check/waiting_for_human</code> run may continue only when its
 lifecycle reason begins with <code>restart reconciliation paused:</code>; use
 <code>factory reconcile</code> first, then <code>factory resume</code> or
 <code>factory draft-pr</code>. The worktree must be clean at the recorded
-checkpoint, and protected test paths must still match. Submit or correct the
-report first; do not create a manual checkpoint on the run branch.
+checkpoint, and required-mode protected test paths must still match. Submit or
+correct the report first; do not create a manual checkpoint on the run branch.
 
 ### The worker image does not match
 

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -59,11 +59,14 @@ factory agent \
 
 The command selects the active role automatically, together with the harness,
 model, and reasoning effort declared for that role. Only the credential source
-of the selected harness is used. For a repository with a
-configured `test` role, `factory issue` leaves a healthy run in `test/active`,
-and this command starts the test agent. An implementation agent is started only
-after the test handoff is accepted, or after an authorized exemption. The
-agent auth flags must name the same sources registered for the repository;
+of the selected harness is used. In `test_policy.mode: required`,
+`factory issue` leaves a healthy run in `test/active`, and this command starts
+the independent test agent; implementation starts only after its handoff is
+accepted or after an authorized exemption. In `test_policy.mode: advisory`,
+the healthy baseline leaves the run in `implementation/active` and this command
+starts implementation directly. The implementation prompt owns the complete
+red/green/refactor loop in advisory mode, including focused behavioral tests.
+The agent auth flags must name the same sources registered for the repository;
 distinct one-off sources are refused because recovery never persists host
 credential paths. Change the registered source with `factory register` instead.
 The command creates or reuses the control workspace and creates one run workspace
@@ -77,8 +80,9 @@ handles. It does not print the role prompt or terminal contents.
 
 `factory issue` completes a claim, runs the frozen baseline suite, and persists
 the worktree, branch, checkpoint, issue projection, and status-comment identity.
-A validated repository advances to `test/active`. A separate coordinator process may
-start the first test or implementation invocation when its
+A required-mode repository advances to `test/active`; an advisory repository
+advances to `implementation/active`. A separate coordinator process may start
+the first test or implementation invocation when its
 read-only recovery diagnosis finds that every checked projection agrees and
 the operational store contains no invocation history. This is a completed
 claim or test handoff awaiting its first invocation, not an interrupted run.
@@ -134,10 +138,12 @@ adapter.
 
 Each invocation receives a read-only `specification.json` packet under the
 worker path `/invocation`. It contains the frozen claim packet, invocation
-identity, role, stage, and prompt version. An implementation packet also carries
-the accepted test handoff and content hashes of protected test paths. The worker
-receives a separate writable `/results` mount containing only that invocation's
-result directory.
+identity, role, stage, prompt version, and `test_policy_mode`. A required-mode
+implementation packet also carries the accepted test handoff and content hashes
+of protected test paths. An advisory implementation packet carries no test-stage
+disposition; its normal implementation handoff may include behavioral tests and
+test infrastructure. The worker receives a separate writable `/results` mount
+containing only that invocation's result directory.
 
 The harness reports through the worker-image command:
 
@@ -171,8 +177,8 @@ The three valid proposals are:
 - `needs_clarification`, with one or more uniquely identified questions;
 - `cannot_proceed`, with concise observable evidence.
 
-Test-stage completion uses a separate handoff and never accepts production
-paths. For example:
+In required mode, test-stage completion uses a separate handoff and never
+accepts production paths. For example:
 
 ```sh
 factory-report \
@@ -192,10 +198,10 @@ command, worker failure, missing expected reason, or path-ownership dispute move
 the coordinator records only the content-free `test_dispute` evaluation
 category and does not revise the test automatically.
 
-On verified red evidence, the coordinator creates a distinct test checkpoint,
-records every changed test/infrastructure path and its SHA-256 content hash,
-then launches implementation. Implementation report acceptance rechecks those
-hashes and rejects any direct edit to a protected test path.
+On verified red evidence in required mode, the coordinator creates a distinct
+test checkpoint, records every changed test/infrastructure path and its SHA-256
+content hash, then launches implementation. Implementation report acceptance
+rechecks those hashes and rejects any direct edit to a protected test path.
 
 ## Specification review
 
@@ -223,8 +229,8 @@ readiness. Taste and scope findings remain visible advisories. The coordinator
 attaches the stable `factory/review/specification` Commit Status to the exact
 reviewed SHA and invalidates the durable review projection when the checkpoint
 changes. Accepted findings appear in both the editable issue status comment and
-the generated pull-request review section. A technical test exemption remains
-marked provisional in the review packet and projections.
+the generated pull-request review section. A technical test exemption in
+required mode remains marked provisional in the review packet and projections.
 
 Human skips must be frozen in the issue before claim with an exact marker:
 
@@ -232,9 +238,10 @@ Human skips must be frozen in the issue before claim with an exact marker:
 <!-- factory-test-exemption: human | documentation-only change -->
 ```
 
-The repository must allow human exemptions. Technical exemptions may be
-reported by the test agent only when policy allows them; they are provisional
-and are carried to later review.
+The repository must allow human exemptions for required-mode skips. Technical
+exemptions may be reported by the required-mode test agent only when policy
+allows them; they are provisional and are carried to later review. Advisory
+implementation reports do not use test-stage exemptions or disputes.
 
 When the harness has reliable measurements or content-free policy signals, it
 may also pass `--input-tokens`, `--output-tokens`, `--total-tokens`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,7 +170,7 @@ evaluation:
   retention: 720h
 ```
 
-The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies (including the mandatory `test` role), optional `reasoning_effort_options` for declared roles, positive durations, positive retry limits, test policy, supported test-role prefixes, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, base-synchronization mode, and optional positive `evaluation.retention`. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. `test_policy.test_paths` and `test_policy.infrastructure_paths` authorize additional repository-relative paths for the test role; conventional `*_test.go`, `test/`, `tests/`, `test-support/`, and `__tests__/` paths are allowed by default. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
+The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies, the mandatory `test` role when `test_policy.mode` is `required`, optional `reasoning_effort_options` for declared roles, positive durations, positive retry limits, test policy, supported test-role prefixes, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, base-synchronization mode, and optional positive `evaluation.retention`. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. `test_policy.test_paths` and `test_policy.infrastructure_paths` authorize additional repository-relative paths for the independent test role; conventional `*_test.go`, `test/`, `tests/`, `test-support/`, and `__tests__/` paths are allowed by default. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
 
 ## Per-role harness, model, and reasoning effort
 
@@ -228,11 +228,21 @@ rejection, so a comment cannot inject a process argument into a launched
 harness. The recorded choice is still validated against the frozen repository
 policy when the next invocation starts.
 
-The test stage is default-on for both supported `test_policy.mode` values.
-A human skip requires `allow_human_exemption: true` and the frozen issue marker
-`<!-- factory-test-exemption: human | justification -->`. The test checkpoint
-and implementation checkpoint are separate commits; the operational store
-retains the test handoff and protected-path hashes between them.
+`test_policy.mode: required` enables the independent test role. A required-mode
+run enters `test/active`, verifies coordinator-rerun red evidence, creates a
+separate test checkpoint, and protects the accepted test paths before
+implementation. A human skip additionally requires
+`allow_human_exemption: true` and the frozen issue marker
+`<!-- factory-test-exemption: human | justification -->`; technical skips are
+still provisional and policy-controlled.
+
+`test_policy.mode: advisory` is the implementation-owned TDD path. A healthy
+baseline moves directly to `implementation/active`; there is no separate test
+invocation, handoff, checkpoint, protected-test path, exemption, or test-stage
+dispute. The implementation prompt owns the complete red/green/refactor loop,
+including focused behavioral tests and essential test infrastructure within its
+permitted scope. Deterministic gates and exact-checkpoint specification review
+remain unchanged in both modes.
 
 ## Worker image build and digest pinning
 

--- a/factory.yaml
+++ b/factory.yaml
@@ -49,7 +49,7 @@ retry_limits:
   review_repair: 2
   test_revision: 2
 test_policy:
-  mode: required
+  mode: advisory
   allow_human_exemption: true
   allow_technical_exemption: true
 allowed_overrides: [model, reasoning_effort]

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -353,14 +353,15 @@ func runIssue(ctx context.Context, args []string, defaultConfigPath string, outp
 		writeError(errorsOutput, err)
 		return 1
 	}
-	if !writeOutput(output, errorsOutput, "claimed issue #%d\nrun: %s\nbranch: %s\nworktree: %s\nstage: %s\nstatus: %s\nbaseline gates: %d\n", baseline.Run.IssueNumber, baseline.Run.ID, baseline.Run.Branch, baseline.Run.Worktree, baseline.Run.Stage, baseline.Run.Status, len(baseline.Gates)) {
+	policyMode := result.Packet.RepositoryConfig.TestPolicy.Mode
+	if !writeOutput(output, errorsOutput, "claimed issue #%d\nrun: %s\nbranch: %s\nworktree: %s\nstage: %s\nstatus: %s\ntest policy: %s\nbaseline gates: %d\n", baseline.Run.IssueNumber, baseline.Run.ID, baseline.Run.Branch, baseline.Run.Worktree, baseline.Run.Stage, baseline.Run.Status, factory.TestPolicyDescription(policyMode), len(baseline.Gates)) {
 		return 1
 	}
 	return 0
 }
 
-// runAgent starts the visible agent for the active run, selecting the required
-// test stage automatically when the frozen repository policy declares it.
+// runAgent starts the visible agent for the active run, selecting the frozen
+// policy's independent test stage or implementation-owned TDD path.
 func runAgent(ctx context.Context, args []string, defaultConfigPath string, output, errorsOutput io.Writer) int {
 	flags := flag.NewFlagSet("agent", flag.ContinueOnError)
 	flags.SetOutput(errorsOutput)
@@ -401,7 +402,7 @@ func runAgent(ctx context.Context, args []string, defaultConfigPath string, outp
 	if agentSurfaceID == "" {
 		agentSurfaceID = launch.Invocation.ImplementationSurfaceID
 	}
-	message := fmt.Sprintf("agent started\nrun: %s\nrole: %s\nstage: %s\ninvocation: %s\nworkspace: %s\nagent surface: %s\n", launch.Invocation.RunID, launch.Invocation.Role, launch.Invocation.Stage, launch.Invocation.ID, launch.Invocation.WorkspaceID, agentSurfaceID)
+	message := fmt.Sprintf("agent started\nrun: %s\nrole: %s\nstage: %s\ntest policy: %s\ninvocation: %s\nworkspace: %s\nagent surface: %s\n", launch.Invocation.RunID, launch.Invocation.Role, launch.Invocation.Stage, factory.TestPolicyDescription(launch.TestPolicyMode), launch.Invocation.ID, launch.Invocation.WorkspaceID, agentSurfaceID)
 	if launch.Invocation.ChecksSurfaceID != "" {
 		message += fmt.Sprintf("checks surface: %s\n", launch.Invocation.ChecksSurfaceID)
 	}
@@ -655,7 +656,7 @@ func runStatus(ctx context.Context, args []string, defaultConfigPath string, out
 		if store.IsTerminalStatus(result.LatestRun.Status) {
 			label = "last run"
 		}
-		if !writeOutput(output, errorsOutput, "%s: %s (stage=%s status=%s branch=%s worktree=%s)\n", label, result.LatestRun.ID, result.LatestRun.Stage, result.LatestRun.Status, result.LatestRun.Branch, result.LatestRun.Worktree) {
+		if !writeOutput(output, errorsOutput, "%s: %s (stage=%s status=%s test_policy=%s branch=%s worktree=%s)\n", label, result.LatestRun.ID, result.LatestRun.Stage, result.LatestRun.Status, factory.TestPolicyDescription(result.TestPolicyMode), result.LatestRun.Branch, result.LatestRun.Worktree) {
 			return 1
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -493,11 +493,16 @@ func ValidateRepository(config RepositoryConfig) error {
 			}
 		}
 	}
-	if _, exists := config.RoleHarnessDefaults["test"]; !exists {
-		return validation("role_harness_defaults.test", "must declare the mandatory test role")
+	if config.TestPolicy.Mode != TestModeRequired && config.TestPolicy.Mode != TestModeAdvisory {
+		return validation("test_policy.mode", "must be required or advisory")
 	}
-	if _, exists := config.ModelOptions["test"]; !exists {
-		return validation("model_options.test", "must declare a model for the mandatory test role")
+	if config.TestPolicy.Mode == TestModeRequired {
+		if _, exists := config.RoleHarnessDefaults["test"]; !exists {
+			return validation("role_harness_defaults.test", "must declare the mandatory test role in required mode")
+		}
+		if _, exists := config.ModelOptions["test"]; !exists {
+			return validation("model_options.test", "must declare a model for the mandatory test role in required mode")
+		}
 	}
 	for field, value := range map[string]string{
 		"timeouts.setup":  config.Timeouts.Setup,
@@ -520,9 +525,6 @@ func ValidateRepository(config RepositoryConfig) error {
 		if field == "retry_limits.check_repair" && value > MaxCheckRepairAttempts {
 			return validation(field, fmt.Sprintf("must not exceed %d", MaxCheckRepairAttempts))
 		}
-	}
-	if config.TestPolicy.Mode != TestModeRequired && config.TestPolicy.Mode != TestModeAdvisory {
-		return validation("test_policy.mode", "must be required or advisory")
 	}
 	if err := validateTestPolicyPaths("test_policy.test_paths", config.TestPolicy.TestPaths); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -128,8 +128,8 @@ func TestValidateRepositoryRequiresMatchingHarnessAndModelRoles(t *testing.T) {
 	}
 }
 
-// TestValidateRepositoryRequiresTheMandatoryTestRole verifies a repository
-// cannot silently opt out of the default test-stage boundary.
+// TestValidateRepositoryRequiresTheMandatoryTestRole verifies required mode
+// cannot silently opt out of the independent test-stage boundary.
 func TestValidateRepositoryRequiresTheMandatoryTestRole(t *testing.T) {
 	t.Parallel()
 
@@ -143,6 +143,20 @@ func TestValidateRepositoryRequiresTheMandatoryTestRole(t *testing.T) {
 	}
 	if validationErr.Field != "role_harness_defaults.test" {
 		t.Fatalf("field = %q, want role_harness_defaults.test", validationErr.Field)
+	}
+}
+
+// TestValidateRepositoryAllowsAdvisoryModeWithoutAnIndependentTestRole
+// verifies implementation-owned TDD does not require an unused test role.
+func TestValidateRepositoryAllowsAdvisoryModeWithoutAnIndependentTestRole(t *testing.T) {
+	t.Parallel()
+
+	policy := validRepositoryConfig()
+	policy.TestPolicy.Mode = config.TestModeAdvisory
+	delete(policy.RoleHarnessDefaults, "test")
+	delete(policy.ModelOptions, "test")
+	if err := config.ValidateRepository(policy); err != nil {
+		t.Fatalf("ValidateRepository() error = %v, want advisory policy without test role to be valid", err)
 	}
 }
 

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -69,6 +69,9 @@ type AgentLaunchResult struct {
 	Invocation store.Invocation
 	// Prompt is returned for operator diagnostics and is not persisted as a transcript.
 	Prompt string
+	// TestPolicyMode identifies whether this invocation belongs to an
+	// implementation-owned or independently staged TDD workflow.
+	TestPolicyMode config.TestMode
 }
 
 // AgentReportRequest selects a previously launched invocation for acceptance.
@@ -106,6 +109,8 @@ type InvocationPacket struct {
 	SpecificationPacket string `json:"specification_packet"`
 	// PromptVersion identifies the versioned core prompt.
 	PromptVersion string `json:"prompt_version"`
+	// TestPolicyMode identifies the frozen TDD ownership mode for this invocation.
+	TestPolicyMode config.TestMode `json:"test_policy_mode"`
 	// PermittedPaths lists repository-relative prefixes the coordinator will
 	// accept in the completed handoff.
 	PermittedPaths []string `json:"permitted_paths"`
@@ -128,8 +133,8 @@ const (
 	// packet shape retained for restart recovery.
 	invocationPacketMinimumSupportedVersion = 1
 	// invocationPacketVersion identifies the read-only invocation packet shape.
-	// Version four adds the independent-review context projection.
-	invocationPacketVersion = 4
+	// Version five adds the frozen TDD ownership projection.
+	invocationPacketVersion = 5
 	// invocationPacketFileName is the stable worker-visible packet filename.
 	invocationPacketFileName = "specification.json"
 )
@@ -294,6 +299,12 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
 	if err != nil {
 		return AgentResult{}, fmt.Errorf("decode specification packet for agent report: %w", err)
+	}
+	if isTestInvocation && packet.RepositoryConfig.TestPolicy.Mode == config.TestModeAdvisory {
+		return AgentResult{}, errors.New("test-stage reports are unavailable in advisory mode; implementation owns TDD")
+	}
+	if err := validateAdvisoryImplementationSignals(value, *invocation, packet); err != nil {
+		return AgentResult{}, err
 	}
 	validationContext.TestPaths = packet.RepositoryConfig.TestPolicy.TestPaths
 	validationContext.TestInfrastructurePaths = packet.RepositoryConfig.TestPolicy.InfrastructurePaths
@@ -809,12 +820,21 @@ func selectAgentRole(run store.Run, request AgentRequest) (AgentRequest, error) 
 // stage from re-entering test or implementation without a matching baseline
 // projection for that exact checkpoint.
 func (s *Service) ensureTransitionBaseline(ctx context.Context, runStore RunStore, run store.Run, request TransitionRequest) error {
-	if run.Stage != store.StageCheck || (request.Stage != store.StageTest && request.Stage != store.StageImplementation) {
+	if request.Stage != store.StageTest && request.Stage != store.StageImplementation {
 		return nil
 	}
 	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
 	if err != nil {
 		return fmt.Errorf("validate baseline before %q transition: %w", request.Stage, err)
+	}
+	if run.Stage == store.StageClaim && request.Stage == store.StageImplementation && packet.RepositoryConfig.TestPolicy.Mode == config.TestModeAdvisory {
+		if err := s.ensureBaselineReady(ctx, runStore, run, packet); err != nil {
+			return fmt.Errorf("cannot transition from claim to implementation without complete baseline results: %w", err)
+		}
+		return nil
+	}
+	if run.Stage != store.StageCheck {
+		return nil
 	}
 	if err := s.ensureBaselineReadyAtCheckpoint(ctx, runStore, run, packet, run.CheckpointSHA); err != nil {
 		return fmt.Errorf("cannot transition from check to %q at checkpoint %q without complete baseline results: %w", request.Stage, run.CheckpointSHA, err)

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -55,7 +55,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 			}
 			if !s.invocationStartedHere(active.ID) && active.RecoveryResumeCount > 0 {
 				s.markInvocationStarted(active.ID)
-				return AgentLaunchResult{Invocation: *active}, nil
+				return AgentLaunchResult{Invocation: *active, TestPolicyMode: testPolicyModeForRun(*run)}, nil
 			}
 			return AgentLaunchResult{}, fmt.Errorf("run %q already has active invocation %q", run.ID, active.ID)
 		}
@@ -115,7 +115,10 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 			return AgentLaunchResult{}, fmt.Errorf("publish pending specification review status: %w", err)
 		}
 	}
-	if roleDefinition.RequiresTestHandoff && run.Stage == store.StageClaim && !run.TestStageSkipped {
+	if roleDefinition.Kind == workflow.RoleKindTest && packet.RepositoryConfig.TestPolicy.Mode == config.TestModeAdvisory {
+		return AgentLaunchResult{}, errors.New("test role is unavailable in advisory mode; implementation owns TDD")
+	}
+	if roleDefinition.RequiresTestHandoff && packet.RepositoryConfig.TestPolicy.Mode == config.TestModeRequired && run.Stage == store.StageClaim && !run.TestStageSkipped {
 		return AgentLaunchResult{}, errors.New("implementation agent cannot bypass the configured test stage")
 	}
 	policy, err := resolveAgentPolicy(packet.RepositoryConfig, request)
@@ -155,6 +158,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		Stage:               stage,
 		SpecificationPacket: run.SpecificationPacket,
 		PromptVersion:       roleDefinition.PromptVersion,
+		TestPolicyMode:      packet.RepositoryConfig.TestPolicy.Mode,
 		PermittedPaths:      append([]string(nil), request.PermittedPaths...),
 		TestHandoff:         run.TestHandoff,
 		ProtectedTestPaths:  append([]store.ProtectedTestPath(nil), run.ProtectedTestPaths...),
@@ -168,6 +172,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		Stage:                   string(stage),
 		SpecificationPacket:     run.SpecificationPacket,
 		RepositoryGuidance:      packet.Issue.Body,
+		TestPolicyMode:          string(packet.RepositoryConfig.TestPolicy.Mode),
 		TestHandoff:             run.TestHandoff,
 		ProtectedTestPaths:      run.ProtectedTestPaths,
 		TestExemption:           run.TestExemption,
@@ -395,7 +400,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		}
 	}
 	s.markInvocationStarted(invocation.ID)
-	return AgentLaunchResult{Invocation: invocation, Prompt: promptText}, nil
+	return AgentLaunchResult{Invocation: invocation, Prompt: promptText, TestPolicyMode: packet.RepositoryConfig.TestPolicy.Mode}, nil
 }
 
 // resumePersistedInvocation restores one active invocation after a coordinator
@@ -520,6 +525,7 @@ func promptForPersistedInvocation(run store.Run, invocation store.Invocation, pa
 		Stage:                   string(invocation.Stage),
 		SpecificationPacket:     run.SpecificationPacket,
 		RepositoryGuidance:      packet.Issue.Body,
+		TestPolicyMode:          string(packet.RepositoryConfig.TestPolicy.Mode),
 		TestHandoff:             persisted.TestHandoff,
 		ProtectedTestPaths:      persisted.ProtectedTestPaths,
 		TestExemption:           persisted.TestExemption,
@@ -575,6 +581,15 @@ func validatePersistedInvocationPacket(run store.Run, invocation store.Invocatio
 	}
 	if invocation.PromptVersion != "" && persisted.PromptVersion != invocation.PromptVersion {
 		return errors.New("persisted invocation packet prompt version does not match the invocation")
+	}
+	if persisted.TestPolicyMode != "" {
+		packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+		if err != nil {
+			return fmt.Errorf("decode persisted invocation test policy: %w", err)
+		}
+		if persisted.TestPolicyMode != packet.RepositoryConfig.TestPolicy.Mode {
+			return errors.New("persisted invocation packet test policy does not match the frozen repository policy")
+		}
 	}
 	if invocation.Role == workflow.RoleSpecificationReview {
 		if persisted.ReviewContext == nil {

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -44,7 +44,7 @@ func TestStartAgentPersistsAReadOnlyPacketAndRecoverableSurfaceState(t *testing.
 	if err := json.Unmarshal(packetData, &packet); err != nil {
 		t.Fatalf("decode invocation packet: %v", err)
 	}
-	if packet.InvocationID != launch.Invocation.ID || packet.SpecificationPacket == "" || packet.PromptVersion != "implementation-v1" {
+	if packet.InvocationID != launch.Invocation.ID || packet.SpecificationPacket == "" || packet.PromptVersion != "implementation-v1" || packet.TestPolicyMode != config.TestModeRequired {
 		t.Fatalf("invocation packet = %#v, want frozen identity and prompt version", packet)
 	}
 	if len(terminalRuntime.notifications) != 1 || len(harnessRuntime.starts) != 1 {
@@ -52,6 +52,105 @@ func TestStartAgentPersistsAReadOnlyPacketAndRecoverableSurfaceState(t *testing.
 	}
 	if len(runStore.invocations) != 1 || runStore.invocations[launch.Invocation.ID].Status != store.InvocationStatusActive {
 		t.Fatalf("stored invocations = %#v, want active invocation", runStore.invocations)
+	}
+}
+
+// TestAdvisoryImplementationOwnsTDDAndAcceptsTestEdits verifies advisory mode
+// launches implementation directly and accepts behavioral tests as part of the
+// implementation handoff without test-stage evidence or an exemption.
+func TestAdvisoryImplementationOwnsTDDAndAcceptsTestEdits(t *testing.T) {
+	service, runStore, _, _, _ := newAgentService(t)
+	run := *runStore.current
+	var packet factory.SpecificationPacket
+	if err := json.Unmarshal([]byte(run.SpecificationPacket), &packet); err != nil {
+		t.Fatalf("decode specification packet: %v", err)
+	}
+	packet.RepositoryConfig.TestPolicy.Mode = config.TestModeAdvisory
+	delete(packet.RepositoryConfig.RoleHarnessDefaults, "test")
+	delete(packet.RepositoryConfig.ModelOptions, "test")
+	packetData, err := json.Marshal(packet)
+	if err != nil {
+		t.Fatalf("encode advisory specification packet: %v", err)
+	}
+	run.SpecificationPacket = string(packetData)
+	run.Stage = store.StageImplementation
+	run.TestStageSkipped = false
+	run.TestExemption = nil
+	run.TestHandoff = nil
+	run.TestCheckpointSHA = ""
+	run.ProtectedTestPaths = nil
+	runStore.worktree.state.ChangedPaths = []string{"internal/factory/agent_test.go", "test-support/factory-fixture.go", "internal/factory/agent.go"}
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("persist advisory implementation fixture: %v", err)
+	}
+
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() advisory error = %v", err)
+	}
+	if launch.Invocation.Role != "implementation" || launch.Invocation.Stage != store.StageImplementation || launch.TestPolicyMode != config.TestModeAdvisory || len(runStore.invocations) != 1 {
+		t.Fatalf("advisory launch = %#v, invocations=%d, want one implementation invocation", launch, len(runStore.invocations))
+	}
+	packetData, err = os.ReadFile(filepath.Join(launch.Invocation.InvocationDirectory, "specification.json"))
+	if err != nil {
+		t.Fatalf("read advisory invocation packet: %v", err)
+	}
+	var invocationPacket factory.InvocationPacket
+	if err := json.Unmarshal(packetData, &invocationPacket); err != nil {
+		t.Fatalf("decode advisory invocation packet: %v", err)
+	}
+	if invocationPacket.TestPolicyMode != config.TestModeAdvisory || invocationPacket.TestHandoff != nil || invocationPacket.TestExemption != nil || len(invocationPacket.ProtectedTestPaths) != 0 {
+		t.Fatalf("advisory invocation packet = %#v, want implementation-owned policy without test disposition", invocationPacket)
+	}
+	for _, marker := range []string{"Implementation-owned TDD:", "red/green/refactor", "focused behavioral test"} {
+		if !strings.Contains(launch.Prompt, marker) {
+			t.Fatalf("advisory implementation prompt missing %q:\n%s", marker, launch.Prompt)
+		}
+	}
+
+	value := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  launch.Invocation.ID,
+		RunID:         launch.Invocation.RunID,
+		Harness:       launch.Invocation.Harness,
+		Role:          launch.Invocation.Role,
+		Stage:         string(launch.Invocation.Stage),
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "implementation complete with focused behavior test",
+		Handoff: &report.Handoff{
+			ChangeSummary:          "implemented behavior and its focused test",
+			AcceptanceMapping:      []report.AcceptanceMapping{{Criterion: "behavior", Evidence: "focused test"}},
+			ProductionFilesChanged: []string{"internal/factory/agent_test.go", "test-support/factory-fixture.go", "internal/factory/agent.go"},
+			FocusedCommands:        []string{"go test ./internal/factory -run TestBehavior"},
+		},
+		NativeSessionID: "advisory-session",
+		ReportedAt:      time.Now().UTC(),
+	}
+	invalid := value
+	invalid.Exemptions = []report.Exemption{report.ExemptionTechnical}
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, invalid); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() invalid advisory error = %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: launch.Invocation.ID}); err == nil || !strings.Contains(err.Error(), "test-stage exemptions") {
+		t.Fatalf("AcceptAgentReport() invalid advisory error = %v, want test-stage exemption rejection", err)
+	}
+	invalid.Exemptions = nil
+	invalid.Escalations = []report.EscalationCategory{report.EscalationTestDispute}
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, invalid); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() invalid advisory dispute error = %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: launch.Invocation.ID}); err == nil || !strings.Contains(err.Error(), "test-stage disputes") {
+		t.Fatalf("AcceptAgentReport() invalid advisory dispute error = %v, want test-stage dispute rejection", err)
+	}
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, value); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() advisory error = %v", err)
+	}
+	accepted, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: launch.Invocation.ID})
+	if err != nil {
+		t.Fatalf("AcceptAgentReport() advisory error = %v", err)
+	}
+	if accepted.Invocation.Status != store.InvocationStatusCompleted || runStore.current.TestStageSkipped || runStore.current.TestExemption != nil || runStore.current.TestHandoff != nil {
+		t.Fatalf("advisory accepted projection = invocation %#v run %#v, want completed implementation without test disposition", accepted.Invocation, runStore.current)
 	}
 }
 

--- a/internal/factory/baseline_test.go
+++ b/internal/factory/baseline_test.go
@@ -66,6 +66,57 @@ func TestRunBaselineAdvancesToTheConfiguredTestStage(t *testing.T) {
 	}
 }
 
+// TestRunBaselineStartsImplementationOwnedTDDInAdvisoryMode verifies advisory
+// mode advances directly to implementation without creating test-stage state.
+func TestRunBaselineStartsImplementationOwnedTDDInAdvisoryMode(t *testing.T) {
+	fixture := newBaselineFixture(t, "<!-- factory-test-exemption: human | documentation-only change -->", []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}})
+	fixture.policy.TestPolicy.Mode = config.TestModeAdvisory
+	fixture.policy.TestPolicy.AllowHumanExemption = true
+	delete(fixture.policy.RoleHarnessDefaults, "test")
+	delete(fixture.policy.ModelOptions, "test")
+	claimed, err := fixture.service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+
+	baseline, err := fixture.service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID})
+	if err != nil {
+		t.Fatalf("RunBaseline() error = %v", err)
+	}
+	if baseline.Run.Stage != store.StageImplementation || baseline.Run.Status != store.StatusActive {
+		t.Fatalf("baseline run = %#v, want active implementation stage", baseline.Run)
+	}
+	if baseline.Run.TestStageSkipped || baseline.Run.TestHandoff != nil || baseline.Run.TestExemption != nil || baseline.Run.TestCheckpointSHA != "" || len(baseline.Run.ProtectedTestPaths) != 0 {
+		t.Fatalf("advisory test projection = %#v, want no independent test-stage state", baseline.Run)
+	}
+	if !strings.Contains(factory.StatusCommentBody(baseline.Run), "advisory") || !strings.Contains(factory.StatusCommentBody(baseline.Run), "implementation-owned TDD") {
+		t.Fatalf("advisory status projection = %q, want explicit implementation-owned policy", factory.StatusCommentBody(baseline.Run))
+	}
+	status, err := fixture.service.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status.TestPolicyMode != config.TestModeAdvisory {
+		t.Fatalf("status test policy = %q, want advisory", status.TestPolicyMode)
+	}
+}
+
+// TestAdvisoryTransitionStillRequiresTheHealthyBaseline verifies advisory mode
+// removes only the independent test gate, not the deterministic pre-edit gate.
+func TestAdvisoryTransitionStillRequiresTheHealthyBaseline(t *testing.T) {
+	fixture := newBaselineFixture(t, "", []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}})
+	fixture.policy.TestPolicy.Mode = config.TestModeAdvisory
+	delete(fixture.policy.RoleHarnessDefaults, "test")
+	delete(fixture.policy.ModelOptions, "test")
+	claimed, err := fixture.service.ClaimIssue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+	if _, err := fixture.service.Transition(context.Background(), factory.TransitionRequest{RunID: claimed.Run.ID, Stage: store.StageImplementation, Status: store.StatusActive}); err == nil || !strings.Contains(err.Error(), "baseline") {
+		t.Fatalf("Transition() error = %v, want advisory transition to require baseline", err)
+	}
+}
+
 // TestRunBaselineRecordsTheFrozenHumanTestExemption verifies an exact issue
 // marker can skip the default test stage only when repository policy allows it.
 func TestRunBaselineRecordsTheFrozenHumanTestExemption(t *testing.T) {

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -712,7 +712,7 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 		definition, declared := workflow.DefaultRegistry().Role(request.Role)
 		reviewStart = declared && definition.Kind == workflow.RoleKindReview
 	}
-	cleanStart := run.Stage == store.StageClaim || run.Stage == store.StageTest || (run.Stage == store.StageImplementation && run.TestStageSkipped)
+	cleanStart := run.Stage == store.StageClaim || run.Stage == store.StageTest || (run.Stage == store.StageImplementation && implementationStartIsClean(*run))
 	if reviewStart && run.Stage == store.StageDraftPR {
 		return nil
 	}
@@ -840,7 +840,7 @@ func (s *Service) ensureLegacyAgentStartup(ctx context.Context, registration con
 		definition, declared := workflow.DefaultRegistry().Role(request.Role)
 		reviewStart = declared && definition.Kind == workflow.RoleKindReview
 	}
-	cleanStart := run.Stage == store.StageClaim || run.Stage == store.StageTest || (run.Stage == store.StageImplementation && run.TestStageSkipped)
+	cleanStart := run.Stage == store.StageClaim || run.Stage == store.StageTest || (run.Stage == store.StageImplementation && implementationStartIsClean(*run))
 	if reviewStart && run.Stage == store.StageDraftPR {
 		return nil
 	}
@@ -991,7 +991,7 @@ func statusCommentBody(run store.Run) string {
 		}
 	}
 	review := specificationReviewStatusComment(run)
-	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, checkRepair, pullRequest, lifecycle, harness, review, questions, commandFeedback)
+	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n- test policy: `%s`\n%s%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, testPolicyDescription(testPolicyModeForRun(run)), checkRepair, pullRequest, lifecycle, harness, review, questions, commandFeedback)
 }
 
 // StatusCommentBody renders the coordinator-owned status projection for one

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -371,6 +371,9 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 // stage receives a new specification packet, including refreshes initiated
 // after implementation has already started.
 func packetResumeStageForPacket(run store.Run, packet SpecificationPacket) store.Stage {
+	if packet.RepositoryConfig.TestPolicy.Mode == config.TestModeAdvisory {
+		return store.StageImplementation
+	}
 	if !testStageConfigured(packet.RepositoryConfig) {
 		return store.StageTest
 	}
@@ -391,6 +394,12 @@ func resetTestProjectionForPacketChange(run *store.Run, packet SpecificationPack
 	run.TestCheckpointSHA = ""
 	run.TestExemption = nil
 	run.TestStageSkipped = false
+	if packet.RepositoryConfig.TestPolicy.Mode == config.TestModeAdvisory {
+		run.Stage = store.StageImplementation
+		run.Status = store.StatusActive
+		run.LifecycleReason = "specification packet changed; implementation-owned TDD ready"
+		return
+	}
 	if !testStageConfigured(packet.RepositoryConfig) {
 		run.Stage = store.StageTest
 		run.Status = store.StatusWaitingForHuman

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -444,9 +444,13 @@ func generatedPullRequestBody(run store.Run, packet SpecificationPacket, gates [
 	if len(gateLines) == 0 {
 		gateLines = append(gateLines, "- (none)")
 	}
-	testStageDisposition := "- test-stage disposition: none"
-	if run.TestExemption != nil {
-		testStageDisposition = fmt.Sprintf("- test-stage disposition: `%s` (provisional): %s", safeStatusCommentValue(run.TestExemption.Kind), safeStatusCommentValue(run.TestExemption.Justification))
+	policyMode := packet.RepositoryConfig.TestPolicy.Mode
+	testStageDisposition := fmt.Sprintf("- test policy: `%s`", safeStatusCommentValue(testPolicyDescription(policyMode)))
+	if policyMode == config.TestModeRequired {
+		testStageDisposition += "\n- test-stage disposition: none"
+		if run.TestExemption != nil {
+			testStageDisposition = fmt.Sprintf("- test policy: `%s`\n- test-stage disposition: `%s` (provisional): %s", safeStatusCommentValue(testPolicyDescription(policyMode)), safeStatusCommentValue(run.TestExemption.Kind), safeStatusCommentValue(run.TestExemption.Justification))
+		}
 	}
 	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `draft_pr`\n- intervention: `%s`\n%s\n\n%s\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, intervention, testStageDisposition, generatedReviewSection(run), issueBody, strings.Join(gateLines, "\n"), run.ID, generatedPullRequestEnd)
 }

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -243,6 +243,8 @@ type StatusResult struct {
 	ConfigPath     string
 	RepositoryPath string
 	LatestRun      *store.Run
+	// TestPolicyMode identifies the frozen TDD ownership mode of LatestRun.
+	TestPolicyMode config.TestMode
 	// Recovery contains the read-only diagnosis for an interrupted run.
 	Recovery *RecoveryDiagnosis
 	// Deprecated: use LatestRun.
@@ -506,6 +508,7 @@ func (s *Service) Status(ctx context.Context) (StatusResult, error) {
 		return StatusResult{}, err
 	}
 	if result.LatestRun != nil {
+		result.TestPolicyMode = testPolicyModeForRun(*result.LatestRun)
 		var pending *store.PendingEffect
 		if journal, ok := opened.(PendingEffectStore); ok {
 			pending, err = journal.PendingEffect(ctx, result.LatestRun.ID)

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -527,6 +527,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		Stage:               string(store.StageImplementation),
 		SpecificationPacket: run.SpecificationPacket,
 		RepositoryGuidance:  packet.Issue.Body,
+		TestPolicyMode:      string(packet.RepositoryConfig.TestPolicy.Mode),
 		CheckRepairAttempt:  repairPacket.Attempt,
 		CheckRepairBudget:   repairPacket.Budget,
 	})
@@ -541,6 +542,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 		Stage:               store.StageImplementation,
 		SpecificationPacket: run.SpecificationPacket,
 		PromptVersion:       prompt.Version,
+		TestPolicyMode:      packet.RepositoryConfig.TestPolicy.Mode,
 		PermittedPaths:      append([]string(nil), previous.PermittedPaths...),
 		CheckRepair:         &repairPacket,
 	}); err != nil {

--- a/internal/factory/test_stage.go
+++ b/internal/factory/test_stage.go
@@ -25,10 +25,56 @@ import (
 // a human test-stage skip.
 const testExemptionMarkerPrefix = "<!-- factory-test-exemption:"
 
+// testPolicyModeForRun returns the frozen test-policy mode used by status and
+// command projections. Invalid historical packets return the empty mode so a
+// projection cannot present an unverified policy as authoritative.
+func testPolicyModeForRun(run store.Run) config.TestMode {
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return ""
+	}
+	return packet.RepositoryConfig.TestPolicy.Mode
+}
+
+// testPolicyDescription renders the stable user-facing meaning of a test
+// policy mode without treating advisory implementation ownership as an
+// exemption.
+func testPolicyDescription(mode config.TestMode) string {
+	switch mode {
+	case config.TestModeAdvisory:
+		return "advisory (implementation-owned TDD)"
+	case config.TestModeRequired:
+		return "required (independent test stage)"
+	default:
+		return "unknown"
+	}
+}
+
+// TestPolicyDescription exposes the stable user-facing meaning of a test
+// policy mode to adapters such as the CLI without exposing packet internals.
+func TestPolicyDescription(mode config.TestMode) string { return testPolicyDescription(mode) }
+
+// implementationStartIsClean reports whether an implementation invocation may
+// begin without a separate test handoff. Required-mode skips retain their
+// recorded exemption, while advisory mode has no skip marker at all.
+func implementationStartIsClean(run store.Run) bool {
+	if run.TestStageSkipped {
+		return true
+	}
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	return err == nil && packet.RepositoryConfig.TestPolicy.Mode == config.TestModeAdvisory
+}
+
 // testStageConfigured reports whether the frozen repository policy declares a
-// usable test role. Repository configuration validation requires this role for
-// every operational packet, so a missing role is a fail-closed invalid fixture.
+// usable independent test role. Advisory mode intentionally has no required
+// test-role configuration because implementation owns its own TDD loop.
 func testStageConfigured(repository config.RepositoryConfig) bool {
+	if repository.TestPolicy.Mode == config.TestModeAdvisory {
+		return true
+	}
+	if repository.TestPolicy.Mode != config.TestModeRequired {
+		return false
+	}
 	if repository.RoleHarnessDefaults == nil || repository.ModelOptions == nil {
 		return false
 	}
@@ -40,6 +86,9 @@ func testStageConfigured(repository config.RepositoryConfig) bool {
 // testStageHumanExemption returns the frozen human exemption projection when
 // the issue marker and repository policy authorize it.
 func testStageHumanExemption(packet SpecificationPacket) (*store.TestExemption, bool) {
+	if packet.RepositoryConfig.TestPolicy.Mode != config.TestModeRequired {
+		return nil, false
+	}
 	if !packet.RepositoryConfig.TestPolicy.AllowHumanExemption {
 		return nil, false
 	}
@@ -53,6 +102,9 @@ func testStageHumanExemption(packet SpecificationPacket) (*store.TestExemption, 
 // testStageShouldRun reports whether the frozen packet requires a visible test
 // role before implementation.
 func testStageShouldRun(packet SpecificationPacket) bool {
+	if packet.RepositoryConfig.TestPolicy.Mode != config.TestModeRequired {
+		return false
+	}
 	_, exempted := testStageHumanExemption(packet)
 	return !exempted
 }
@@ -60,6 +112,17 @@ func testStageShouldRun(packet SpecificationPacket) bool {
 // validateTestStageTransition prevents a generic coordinator transition from
 // bypassing the configured test handoff or inventing an unconfigured test role.
 func validateTestStageTransition(run store.Run, packet SpecificationPacket, requested store.Stage) error {
+	switch packet.RepositoryConfig.TestPolicy.Mode {
+	case config.TestModeAdvisory:
+		if requested == store.StageTest {
+			return errors.New("test stage is unavailable in advisory mode; implementation owns TDD")
+		}
+		return nil
+	case config.TestModeRequired:
+		// Continue with the independent test-stage checks below.
+	default:
+		return errors.New("frozen repository packet has an unsupported test policy mode")
+	}
 	configured := testStageConfigured(packet.RepositoryConfig)
 	if !configured {
 		return errors.New("frozen repository packet lacks the mandatory test-stage role policy")
@@ -85,14 +148,29 @@ func validateTestStageTransition(run store.Run, packet SpecificationPacket, requ
 	return nil
 }
 
-// advanceAfterBaseline moves a configured run to test stage, or records an
-// authorized skip before implementation. The transition is persisted through
+// advanceAfterBaseline moves a required run to test stage, or moves an
+// advisory run directly to implementation. The transition is persisted through
 // the same status-comment boundary as every other visible run transition.
 func (s *Service) advanceAfterBaseline(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, packet SpecificationPacket) (store.Run, error) {
 	if !testStageConfigured(packet.RepositoryConfig) {
 		return run, errors.New("frozen repository packet lacks the mandatory test-stage role policy")
 	}
 	next := run
+	if packet.RepositoryConfig.TestPolicy.Mode == config.TestModeAdvisory {
+		next.Stage = store.StageImplementation
+		next.Status = store.StatusActive
+		next.TestHandoff = nil
+		next.TestCheckpointSHA = ""
+		next.ProtectedTestPaths = nil
+		next.TestExemption = nil
+		next.TestStageSkipped = false
+		next.LifecycleReason = "baseline passed; implementation-owned TDD ready"
+		next.UpdatedAt = s.deps.Now().UTC()
+		if err := s.persistAgentRunState(ctx, registration, runStore, run, next); err != nil {
+			return run, fmt.Errorf("persist post-baseline implementation transition: %w", err)
+		}
+		return next, nil
+	}
 	skip := !testStageShouldRun(packet)
 	justification := ""
 	if exemption, ok := testStageHumanExemption(packet); ok {
@@ -207,6 +285,26 @@ func containsReportExemption(values []report.Exemption, wanted report.Exemption)
 		}
 	}
 	return false
+}
+
+// validateAdvisoryImplementationSignals rejects test-stage-only dispositions
+// from the implementation contract when advisory mode owns the TDD loop.
+func validateAdvisoryImplementationSignals(value report.Report, invocation store.Invocation, packet SpecificationPacket) error {
+	if invocation.Role != workflow.RoleImplementation || packet.RepositoryConfig.TestPolicy.Mode != config.TestModeAdvisory {
+		return nil
+	}
+	for _, exemption := range value.Exemptions {
+		switch exemption {
+		case report.ExemptionHuman, report.ExemptionTechnical, report.ExemptionBaseline:
+			return errors.New("advisory implementation reports cannot record test-stage exemptions")
+		}
+	}
+	for _, escalation := range value.Escalations {
+		if escalation == report.EscalationTestDispute {
+			return errors.New("advisory implementation reports cannot record test-stage disputes")
+		}
+	}
+	return nil
 }
 
 // isUnverifiableTestReport identifies a completed test envelope whose identity

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -62,6 +62,9 @@ type Request struct {
 	TestPaths []string
 	// TestInfrastructurePaths lists frozen essential test-infrastructure prefixes.
 	TestInfrastructurePaths []string
+	// TestPolicyMode identifies whether implementation owns TDD or consumes an
+	// independently verified test-stage handoff.
+	TestPolicyMode string
 	// ReviewContext is the frozen, content-limited packet supplied to the
 	// independent reviewer. It is omitted for non-review roles.
 	ReviewContext *ReviewContext
@@ -138,12 +141,16 @@ func (r Registry) Build(request Request) (string, error) {
 	}
 	repairContext := ""
 	if request.CheckRepairAttempt > 0 {
+		repairInstruction := "- Repair the implementation in the mounted worktree; do not edit tests or gates merely to make them pass."
+		if request.TestPolicyMode == "advisory" {
+			repairInstruction = "- Repair the implementation in the mounted worktree and revise behavioral tests or essential test infrastructure when needed; do not weaken deterministic gates merely to make them pass."
+		}
 		repairContext = fmt.Sprintf(`
 Check-repair context:
 - This is repair attempt %d of %d for a failed deterministic checkpoint.
 - Read the coordinator-supplied check-repair packet in /invocation/specification.json.
-- Repair the implementation in the mounted worktree; do not edit tests or gates merely to make them pass.
-`, request.CheckRepairAttempt, request.CheckRepairBudget)
+%s
+`, request.CheckRepairAttempt, request.CheckRepairBudget, repairInstruction)
 	}
 	version := definition.PromptVersion
 	testContext := ""
@@ -164,6 +171,14 @@ Test-stage ownership:
 - A technical exemption is provisional and must include a bounded reason for later review.
 `
 		testContext += fmt.Sprintf("- Frozen additional test scope: %s\n", string(scope))
+	} else if request.TestPolicyMode == "advisory" && definition.Kind == workflow.RoleKindHandoff && request.Role == workflow.RoleImplementation {
+		testContext = `
+Implementation-owned TDD:
+- Own the complete red/green/refactor loop for the frozen specification.
+- Write or update a focused behavioral test before production behavior when practical, then run the focused command.
+- Revise the initial test design when implementation evidence requires it; tests and production behavior are both within your implementation scope.
+- Include the focused test commands and behavioral evidence in the structured implementation handoff.
+`
 	} else if request.TestHandoff != nil || len(request.ProtectedTestPaths) > 0 || request.TestExemption != nil {
 		data, err := json.Marshal(struct {
 			Handoff   *store.TestHandoff        `json:"test_handoff,omitempty"`

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -39,6 +39,61 @@ func TestBuildImplementationPromptKeepsFactoryRulesAuthoritative(t *testing.T) {
 	}
 }
 
+// TestBuildAdvisoryImplementationPromptAssignsTheCompleteTDDLoop verifies the
+// implementation role receives explicit red/green/refactor ownership in the
+// advisory path without an independent test handoff.
+func TestBuildAdvisoryImplementationPromptAssignsTheCompleteTDDLoop(t *testing.T) {
+	value, err := prompt.Build(prompt.Request{
+		InvocationID:        "inv-advisory",
+		RunID:               "run-advisory",
+		Role:                "implementation",
+		Stage:               "implementation",
+		TestPolicyMode:      "advisory",
+		SpecificationPacket: `{"issue":{"title":"Add behavior"}}`,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	for _, marker := range []string{
+		"Implementation-owned TDD:",
+		"complete red/green/refactor loop",
+		"Write or update a focused behavioral test before production behavior when practical",
+		"Revise the initial test design when implementation evidence requires it",
+	} {
+		if !strings.Contains(value, marker) {
+			t.Fatalf("advisory prompt missing %q:\n%s", marker, value)
+		}
+	}
+	if strings.Contains(value, "Protected test-stage handoff") || strings.Contains(value, "test-stage exemption") {
+		t.Fatalf("advisory prompt contains independent-test disposition:\n%s", value)
+	}
+}
+
+// TestBuildAdvisoryCheckRepairPromptKeepsTestRevisionWithinImplementationScope
+// verifies deterministic repair does not silently restore the independent-test
+// restriction for an advisory implementation invocation.
+func TestBuildAdvisoryCheckRepairPromptKeepsTestRevisionWithinImplementationScope(t *testing.T) {
+	value, err := prompt.Build(prompt.Request{
+		InvocationID:        "inv-advisory-repair",
+		RunID:               "run-advisory",
+		Role:                "implementation",
+		Stage:               "implementation",
+		TestPolicyMode:      "advisory",
+		SpecificationPacket: `{"issue":{"title":"Repair behavior"}}`,
+		CheckRepairAttempt:  1,
+		CheckRepairBudget:   3,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if !strings.Contains(value, "revise behavioral tests or essential test infrastructure when needed") {
+		t.Fatalf("advisory repair prompt missing test revision guidance:\n%s", value)
+	}
+	if strings.Contains(value, "do not edit tests or gates merely to make them pass") {
+		t.Fatalf("advisory repair prompt retained required-mode test restriction:\n%s", value)
+	}
+}
+
 // TestBuildRejectsMissingInvocationIdentity verifies that prompts cannot be
 // launched without the identity required by the report validator.
 func TestBuildRejectsMissingInvocationIdentity(t *testing.T) {


### PR DESCRIPTION
## Summary

- route healthy advisory baselines directly to implementation-owned red/green/refactor work
- let advisory implementation handoffs include test, test-support, and production edits without test-stage artifacts
- preserve required-mode independent red-test handoff, checkpoint, and protected-path enforcement
- expose the frozen policy mode in prompts, invocation packets, status, and generated PR projections
- update factory.yaml, docs, and workflow coverage

## Verification

- go test ./...
- go vet ./...
- git diff --check

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advisory test policy is now the default, allowing implementation to own the complete test-driven development cycle.
  * Required mode continues to support an independent test stage, handoff, checkpoints, and exemptions.
  * CLI status, launch information, prompts, and generated pull request details now show the active test policy.

* **Bug Fixes**
  * Advisory configurations no longer require separate test roles or models.
  * Invalid test-stage requests, reports, exemptions, and disputes are rejected when advisory mode is active.

* **Documentation**
  * Updated configuration, workflow, runtime, troubleshooting, and terminology guidance for both policy modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->