### PR TITLE
Drive unattended claim-to-draft-PR progression

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,20 @@ _Avoid_: Container in workflow decisions
 The portable seam that starts, resumes, commands, stops, and inspects a worker while hiding runtime identifiers, container paths, role homes, invocation packets, result files, and process tracking.
 _Avoid_: Docker API
 
+**Unattended progression**:
+The persistent coordinator's bounded pass that drives one claimed run through
+baseline, its route-selected stages, result acceptance, the exact-checkpoint
+gates, the bounded check-repair loop, the push, and one draft pull request
+without an operator running a stage-driving command. It stops at the first
+human or infrastructure waiting state.
+_Avoid_: Autonomous agent, agent-driven workflow, auto-merge
+
+**Run activity**:
+The published distinction between an active run whose next transition the
+coordinator owns, an active invocation whose harness is executing, and a
+waiting state. The `agent-running` label alone cannot express it.
+_Avoid_: Agent-running label, run status
+
 **Invocation**:
 One immutable harness attempt within a run, with its own invocation packet, role-owned visible surface handles, factory prompt version, and native session identifier when known.
 _Avoid_: Terminal transcript

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ repository. The deeper contracts live in
 - [GitHub commands and human intervention](#github-commands-and-human-intervention)
 - [Recovery and authentication](#recovery-and-authentication)
 - [Persistent polling](#persistent-polling)
+  - [Unattended claim-to-draft-PR progression](#unattended-claim-to-draft-pr-progression)
 - [Evaluation and cleanup](#evaluation-and-cleanup)
 - [Security and data boundaries](#security-and-data-boundaries)
 - [Command reference](#command-reference)
@@ -546,8 +547,13 @@ model.
 
 ## Run an issue from start to draft PR
 
-For a manually supervised run, use the one-shot claim path. It is the clearest
-way to see each boundary in the current implementation.
+Routine operation needs one command: <code>factory start</code> claims the
+oldest eligible issue and drives it to a draft pull request without any further
+CLI step. See [Persistent polling](#persistent-polling).
+
+The one-shot commands below perform the same boundaries one at a time. Use them
+for diagnosis or a deliberately manual run; they are the clearest way to see
+each boundary.
 
 ### 1. Bootstrap the factory labels once
 
@@ -1033,11 +1039,12 @@ to preserve idempotence.
 
 ## Persistent polling
 
-<code>factory start</code> is the long-lived queue and lease supervisor. It
-performs the full startup diagnosis, takes a private host lock, renews a visible
-<code>factory/lease</code> commit status, backs off transient queue/lease
-transport failures, suppresses new claims while a run is active, and claims
-the oldest eligible open issue by issue number.
+<code>factory start</code> is the long-lived queue supervisor and the
+unattended driver of the routine path. It performs the full startup diagnosis,
+takes a private host lock, renews a visible <code>factory/lease</code> commit
+status, backs off transient queue/lease transport failures, suppresses new
+claims while a run is active, and claims the oldest eligible open issue by
+issue number.
 
 Start and stop it with:
 
@@ -1051,25 +1058,68 @@ factory stop --config /Users/me/.config/factory/config.yaml
 <code>stop</code> stops polling and leaves the active run, branch, worktree,
 worker artifacts, and workflow status intact. It is not a cancellation command.
 
-### Current polling boundary
+### Unattended claim-to-draft-PR progression
 
-In the current implementation, a new issue claimed by the persistent polling
-loop is only claimed: that polling pass does not run the baseline or launch the
-first role. The public CLI does not currently expose a follow-up baseline
-command for that newly claimed state. Use the one-shot
-<code>factory issue</code> path for a complete manually driven run, and treat
-new claims made by <code>factory start</code> as an operational limitation that
-requires inspection rather than as unattended end-to-end execution. The
-supervisor observes a tracked issue or pull request before restart
-reconciliation when no effect is pending. This lets an already-merged or closed
-target enter its terminal state even after GitHub deletes the run branch. An
-unchanged non-terminal run still requires a clean restart diagnosis.
+After every polling observation that claimed or found a run, the coordinator
+drives that run as far as the frozen packet allows. It owns every transition;
+no agent may choose, skip, or redefine one.
 
-Likewise, <code>factory poll</code> is the explicit one-shot command for
-issue/PR lifecycle observation and structured GitHub command handling. This
-distinction keeps the documented behavior aligned with the current CLI while
-the persistent queue driver remains useful for exclusive claiming, lease
-publication, and restart supervision.
+1. A newly claimed run evaluates the frozen baseline against its immutable base
+   checkpoint.
+2. A healthy baseline enters the stage the frozen route and repository test
+   policy select. With advisory policy and no route, that is
+   implementation-owned TDD: no test invocation, test handoff, protected test
+   path, or test checkpoint is created. The <code>acceptance</code> and
+   <code>design-acceptance</code> routes and required policy enter their own
+   declared stages instead.
+3. The coordinator launches the role the workflow registry declares for that
+   stage, then waits while the invocation runs.
+4. When the invocation writes its structured report, the coordinator validates
+   and accepts it through the same boundary as <code>factory agent-report</code>
+   and advances to the next legal stage.
+5. An accepted implementation is checkpointed, every configured gate runs
+   against that exact checkpoint, and a failed gate enters the bounded
+   check-repair loop.
+6. A coherent checkpoint that passes every gate is pushed and receives one
+   draft pull request.
+
+Progression stops in its defined waiting state, and publishes the reason in the
+editable status comment, for a clarification request, a policy rejection, an
+exhausted retry budget, a harness rate limit, an authentication failure, an
+invocation that requires <code>factory attach</code>, or an ambiguous recovery.
+The independent specification review remains a deliberate step; unattended
+progression ends at the draft pull request.
+
+Repeated polling and a coordinator restart are safe. Every transition runs
+through the same durable effect journal as the one-shot commands, so a second
+pass reconciles pending effects instead of creating a second invocation,
+checkpoint, push, comment, status, or pull request. The supervisor also
+observes a tracked issue or pull request before restart reconciliation when no
+effect is pending, which lets an already-merged or closed target enter its
+terminal state even after GitHub deletes the run branch.
+
+### Activity in status output
+
+The <code>agent-running</code> issue label covers every active run, so it
+cannot say whether a harness is executing. <code>factory status</code> and the
+editable status comment publish a separate activity value:
+
+| Activity                          | Meaning                                                             |
+| --------------------------------- | ------------------------------------------------------------------- |
+| <code>invocation-active</code>    | One harness invocation is executing; its identity is published too. |
+| <code>run-active</code>           | The run is active and the coordinator owns the next transition.     |
+| <code>waiting-for-human</code>    | Progression stopped until a person answers or disposes.             |
+| <code>waiting-for-harness</code>  | Progression stopped until harness infrastructure recovers.          |
+| <code>terminal</code>             | The run is complete, cancelled, or failed.                          |
+
+### One-shot commands
+
+<code>factory issue</code>, <code>factory agent</code>,
+<code>factory agent-report</code>, and <code>factory draft-pr</code> remain
+available for diagnosis and deliberate manual operation. They are not part of
+routine unattended progression. Likewise, <code>factory poll</code> is the
+explicit one-shot command for issue/PR lifecycle observation and structured
+GitHub command handling.
 
 ## Evaluation and cleanup
 
@@ -1211,14 +1261,14 @@ supported by the installed binary.
 | <code>factory register</code>               | Register the one repository, GitHub identity, authorized users, polling settings, cmux settings, auth sources, repository policy path, and SQLite path.           |
 | <code>factory bootstrap-labels</code>       | Create the six factory-owned GitHub labels explicitly and idempotently.                                                                                           |
 | <code>factory doctor</code>                 | Run the complete startup diagnosis and print every problem/action.                                                                                                |
-| <code>factory start</code>                  | Run the persistent queue/lease supervisor.                                                                                                                        |
+| <code>factory start</code>                  | Run the persistent queue/lease supervisor and drive each claimed run to its draft pull request.                                                                    |
 | <code>factory stop</code>                   | Stop a running supervisor without cancelling the active run.                                                                                                      |
-| <code>factory issue [--issue N] N</code>    | Claim one issue and run its baseline. The number may be positional or supplied with <code>--issue</code>, but not both.                                           |
-| <code>factory agent</code>                  | Start the active stage's visible role, or select a validated role/stage/harness/model/reasoning override.                                                         |
-| <code>factory agent-report</code>           | Validate and accept a report already written by one invocation. Requires <code>--run-id</code> and <code>--invocation-id</code>.                                  |
-| <code>factory draft-pr</code>               | Create the implementation checkpoint, push the branch, run gates, and create/update the draft PR. <code>--intervention</code> records a one-line operator marker. |
+| <code>factory issue [--issue N] N</code>    | Diagnostic: claim one issue and run its baseline. The number may be positional or supplied with <code>--issue</code>, but not both.                               |
+| <code>factory agent</code>                  | Diagnostic: start the active stage's visible role, or select a validated role/stage/harness/model/reasoning override.                                             |
+| <code>factory agent-report</code>           | Diagnostic: validate and accept a report already written by one invocation. Requires <code>--run-id</code> and <code>--invocation-id</code>.                      |
+| <code>factory draft-pr</code>               | Diagnostic: checkpoint the implementation, push the branch, run gates, and create/update the draft PR. <code>--intervention</code> records a one-line marker.     |
 | <code>factory poll</code>                   | Process one lifecycle and structured-command observation for the current run.                                                                                     |
-| <code>factory status</code>                 | Show the selected host configuration, repository, latest run, and recovery diagnosis.                                                                             |
+| <code>factory status</code>                 | Show the selected host configuration, repository, latest run, its activity, and recovery diagnosis.                                                                |
 | <code>factory resume</code>                 | Perform explicit native-session or harness-capacity recovery, or re-enter a recovery-paused check stage.                                                          |
 | <code>factory attach</code>                 | Restore worker/terminal topology after a manual resume and clear the attach gate.                                                                                 |
 | <code>factory auth refresh</code>           | Reseed a managed worker credential for the active invocation harness.                                                                                             |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,16 @@ coordinator and leaves any active run, branch, worktree, worker, and session
 artifacts in place. Polling never creates factory labels; use
 `factory bootstrap-labels` explicitly.
 
+After each observation that claimed or found a run, the coordinator drives that
+run through baseline, the stages its frozen route and test policy select, the
+checkpoint gate suite, the bounded check-repair loop, the branch push, and one
+draft pull request. It stops in a defined waiting state for clarification, a
+policy rejection, an exhausted budget, a harness limit, an authentication
+failure, or an ambiguous recovery, and publishes the reason in the editable
+status comment. `factory issue`, `factory agent`, `factory agent-report`, and
+`factory draft-pr` stay available for diagnosis and deliberate manual
+operation; they are not part of routine unattended progression.
+
 ## Host configuration
 
 The generated host file contains the repository path, GitHub identity, authorized maintainers, polling settings, cmux settings, the checked-in repository configuration path, and the operational-data path.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -659,8 +659,8 @@ func runStatus(ctx context.Context, args []string, defaultConfigPath string, out
 		if !writeOutput(output, errorsOutput, "%s: %s (stage=%s status=%s activity=%s test_policy=%s route=%s branch=%s worktree=%s)\n", label, result.LatestRun.ID, result.LatestRun.Stage, result.LatestRun.Status, result.Activity, factory.TestPolicyDescription(result.TestPolicyMode), result.Route.Description(), result.LatestRun.Branch, result.LatestRun.Worktree) {
 			return 1
 		}
-		if result.ActiveInvocationID != "" {
-			if !writeOutput(output, errorsOutput, "active invocation: %s\n", result.ActiveInvocationID) {
+		if result.Activity == factory.ActivityInvocationActive {
+			if !writeOutput(output, errorsOutput, "active invocation: %s\n", result.LatestRun.ActiveInvocationID) {
 				return 1
 			}
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -656,8 +656,13 @@ func runStatus(ctx context.Context, args []string, defaultConfigPath string, out
 		if store.IsTerminalStatus(result.LatestRun.Status) {
 			label = "last run"
 		}
-		if !writeOutput(output, errorsOutput, "%s: %s (stage=%s status=%s test_policy=%s route=%s branch=%s worktree=%s)\n", label, result.LatestRun.ID, result.LatestRun.Stage, result.LatestRun.Status, factory.TestPolicyDescription(result.TestPolicyMode), result.Route.Description(), result.LatestRun.Branch, result.LatestRun.Worktree) {
+		if !writeOutput(output, errorsOutput, "%s: %s (stage=%s status=%s activity=%s test_policy=%s route=%s branch=%s worktree=%s)\n", label, result.LatestRun.ID, result.LatestRun.Stage, result.LatestRun.Status, result.Activity, factory.TestPolicyDescription(result.TestPolicyMode), result.Route.Description(), result.LatestRun.Branch, result.LatestRun.Worktree) {
 			return 1
+		}
+		if result.ActiveInvocationID != "" {
+			if !writeOutput(output, errorsOutput, "active invocation: %s\n", result.ActiveInvocationID) {
+				return 1
+			}
 		}
 	}
 	if result.Recovery != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -419,6 +419,68 @@ func TestRunStatusReportsNoRegisteredRepository(t *testing.T) {
 	}
 }
 
+// TestRunStatusDistinguishesAnActiveInvocationFromAnActiveRun verifies the
+// status command never lets the single `agent-running` label imply that a
+// harness is executing when none is.
+func TestRunStatusDistinguishesAnActiveInvocationFromAnActiveRun(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	configPath := filepath.Join(root, "config.yaml")
+	repositoryPath := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeValidRepositoryConfig(t, repositoryPath)
+	var output bytes.Buffer
+	if code := cli.Run(context.Background(), []string{"init", "--config", configPath}, &output, &output); code != 0 {
+		t.Fatalf("init exit code = %d, output = %s", code, output.String())
+	}
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	output.Reset()
+	if code := cli.Run(context.Background(), []string{"register", "--config", configPath, "--repository", repositoryPath, "--github-owner", "example", "--github-repository", "project", "--authorized-user", "alice", "--operational-data", operationalPath}, &output, &output); code != 0 {
+		t.Fatalf("register exit code = %d, output = %s", code, output.String())
+	}
+	started := time.Date(2026, 8, 29, 9, 0, 0, 0, time.UTC)
+	run := store.Run{
+		ID: "run-cli-activity", RepositoryPath: repositoryPath, IssueNumber: 12,
+		Stage: store.StageImplementation, Status: store.StatusActive,
+		CreatedAt: started, UpdatedAt: started,
+	}
+	saveRun := func(value store.Run) {
+		opened, err := store.Open(context.Background(), operationalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := opened.SaveRun(context.Background(), value); err != nil {
+			_ = opened.Close()
+			t.Fatal(err)
+		}
+		if err := opened.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	saveRun(run)
+	output.Reset()
+	if code := cli.Run(context.Background(), []string{"status", "--config", configPath}, &output, &output); code != 0 {
+		t.Fatalf("status exit code = %d, output = %s", code, output.String())
+	}
+	if !strings.Contains(output.String(), "activity=run-active") || strings.Contains(output.String(), "active invocation:") {
+		t.Fatalf("status output = %q, want run-active without an invocation identity", output.String())
+	}
+
+	run.ActiveInvocationID = "inv-cli-activity"
+	run.UpdatedAt = started.Add(time.Minute)
+	saveRun(run)
+	output.Reset()
+	if code := cli.Run(context.Background(), []string{"status", "--config", configPath}, &output, &output); code != 0 {
+		t.Fatalf("status exit code = %d, output = %s", code, output.String())
+	}
+	if !strings.Contains(output.String(), "activity=invocation-active") || !strings.Contains(output.String(), "active invocation: inv-cli-activity") {
+		t.Fatalf("status output = %q, want the executing invocation identity", output.String())
+	}
+}
+
 // TestRunEvaluationReportsAndDeliberatelyDeletesLocalSummaries verifies the
 // user-facing local report and explicit deletion commands do not need GitHub.
 func TestRunEvaluationReportsAndDeliberatelyDeletesLocalSummaries(t *testing.T) {

--- a/internal/factory/activity.go
+++ b/internal/factory/activity.go
@@ -19,10 +19,10 @@ const (
 	// ActivityRunActive means the run is active and the coordinator owns the
 	// next transition; no harness is executing.
 	ActivityRunActive RunActivity = "run-active"
-	// ActivityWaitingForHuman means automatic progression stopped until a
+	// ActivityWaitingForHuman means unattended progression stopped until a
 	// person answers, disposes, or reconciles the run.
 	ActivityWaitingForHuman RunActivity = "waiting-for-human"
-	// ActivityWaitingForHarness means automatic progression stopped until
+	// ActivityWaitingForHarness means unattended progression stopped until
 	// harness or worker infrastructure recovers.
 	ActivityWaitingForHarness RunActivity = "waiting-for-harness"
 	// ActivityTerminal means the run has no further coordinator progression.

--- a/internal/factory/activity.go
+++ b/internal/factory/activity.go
@@ -1,0 +1,60 @@
+package factory
+
+import (
+	"fmt"
+
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// RunActivity is the operator-facing distinction between a run that exists, a
+// run whose harness invocation is executing, and a run that is parked in a
+// waiting state. The single `agent-running` GitHub label cannot express it,
+// so unattended progression publishes this value beside the label.
+type RunActivity string
+
+const (
+	// ActivityInvocationActive means one harness invocation is executing for
+	// the run and the coordinator is waiting for its structured result.
+	ActivityInvocationActive RunActivity = "invocation-active"
+	// ActivityRunActive means the run is active and the coordinator owns the
+	// next transition; no harness is executing.
+	ActivityRunActive RunActivity = "run-active"
+	// ActivityWaitingForHuman means automatic progression stopped until a
+	// person answers, disposes, or reconciles the run.
+	ActivityWaitingForHuman RunActivity = "waiting-for-human"
+	// ActivityWaitingForHarness means automatic progression stopped until
+	// harness or worker infrastructure recovers.
+	ActivityWaitingForHarness RunActivity = "waiting-for-harness"
+	// ActivityTerminal means the run has no further coordinator progression.
+	ActivityTerminal RunActivity = "terminal"
+)
+
+// RunActivityFor derives the operator-facing activity of one persisted run.
+// It reads only the run projection, so the status comment stays a pure
+// function of the record that restart reconciliation compares.
+func RunActivityFor(run store.Run) RunActivity {
+	if store.IsTerminalStatus(run.Status) {
+		return ActivityTerminal
+	}
+	switch run.Status {
+	case store.StatusWaitingForHuman:
+		return ActivityWaitingForHuman
+	case store.StatusWaitingForHarness:
+		return ActivityWaitingForHarness
+	}
+	if run.ActiveInvocationID != "" {
+		return ActivityInvocationActive
+	}
+	return ActivityRunActive
+}
+
+// activityStatusComment renders the activity distinction for the single
+// editable supervision comment. The invocation identity appears only while
+// that invocation is the one the run currently delegates to.
+func activityStatusComment(run store.Run) string {
+	activity := RunActivityFor(run)
+	if activity != ActivityInvocationActive {
+		return fmt.Sprintf("- activity: `%s`\n", activity)
+	}
+	return fmt.Sprintf("- activity: `%s`\n- active invocation: `%s`\n", activity, safeStatusCommentValue(run.ActiveInvocationID))
+}

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -404,6 +404,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		acceptedInvocation.UpdatedAt = s.deps.Now().UTC()
 		previousRun := *run
 		nextRun := previousRun
+		releaseActiveInvocation(&nextRun, invocation.ID)
 		isTestReport := isTestInvocation
 		isReviewReport := isReviewInvocation
 		if !isTestReport && !isReviewReport {
@@ -455,6 +456,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		return AgentResult{}, fmt.Errorf("persist accepted invocation: %w", err)
 	}
 	previousRun := *run
+	releaseActiveInvocation(run, invocation.ID)
 	if isTestInvocation {
 		return s.acceptTestStageReport(ctx, registration, runStore, run, invocation, value, state)
 	}
@@ -503,6 +505,16 @@ func (s *Service) resumeAcceptedStageProjection(ctx context.Context, registratio
 	return AgentResult{}, false, nil
 }
 
+// releaseActiveInvocation clears the run's delegation marker when the named
+// invocation is the one the run currently waits on. A run that already
+// delegates elsewhere keeps its marker, so a repeated acceptance of an older
+// invocation cannot hide a live harness session.
+func releaseActiveInvocation(run *store.Run, invocationID string) {
+	if run != nil && run.ActiveInvocationID == invocationID {
+		run.ActiveInvocationID = ""
+	}
+}
+
 // acceptedInvocationStatus maps a validated report outcome to its durable
 // invocation lifecycle state, keeping result acceptance consistent across all
 // visible roles.
@@ -525,6 +537,9 @@ func acceptedInvocationStatus(outcome report.Outcome) store.InvocationStatus {
 // stage instead of guessing a route that could skip a selected stage.
 func agentReportRunProjection(previous store.Run, invocationStage store.Stage, value report.Report) store.Run {
 	next := previous
+	// An accepted report ends the run's delegation to its invocation, so the
+	// status projection stops implying that a harness is executing.
+	next.ActiveInvocationID = ""
 	route, readable := routeForRun(previous)
 	if !readable {
 		next.Stage = invocationStage

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -266,7 +266,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 			return AgentResult{}, errors.New("agent report permitted paths do not match the invocation policy")
 		}
 	}
-	path := filepath.Join(invocation.ResultDirectory, report.ReportFileName)
+	path := reportPath(*invocation)
 	var value report.Report
 	if isTestInvocation {
 		value, err = report.ReadEnvelope(path)
@@ -579,7 +579,7 @@ func agentReportRunProjection(previous store.Run, invocationStage store.Stage, v
 // function reads from the filesystem and should only be used as a fallback when
 // the pending effect payload is unavailable.
 func readAcceptedAgentReport(invocation store.Invocation) (report.Report, error) {
-	path := filepath.Join(invocation.ResultDirectory, report.ReportFileName)
+	path := reportPath(invocation)
 	if roleIsKind(invocation, workflow.RoleKindTest) {
 		return report.ReadEnvelope(path)
 	}

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -396,6 +396,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	previousRun := *run
 	run.Stage = stage
 	run.Status = store.StatusActive
+	run.ActiveInvocationID = invocation.ID
 	run.UpdatedAt = s.deps.Now().UTC()
 	if err := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("persist %s stage: %w", role, err)

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -1018,7 +1018,8 @@ func statusCommentBody(run store.Run) string {
 		}
 	}
 	review := specificationReviewStatusComment(run)
-	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n- test policy: `%s`\n- route: `%s`\n%s%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, testPolicyDescription(testPolicyModeForRun(run)), routeDescriptionForRun(run), checkRepair, pullRequest, lifecycle, harness, review, questions, commandFeedback)
+	activity := activityStatusComment(run)
+	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s- test policy: `%s`\n- route: `%s`\n%s%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, activity, testPolicyDescription(testPolicyModeForRun(run)), routeDescriptionForRun(run), checkRepair, pullRequest, lifecycle, harness, review, questions, commandFeedback)
 }
 
 // StatusCommentBody renders the coordinator-owned status projection for one

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -249,6 +249,12 @@ type StatusResult struct {
 	// Route identifies the frozen contract-first workflow route of LatestRun,
 	// or an explicit unknown value when its specification packet is unreadable.
 	Route workflow.Route
+	// Activity distinguishes an active run, an active harness invocation, and
+	// a waiting state for LatestRun. It is empty when no run exists.
+	Activity RunActivity
+	// ActiveInvocationID names the invocation LatestRun currently delegates
+	// to, and is empty whenever no harness is executing.
+	ActiveInvocationID string
 	// Recovery contains the read-only diagnosis for an interrupted run.
 	Recovery *RecoveryDiagnosis
 	// Deprecated: use LatestRun.
@@ -514,6 +520,10 @@ func (s *Service) Status(ctx context.Context) (StatusResult, error) {
 	if result.LatestRun != nil {
 		result.TestPolicyMode = testPolicyModeForRun(*result.LatestRun)
 		result.Route = statusRouteForRun(*result.LatestRun)
+		result.Activity = RunActivityFor(*result.LatestRun)
+		if result.Activity == ActivityInvocationActive {
+			result.ActiveInvocationID = result.LatestRun.ActiveInvocationID
+		}
 		var pending *store.PendingEffect
 		if journal, ok := opened.(PendingEffectStore); ok {
 			pending, err = journal.PendingEffect(ctx, result.LatestRun.ID)

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -252,9 +252,6 @@ type StatusResult struct {
 	// Activity distinguishes an active run, an active harness invocation, and
 	// a waiting state for LatestRun. It is empty when no run exists.
 	Activity RunActivity
-	// ActiveInvocationID names the invocation LatestRun currently delegates
-	// to, and is empty whenever no harness is executing.
-	ActiveInvocationID string
 	// Recovery contains the read-only diagnosis for an interrupted run.
 	Recovery *RecoveryDiagnosis
 	// Deprecated: use LatestRun.
@@ -521,9 +518,6 @@ func (s *Service) Status(ctx context.Context) (StatusResult, error) {
 		result.TestPolicyMode = testPolicyModeForRun(*result.LatestRun)
 		result.Route = statusRouteForRun(*result.LatestRun)
 		result.Activity = RunActivityFor(*result.LatestRun)
-		if result.Activity == ActivityInvocationActive {
-			result.ActiveInvocationID = result.LatestRun.ActiveInvocationID
-		}
 		var pending *store.PendingEffect
 		if journal, ok := opened.(PendingEffectStore); ok {
 			pending, err = journal.PendingEffect(ctx, result.LatestRun.ID)

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -136,7 +136,7 @@ func (s *Service) Resume(ctx context.Context, request ResumeRequest) (ResumeResu
 			return ResumeResult{Run: *run, Invocation: *active, WaitingForAttach: true}, &ManualResumeRequiredError{RunID: run.ID}
 		}
 		if strings.TrimSpace(active.NativeSessionID) == "" {
-			if err := s.supersedeInvocation(ctx, runStore, *active); err != nil {
+			if err := s.supersedeInvocation(ctx, registration, runStore, *active); err != nil {
 				return ResumeResult{}, err
 			}
 			active = nil
@@ -456,7 +456,7 @@ func (s *Service) retryWaitingForHarness(ctx context.Context, registration confi
 		return stateErr
 	}
 	if active != nil {
-		if err := s.supersedeInvocation(ctx, runStore, *active); err != nil {
+		if err := s.supersedeInvocation(ctx, registration, runStore, *active); err != nil {
 			return err
 		}
 	}
@@ -752,8 +752,10 @@ func latestInvocationForAuthRefresh(ctx context.Context, runStore RunStore, run 
 }
 
 // supersedeInvocation closes an incomplete launch before a fresh capacity or
-// authentication retry creates the next immutable invocation identity.
-func (s *Service) supersedeInvocation(ctx context.Context, runStore RunStore, invocation store.Invocation) error {
+// authentication retry creates the next immutable invocation identity. It also
+// releases the run's delegation marker, so a published activity can never name
+// an invocation that will never produce a result.
+func (s *Service) supersedeInvocation(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, invocation store.Invocation) error {
 	invocationStore, ok := runStore.(InvocationStore)
 	if !ok {
 		return errors.New("operational store does not support invocation recovery")
@@ -762,6 +764,20 @@ func (s *Service) supersedeInvocation(ctx context.Context, runStore RunStore, in
 	invocation.UpdatedAt = s.deps.Now().UTC()
 	if err := invocationStore.SaveInvocation(ctx, invocation); err != nil {
 		return fmt.Errorf("supersede interrupted invocation: %w", err)
+	}
+	current, err := runStore.CurrentRun(ctx)
+	if err != nil {
+		return fmt.Errorf("read run to release superseded invocation: %w", err)
+	}
+	if current == nil || current.ActiveInvocationID != invocation.ID {
+		return nil
+	}
+	previous := *current
+	next := previous
+	next.ActiveInvocationID = ""
+	next.UpdatedAt = s.deps.Now().UTC()
+	if err := s.persistAgentRunState(ctx, registration, runStore, previous, next); err != nil {
+		return fmt.Errorf("release superseded invocation delegation: %w", err)
 	}
 	return nil
 }

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -30,6 +30,10 @@ const (
 	// maxConsecutiveLeaseFailures limits lease-renewal retry attempts before
 	// returning a persistent error to the caller.
 	maxConsecutiveLeaseFailures = 5
+	// maxConsecutiveProgressionFailures limits how long the supervisor backs
+	// off an unattended progression pass whose durable state it cannot read
+	// before it reports a persistent coordinator failure.
+	maxConsecutiveProgressionFailures = 5
 )
 
 // PollResult reports one deterministic polling observation and any run it
@@ -122,6 +126,7 @@ func (s *Service) Start(ctx context.Context) error {
 	leaseRunID := ""
 	delay := time.Duration(0)
 	consecutiveLeaseFailures := 0
+	consecutiveProgressionFailures := 0
 	for {
 		if err := waitPolling(pollContext, delay); err != nil {
 			if pollingContextDone(err) {
@@ -179,8 +184,14 @@ func (s *Service) Start(ctx context.Context) error {
 				if pollingContextDone(err) {
 					return nil
 				}
-				return fmt.Errorf("drive run %s: %w", result.Run.ID, err)
+				consecutiveProgressionFailures++
+				if consecutiveProgressionFailures > maxConsecutiveProgressionFailures {
+					return fmt.Errorf("drive run %s after %d consecutive attempts: %w", result.Run.ID, maxConsecutiveProgressionFailures, err)
+				}
+				delay = backoff
+				continue
 			}
+			consecutiveProgressionFailures = 0
 		}
 		delay = interval
 	}

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -75,8 +75,10 @@ func (e *StartupBlockedError) Error() string {
 // diagnoses the full host before taking the lock, acquires exclusive ownership
 // before reconciliation, renews a visible GitHub lease, and backs off read-only
 // queue or lease transport failures without changing run state or retry
-// budgets. Claim failures are returned because the claim state machine may
-// already have performed compensating effects.
+// budgets. After every observation that found or claimed a run it drives that
+// run toward its draft pull request, so the routine path needs no
+// stage-driving CLI command. Claim failures are returned because the claim
+// state machine may already have performed compensating effects.
 func (s *Service) Start(ctx context.Context) error {
 	diagnosis, err := s.startupDiagnosis(ctx)
 	if err != nil {
@@ -172,6 +174,14 @@ func (s *Service) Start(ctx context.Context) error {
 			return err
 		}
 		leaseRunID = result.Run.ID
+		if result.Outcome == PollClaimed || result.Outcome == PollActiveRun {
+			if _, err := s.driveRun(pollContext, registration); err != nil {
+				if pollingContextDone(err) {
+					return nil
+				}
+				return fmt.Errorf("drive run %s: %w", result.Run.ID, err)
+			}
+		}
 		delay = interval
 	}
 }

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -19,32 +19,32 @@ import (
 // than ordinary work.
 const maxProgressionSteps = 32
 
-// ProgressionOutcome identifies why one unattended progression pass stopped.
-type ProgressionOutcome string
+// progressionOutcome identifies why one unattended progression pass stopped.
+type progressionOutcome string
 
 const (
-	// ProgressionIdle means no run was available to drive.
-	ProgressionIdle ProgressionOutcome = "idle"
-	// ProgressionInvocationActive means a harness invocation is executing and
+	// progressionIdle means no run was available to drive.
+	progressionIdle progressionOutcome = "idle"
+	// progressionInvocationActive means a harness invocation is executing and
 	// the coordinator is waiting for its structured result.
-	ProgressionInvocationActive ProgressionOutcome = "invocation_active"
-	// ProgressionWaiting means the run reached a human or infrastructure
-	// waiting state that automatic progression must not cross.
-	ProgressionWaiting ProgressionOutcome = "waiting"
-	// ProgressionDraftPullRequest means the run reached its draft pull
+	progressionInvocationActive progressionOutcome = "invocation_active"
+	// progressionWaiting means the run reached a human or infrastructure
+	// waiting state that unattended progression must not cross.
+	progressionWaiting progressionOutcome = "waiting"
+	// progressionDraftPullRequest means the run reached its draft pull
 	// request, which is the end of unattended claim-to-draft-PR progression.
-	ProgressionDraftPullRequest ProgressionOutcome = "draft_pull_request"
-	// ProgressionTerminal means the run has no further progression.
-	ProgressionTerminal ProgressionOutcome = "terminal"
-	// ProgressionUnsupported means the operational store cannot expose the
+	progressionDraftPullRequest progressionOutcome = "draft_pull_request"
+	// progressionTerminal means the run has no further progression.
+	progressionTerminal progressionOutcome = "terminal"
+	// progressionUnsupported means the operational store cannot expose the
 	// durable invocation history that exactly-once progression requires.
-	ProgressionUnsupported ProgressionOutcome = "unsupported"
+	progressionUnsupported progressionOutcome = "unsupported"
 )
 
-// ProgressionResult reports one unattended progression pass.
-type ProgressionResult struct {
+// progressionResult reports one unattended progression pass.
+type progressionResult struct {
 	// Outcome identifies why the pass stopped.
-	Outcome ProgressionOutcome
+	Outcome progressionOutcome
 	// Run is the run projection observed when the pass stopped.
 	Run store.Run
 	// Steps counts the coordinator transitions performed in this pass.
@@ -67,24 +67,15 @@ type progressionState struct {
 	Supported bool
 }
 
-// AdvanceRun drives the current run as far as the frozen route, repository
-// policy, and durable evidence allow, without an operator running a
-// stage-driving command. Every transition is performed through the same
-// coordinator seams the one-shot commands use, so a repeated pass or a
-// coordinator restart reuses their exactly-once effect journal instead of
+// driveRun performs one bounded unattended progression pass for the registered
+// repository. It drives the current run as far as the frozen route, the
+// repository policy, and the durable evidence allow, and stops at the first
+// state a person or infrastructure owns. Every transition runs through the
+// same coordinator seam the matching one-shot command uses, so a repeated pass
+// or a coordinator restart reuses their exactly-once effect journal instead of
 // creating a second invocation, checkpoint, push, comment, or pull request.
-func (s *Service) AdvanceRun(ctx context.Context) (ProgressionResult, error) {
-	registration, err := s.registration()
-	if err != nil {
-		return ProgressionResult{}, err
-	}
-	return s.driveRun(ctx, registration)
-}
-
-// driveRun performs bounded unattended progression for one registered
-// repository. It stops at the first state a person or infrastructure owns.
-func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRegistration) (ProgressionResult, error) {
-	result := ProgressionResult{Outcome: ProgressionIdle}
+func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRegistration) (progressionResult, error) {
+	result := progressionResult{Outcome: progressionIdle}
 	for result.Steps < maxProgressionSteps {
 		if err := ctx.Err(); err != nil {
 			return result, err
@@ -94,33 +85,19 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 			return result, err
 		}
 		if !state.Supported {
-			return ProgressionResult{Outcome: ProgressionUnsupported, Steps: result.Steps, Reason: "operational store has no durable invocation history"}, nil
+			return progressionResult{Outcome: progressionUnsupported, Steps: result.Steps, Reason: "operational store has no durable invocation history"}, nil
 		}
 		if state.Run == nil {
-			return ProgressionResult{Outcome: ProgressionIdle, Steps: result.Steps, Reason: "no run to drive"}, nil
+			return progressionResult{Outcome: progressionIdle, Steps: result.Steps, Reason: "no run to drive"}, nil
 		}
 		result.Run = *state.Run
 		step, stop := s.progressionStep(state)
 		if stop != nil {
 			stop.Steps = result.Steps
-			stop.Run = *state.Run
-			return *stop, nil
+			return s.publishProgressionStop(ctx, registration, *state.Run, *stop)
 		}
 		if err := step.action(ctx); err != nil {
-			paused, pauseErr := s.pauseProgression(ctx, registration, *state.Run, step.name, err)
-			if pauseErr != nil {
-				return result, errors.Join(err, pauseErr)
-			}
-			outcome := ProgressionWaiting
-			if store.IsTerminalStatus(paused.Status) {
-				outcome = ProgressionTerminal
-			}
-			return ProgressionResult{
-				Outcome: outcome,
-				Run:     paused,
-				Steps:   result.Steps,
-				Reason:  waitingReason(paused, err.Error()),
-			}, nil
+			return s.stopProgressionAfterFailure(ctx, registration, *state.Run, step.name, err, result.Steps)
 		}
 		result.Steps++
 		advanced, err := s.readProgressionState(ctx, registration)
@@ -128,21 +105,22 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 			return result, err
 		}
 		if advanced.Run == nil {
-			return ProgressionResult{Outcome: ProgressionIdle, Steps: result.Steps, Reason: "run disappeared after " + step.name}, nil
+			return progressionResult{Outcome: progressionIdle, Steps: result.Steps, Reason: "run disappeared after " + step.name}, nil
 		}
 		result.Run = *advanced.Run
 		if !progressionAdvanced(*state.Run, state.Active, *advanced.Run, advanced.Active) {
-			return ProgressionResult{
-				Outcome: ProgressionWaiting,
-				Run:     *advanced.Run,
+			return s.publishProgressionStop(ctx, registration, *advanced.Run, progressionResult{
+				Outcome: progressionWaiting,
 				Steps:   result.Steps,
 				Reason:  fmt.Sprintf("%s did not advance the run", step.name),
-			}, nil
+			})
 		}
 	}
-	result.Outcome = ProgressionWaiting
-	result.Reason = fmt.Sprintf("progression exceeded %d coordinator transitions", maxProgressionSteps)
-	return result, nil
+	return s.publishProgressionStop(ctx, registration, result.Run, progressionResult{
+		Outcome: progressionWaiting,
+		Steps:   result.Steps,
+		Reason:  fmt.Sprintf("progression exceeded %d coordinator transitions", maxProgressionSteps),
+	})
 }
 
 // progressionAction is one coordinator-owned transition selected from durable
@@ -155,28 +133,27 @@ type progressionAction struct {
 }
 
 // progressionStep selects the single legal next transition for a run, or the
-// waiting state that stops automatic progression. Exactly one of the two
+// waiting state that stops unattended progression. Exactly one of the two
 // return values is set.
-func (s *Service) progressionStep(state progressionState) (progressionAction, *ProgressionResult) {
+func (s *Service) progressionStep(state progressionState) (progressionAction, *progressionResult) {
 	run := *state.Run
-	if store.IsTerminalStatus(run.Status) {
-		return progressionAction{}, &ProgressionResult{Outcome: ProgressionTerminal, Reason: "run is " + string(run.Status)}
-	}
-	switch run.Status {
-	case store.StatusWaitingForHuman:
-		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: waitingReason(run, "waiting for human disposition")}
-	case store.StatusWaitingForHarness:
-		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: waitingReason(run, "waiting for harness capacity")}
+	switch RunActivityFor(run) {
+	case ActivityTerminal:
+		return progressionAction{}, &progressionResult{Outcome: progressionTerminal, Reason: "run is " + string(run.Status)}
+	case ActivityWaitingForHuman:
+		return progressionAction{}, &progressionResult{Outcome: progressionWaiting, Reason: waitingReason(run, "waiting for human disposition")}
+	case ActivityWaitingForHarness:
+		return progressionAction{}, &progressionResult{Outcome: progressionWaiting, Reason: waitingReason(run, "waiting for harness capacity")}
 	}
 	if run.CheckRepairPendingAttempt != 0 {
-		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: fmt.Sprintf("check-repair attempt %d is pending reconciliation", run.CheckRepairPendingAttempt)}
+		return progressionAction{}, &progressionResult{Outcome: progressionWaiting, Reason: fmt.Sprintf("check-repair attempt %d is pending reconciliation", run.CheckRepairPendingAttempt)}
 	}
 	if state.Active != nil {
 		if state.Active.AttachRequired {
-			return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: fmt.Sprintf("invocation %q requires `factory attach`", state.Active.ID)}
+			return progressionAction{}, &progressionResult{Outcome: progressionWaiting, Reason: fmt.Sprintf("invocation %q requires `factory attach`", state.Active.ID)}
 		}
 		if !agentResultReady(*state.Active) {
-			return progressionAction{}, &ProgressionResult{Outcome: ProgressionInvocationActive, Reason: fmt.Sprintf("invocation %q is executing", state.Active.ID)}
+			return progressionAction{}, &progressionResult{Outcome: progressionInvocationActive, Reason: fmt.Sprintf("invocation %q is executing", state.Active.ID)}
 		}
 		invocationID := state.Active.ID
 		return progressionAction{name: "accept agent report", action: func(ctx context.Context) error {
@@ -187,39 +164,41 @@ func (s *Service) progressionStep(state progressionState) (progressionAction, *P
 	return s.progressionStageStep(state)
 }
 
-// progressionStageStep selects the transition owned by the run stage once no
-// invocation is executing.
-func (s *Service) progressionStageStep(state progressionState) (progressionAction, *ProgressionResult) {
+// progressionStageStep selects the transition the workflow registry declares
+// for the run stage once no invocation is executing. The registry stays the
+// stage authority: a stage that declares a coordinator event is driven by the
+// draft-pull-request seam that owns those events, and a stage that declares a
+// role is driven by launching that role.
+func (s *Service) progressionStageStep(state progressionState) (progressionAction, *progressionResult) {
 	run := *state.Run
+	registry := workflow.DefaultRegistry()
 	switch run.Stage {
 	case store.StageClaim:
+		// Leaving claim is the frozen baseline, whose healthy result selects
+		// the entry stage from the route and the repository test policy.
 		return progressionAction{name: "run baseline", action: func(ctx context.Context) error {
 			_, err := s.RunBaseline(ctx, BaselineRequest{RunID: run.ID})
 			return err
 		}}, nil
-	case store.StagePreflight:
-		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: waitingReason(run, "baseline preflight needs human attention")}
-	case store.StageCheck:
-		return progressionAction{name: "create draft pull request", action: func(ctx context.Context) error {
-			_, err := s.CreateDraftPullRequest(ctx, DraftPullRequestRequest{RunID: run.ID})
-			return err
-		}}, nil
 	case store.StageDraftPR:
-		return progressionAction{}, &ProgressionResult{Outcome: ProgressionDraftPullRequest, Reason: fmt.Sprintf("draft pull request #%d is ready for review", run.PullRequestNumber)}
-	case store.StageReady:
-		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: waitingReason(run, "run is ready for human review")}
+		// The independent specification review is a deliberate step, so
+		// unattended progression ends at the draft pull request.
+		return progressionAction{}, &progressionResult{Outcome: progressionDraftPullRequest, Reason: fmt.Sprintf("draft pull request #%d is ready for review", run.PullRequestNumber)}
 	}
-	if _, declared := workflow.DefaultRegistry().RoleForRunStage(run.Stage); !declared {
-		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: fmt.Sprintf("no factory role owns run stage %q", run.Stage)}
+	definition, declared := registry.Stage(run.Stage)
+	if !declared {
+		return progressionAction{}, &progressionResult{Outcome: progressionWaiting, Reason: fmt.Sprintf("run stage %q is not declared by the workflow registry", run.Stage)}
 	}
-	if state.Latest != nil && state.Latest.Stage == run.Stage && state.Latest.Status == store.InvocationStatusCompleted {
-		if run.Stage != store.StageImplementation {
-			return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: fmt.Sprintf("stage %q has a completed invocation but no declared coordinator transition", run.Stage)}
-		}
+	_, roleDeclared := registry.RoleForRunStage(run.Stage)
+	stageComplete := state.Latest != nil && state.Latest.Stage == run.Stage && state.Latest.Status == store.InvocationStatusCompleted
+	if len(definition.Events) > 0 && (!roleDeclared || stageComplete) {
 		return progressionAction{name: "create draft pull request", action: func(ctx context.Context) error {
 			_, err := s.CreateDraftPullRequest(ctx, DraftPullRequestRequest{RunID: run.ID})
 			return err
 		}}, nil
+	}
+	if !roleDeclared {
+		return progressionAction{}, &progressionResult{Outcome: progressionWaiting, Reason: fmt.Sprintf("no coordinator transition is declared for run stage %q", run.Stage)}
 	}
 	return progressionAction{name: "start agent", action: func(ctx context.Context) error {
 		_, err := s.StartAgent(ctx, AgentRequest{RunID: run.ID})
@@ -229,7 +208,8 @@ func (s *Service) progressionStageStep(state progressionState) (progressionActio
 
 // readProgressionState reads the run and its invocation projection once. A
 // store without durable invocation history cannot support exactly-once
-// unattended progression, so it reports no run instead of guessing.
+// unattended progression, so it reports the run as undrivable rather than
+// guessing whether a harness is executing.
 func (s *Service) readProgressionState(ctx context.Context, registration config.RepositoryRegistration) (progressionState, error) {
 	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
 	if err != nil {
@@ -287,8 +267,14 @@ func agentResultReady(invocation store.Invocation) bool {
 	if invocation.ResultDirectory == "" {
 		return false
 	}
-	info, err := os.Stat(filepath.Join(invocation.ResultDirectory, report.ReportFileName))
+	info, err := os.Stat(reportPath(invocation))
 	return err == nil && info.Mode().IsRegular()
+}
+
+// reportPath returns the only accepted structured-report location inside one
+// invocation result directory.
+func reportPath(invocation store.Invocation) string {
+	return filepath.Join(invocation.ResultDirectory, report.ReportFileName)
 }
 
 // waitingReason prefers the coordinator's recorded lifecycle reason so the
@@ -300,9 +286,49 @@ func waitingReason(run store.Run, fallback string) string {
 	return fallback
 }
 
-// pauseProgression stops automatic progression in a visible human waiting
-// state and publishes an actionable status. A run that a seam already moved
-// out of active is left untouched, because that seam owns the more specific
+// publishProgressionStop makes a stall visible. A run that unattended
+// progression refuses to move must never stay active and silent, because the
+// `agent-running` label would then imply work nobody is doing. Waiting states
+// a seam already published, and the legitimate active outcomes, are returned
+// unchanged.
+func (s *Service) publishProgressionStop(ctx context.Context, registration config.RepositoryRegistration, run store.Run, stop progressionResult) (progressionResult, error) {
+	stop.Run = run
+	if stop.Outcome != progressionWaiting || run.Status != store.StatusActive {
+		return stop, nil
+	}
+	paused, err := s.pauseProgression(ctx, registration, run, "stall", errors.New(stop.Reason))
+	if err != nil {
+		return stop, err
+	}
+	stop.Run = paused
+	stop.Reason = waitingReason(paused, stop.Reason)
+	return stop, nil
+}
+
+// stopProgressionAfterFailure parks the run in a visible waiting state,
+// publishes an actionable status, and reports the pass that stopped. A
+// cancelled context is an operator `factory stop`, which must leave the run
+// exactly as it was.
+func (s *Service) stopProgressionAfterFailure(ctx context.Context, registration config.RepositoryRegistration, observed store.Run, step string, cause error, steps int) (progressionResult, error) {
+	if pollingContextDone(cause) || ctx.Err() != nil {
+		return progressionResult{Outcome: progressionWaiting, Run: observed, Steps: steps, Reason: "coordinator stopped"}, nil
+	}
+	paused, err := s.pauseProgression(ctx, registration, observed, step, cause)
+	if err != nil {
+		return progressionResult{Run: observed, Steps: steps}, errors.Join(cause, err)
+	}
+	outcome := progressionWaiting
+	if store.IsTerminalStatus(paused.Status) {
+		outcome = progressionTerminal
+	}
+	return progressionResult{Outcome: outcome, Run: paused, Steps: steps, Reason: waitingReason(paused, cause.Error())}, nil
+}
+
+// pauseProgression stops unattended progression in a visible human waiting
+// state. The coordinator fails closed here: it cannot tell a transient
+// adapter failure from one that already changed external state, so it asks a
+// person rather than retrying an effect. A run that a seam already moved out
+// of active is left untouched, because that seam owns the more specific
 // waiting state it published.
 func (s *Service) pauseProgression(ctx context.Context, registration config.RepositoryRegistration, observed store.Run, step string, cause error) (store.Run, error) {
 	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
@@ -327,10 +353,10 @@ func (s *Service) pauseProgression(ctx context.Context, registration config.Repo
 	previous := *current
 	next := previous
 	next.Status = store.StatusWaitingForHuman
-	next.LifecycleReason = fmt.Sprintf("automatic progression stopped at %s: %s", step, cause)
+	next.LifecycleReason = fmt.Sprintf("unattended progression stopped at %s: %s", step, cause)
 	next.UpdatedAt = s.deps.Now().UTC()
 	if err := s.persistAgentRunState(ctx, registration, runStore, previous, next); err != nil {
-		return previous, errors.Join(cause, fmt.Errorf("publish progression waiting state: %w", err))
+		return previous, fmt.Errorf("publish progression waiting state: %w", err)
 	}
 	return next, nil
 }

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -1,0 +1,336 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/workflow"
+)
+
+// maxProgressionSteps bounds one unattended progression pass. A healthy run
+// needs a handful of transitions between two harness invocations, so a pass
+// that keeps changing state beyond this ceiling is a coordinator defect rather
+// than ordinary work.
+const maxProgressionSteps = 32
+
+// ProgressionOutcome identifies why one unattended progression pass stopped.
+type ProgressionOutcome string
+
+const (
+	// ProgressionIdle means no run was available to drive.
+	ProgressionIdle ProgressionOutcome = "idle"
+	// ProgressionInvocationActive means a harness invocation is executing and
+	// the coordinator is waiting for its structured result.
+	ProgressionInvocationActive ProgressionOutcome = "invocation_active"
+	// ProgressionWaiting means the run reached a human or infrastructure
+	// waiting state that automatic progression must not cross.
+	ProgressionWaiting ProgressionOutcome = "waiting"
+	// ProgressionDraftPullRequest means the run reached its draft pull
+	// request, which is the end of unattended claim-to-draft-PR progression.
+	ProgressionDraftPullRequest ProgressionOutcome = "draft_pull_request"
+	// ProgressionTerminal means the run has no further progression.
+	ProgressionTerminal ProgressionOutcome = "terminal"
+	// ProgressionUnsupported means the operational store cannot expose the
+	// durable invocation history that exactly-once progression requires.
+	ProgressionUnsupported ProgressionOutcome = "unsupported"
+)
+
+// ProgressionResult reports one unattended progression pass.
+type ProgressionResult struct {
+	// Outcome identifies why the pass stopped.
+	Outcome ProgressionOutcome
+	// Run is the run projection observed when the pass stopped.
+	Run store.Run
+	// Steps counts the coordinator transitions performed in this pass.
+	Steps int
+	// Reason is the operator-facing explanation of Outcome.
+	Reason string
+}
+
+// progressionState is one consistent read of the run and the invocation it
+// currently delegates to.
+type progressionState struct {
+	// Run is the persisted non-terminal or terminal run, when one exists.
+	Run *store.Run
+	// Active is the invocation that may still produce a report.
+	Active *store.Invocation
+	// Latest is the most recent invocation of any status.
+	Latest *store.Invocation
+	// Supported reports whether the operational store exposes the durable
+	// invocation history that exactly-once progression requires.
+	Supported bool
+}
+
+// AdvanceRun drives the current run as far as the frozen route, repository
+// policy, and durable evidence allow, without an operator running a
+// stage-driving command. Every transition is performed through the same
+// coordinator seams the one-shot commands use, so a repeated pass or a
+// coordinator restart reuses their exactly-once effect journal instead of
+// creating a second invocation, checkpoint, push, comment, or pull request.
+func (s *Service) AdvanceRun(ctx context.Context) (ProgressionResult, error) {
+	registration, err := s.registration()
+	if err != nil {
+		return ProgressionResult{}, err
+	}
+	return s.driveRun(ctx, registration)
+}
+
+// driveRun performs bounded unattended progression for one registered
+// repository. It stops at the first state a person or infrastructure owns.
+func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRegistration) (ProgressionResult, error) {
+	result := ProgressionResult{Outcome: ProgressionIdle}
+	for result.Steps < maxProgressionSteps {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		state, err := s.readProgressionState(ctx, registration)
+		if err != nil {
+			return result, err
+		}
+		if !state.Supported {
+			return ProgressionResult{Outcome: ProgressionUnsupported, Steps: result.Steps, Reason: "operational store has no durable invocation history"}, nil
+		}
+		if state.Run == nil {
+			return ProgressionResult{Outcome: ProgressionIdle, Steps: result.Steps, Reason: "no run to drive"}, nil
+		}
+		result.Run = *state.Run
+		step, stop := s.progressionStep(state)
+		if stop != nil {
+			stop.Steps = result.Steps
+			stop.Run = *state.Run
+			return *stop, nil
+		}
+		if err := step.action(ctx); err != nil {
+			paused, pauseErr := s.pauseProgression(ctx, registration, *state.Run, step.name, err)
+			if pauseErr != nil {
+				return result, errors.Join(err, pauseErr)
+			}
+			outcome := ProgressionWaiting
+			if store.IsTerminalStatus(paused.Status) {
+				outcome = ProgressionTerminal
+			}
+			return ProgressionResult{
+				Outcome: outcome,
+				Run:     paused,
+				Steps:   result.Steps,
+				Reason:  waitingReason(paused, err.Error()),
+			}, nil
+		}
+		result.Steps++
+		advanced, err := s.readProgressionState(ctx, registration)
+		if err != nil {
+			return result, err
+		}
+		if advanced.Run == nil {
+			return ProgressionResult{Outcome: ProgressionIdle, Steps: result.Steps, Reason: "run disappeared after " + step.name}, nil
+		}
+		result.Run = *advanced.Run
+		if !progressionAdvanced(*state.Run, state.Active, *advanced.Run, advanced.Active) {
+			return ProgressionResult{
+				Outcome: ProgressionWaiting,
+				Run:     *advanced.Run,
+				Steps:   result.Steps,
+				Reason:  fmt.Sprintf("%s did not advance the run", step.name),
+			}, nil
+		}
+	}
+	result.Outcome = ProgressionWaiting
+	result.Reason = fmt.Sprintf("progression exceeded %d coordinator transitions", maxProgressionSteps)
+	return result, nil
+}
+
+// progressionAction is one coordinator-owned transition selected from durable
+// run state. The coordinator, never an agent, chooses it.
+type progressionAction struct {
+	// name is the operator-facing transition identity used in status text.
+	name string
+	// action performs the transition through an existing coordinator seam.
+	action func(context.Context) error
+}
+
+// progressionStep selects the single legal next transition for a run, or the
+// waiting state that stops automatic progression. Exactly one of the two
+// return values is set.
+func (s *Service) progressionStep(state progressionState) (progressionAction, *ProgressionResult) {
+	run := *state.Run
+	if store.IsTerminalStatus(run.Status) {
+		return progressionAction{}, &ProgressionResult{Outcome: ProgressionTerminal, Reason: "run is " + string(run.Status)}
+	}
+	switch run.Status {
+	case store.StatusWaitingForHuman:
+		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: waitingReason(run, "waiting for human disposition")}
+	case store.StatusWaitingForHarness:
+		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: waitingReason(run, "waiting for harness capacity")}
+	}
+	if run.CheckRepairPendingAttempt != 0 {
+		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: fmt.Sprintf("check-repair attempt %d is pending reconciliation", run.CheckRepairPendingAttempt)}
+	}
+	if state.Active != nil {
+		if state.Active.AttachRequired {
+			return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: fmt.Sprintf("invocation %q requires `factory attach`", state.Active.ID)}
+		}
+		if !agentResultReady(*state.Active) {
+			return progressionAction{}, &ProgressionResult{Outcome: ProgressionInvocationActive, Reason: fmt.Sprintf("invocation %q is executing", state.Active.ID)}
+		}
+		invocationID := state.Active.ID
+		return progressionAction{name: "accept agent report", action: func(ctx context.Context) error {
+			_, err := s.AcceptAgentReport(ctx, AgentReportRequest{RunID: run.ID, InvocationID: invocationID})
+			return err
+		}}, nil
+	}
+	return s.progressionStageStep(state)
+}
+
+// progressionStageStep selects the transition owned by the run stage once no
+// invocation is executing.
+func (s *Service) progressionStageStep(state progressionState) (progressionAction, *ProgressionResult) {
+	run := *state.Run
+	switch run.Stage {
+	case store.StageClaim:
+		return progressionAction{name: "run baseline", action: func(ctx context.Context) error {
+			_, err := s.RunBaseline(ctx, BaselineRequest{RunID: run.ID})
+			return err
+		}}, nil
+	case store.StagePreflight:
+		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: waitingReason(run, "baseline preflight needs human attention")}
+	case store.StageCheck:
+		return progressionAction{name: "create draft pull request", action: func(ctx context.Context) error {
+			_, err := s.CreateDraftPullRequest(ctx, DraftPullRequestRequest{RunID: run.ID})
+			return err
+		}}, nil
+	case store.StageDraftPR:
+		return progressionAction{}, &ProgressionResult{Outcome: ProgressionDraftPullRequest, Reason: fmt.Sprintf("draft pull request #%d is ready for review", run.PullRequestNumber)}
+	case store.StageReady:
+		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: waitingReason(run, "run is ready for human review")}
+	}
+	if _, declared := workflow.DefaultRegistry().RoleForRunStage(run.Stage); !declared {
+		return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: fmt.Sprintf("no factory role owns run stage %q", run.Stage)}
+	}
+	if state.Latest != nil && state.Latest.Stage == run.Stage && state.Latest.Status == store.InvocationStatusCompleted {
+		if run.Stage != store.StageImplementation {
+			return progressionAction{}, &ProgressionResult{Outcome: ProgressionWaiting, Reason: fmt.Sprintf("stage %q has a completed invocation but no declared coordinator transition", run.Stage)}
+		}
+		return progressionAction{name: "create draft pull request", action: func(ctx context.Context) error {
+			_, err := s.CreateDraftPullRequest(ctx, DraftPullRequestRequest{RunID: run.ID})
+			return err
+		}}, nil
+	}
+	return progressionAction{name: "start agent", action: func(ctx context.Context) error {
+		_, err := s.StartAgent(ctx, AgentRequest{RunID: run.ID})
+		return err
+	}}, nil
+}
+
+// readProgressionState reads the run and its invocation projection once. A
+// store without durable invocation history cannot support exactly-once
+// unattended progression, so it reports no run instead of guessing.
+func (s *Service) readProgressionState(ctx context.Context, registration config.RepositoryRegistration) (progressionState, error) {
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return progressionState{}, fmt.Errorf("open operational store for progression: %w", err)
+	}
+	defer func() { _ = opened.Close() }()
+	run, err := opened.CurrentRun(ctx)
+	if err != nil {
+		return progressionState{}, fmt.Errorf("read run for progression: %w", err)
+	}
+	activeStore, hasActive := opened.(ActiveInvocationStore)
+	latestStore, hasLatest := opened.(LatestInvocationStore)
+	if !hasActive || !hasLatest {
+		return progressionState{}, nil
+	}
+	state := progressionState{Run: run, Supported: true}
+	if run == nil {
+		return state, nil
+	}
+	if state.Active, err = activeStore.ActiveInvocation(ctx, run.ID); err != nil {
+		return progressionState{}, fmt.Errorf("read active invocation for progression: %w", err)
+	}
+	if state.Latest, err = latestStore.LatestInvocation(ctx, run.ID); err != nil {
+		return progressionState{}, fmt.Errorf("read latest invocation for progression: %w", err)
+	}
+	return state, nil
+}
+
+// progressionAdvanced reports whether a transition changed durable run state.
+// Without this check a seam that returns success without advancing the run
+// would keep the coordinator repeating the same external operation.
+func progressionAdvanced(previous store.Run, previousInvocation *store.Invocation, next store.Run, nextInvocation *store.Invocation) bool {
+	if previous.Stage != next.Stage || previous.Status != next.Status || previous.Revision != next.Revision {
+		return true
+	}
+	if previous.CheckpointSHA != next.CheckpointSHA || previous.PullRequestNumber != next.PullRequestNumber {
+		return true
+	}
+	return invocationIdentity(previousInvocation) != invocationIdentity(nextInvocation)
+}
+
+// invocationIdentity renders the comparable identity of an optional
+// invocation for progress detection.
+func invocationIdentity(invocation *store.Invocation) string {
+	if invocation == nil {
+		return ""
+	}
+	return invocation.ID + "/" + string(invocation.Status)
+}
+
+// agentResultReady reports whether the invocation has written its structured
+// report. `factory-report` renames the file into place, so its presence is the
+// durable signal that the coordinator may validate a completed result.
+func agentResultReady(invocation store.Invocation) bool {
+	if invocation.ResultDirectory == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(invocation.ResultDirectory, report.ReportFileName))
+	return err == nil && info.Mode().IsRegular()
+}
+
+// waitingReason prefers the coordinator's recorded lifecycle reason so the
+// published status keeps the exact cause of the pause.
+func waitingReason(run store.Run, fallback string) string {
+	if run.LifecycleReason != "" {
+		return run.LifecycleReason
+	}
+	return fallback
+}
+
+// pauseProgression stops automatic progression in a visible human waiting
+// state and publishes an actionable status. A run that a seam already moved
+// out of active is left untouched, because that seam owns the more specific
+// waiting state it published.
+func (s *Service) pauseProgression(ctx context.Context, registration config.RepositoryRegistration, observed store.Run, step string, cause error) (store.Run, error) {
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return observed, fmt.Errorf("open operational store to pause progression: %w", err)
+	}
+	defer func() { _ = opened.Close() }()
+	runStore, ok := opened.(RunStore)
+	if !ok {
+		return observed, errors.New("operational store does not support pausing progression")
+	}
+	current, err := readReconciliationRun(ctx, runStore)
+	if err != nil {
+		return observed, fmt.Errorf("read run to pause progression: %w", err)
+	}
+	if current == nil {
+		return observed, nil
+	}
+	if current.Status != store.StatusActive {
+		return *current, nil
+	}
+	previous := *current
+	next := previous
+	next.Status = store.StatusWaitingForHuman
+	next.LifecycleReason = fmt.Sprintf("automatic progression stopped at %s: %s", step, cause)
+	next.UpdatedAt = s.deps.Now().UTC()
+	if err := s.persistAgentRunState(ctx, registration, runStore, previous, next); err != nil {
+		return previous, errors.Join(cause, fmt.Errorf("publish progression waiting state: %w", err))
+	}
+	return next, nil
+}

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -681,6 +681,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 	next := run
 	next.Stage = store.StageImplementation
 	next.Status = store.StatusActive
+	next.ActiveInvocationID = invocation.ID
 	next.CheckRepairBudget = repairPacket.Budget
 	next.CheckRepairPendingAttempt = repairPacket.Attempt
 	next.LifecycleReason = fmt.Sprintf("check-repair attempt %d active", repairPacket.Attempt)

--- a/internal/factory/unattended_test.go
+++ b/internal/factory/unattended_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
@@ -69,11 +71,11 @@ func TestStartDrivesAnAdvisoryIssueFromQueueToDraftPullRequest(t *testing.T) {
 	}
 }
 
-// TestAdvanceRunStopsAtAWaitingStateAndPublishesIt verifies that a run parked
-// in a human waiting state stops automatic progression instead of relaunching
-// a role, and that the published status distinguishes it from a run whose
-// harness is executing.
-func TestAdvanceRunStopsAtAWaitingStateAndPublishesIt(t *testing.T) {
+// TestUnattendedProgressionStopsAtAWaitingStateAndPublishesIt verifies that a
+// run parked in a human waiting state stops unattended progression instead of
+// relaunching a role, and that the published status distinguishes it from a
+// run whose harness is executing.
+func TestUnattendedProgressionStopsAtAWaitingStateAndPublishesIt(t *testing.T) {
 	t.Parallel()
 
 	fixture := newUnattendedFixture(t)
@@ -184,6 +186,78 @@ func TestRepeatedPollingAndRestartDoNotDuplicateProgressionEffects(t *testing.T)
 	}
 }
 
+// TestUnattendedProgressionRepairsAFailedGateAndStillReachesTheDraftPR
+// verifies the bounded check-repair loop runs under unattended progression: a
+// failed checkpoint gate resumes the implementation session, and the repaired
+// checkpoint is evaluated, pushed, and published without an operator command.
+func TestUnattendedProgressionRepairsAFailedGateAndStillReachesTheDraftPR(t *testing.T) {
+	t.Parallel()
+
+	fixture := newUnattendedFixture(t)
+	fixture.workspace.checkpointSHAs = []string{implementationCheckpoint, repairedImplementationCheckpoint}
+	// Baseline setup and gate pass; the first checkpoint gate fails; every
+	// later command succeeds through the fake's zero-value default.
+	fixture.worker.results = []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0}, {ExitCode: 1}}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopWhenPullRequestExists(cancel)
+
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if len(fixture.harness.starts) != 1 || len(fixture.harness.resumes) != 1 {
+		t.Fatalf("harness lifecycle = %d starts %d resumes, want one launch and one repair resume", len(fixture.harness.starts), len(fixture.harness.resumes))
+	}
+	if fixture.harness.resumes[0].ResumeSessionID != "session-unattended" {
+		t.Fatalf("repair resume = %#v, want the accepted native session", fixture.harness.resumes[0])
+	}
+	if len(fixture.workspace.checkpoints) != 2 || fixture.workspace.checkpoints[1].ParentSHA != implementationCheckpoint {
+		t.Fatalf("checkpoints = %#v, want the repair checkpoint on top of the failed one", fixture.workspace.checkpoints)
+	}
+	if len(fixture.pullRequests.createdRequests) != 1 {
+		t.Fatalf("pull request creates = %d, want exactly one after the repair", len(fixture.pullRequests.createdRequests))
+	}
+	final := fixture.currentRun(t)
+	if final.Stage != store.StageDraftPR || final.CheckpointSHA != repairedImplementationCheckpoint {
+		t.Fatalf("final run = stage %q checkpoint %q, want the draft PR at the repaired checkpoint", final.Stage, final.CheckpointSHA)
+	}
+	if final.CheckRepairAttempts != 1 {
+		t.Fatalf("check-repair attempts = %d, want exactly one consumed attempt", final.CheckRepairAttempts)
+	}
+}
+
+// TestUnattendedProgressionPublishesAnUnclassifiedStepFailure verifies a step
+// failure that no seam classified still leaves a visible waiting state and an
+// actionable reason, instead of an `agent-running` run nobody is working on.
+func TestUnattendedProgressionPublishesAnUnclassifiedStepFailure(t *testing.T) {
+	t.Parallel()
+
+	fixture := newUnattendedFixture(t)
+	fixture.terminal = &unavailableTerminal{}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopAfterLeaseRenewals(cancel, 3)
+
+	if err := fixture.restart().Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if len(fixture.harness.starts) != 0 {
+		t.Fatalf("harness starts = %d, want none once the terminal is unavailable", len(fixture.harness.starts))
+	}
+	final := fixture.currentRun(t)
+	if final.Status != store.StatusWaitingForHuman {
+		t.Fatalf("final status = %q, want waiting_for_human", final.Status)
+	}
+	if !strings.Contains(final.LifecycleReason, "unattended progression stopped at start agent") {
+		t.Fatalf("lifecycle reason = %q, want the failed transition named", final.LifecycleReason)
+	}
+	if !strings.Contains(factory.StatusCommentBody(final), "- activity: `waiting-for-human`") {
+		t.Fatalf("status comment = %q, want the published waiting activity", factory.StatusCommentBody(final))
+	}
+}
+
 // TestStatusCommentSeparatesAnActiveInvocationFromAnActiveRun verifies the
 // published supervision comment never implies that a harness is executing
 // when the coordinator owns the next transition.
@@ -221,6 +295,7 @@ type unattendedFixture struct {
 	workspace       *unattendedWorkspace
 	pullRequests    *fakePullRequests
 	lease           *pollingLease
+	terminal        terminal.TerminalRuntime
 	operationalPath string
 	configPath      string
 	dependencies    func() factory.Dependencies
@@ -269,6 +344,7 @@ func newUnattendedFixtureWith(t *testing.T, testPolicy config.TestPolicy, issueB
 			HeadBranch: "factory/run-unattended", BaseBranch: "main",
 		}},
 		lease:           &pollingLease{},
+		terminal:        &agentTerminal{},
 		operationalPath: filepath.Join(root, "state", "factory.db"),
 	}
 	fixture.agentReport = fixture.completedReport
@@ -296,7 +372,7 @@ func newUnattendedFixtureWith(t *testing.T, testPolicy config.TestPolicy, issueB
 			Worktree:       fixture.workspace,
 			GitWorkspace:   fixture.workspace,
 			Worker:         fixture.worker,
-			Terminal:       &agentTerminal{},
+			Terminal:       fixture.terminal,
 			Harness:        fixture.harness,
 			Now:            func() time.Time { return time.Date(2026, 8, 29, 9, 0, 0, 0, time.UTC) },
 			NewRunID:       newSequentialRunID("run-unattended"),
@@ -494,6 +570,37 @@ func (h *unattendedHarness) Start(ctx context.Context, request harness.StartRequ
 	return session, nil
 }
 
+// Resume applies the repair edits and writes the resumed invocation's report,
+// standing in for an implementation session that fixed a failed gate.
+func (h *unattendedHarness) Resume(ctx context.Context, request harness.StartRequest) (harness.Session, error) {
+	session, err := h.agentHarness.Resume(ctx, request)
+	if err != nil {
+		return session, err
+	}
+	h.fixture.workspace.state.ChangedPaths = []string{"internal/factory.go"}
+	value := h.fixture.agentReport(request)
+	if value.Outcome == "" {
+		return session, nil
+	}
+	value.NativeSessionID = session.NativeSessionID
+	if _, err := report.WriteAtomicForInvocation(h.fixture.worker.resultPath, request.InvocationID, value); err != nil {
+		return session, err
+	}
+	return session, nil
+}
+
+// unavailableTerminal refuses the run workspace, standing in for a terminal
+// failure the coordinator cannot classify into a known waiting state.
+type unavailableTerminal struct {
+	agentTerminal
+}
+
+// EnsureRunWorkspace always fails.
+func (*unavailableTerminal) EnsureRunWorkspace(context.Context, terminal.RunWorkspaceRequest) (terminal.RunWorkspace, error) {
+	return terminal.RunWorkspace{}, errors.New("terminal runtime unavailable")
+}
+
+var _ terminal.TerminalRuntime = (*unavailableTerminal)(nil)
 var _ worker.WorkerRuntime = (*unattendedWorker)(nil)
 var _ harness.Runtime = (*unattendedHarness)(nil)
 var _ github.IssuePoller = (*unattendedGitHub)(nil)

--- a/internal/factory/unattended_test.go
+++ b/internal/factory/unattended_test.go
@@ -1,0 +1,500 @@
+package factory_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+)
+
+// TestStartDrivesAnAdvisoryIssueFromQueueToDraftPullRequest is the end-to-end
+// proof for unattended claim-to-draft-PR progression: one `factory start`
+// takes an eligible advisory-policy issue through baseline, implementation,
+// the checkpoint gate suite, the branch push, and one draft pull request
+// without any stage-driving CLI command.
+func TestStartDrivesAnAdvisoryIssueFromQueueToDraftPullRequest(t *testing.T) {
+	t.Parallel()
+
+	fixture := newUnattendedFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopWhenPullRequestExists(cancel)
+
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if fixture.commands.claimed != 7 {
+		t.Fatalf("claimed issue = %d, want the only eligible issue 7", fixture.commands.claimed)
+	}
+	if len(fixture.harness.starts) != 1 || fixture.harness.starts[0].Role != "implementation" {
+		t.Fatalf("harness starts = %#v, want one implementation invocation", fixture.harness.starts)
+	}
+	if len(fixture.workspace.checkpoints) != 1 || len(fixture.workspace.pushes) != 1 {
+		t.Fatalf("git effects = checkpoints %d pushes %d, want one each", len(fixture.workspace.checkpoints), len(fixture.workspace.pushes))
+	}
+	if len(fixture.pullRequests.createdRequests) != 1 {
+		t.Fatalf("pull request creates = %d, want exactly one", len(fixture.pullRequests.createdRequests))
+	}
+
+	final := fixture.currentRun(t)
+	if final.Stage != store.StageDraftPR || final.PullRequestNumber != 17 {
+		t.Fatalf("final run = stage %q pull request #%d, want draft_pr/#17", final.Stage, final.PullRequestNumber)
+	}
+	if final.CheckpointSHA != implementationCheckpoint {
+		t.Fatalf("final checkpoint = %q, want the implementation checkpoint", final.CheckpointSHA)
+	}
+	if final.ActiveInvocationID != "" {
+		t.Fatalf("final active invocation = %q, want none once no harness executes", final.ActiveInvocationID)
+	}
+	if final.TestHandoff != nil || final.TestCheckpointSHA != "" || len(final.ProtectedTestPaths) != 0 || final.TestStageSkipped {
+		t.Fatalf("advisory run = %#v, want no independent test-stage artifacts", final)
+	}
+	for _, request := range fixture.worker.starts {
+		if request.Role == "test" {
+			t.Fatal("advisory progression started a test-role worker")
+		}
+	}
+}
+
+// TestAdvanceRunStopsAtAWaitingStateAndPublishesIt verifies that a run parked
+// in a human waiting state stops automatic progression instead of relaunching
+// a role, and that the published status distinguishes it from a run whose
+// harness is executing.
+func TestAdvanceRunStopsAtAWaitingStateAndPublishesIt(t *testing.T) {
+	t.Parallel()
+
+	fixture := newUnattendedFixture(t)
+	fixture.agentReport = func(request harness.StartRequest) report.Report {
+		value := fixture.completedReport(request)
+		value.Outcome = report.OutcomeNeedsClarification
+		value.Handoff = nil
+		value.Questions = []report.Question{{ID: "q1", Prompt: "Which target branch should the change use?"}}
+		return value
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopAfterLeaseRenewals(cancel, 3)
+
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if len(fixture.harness.starts) != 1 {
+		t.Fatalf("harness starts = %d, want one invocation before the waiting state", len(fixture.harness.starts))
+	}
+	if len(fixture.workspace.checkpoints) != 0 || len(fixture.pullRequests.createdRequests) != 0 {
+		t.Fatalf("waiting run produced checkpoints=%d pull requests=%d, want none", len(fixture.workspace.checkpoints), len(fixture.pullRequests.createdRequests))
+	}
+	final := fixture.currentRun(t)
+	if final.Status != store.StatusWaitingForHuman {
+		t.Fatalf("final status = %q, want waiting_for_human", final.Status)
+	}
+	if activity := factory.RunActivityFor(final); activity != factory.ActivityWaitingForHuman {
+		t.Fatalf("activity = %q, want waiting-for-human", activity)
+	}
+	if !strings.Contains(factory.StatusCommentBody(final), "- activity: `waiting-for-human`") {
+		t.Fatalf("status comment = %q, want the waiting activity", factory.StatusCommentBody(final))
+	}
+}
+
+// TestStartLaunchesOnlyTheStageTheFrozenRouteSelects verifies the acceptance
+// route runs the independent test role first under unattended progression,
+// and that no implementation invocation, checkpoint, or pull request is
+// created while that invocation is still executing.
+func TestStartLaunchesOnlyTheStageTheFrozenRouteSelects(t *testing.T) {
+	t.Parallel()
+
+	fixture := newUnattendedFixtureWith(t, config.TestPolicy{Mode: config.TestModeAdvisory},
+		"Author the acceptance contract.\n<!-- factory-route: acceptance -->\n")
+	// An invocation that has not written a report keeps the coordinator waiting.
+	fixture.agentReport = func(harness.StartRequest) report.Report { return report.Report{} }
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopAfterLeaseRenewals(cancel, 3)
+
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if len(fixture.harness.starts) != 1 || fixture.harness.starts[0].Role != "test" {
+		t.Fatalf("harness starts = %#v, want exactly one test-role invocation", fixture.harness.starts)
+	}
+	if len(fixture.workspace.checkpoints) != 0 || len(fixture.pullRequests.createdRequests) != 0 {
+		t.Fatalf("route effects = checkpoints %d pull requests %d, want none while the test role runs", len(fixture.workspace.checkpoints), len(fixture.pullRequests.createdRequests))
+	}
+	run := fixture.currentRun(t)
+	if run.Stage != store.StageTest || run.ActiveInvocationID == "" {
+		t.Fatalf("run = stage %q active invocation %q, want the test stage with a live invocation", run.Stage, run.ActiveInvocationID)
+	}
+	if activity := factory.RunActivityFor(run); activity != factory.ActivityInvocationActive {
+		t.Fatalf("activity = %q, want invocation-active", activity)
+	}
+}
+
+// TestRepeatedPollingAndRestartDoNotDuplicateProgressionEffects verifies that
+// continued polling and a coordinator process boundary reconcile the finished
+// run instead of creating a second checkpoint, push, or pull request.
+func TestRepeatedPollingAndRestartDoNotDuplicateProgressionEffects(t *testing.T) {
+	t.Parallel()
+
+	fixture := newUnattendedFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopWhenPullRequestExists(cancel)
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("first Start() error = %v", err)
+	}
+	comments := len(fixture.commands.editedComments)
+	fixture.pullRequests.existing = fixture.pullRequests.created
+
+	restarted, restartCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer restartCancel()
+	fixture.stopAfterLeaseRenewals(restartCancel, 3)
+	if err := fixture.restart().Start(restarted); err != nil {
+		t.Fatalf("restarted Start() error = %v", err)
+	}
+
+	if len(fixture.harness.starts) != 1 {
+		t.Fatalf("harness starts after restart = %d, want one", len(fixture.harness.starts))
+	}
+	if len(fixture.workspace.checkpoints) != 1 || len(fixture.workspace.pushes) != 1 {
+		t.Fatalf("git effects after restart = checkpoints %d pushes %d, want one each", len(fixture.workspace.checkpoints), len(fixture.workspace.pushes))
+	}
+	if len(fixture.pullRequests.createdRequests) != 1 {
+		t.Fatalf("pull request creates after restart = %d, want one", len(fixture.pullRequests.createdRequests))
+	}
+	if len(fixture.commands.createdComments) != 1 {
+		t.Fatalf("status comments = %d, want the single editable supervision comment", len(fixture.commands.createdComments))
+	}
+	if len(fixture.commands.editedComments) != comments {
+		t.Fatalf("status comment edits after restart = %d, want the %d edits the first pass made", len(fixture.commands.editedComments), comments)
+	}
+}
+
+// TestStatusCommentSeparatesAnActiveInvocationFromAnActiveRun verifies the
+// published supervision comment never implies that a harness is executing
+// when the coordinator owns the next transition.
+func TestStatusCommentSeparatesAnActiveInvocationFromAnActiveRun(t *testing.T) {
+	t.Parallel()
+
+	run := store.Run{ID: "run-activity", IssueNumber: 4, Stage: store.StageImplementation, Status: store.StatusActive}
+	if got := factory.RunActivityFor(run); got != factory.ActivityRunActive {
+		t.Fatalf("RunActivityFor(no invocation) = %q, want run-active", got)
+	}
+	if body := factory.StatusCommentBody(run); !strings.Contains(body, "- activity: `run-active`") || strings.Contains(body, "active invocation") {
+		t.Fatalf("status comment = %q, want run-active without an invocation identity", body)
+	}
+	run.ActiveInvocationID = "inv-1"
+	if got := factory.RunActivityFor(run); got != factory.ActivityInvocationActive {
+		t.Fatalf("RunActivityFor(active invocation) = %q, want invocation-active", got)
+	}
+	body := factory.StatusCommentBody(run)
+	if !strings.Contains(body, "- activity: `invocation-active`") || !strings.Contains(body, "- active invocation: `inv-1`") {
+		t.Fatalf("status comment = %q, want the active invocation identity", body)
+	}
+	run.Status = store.StatusComplete
+	if got := factory.RunActivityFor(run); got != factory.ActivityTerminal {
+		t.Fatalf("RunActivityFor(terminal) = %q, want terminal", got)
+	}
+}
+
+// unattendedFixture wires the real operational store to deterministic
+// adapters so the polling coordinator can be driven end to end.
+type unattendedFixture struct {
+	service         *factory.Service
+	commands        *unattendedGitHub
+	worker          *unattendedWorker
+	harness         *unattendedHarness
+	workspace       *unattendedWorkspace
+	pullRequests    *fakePullRequests
+	lease           *pollingLease
+	operationalPath string
+	configPath      string
+	dependencies    func() factory.Dependencies
+	agentReport     func(harness.StartRequest) report.Report
+}
+
+// newUnattendedFixture builds one advisory-policy repository whose harness
+// answers every invocation with a completed structured result.
+func newUnattendedFixture(t *testing.T) *unattendedFixture {
+	t.Helper()
+	return newUnattendedFixtureWith(t, config.TestPolicy{Mode: config.TestModeAdvisory}, "Implement unattended progression.")
+}
+
+// newUnattendedFixtureWith builds the same repository with an explicit frozen
+// test policy and issue body, so a route marker or required policy can select
+// a different stage sequence.
+func newUnattendedFixtureWith(t *testing.T, testPolicy config.TestPolicy, issueBody string) *unattendedFixture {
+	t.Helper()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-unattended\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := validRepositoryConfig()
+	policy.TestPolicy = testPolicy
+	fixture := &unattendedFixture{
+		commands: &unattendedGitHub{fakeGitHub: &fakeGitHub{}, issues: []github.Issue{{
+			Number: 7, Title: "Drive the routine path", Body: issueBody,
+			State: "open", Labels: []string{github.LabelAgentReady},
+		}}},
+		worker: &unattendedWorker{},
+		workspace: &unattendedWorkspace{draftGitWorkspace: &draftGitWorkspace{
+			workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-unattended", Worktree: worktreePath},
+			state:     gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-unattended", HeadSHA: factoryGateCheckpoint},
+		}},
+		pullRequests: &fakePullRequests{created: github.PullRequest{
+			Number: 17, URL: "https://github.com/example/project/pull/17", State: "open", Draft: true,
+			HeadBranch: "factory/run-unattended", BaseBranch: "main",
+		}},
+		lease:           &pollingLease{},
+		operationalPath: filepath.Join(root, "state", "factory.db"),
+	}
+	fixture.agentReport = fixture.completedReport
+	fixture.harness = &unattendedHarness{fixture: fixture}
+
+	registration := config.RepositoryRegistration{
+		Path:                 repositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		AuthorizedUsers:      []string{"alice"},
+		Polling:              config.PollingConfig{Interval: "1ms", Backoff: "1ms"},
+		OperationalDataPath:  fixture.operationalPath,
+		RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+	}
+	fixture.configPath = filepath.Join(root, "config.yaml")
+	fixture.dependencies = func() factory.Dependencies {
+		return factory.Dependencies{
+			Config:         &fakeConfig{value: config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{registration}}},
+			OpenStore:      func(ctx context.Context, path string) (factory.OperationalStore, error) { return store.Open(ctx, path) },
+			LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+			GitHub:         fixture.commands,
+			IssuePoller:    fixture.commands,
+			Lease:          fixture.lease,
+			PullRequests:   fixture.pullRequests,
+			CommitStatuses: &gateStatuses{},
+			Worktree:       fixture.workspace,
+			GitWorkspace:   fixture.workspace,
+			Worker:         fixture.worker,
+			Terminal:       &agentTerminal{},
+			Harness:        fixture.harness,
+			Now:            func() time.Time { return time.Date(2026, 8, 29, 9, 0, 0, 0, time.UTC) },
+			NewRunID:       newSequentialRunID("run-unattended"),
+			Coordinator:    "coordinator-test",
+			StartupDiagnosis: func(context.Context) (factory.DoctorResult, error) {
+				return factory.DoctorResult{Report: doctor.Report{Results: []doctor.Result{doctor.Success("startup")}}}, nil
+			},
+		}
+	}
+	fixture.service = factory.NewWithDependencies(fixture.configPath, fixture.dependencies())
+	return fixture
+}
+
+// restart models a coordinator process boundary: a fresh service opens the
+// same operational store and adapters without any in-memory continuity.
+func (f *unattendedFixture) restart() *factory.Service {
+	f.service = factory.NewWithDependencies(f.configPath, f.dependencies())
+	return f.service
+}
+
+// stopWhenPullRequestExists cancels the coordinator on the first lease
+// renewal observed after the draft pull request was created.
+func (f *unattendedFixture) stopWhenPullRequestExists(cancel context.CancelFunc) {
+	f.lease.onRenew = func(github.Lease) {
+		if len(f.pullRequests.createdRequests) > 0 {
+			cancel()
+		}
+	}
+}
+
+// stopAfterLeaseRenewals cancels the coordinator after a bounded number of
+// polling ticks, which is enough to prove repeated polling adds no effects.
+func (f *unattendedFixture) stopAfterLeaseRenewals(cancel context.CancelFunc, ticks int) {
+	f.lease.onRenew = func(github.Lease) {
+		if len(f.lease.calls) >= ticks {
+			cancel()
+		}
+	}
+}
+
+// currentRun reads the persisted run from the real operational store.
+func (f *unattendedFixture) currentRun(t *testing.T) store.Run {
+	t.Helper()
+	opened, err := store.Open(context.Background(), f.operationalPath)
+	if err != nil {
+		t.Fatalf("open operational store: %v", err)
+	}
+	defer func() { _ = opened.Close() }()
+	run, err := opened.LatestRun(context.Background())
+	if err != nil {
+		t.Fatalf("read latest run: %v", err)
+	}
+	if run == nil {
+		t.Fatal("no persisted run")
+	}
+	return *run
+}
+
+// completedReport is the valid implementation handoff the fake harness writes
+// for one launched invocation.
+func (f *unattendedFixture) completedReport(request harness.StartRequest) report.Report {
+	return report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  request.InvocationID,
+		RunID:         request.RunID,
+		Harness:       string(config.HarnessCodex),
+		Role:          request.Role,
+		Stage:         request.Stage,
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "implemented unattended progression with a focused test",
+		Handoff: &report.Handoff{
+			ChangeSummary:          "drove the routine path to a draft pull request",
+			AcceptanceMapping:      []report.AcceptanceMapping{{Criterion: "unattended progression", Evidence: "internal/factory.go"}},
+			ProductionFilesChanged: []string{"internal/factory.go"},
+			FocusedCommands:        []string{"go test ./internal/factory"},
+		},
+		NativeSessionID: "session-unattended",
+		ReportedAt:      time.Date(2026, 8, 29, 9, 5, 0, 0, time.UTC),
+	}
+}
+
+// newSequentialRunID returns distinct identifiers for the run and each of its
+// invocations, matching the production generator's uniqueness contract.
+func newSequentialRunID(runID string) func() (string, error) {
+	calls := 0
+	return func() (string, error) {
+		calls++
+		if calls == 1 {
+			return runID, nil
+		}
+		return runID + "-" + string(rune('a'+calls-2)), nil
+	}
+}
+
+// unattendedGitHub serves the queue and the claimed issue from one fixture.
+type unattendedGitHub struct {
+	*fakeGitHub
+	issues  []github.Issue
+	claimed int
+}
+
+// ListEligibleIssues returns the configured queue.
+func (f *unattendedGitHub) ListEligibleIssues(context.Context, github.Repository) ([]github.Issue, error) {
+	return append([]github.Issue(nil), f.issues...), nil
+}
+
+// Issue serves the queue snapshot once and then the mutated projection, so
+// later label transitions remain observable to restart reconciliation.
+func (f *unattendedGitHub) Issue(ctx context.Context, repository github.Repository, number int) (github.Issue, error) {
+	if f.fakeGitHub.issueValue.Number != number {
+		for _, issue := range f.issues {
+			if issue.Number == number {
+				f.claimed = number
+				f.fakeGitHub.issueValue = issue
+			}
+		}
+	}
+	return f.fakeGitHub.Issue(ctx, repository, number)
+}
+
+// CreateIssueComment records the created supervision comment so a restarted
+// coordinator can recover it by identity instead of creating a second one.
+func (f *unattendedGitHub) CreateIssueComment(ctx context.Context, repository github.Repository, number int, body string) (github.Comment, error) {
+	comment, err := f.fakeGitHub.CreateIssueComment(ctx, repository, number, body)
+	if err == nil {
+		f.fakeGitHub.statusComment = comment
+	}
+	return comment, err
+}
+
+// EditIssueComment keeps the recoverable comment body current.
+func (f *unattendedGitHub) EditIssueComment(ctx context.Context, repository github.Repository, id, body string) error {
+	if err := f.fakeGitHub.EditIssueComment(ctx, repository, id, body); err != nil {
+		return err
+	}
+	if f.fakeGitHub.statusComment.ID == id {
+		f.fakeGitHub.statusComment.Body = body
+	}
+	return nil
+}
+
+// unattendedWorkspace adds the read-only remote-head projection that restart
+// reconciliation needs once a pull request tracks the pushed branch.
+type unattendedWorkspace struct {
+	*draftGitWorkspace
+}
+
+// RemoteBranchHead reports the last checkpoint the branch push published.
+func (w *unattendedWorkspace) RemoteBranchHead(context.Context, gitadapter.PushRequest) (string, error) {
+	if len(w.pushedSHAs) == 0 {
+		return "", nil
+	}
+	return w.pushedSHAs[len(w.pushedSHAs)-1], nil
+}
+
+// unattendedWorker records the result directory of the invocation currently
+// being launched so the fake harness can write its structured report there.
+type unattendedWorker struct {
+	agentWorker
+	resultPath string
+}
+
+// Start records the mounted result directory before delegating.
+func (w *unattendedWorker) Start(ctx context.Context, request worker.StartRequest) error {
+	if request.ResultPath != "" {
+		w.resultPath = request.ResultPath
+	}
+	return w.agentWorker.Start(ctx, request)
+}
+
+// unattendedHarness answers every launch with a completed structured result,
+// standing in for an interactive harness that finished its work.
+type unattendedHarness struct {
+	agentHarness
+	fixture *unattendedFixture
+}
+
+// Start applies the edits a role would make and writes its structured
+// report, so the coordinator observes the same evidence a real invocation
+// leaves behind.
+func (h *unattendedHarness) Start(ctx context.Context, request harness.StartRequest) (harness.Session, error) {
+	session, err := h.agentHarness.Start(ctx, request)
+	if err != nil {
+		return session, err
+	}
+	h.fixture.workspace.state.ChangedPaths = []string{"internal/factory.go"}
+	value := h.fixture.agentReport(request)
+	if value.Outcome == "" {
+		// The invocation is still working; the coordinator must wait for it.
+		return session, nil
+	}
+	if _, err := report.WriteAtomicForInvocation(h.fixture.worker.resultPath, request.InvocationID, value); err != nil {
+		return session, err
+	}
+	return session, nil
+}
+
+var _ worker.WorkerRuntime = (*unattendedWorker)(nil)
+var _ harness.Runtime = (*unattendedHarness)(nil)
+var _ github.IssuePoller = (*unattendedGitHub)(nil)
+var _ gitadapter.RemoteBranchInspector = (*unattendedWorkspace)(nil)

--- a/internal/store/cleanup.go
+++ b/internal/store/cleanup.go
@@ -255,6 +255,7 @@ func (s *Store) cleanupRun(ctx context.Context, runID string) (*Run, error) {
 		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
 		       test_handoff, implementation_handoff, specification_review,
 		       test_exemption, protected_test_paths, test_stage_skipped,
+		       active_invocation_id,
 		       image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CurrentSchemaVersion is the supported operational-store schema version.
-const CurrentSchemaVersion = 25
+const CurrentSchemaVersion = 26
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -337,9 +337,14 @@ type Run struct {
 	ProtectedTestPaths []ProtectedTestPath
 	// TestStageSkipped records an authorized skip before implementation.
 	TestStageSkipped bool
-	ImageDigest      string
-	Coordinator      string
-	StatusCommentID  string
+	// ActiveInvocationID identifies the harness invocation the run currently
+	// delegates to. It is empty whenever no harness is executing for the run,
+	// which lets a status projection separate an active run from an active
+	// invocation without reading the invocation table.
+	ActiveInvocationID string
+	ImageDigest        string
+	Coordinator        string
+	StatusCommentID    string
 	// PullRequestNumber is the persisted idempotency identity of the draft PR.
 	PullRequestNumber int
 	// PullRequestURL is the operator-facing URL of the draft PR.
@@ -643,6 +648,7 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
 		       test_handoff, implementation_handoff, specification_review,
 		       test_exemption, protected_test_paths, test_stage_skipped,
+		       active_invocation_id,
 		       image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent,
@@ -667,6 +673,7 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
 		       test_handoff, implementation_handoff, specification_review,
 		       test_exemption, protected_test_paths, test_stage_skipped,
+		       active_invocation_id,
 		       image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent,
@@ -708,6 +715,7 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&testExemptionJSON,
 		&protectedTestPathsJSON,
 		&run.TestStageSkipped,
+		&run.ActiveInvocationID,
 		&run.ImageDigest,
 		&run.Coordinator,
 		&run.StatusCommentID,
@@ -1295,6 +1303,7 @@ func runValues(run Run) []any {
 		testExemptionJSON(run.TestExemption),
 		protectedTestPathsJSON(run.ProtectedTestPaths),
 		run.TestStageSkipped,
+		run.ActiveInvocationID,
 		run.ImageDigest,
 		run.Coordinator,
 		run.StatusCommentID,
@@ -1338,6 +1347,7 @@ const saveRunStatement = `
 			checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
 			test_handoff, implementation_handoff, specification_review,
 			test_exemption, protected_test_paths, test_stage_skipped,
+			active_invocation_id,
 			image_digest, coordinator, status_comment_id,
 			pull_request_number, pull_request_url, merge_commit_sha, lifecycle_reason,
 			lifecycle_notification_sent,
@@ -1351,7 +1361,7 @@ const saveRunStatement = `
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
@@ -1369,6 +1379,7 @@ const saveRunStatement = `
 			test_exemption = excluded.test_exemption,
 			protected_test_paths = excluded.protected_test_paths,
 			test_stage_skipped = excluded.test_stage_skipped,
+			active_invocation_id = excluded.active_invocation_id,
 			image_digest = excluded.image_digest,
 			coordinator = excluded.coordinator,
 			status_comment_id = excluded.status_comment_id,
@@ -1400,6 +1411,7 @@ const saveRunIfRevisionStatement = `
 			checkpoint_sha = ?, base_checkpoint_sha = ?, test_checkpoint_sha = ?,
 			test_handoff = ?, implementation_handoff = ?, specification_review = ?,
 			test_exemption = ?, protected_test_paths = ?, test_stage_skipped = ?,
+			active_invocation_id = ?,
 			image_digest = ?, coordinator = ?, status_comment_id = ?,
 			pull_request_number = ?, pull_request_url = ?, merge_commit_sha = ?, lifecycle_reason = ?,
 			lifecycle_notification_sent = ?,
@@ -2390,6 +2402,10 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 				if _, err := tx.ExecContext(ctx, statement); err != nil {
 					return fmt.Errorf("apply store migration 25: %w", err)
 				}
+			}
+		case 26:
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN active_invocation_id TEXT NOT NULL DEFAULT ''"); err != nil {
+				return fmt.Errorf("apply store migration 26: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -625,6 +625,58 @@ func TestStorePersistsCheckRepairBudget(t *testing.T) {
 	}
 }
 
+// TestStorePersistsTheActiveInvocationDelegation verifies the durable marker
+// that lets a status projection separate an active run from an active harness
+// invocation without reading the invocation table.
+func TestStorePersistsTheActiveInvocationDelegation(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	run := store.Run{
+		ID:                 "run-delegation",
+		RepositoryPath:     "/work/repository",
+		Stage:              store.StageImplementation,
+		Status:             store.StatusActive,
+		ActiveInvocationID: "inv-delegation",
+		CreatedAt:          time.Unix(100, 0).UTC(),
+		UpdatedAt:          time.Unix(200, 0).UTC(),
+	}
+	if err := opened.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	reopened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("reopen error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentRun() error = %v", err)
+	}
+	if got == nil || got.ActiveInvocationID != "inv-delegation" {
+		t.Fatalf("CurrentRun() = %#v, want the persisted active invocation identity", got)
+	}
+	run.ActiveInvocationID = ""
+	run.UpdatedAt = time.Unix(300, 0).UTC()
+	if err := reopened.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun() clearing error = %v", err)
+	}
+	cleared, err := reopened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentRun() after clearing error = %v", err)
+	}
+	if cleared == nil || cleared.ActiveInvocationID != "" {
+		t.Fatalf("CurrentRun() = %#v, want the delegation cleared", cleared)
+	}
+}
+
 func TestSaveRunUpsertsAnExistingRunByID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #85.

## Summary

`factory start` was a queue supervisor that stopped after claiming an issue. Every routine run still needed `factory issue`, `factory agent`, `factory agent-report`, and `factory draft-pr` to reach a draft pull request.

The polling coordinator now drives each claimed or active run to its draft pull request. After every observation that claimed or found a run, `driveRun` performs a bounded progression pass:

1. `claim` → the frozen baseline.
2. A healthy baseline enters the stage the frozen route and test policy select. Advisory policy with no route goes straight to implementation-owned TDD — no test invocation, handoff, protected path, or test checkpoint.
3. The role the workflow registry declares for the stage is launched, and the coordinator waits while it runs.
4. A written structured report is validated through the same boundary as `factory agent-report`, and the run advances.
5. An accepted implementation is checkpointed, every gate runs against that exact checkpoint, and a failed gate enters the existing bounded check-repair loop.
6. A coherent checkpoint is pushed and receives one draft pull request.

The coordinator owns every transition; no agent may choose, skip, or redefine one. The workflow registry stays the stage authority — the stage step reads declared coordinator events and roles rather than a second stage graph.

Every transition runs through the same seam the matching one-shot command uses, so repeated polling and coordinator restart reconcile pending effects instead of duplicating an invocation, checkpoint, push, comment, status, or pull request. Progression stops in its defined waiting state — clarification, policy rejection, exhausted budget, harness limit, authentication failure, attach gate, recovery ambiguity — and publishes the reason. A stall never leaves a run active and silent. A cancelled context is recognised as `factory stop`, which keeps its existing contract.

Runs now record the invocation they delegate to, so `factory status` and the editable comment separate `run-active` from `invocation-active` and the waiting states, instead of leaving `agent-running` ambiguous. This adds operational store schema version 26.

The one-shot commands remain available for diagnosis and deliberate manual operation.

## Test plan

- `make check` and `go test -race ./internal/factory ./internal/cli ./internal/store` pass (696 tests).
- New end-to-end test: one `factory start` takes an advisory-policy `agent-ready` issue from queue selection through implementation, gates, push, and draft-PR creation with no stage-driving command, and creates no test-stage artifacts.
- New tests also cover: the `acceptance` route launching only the test stage; a failed gate repaired through the bounded check-repair loop and still reaching the draft PR; a clarification request stopping progression; an unclassified step failure publishing a waiting state; repeated polling plus a coordinator restart producing exactly one checkpoint, push, pull request, and supervision comment.
- CLI and store coverage for the published activity and its durable marker.

## Contract impact

- **Operational store**: schema 25 → 26, adding `operational_runs.active_invocation_id`. Migration is additive with a default; existing rows are unaffected. Older binaries reject a newer schema, so this is forward-only as usual.
- **Status projections**: the editable status comment gains `- activity:` (and `- active invocation:` while one executes); `factory status` gains `activity=` and an `active invocation:` line. Both are derived from the run record, so restart reconciliation still compares a pure projection.
- **`factory stop`**: unchanged — it stops the supervisor without cancelling or destroying the active run.
- **One-shot commands**: unchanged behaviour, now documented as diagnostic and manual alternatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrDRfPTNz7htCGCEbaFmdr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unattended progression from issue claim through validation, repair, branch push, and a single draft pull request.
  * Added visible activity states, including active work, invocation execution, human waiting, harness waiting, and terminal status.
  * Status output now shows the active invocation when applicable.

* **Bug Fixes**
  * Improved recovery, retry handling, restart behavior, and prevention of stale invocation assignments.
  * Added safeguards for repeated progression failures and stalled workflows.

* **Documentation**
  * Updated the glossary, README, and configuration guidance with workflow states, waiting conditions, and manual command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->