### PR TITLE
Implement test-versus-implementation objection cycle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,6 +29,14 @@ _Avoid_: Agent claim, transcript, implementation handoff
 A repository-relative test or authorized test-infrastructure path recorded at the test checkpoint with its SHA-256 content identity; implementation cannot edit it directly.
 _Avoid_: Mutable test file, permitted production path
 
+**Test objection cycle**:
+A bounded implementation-to-test dispute in which implementation submits the
+protected test's claim and observable evidence, the original test session may
+accept or reject that objection, and an accepted revision must pass independent
+red verification before implementation resumes. Automation is gated by the
+measured pilot and permits at most two revision attempts before human review.
+_Avoid_: Test rewrite, implementation-owned test edit, unbounded repair
+
 **Workflow route**:
 The factory-owned stage sequence an authorized issue author selects with one bounded frozen issue marker before claim. `acceptance` runs the independent test role before implementation; `design-acceptance` runs architecture, then the test role, then implementation. An absent marker follows the repository test policy. The route is recorded in the specification packet and is immutable for the run; it is never inferred from changed files, issue prose, or model judgment.
 _Avoid_: Inferred workflow, repository-declared route, mode

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ operational store, GitHub comments, and the documentation.
 | **Gate**                 | A deterministic repository command, such as formatting, vetting, testing, or building, run in the policy-defined environment.                                  |
 | **Operational store**    | A private SQLite database that records run state, identities, effects, reports, gate results, and content-free evaluation summaries.                           |
 | **Baseline**             | The pre-edit setup and gate result for the frozen packet. It proves what the repository looked like before agent edits.                                        |
+| **Test objection cycle** | A bounded implementation-to-test dispute: implementation supplies a test claim and evidence, the original test session accepts or rejects it, and an accepted revision must pass independent red verification. Automation is pilot-gated and capped at two attempts. |
 | **Recovery diagnosis**   | A read-only comparison of durable state against Git, GitHub, the worktree, worker, terminal, harness, and operational store.                                   |
 | **Reconciliation**       | A deliberate restart pass that replays an exact pending effect or pauses for human inspection when external state is ambiguous.                                |
 
@@ -124,6 +125,8 @@ implementation role owns the complete red/green/refactor loop. It may add or
 revise focused behavioral tests and essential test infrastructure within its
 permitted scope. There is no separate test invocation, handoff, checkpoint,
 protected-test path, exemption, or test-stage dispute in advisory mode.
+The checked-in policy also keeps automated implementation objections disabled;
+the measured pilot must record `proceed` before that switch is enabled.
 
 Repositories using required mode, and any run whose issue selected a workflow
 route, enter the independent test stage. In required mode that stage can be
@@ -138,7 +141,11 @@ claim:
 The test policy must allow that exemption. In required mode, a test handoff never
 owns production files. Once accepted, its test checkpoint and protected test
 paths are carried into implementation, and an implementation report that changes
-a protected test path is rejected.
+a protected test path is rejected. Instead, implementation can submit a
+structured objection naming the test, disputed claim, and observable evidence.
+Before pilot authorization the objection is preserved for human disposition; an
+authorized run can resume the original test session for at most two independently
+verified revision attempts.
 
 ### Workflow routes
 
@@ -489,6 +496,8 @@ test_policy:
   mode: required
   allow_human_exemption: true
   allow_technical_exemption: true
+  # Enable only after the measured pilot records a proceed decision in #26.
+  allow_automated_objections: false
 
 allowed_overrides: [model, reasoning_effort]
 
@@ -709,6 +718,30 @@ worktree state, and native session identity. Terminal output is never treated
 as a result. An accepted implementation report leaves the run ready for the
 host-owned checkpoint and check sequence.
 
+If implementation finds that a protected test encodes the wrong contract, it
+can add a structured objection instead of editing that test:
+
+~~~sh
+factory-report \
+  --outcome completed \
+  --summary 'implementation found a disputed test claim' \
+  --change-summary 'implemented the observable behavior' \
+  --acceptance 'criterion=focused test' \
+  --production-file internal/example.go \
+  --focused-command 'go test ./internal/...' \
+  --test-objection 'internal/example_test.go:TestBehavior|the assertion is too narrow|public behavior passes while the assertion fails'
+~~~
+
+The coordinator preserves the objection and waits for a human while
+`test_policy.allow_automated_objections` is false. Once the measured pilot has
+authorized automation, and the latest authorized maintainer decision comment
+on issue #26 says `Decision: proceed`, it resumes the original test session
+with the current implementation context. A later `revise and repeat` or `stop`
+decision closes that gate. The test role may accept or reject the objection; an
+accepted revision must pass a new independent red verification before
+implementation resumes, and the cycle stops for human disposition after two
+attempts or any verification failure.
+
 An optional architecture detour can be started when the run has no conflicting
 active invocation:
 
@@ -881,7 +914,27 @@ factory-report \
 The coordinator reruns <code>--focused-test-command</code> inside the worker.
 Passing output, a missing expected failure reason, a command/path dispute, or
 any other unverifiable result becomes a <code>test_dispute</code> escalation
-and pauses for a human; it does not trigger an automatic revision loop.
+and pauses for a human; it does not trigger the implementation objection cycle.
+
+For an implementation objection, repeat `--test-objection` once per disputed
+claim. A resumed test role reports its decision with the test response flags:
+
+~~~sh
+factory-report \
+  --outcome completed \
+  --summary 'test objection accepted' \
+  --objection-decision accepted \
+  --objection-reason 'the public behavior is the stable contract' \
+  --acceptance 'criterion=revised focused test' \
+  --test-file internal/example_test.go \
+  --focused-test-command 'go test ./internal -run TestBehavior' \
+  --expected-failure-reason 'expected behavior assertion' \
+  --observed-failure 'exit_code=1'
+~~~
+
+Use `--objection-decision rejected` with a concise reason when the test claim
+stands. Rejection, direct edits to protected paths, or failed red verification
+pauses the run for human disposition.
 
 ### Clarification and blocked outcomes
 
@@ -1075,8 +1128,12 @@ no agent may choose, skip, or redefine one.
 3. The coordinator launches the role the workflow registry declares for that
    stage, then waits while the invocation runs.
 4. When the invocation writes its structured report, the coordinator validates
-   and accepts it through the same boundary as <code>factory agent-report</code>
-   and advances to the next legal stage.
+   and accepts it through the same boundary as <code>factory agent-report</code>.
+   A structured implementation objection either waits for the measured-pilot
+   gate, or starts the bounded native-resume test cycle; an accepted revision
+   must pass independent red verification before the implementation stage can
+   continue. Rejection, failed verification, or an objection after the second
+   attempt pauses for a human.
 5. An accepted implementation is checkpointed, every configured gate runs
    against that exact checkpoint, and a failed gate enters the bounded
    check-repair loop.
@@ -1312,6 +1369,9 @@ The worker-facing command supports:
 --focused-test-command <command>
 --expected-failure-reason <text>
 --observed-failure kind=detail                            # repeatable
+--test-objection test|claim|evidence                      # repeatable, implementation only
+--objection-decision accepted|rejected                   # test revision only
+--objection-reason <reason>                              # test revision only
 --uncovered-criterion <criterion>                        # repeatable
 --finding location|claim|evidence|severity|category|resolution|owner  # repeatable
 --question id=text                                        # repeatable

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -153,6 +153,20 @@ on the `design-acceptance` route also receives `design_handoff`, the accepted
 architecture design it must exercise. The worker receives a separate writable `/results` mount
 containing only that invocation's result directory.
 
+An implementation report may include one or more structured `test_objection`
+entries. Each entry identifies the protected test, the claim under dispute, and
+observable evidence; it does not authorize an implementation edit to the
+protected path. When `test_policy.allow_automated_objections` is disabled, the
+coordinator records the objection and pauses for a human. After the measured
+pilot authorizes automation and an authorized maintainer's latest #26 decision
+comment says `Decision: proceed`, the coordinator resumes the original test
+session with the current implementation context. A later `revise and repeat`
+or `stop` decision closes the gate. The test role returns an accepted or
+rejected response; an accepted revision must produce new test content and pass
+an independently rerun focused command with the expected red failure before the
+implementation role resumes. A rejection, verification failure, or an objection
+after the second attempt pauses for human disposition.
+
 The harness reports through the worker-image command:
 
 ```sh
@@ -204,7 +218,9 @@ and requires the reported `expected_failure_reason` to appear in the captured
 output. Only that matching non-zero exit is verified red evidence. A passing
 command, worker failure, missing expected reason, or path-ownership dispute moves the run to `test/waiting_for_human`;
 the coordinator records only the content-free `test_dispute` evaluation
-category and does not revise the test automatically.
+category. An implementation objection follows the separately gated objection
+cycle described above; ordinary unverifiable test-stage reports never trigger
+that cycle.
 
 On verified red evidence in required mode, the coordinator creates a distinct
 test checkpoint, records every changed test/infrastructure path and its SHA-256
@@ -249,7 +265,9 @@ Human skips must be frozen in the issue before claim with an exact marker:
 The repository must allow human exemptions for required-mode skips. Technical
 exemptions may be reported by the required-mode test agent only when policy
 allows them; they are provisional and are carried to later review. Advisory
-implementation reports do not use test-stage exemptions or disputes.
+implementation reports do not use test-stage exemptions or disputes, but an
+implementation-owned advisory handoff may still include its own behavioral
+tests without invoking the protected-test objection cycle.
 
 When the harness has reliable measurements or content-free policy signals, it
 may also pass `--input-tokens`, `--output-tokens`, `--total-tokens`,

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -153,19 +153,19 @@ on the `design-acceptance` route also receives `design_handoff`, the accepted
 architecture design it must exercise. The worker receives a separate writable `/results` mount
 containing only that invocation's result directory.
 
-An implementation report may include one or more structured `test_objection`
-entries. Each entry identifies the protected test, the claim under dispute, and
-observable evidence; it does not authorize an implementation edit to the
-protected path. When `test_policy.allow_automated_objections` is disabled, the
-coordinator records the objection and pauses for a human. After the measured
-pilot authorizes automation and an authorized maintainer's latest #26 decision
-comment says `Decision: proceed`, the coordinator resumes the original test
-session with the current implementation context. A later `revise and repeat`
-or `stop` decision closes the gate. The test role returns an accepted or
-rejected response; an accepted revision must produce new test content and pass
-an independently rerun focused command with the expected red failure before the
-implementation role resumes. A rejection, verification failure, or an objection
-after the second attempt pauses for human disposition.
+Only a required-mode implementation report may include one structured
+`test_objection` entry. It identifies the protected test, the claim under
+dispute, and observable evidence; it does not authorize an implementation edit
+to the protected path. When `test_policy.allow_automated_objections` is
+disabled, the coordinator records the objection and pauses for a human. After
+the measured pilot authorizes automation and an authorized maintainer's latest
+#26 decision comment says `Decision: proceed`, the coordinator resumes the
+original test session with the current implementation context. A later `revise
+and repeat` or `stop` decision closes the gate. The test role returns an
+accepted or rejected response; an accepted revision must produce new test
+content and pass an independently rerun focused command with the expected red
+failure before the implementation role resumes. A rejection, verification
+failure, or an objection after the second attempt pauses for human disposition.
 
 The harness reports through the worker-image command:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,8 @@ test_policy:
   mode: required
   allow_human_exemption: true
   allow_technical_exemption: true
+  # Enable only after the measured pilot records a proceed decision in #26.
+  allow_automated_objections: false
   # Optional prefixes for essential test infrastructure.
   test_paths: []
   infrastructure_paths: []
@@ -181,6 +183,16 @@ evaluation:
 ```
 
 The validator checks the schema version, target branch, setup, optional repository-relative `setup_files`, setup environment policy, ordered unique gates and earlier dependencies, matching role harness/model policies, the mandatory `test` role when `test_policy.mode` is `required`, optional `reasoning_effort_options` for declared roles, positive durations, positive retry limits, test policy, supported test-role prefixes, supported unique overrides (`model`, `reasoning_effort`, or `harness`), caches, worker image, base-synchronization mode, and optional positive `evaluation.retention`. `setup_files` names the checked-in manifests and lockfiles whose contents identify the dependency graph; an empty list is valid. `test_policy.test_paths` and `test_policy.infrastructure_paths` authorize additional repository-relative paths for the independent test role; conventional `*_test.go`, `test/`, `tests/`, `test-support/`, and `__tests__/` paths are allowed by default. An empty `allowed_overrides` list is valid and means that issue-level overrides are disabled. Validation errors are typed and identify the offending field, including `schema_version` for an unsupported newer schema.
+
+`test_policy.allow_automated_objections` is the evidence-gated switch for the
+implementation-to-test objection cycle. Keep it `false` until the measured
+pilot in issue #26 records `proceed`; while disabled, a structured objection is
+persisted and the run waits for a human. When enabled, the coordinator resumes
+the original test session, permits at most two revision attempts, and reruns the
+revised focused command independently before implementation can continue.
+The coordinator also verifies the latest decision comment on #26 from an
+authorized maintainer (`Decision: proceed` or the equivalent machine-readable
+pilot marker); a later `revise and repeat` or `stop` decision closes the gate.
 
 ## Per-role harness, model, and reasoning effort
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,8 +191,11 @@ persisted and the run waits for a human. When enabled, the coordinator resumes
 the original test session, permits at most two revision attempts, and reruns the
 revised focused command independently before implementation can continue.
 The coordinator also verifies the latest decision comment on #26 from an
-authorized maintainer (`Decision: proceed` or the equivalent machine-readable
-pilot marker); a later `revise and repeat` or `stop` decision closes the gate.
+authorized maintainer. Use either `Decision: proceed` or
+`<!-- factory-pilot-decision: proceed -->` to open the gate. Use either
+`Decision: revise and repeat` or
+`<!-- factory-pilot-decision: revise and repeat -->`, or either `Decision:
+stop` or `<!-- factory-pilot-decision: stop -->`, to close it.
 
 ## Per-role harness, model, and reasoning effort
 

--- a/factory.yaml
+++ b/factory.yaml
@@ -52,6 +52,8 @@ test_policy:
   mode: advisory
   allow_human_exemption: true
   allow_technical_exemption: true
+  # Enable only after the measured pilot records a proceed decision in #26.
+  allow_automated_objections: false
 allowed_overrides: [model, reasoning_effort]
 caches:
   - name: go-build

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,10 @@ type RetryLimits struct {
 // Repository policy may choose a lower value, but never a higher one.
 const MaxCheckRepairAttempts = 3
 
+// MaxTestRevisionAttempts is the hard safety ceiling for automated disputes
+// between implementation-owned behavior and protected tests.
+const MaxTestRevisionAttempts = 2
+
 type TestMode string
 
 const (
@@ -142,6 +146,10 @@ type TestPolicy struct {
 	Mode                    TestMode `yaml:"mode"`
 	AllowHumanExemption     bool     `yaml:"allow_human_exemption"`
 	AllowTechnicalExemption bool     `yaml:"allow_technical_exemption"`
+	// AllowAutomatedObjections is the explicit evidence-gate switch for the
+	// bounded implementation-versus-test revision loop. It remains disabled
+	// until the measured pilot authorizes automation.
+	AllowAutomatedObjections bool `yaml:"allow_automated_objections"`
 	// TestPaths adds repository-relative prefixes where the test role may edit.
 	TestPaths []string `yaml:"test_paths"`
 	// InfrastructurePaths adds essential test-support prefixes owned by the test role.
@@ -524,6 +532,9 @@ func ValidateRepository(config RepositoryConfig) error {
 		}
 		if field == "retry_limits.check_repair" && value > MaxCheckRepairAttempts {
 			return validation(field, fmt.Sprintf("must not exceed %d", MaxCheckRepairAttempts))
+		}
+		if field == "retry_limits.test_revision" && value > MaxTestRevisionAttempts {
+			return validation(field, fmt.Sprintf("must not exceed %d", MaxTestRevisionAttempts))
 		}
 	}
 	if err := validateTestPolicyPaths("test_policy.test_paths", config.TestPolicy.TestPaths); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -643,6 +643,14 @@ func TestValidateRepositoryRejectsInvalidFieldsOneAtATime(t *testing.T) {
 			field: "retry_limits.check_repair",
 		},
 		{
+			name: "test revision limit above hard ceiling",
+			mutate: func(c config.RepositoryConfig) config.RepositoryConfig {
+				c.RetryLimits.TestRevision = config.MaxTestRevisionAttempts + 1
+				return c
+			},
+			field: "retry_limits.test_revision",
+		},
+		{
 			name: "invalid test policy mode",
 			mutate: func(c config.RepositoryConfig) config.RepositoryConfig {
 				c.TestPolicy.Mode = "sometimes"

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -61,6 +61,10 @@ type AgentRequest struct {
 	ClaudeAuthPath string
 	// PermittedPaths constrains production paths in the accepted handoff.
 	PermittedPaths []string
+	// testRevision requests a native resume of the original test session for
+	// an automated objection cycle. It is coordinator-internal and never
+	// exposed as a user-selectable authority.
+	testRevision bool
 }
 
 // AgentLaunchResult reports the persisted invocation and prompt after launch.
@@ -123,6 +127,13 @@ type InvocationPacket struct {
 	PermittedPaths []string `json:"permitted_paths"`
 	// TestHandoff carries the accepted test-stage evidence to implementation.
 	TestHandoff *store.TestHandoff `json:"test_handoff,omitempty"`
+	// TestObjection carries the current implementation dispute to a resumed
+	// test role.
+	TestObjection *store.TestObjection `json:"test_objection,omitempty"`
+	// TestRevisionAttempt identifies the active objection cycle.
+	TestRevisionAttempt int `json:"test_revision_attempt,omitempty"`
+	// TestRevisionBudget is the frozen objection-cycle ceiling.
+	TestRevisionBudget int `json:"test_revision_budget,omitempty"`
 	// ProtectedTestPaths records test files implementation must not edit.
 	ProtectedTestPaths []store.ProtectedTestPath `json:"protected_test_paths,omitempty"`
 	// TestExemption carries a provisional technical exemption to the reviewer.
@@ -140,8 +151,8 @@ const (
 	// packet shape retained for restart recovery.
 	invocationPacketMinimumSupportedVersion = 1
 	// invocationPacketVersion identifies the read-only invocation packet shape.
-	// Version six adds the frozen contract-first route and its design handoff.
-	invocationPacketVersion = 6
+	// Version seven adds the current test objection and revision budget.
+	invocationPacketVersion = 7
 	// invocationPacketFileName is the stable worker-visible packet filename.
 	invocationPacketFileName = "specification.json"
 )
@@ -295,7 +306,15 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	if inspectErr != nil {
 		return AgentResult{}, fmt.Errorf("inspect worktree for agent report: %w", inspectErr)
 	}
-	validationContext.ObservedChanges = state.ChangedPaths
+	testRevisionActive := isTestInvocation && run.TestObjection != nil
+	observedChanges := append([]string(nil), state.ChangedPaths...)
+	if testRevisionActive {
+		observedChanges, err = testRevisionChangedPaths(state, run.TestRevisionBaseChangedPaths)
+		if err != nil {
+			return AgentResult{}, fmt.Errorf("compute test revision worktree changes: %w", err)
+		}
+	}
+	validationContext.ObservedChanges = observedChanges
 	validationContext.WorktreeObserved = true
 	if run.CheckpointSHA != "" && state.HeadSHA != run.CheckpointSHA {
 		return AgentResult{}, fmt.Errorf("agent report worktree HEAD %q does not match checkpoint %q", state.HeadSHA, run.CheckpointSHA)
@@ -317,6 +336,9 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	validationContext.TestInfrastructurePaths = packet.RepositoryConfig.TestPolicy.InfrastructurePaths
 	if err := report.Validate(value, validationContext); err != nil {
 		if isUnverifiableTestReport(value, *invocation) {
+			if testRevisionActive {
+				return s.pauseUnverifiableTestRevisionReport(ctx, registration, runStore, run, invocation, value)
+			}
 			return s.pauseUnverifiableTestReport(ctx, registration, runStore, run, invocation, value)
 		}
 		return AgentResult{}, err
@@ -326,7 +348,24 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 			return AgentResult{}, err
 		}
 	}
-	if err := validateProtectedTestPaths(run.Worktree, state, run.ProtectedTestPaths); err != nil {
+	implementationObjection := implementationTestObjection(value, *invocation)
+	if value.TestObjectionResponse != nil && !testRevisionActive {
+		return AgentResult{}, errors.New("test objection response requires an active implementation objection")
+	}
+	if implementationObjection {
+		if err := validateImplementationTestObjection(value, *invocation, *run, packet); err != nil {
+			return AgentResult{}, err
+		}
+	}
+	automatedObjection, objectionGateReason := false, ""
+	if implementationObjection {
+		automatedObjection, objectionGateReason = s.automatedTestObjectionGate(ctx, registration, packet)
+	}
+	if testRevisionActive {
+		if err := validateTestChangedPaths(observedChanges, packet.RepositoryConfig.TestPolicy); err != nil {
+			return AgentResult{}, fmt.Errorf("test revision path ownership: %w", err)
+		}
+	} else if err := validateProtectedTestPaths(run.Worktree, state, run.ProtectedTestPaths); err != nil {
 		return AgentResult{}, err
 	}
 	if value.Outcome == report.OutcomeNeedsClarification {
@@ -371,6 +410,11 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 				return AgentResult{}, fmt.Errorf("record local evaluation usage: %w", err)
 			}
 		}
+		if implementationObjection || (testRevisionActive && value.TestObjectionResponse != nil) {
+			if err := recorder.RecordEvaluationEscalation(ctx, run.ID, store.EvaluationEscalationTestDispute); err != nil {
+				return AgentResult{}, fmt.Errorf("record test objection escalation: %w", err)
+			}
+		}
 		switch value.Outcome {
 		case report.OutcomeNeedsClarification:
 			if err := recorder.RecordEvaluationEscalation(ctx, run.ID, store.EvaluationEscalationClarification); err != nil {
@@ -407,7 +451,12 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		releaseActiveInvocation(&nextRun, invocation.ID)
 		isTestReport := isTestInvocation
 		isReviewReport := isReviewInvocation
-		if !isTestReport && !isReviewReport {
+		if implementationObjection {
+			nextRun, err = projectImplementationTestObjection(previousRun, value, *invocation, packet, state, automatedObjection, objectionGateReason)
+			if err != nil {
+				return AgentResult{}, err
+			}
+		} else if !isTestReport && !isReviewReport {
 			nextRun = agentReportRunProjection(previousRun, invocation.Stage, value)
 		}
 		nextRun.Revision = previousRun.Revision + 1
@@ -415,7 +464,7 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 			nextRun.Revision = previousRun.Revision
 		}
 		nextRun.UpdatedAt = s.deps.Now().UTC()
-		stopWorkerAfterReport := value.Outcome == report.OutcomeNeedsClarification || isReviewReport
+		stopWorkerAfterReport := value.Outcome == report.OutcomeNeedsClarification || isReviewReport || implementationObjection
 		acceptedInvocation, nextRun, err = s.acceptResultWithEffect(ctx, runStore, invocationStore, registration, harnessRuntime, harness.Session{
 			InvocationID:    acceptedInvocation.ID,
 			NativeSessionID: nativeSessionID,
@@ -426,6 +475,9 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 		}
 		*invocation = acceptedInvocation
 		*run = nextRun
+		if implementationObjection {
+			return s.finishImplementationTestObjection(ctx, registration, runStore, run, invocation, value)
+		}
 		if isTestReport {
 			return s.acceptTestStageReport(ctx, registration, runStore, run, invocation, value, state)
 		}
@@ -457,6 +509,18 @@ func (s *Service) AcceptAgentReport(ctx context.Context, request AgentReportRequ
 	}
 	previousRun := *run
 	releaseActiveInvocation(run, invocation.ID)
+	if implementationObjection {
+		*run, err = projectImplementationTestObjection(previousRun, value, *invocation, packet, state, automatedObjection, objectionGateReason)
+		if err != nil {
+			return AgentResult{}, err
+		}
+		run.Revision = previousRun.Revision + 1
+		run.UpdatedAt = s.deps.Now().UTC()
+		if err := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); err != nil {
+			return AgentResult{}, fmt.Errorf("persist implementation test objection: %w", err)
+		}
+		return s.finishImplementationTestObjection(ctx, registration, runStore, run, invocation, value)
+	}
 	if isTestInvocation {
 		return s.acceptTestStageReport(ctx, registration, runStore, run, invocation, value, state)
 	}

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -82,13 +82,46 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	if !roleDeclared {
 		return AgentLaunchResult{}, fmt.Errorf("agent role %q is not declared by the workflow registry", request.Role)
 	}
+	testRevision := roleDefinition.Kind == workflow.RoleKindTest && run.Stage == store.StageTest && run.TestObjection != nil
+	if request.testRevision && !testRevision {
+		return AgentLaunchResult{}, errors.New("test revision requires an active test objection")
+	}
+	if roleDefinition.Kind == workflow.RoleKindTest && run.TestRevisionBudget == 0 {
+		run.TestRevisionBudget = packet.RepositoryConfig.RetryLimits.TestRevision
+	}
+	var resumeSource *store.Invocation
+	if testRevision {
+		testInvocationID := run.TestInvocationID
+		if testInvocationID == "" {
+			testInvocationID = run.TestObjection.InvocationID
+		}
+		if testInvocationID == "" {
+			return AgentLaunchResult{}, errors.New("test objection has no original test invocation")
+		}
+		resumeSource, err = invocationStore.Invocation(ctx, run.ID, testInvocationID)
+		if err != nil {
+			return AgentLaunchResult{}, fmt.Errorf("read original test invocation for objection revision: %w", err)
+		}
+		if resumeSource == nil {
+			return AgentLaunchResult{}, fmt.Errorf("original test invocation %q does not belong to run %q", testInvocationID, run.ID)
+		}
+		if resumeSource.Role != workflow.RoleTest || resumeSource.Stage != store.StageTest {
+			return AgentLaunchResult{}, errors.New("test objection original invocation is not a test-stage invocation")
+		}
+		if resumeSource.Status == store.InvocationStatusActive {
+			return AgentLaunchResult{}, fmt.Errorf("original test invocation %q is still active", resumeSource.ID)
+		}
+		if strings.TrimSpace(resumeSource.NativeSessionID) == "" {
+			return AgentLaunchResult{}, errors.New("original test invocation has no native session identifier")
+		}
+	}
 	if len(request.PermittedPaths) == 0 {
 		request.PermittedPaths = append([]string(nil), roleDefinition.DefaultPermittedPaths...)
 	}
 	if err := report.ValidatePermittedPaths(request.PermittedPaths); err != nil {
 		return AgentLaunchResult{}, err
 	}
-	if latestStore, ok := runStore.(LatestInvocationStore); ok {
+	if latestStore, ok := runStore.(LatestInvocationStore); ok && !testRevision {
 		latest, latestErr := latestStore.LatestInvocation(ctx, run.ID)
 		if latestErr != nil {
 			return AgentLaunchResult{}, fmt.Errorf("look up latest invocation before launch: %w", latestErr)
@@ -126,6 +159,17 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	policy, err := resolveAgentPolicy(packet.RepositoryConfig, request)
 	if err != nil {
 		return AgentLaunchResult{}, err
+	}
+	if resumeSource != nil {
+		if resumeSource.Harness != string(policy.Harness) {
+			return AgentLaunchResult{}, fmt.Errorf("test objection must resume the original %s harness, not %s", resumeSource.Harness, policy.Harness)
+		}
+		if resumeSource.Model != "" {
+			policy.Model = resumeSource.Model
+		}
+		if resumeSource.ReasoningEffort != "" {
+			policy.ReasoningEffort = resumeSource.ReasoningEffort
+		}
 	}
 	seedCredentials, credentialStoreID, err := s.credentialSeeding(registration, request, policy.Harness)
 	if err != nil {
@@ -165,6 +209,9 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		DesignHandoff:       designHandoff,
 		PermittedPaths:      append([]string(nil), request.PermittedPaths...),
 		TestHandoff:         run.TestHandoff,
+		TestObjection:       run.TestObjection,
+		TestRevisionAttempt: run.TestRevisionAttempts,
+		TestRevisionBudget:  run.TestRevisionBudget,
 		ProtectedTestPaths:  append([]store.ProtectedTestPath(nil), run.ProtectedTestPaths...),
 		TestExemption:       run.TestExemption,
 		ReviewContext:       reviewContext,
@@ -180,6 +227,9 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		Route:                   packet.Route,
 		DesignHandoff:           designHandoff,
 		TestHandoff:             run.TestHandoff,
+		TestObjection:           run.TestObjection,
+		TestRevisionAttempt:     run.TestRevisionAttempts,
+		TestRevisionBudget:      run.TestRevisionBudget,
 		ProtectedTestPaths:      run.ProtectedTestPaths,
 		TestExemption:           run.TestExemption,
 		TestPaths:               packet.RepositoryConfig.TestPolicy.TestPaths,
@@ -209,6 +259,9 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		Status:              store.InvocationStatusActive,
 		CreatedAt:           createdAt,
 		UpdatedAt:           createdAt,
+	}
+	if resumeSource != nil {
+		invocation.NativeSessionID = resumeSource.NativeSessionID
 	}
 	invocationPersisted := false
 	workerStarted := false
@@ -330,7 +383,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	if err := terminalRuntime.Notify(ctx, terminal.Notification{WorkspaceID: control.ID, Title: "factory run started", Body: fmt.Sprintf("%s %s agent active", run.ID, role)}); err != nil {
 		return AgentLaunchResult{}, err
 	}
-	session, err := harnessRuntime.Start(ctx, harness.StartRequest{
+	startRequest := harness.StartRequest{
 		InvocationID:    invocationID,
 		RunID:           run.ID,
 		Role:            role,
@@ -341,7 +394,14 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		Prompt:          promptText,
 		Model:           policy.Model,
 		ReasoningEffort: policy.ReasoningEffort,
-	})
+	}
+	var session harness.Session
+	if resumeSource != nil {
+		startRequest.ResumeSessionID = resumeSource.NativeSessionID
+		session, err = harnessRuntime.Resume(ctx, startRequest)
+	} else {
+		session, err = harnessRuntime.Start(ctx, startRequest)
+	}
 	if err != nil {
 		classified := harness.ClassifyError(err, string(policy.Harness))
 		if harness.IsRateLimited(classified) {
@@ -397,6 +457,12 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	run.Stage = stage
 	run.Status = store.StatusActive
 	run.ActiveInvocationID = invocation.ID
+	if roleDefinition.Kind == workflow.RoleKindTest {
+		run.TestInvocationID = invocation.ID
+		if run.TestRevisionBudget == 0 {
+			run.TestRevisionBudget = packet.RepositoryConfig.RetryLimits.TestRevision
+		}
+	}
 	run.UpdatedAt = s.deps.Now().UTC()
 	if err := s.persistAgentRunState(ctx, registration, runStore, previousRun, *run); err != nil {
 		return AgentLaunchResult{}, fmt.Errorf("persist %s stage: %w", role, err)
@@ -536,6 +602,9 @@ func promptForPersistedInvocation(run store.Run, invocation store.Invocation, pa
 		Route:                   packet.Route,
 		DesignHandoff:           persisted.DesignHandoff,
 		TestHandoff:             persisted.TestHandoff,
+		TestObjection:           persisted.TestObjection,
+		TestRevisionAttempt:     persisted.TestRevisionAttempt,
+		TestRevisionBudget:      persisted.TestRevisionBudget,
 		ProtectedTestPaths:      persisted.ProtectedTestPaths,
 		TestExemption:           persisted.TestExemption,
 		TestPaths:               packet.RepositoryConfig.TestPolicy.TestPaths,
@@ -603,6 +672,14 @@ func validatePersistedInvocationPacket(run store.Run, invocation store.Invocatio
 			return errors.New("persisted invocation packet route does not match the frozen specification packet route")
 		}
 	}
+	if persisted.SchemaVersion >= 7 {
+		if !sameTestObjection(persisted.TestObjection, run.TestObjection) {
+			return errors.New("persisted invocation packet test objection does not match the run")
+		}
+		if run.TestObjection != nil && (persisted.TestRevisionAttempt != run.TestRevisionAttempts || persisted.TestRevisionBudget != run.TestRevisionBudget) {
+			return errors.New("persisted invocation packet test revision state does not match the run")
+		}
+	}
 	if invocation.Role == workflow.RoleSpecificationReview {
 		if persisted.ReviewContext == nil {
 			return errors.New("persisted specification-review invocation packet has no review context")
@@ -615,6 +692,15 @@ func validatePersistedInvocationPacket(run store.Run, invocation store.Invocatio
 		}
 	}
 	return nil
+}
+
+// sameTestObjection compares the coordinator-owned objection payload without
+// exposing pointer identity as part of restart validation.
+func sameTestObjection(left, right *store.TestObjection) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.Test == right.Test && left.Claim == right.Claim && left.Evidence == right.Evidence && left.InvocationID == right.InvocationID
 }
 
 // checkRepairAttempt extracts the bounded repair attempt from a persisted

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -217,6 +217,7 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 		}
 		return cause
 	}
+	testRevisionBudget := testRevisionBudgetForPacket(packet)
 	run := store.Run{
 		ID:                  runID,
 		RepositoryPath:      registration.Path,
@@ -230,6 +231,7 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 		ImageDigest:         repositoryConfig.WorkerBuild.Digest,
 		Coordinator:         s.deps.Coordinator,
 		CheckRepairBudget:   repositoryConfig.RetryLimits.CheckRepair,
+		TestRevisionBudget:  testRevisionBudget,
 		SpecificationPacket: string(packetData),
 		CreatedAt:           startedAt,
 		UpdatedAt:           startedAt,
@@ -255,6 +257,16 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 		return IssueResult{}, cleanupWorkspace(failureErr)
 	}
 	return IssueResult{Run: run, Packet: packet}, nil
+}
+
+// testRevisionBudgetForPacket returns a revision ceiling only for runs that
+// actually have an independently owned test stage. Advisory implementation
+// runs do not expose the protected-test objection protocol.
+func testRevisionBudgetForPacket(packet SpecificationPacket) int {
+	if packet.Route.RequiresIndependentTestStage() || packet.RepositoryConfig.TestPolicy.Mode == config.TestModeRequired {
+		return packet.RepositoryConfig.RetryLimits.TestRevision
+	}
+	return 0
 }
 
 // Transition edits the existing status comment and updates the orthogonal
@@ -743,7 +755,7 @@ func (s *Service) ensureAgentStartup(ctx context.Context, registration config.Re
 			return s.pauseAgentStartup(ctx, registration, runStore, run, diagnosis)
 		}
 		resumedActiveInvocation := latest != nil && latest.Status == store.InvocationStatusActive && latest.RecoveryResumeCount > 0
-		if latest != nil && latest.Status != store.InvocationStatusSuperseded && !resumedActiveInvocation && invocationBlocksCleanStart(*run, *latest) {
+		if latest != nil && latest.Status != store.InvocationStatusSuperseded && !resumedActiveInvocation && invocationBlocksCleanStart(*run, *latest) && !testRevisionPending(*run) {
 			diagnosis.InvocationExists = true
 			addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
 				Kind:     RecoveryDiscrepancyWorkflow,
@@ -1010,6 +1022,7 @@ func statusCommentBody(run store.Run) string {
 			checkRepair += fmt.Sprintf("- check-repair pending: attempt %d\n", run.CheckRepairPendingAttempt)
 		}
 	}
+	testRevision := testRevisionStatusComment(run)
 	questions := ""
 	if len(run.PendingQuestions) > 0 {
 		questions = "\n### Pending clarification\n\n"
@@ -1019,7 +1032,31 @@ func statusCommentBody(run store.Run) string {
 	}
 	review := specificationReviewStatusComment(run)
 	activity := activityStatusComment(run)
-	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s- test policy: `%s`\n- route: `%s`\n%s%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, activity, testPolicyDescription(testPolicyModeForRun(run)), routeDescriptionForRun(run), checkRepair, pullRequest, lifecycle, harness, review, questions, commandFeedback)
+	return fmt.Sprintf("%s\n## Factory run\n\n- run identifier: `%s`\n- issue: #%d\n- branch: `%s`\n- worktree: `%s`\n- coordinator: `%s`\n- start time: `%s`\n- checkpoint: `%s`\n- stage: `%s`\n- status: `%s`\n%s- test policy: `%s`\n- route: `%s`\n%s%s%s%s%s%s%s%s", statusCommentMarker(run.ID), run.ID, run.IssueNumber, run.Branch, run.Worktree, run.Coordinator, started, run.CheckpointSHA, run.Stage, run.Status, activity, testPolicyDescription(testPolicyModeForRun(run)), routeDescriptionForRun(run), checkRepair, testRevision, pullRequest, lifecycle, harness, review, questions, commandFeedback)
+}
+
+// testRevisionStatusComment renders the bounded objection-cycle projection
+// without exposing test claims or implementation transcripts.
+func testRevisionStatusComment(run store.Run) string {
+	if run.TestRevisionBudget <= 0 && len(run.TestRevisionHistory) == 0 && run.TestObjection == nil {
+		return ""
+	}
+	remaining := run.TestRevisionBudget - run.TestRevisionAttempts
+	if remaining < 0 {
+		remaining = 0
+	}
+	result := fmt.Sprintf("\n### Test objection cycle\n\n- attempts: %d/%d\n- remaining: %d\n", run.TestRevisionAttempts, run.TestRevisionBudget, remaining)
+	if len(run.TestRevisionHistory) > 0 {
+		outcomes := make([]string, 0, len(run.TestRevisionHistory))
+		for _, revision := range run.TestRevisionHistory {
+			outcomes = append(outcomes, fmt.Sprintf("%d=%s", revision.Attempt, safeStatusCommentValue(string(revision.Outcome))))
+		}
+		result += "- outcomes: " + strings.Join(outcomes, ", ") + "\n"
+	}
+	if run.TestObjection != nil {
+		result += fmt.Sprintf("- current test: `%s`\n", safeStatusCommentValue(run.TestObjection.Test))
+	}
+	return result
 }
 
 // StatusCommentBody renders the coordinator-owned status projection for one

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -396,6 +396,12 @@ func packetResumeStageForPacket(run store.Run, packet SpecificationPacket) store
 // produced for an older specification packet before a new role starts.
 func resetTestProjectionForPacketChange(run *store.Run, packet SpecificationPacket) {
 	run.TestHandoff = nil
+	run.TestInvocationID = ""
+	run.TestRevisionAttempts = 0
+	run.TestRevisionBudget = testRevisionBudgetForPacket(packet)
+	run.TestRevisionHistory = nil
+	run.TestObjection = nil
+	run.TestRevisionBaseChangedPaths = nil
 	run.RoleHandoff = nil
 	run.ImplementationHandoff = nil
 	run.SpecificationReview = nil

--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -31,12 +31,20 @@ func roleHandoffFromReport(value report.Handoff) *store.RoleHandoff {
 		ProductionFilesChanged: append([]string(nil), value.ProductionFilesChanged...),
 		FocusedCommands:        append([]string(nil), value.FocusedCommands...),
 		KnownLimitations:       append([]string(nil), value.KnownLimitations...),
+		TestObjections:         make([]store.TestObjection, 0, len(value.TestObjections)),
 		AcceptanceMapping:      make([]store.HandoffAcceptance, 0, len(value.AcceptanceMapping)),
 	}
 	for _, mapping := range value.AcceptanceMapping {
 		result.AcceptanceMapping = append(result.AcceptanceMapping, store.HandoffAcceptance{
 			Criterion: mapping.Criterion,
 			Evidence:  mapping.Evidence,
+		})
+	}
+	for _, objection := range value.TestObjections {
+		result.TestObjections = append(result.TestObjections, store.TestObjection{
+			Test:     objection.Test,
+			Claim:    objection.Claim,
+			Evidence: objection.Evidence,
 		})
 	}
 	return result

--- a/internal/factory/test_objection_gate_test.go
+++ b/internal/factory/test_objection_gate_test.go
@@ -1,0 +1,81 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
+)
+
+// TestAutomatedTestObjectionGateRequiresTheLatestAuthorizedProceedDecision
+// verifies that a configuration flag cannot bypass the measured-pilot gate.
+func TestAutomatedTestObjectionGateRequiresTheLatestAuthorizedProceedDecision(t *testing.T) {
+	reader := &pilotGateCommentReader{comments: []github.Comment{
+		{ID: "2", Author: "alice", Body: "Decision: stop"},
+		{ID: "1", Author: "alice", Body: "Decision: proceed"},
+		{ID: "3", Author: "bob", Body: "Decision: proceed"},
+	}}
+	service := &Service{deps: Dependencies{Comments: reader}}
+	registration := config.RepositoryRegistration{
+		GitHub:          config.GitHubConfig{Owner: "example", Repository: "factory"},
+		AuthorizedUsers: []string{"alice"},
+	}
+	packet := SpecificationPacket{RepositoryConfig: config.RepositoryConfig{
+		TestPolicy: config.TestPolicy{AllowAutomatedObjections: true},
+	}}
+
+	allowed, reason := service.automatedTestObjectionGate(context.Background(), registration, packet)
+	if allowed || reason == "" {
+		t.Fatalf("gate with unauthorized/latest revise decision = allowed=%v reason=%q, want denied with reason", allowed, reason)
+	}
+
+	reader.comments = append(reader.comments, github.Comment{ID: "4", Author: "alice", Body: "<!-- factory-pilot-decision: proceed -->"})
+	allowed, reason = service.automatedTestObjectionGate(context.Background(), registration, packet)
+	if !allowed || reason != "" {
+		t.Fatalf("gate with authorized proceed decision = allowed=%v reason=%q, want allowed", allowed, reason)
+	}
+
+	reader.comments = append(reader.comments, github.Comment{ID: "5", Author: "alice", Body: "Decision: stop"})
+	allowed, reason = service.automatedTestObjectionGate(context.Background(), registration, packet)
+	if allowed || reason == "" {
+		t.Fatalf("gate after later stop decision = allowed=%v reason=%q, want denied", allowed, reason)
+	}
+}
+
+// TestAutomatedTestObjectionGateFailsClosedWhenDecisionCannotBeRead verifies
+// missing and failing comment readers keep the objection human-supervised.
+func TestAutomatedTestObjectionGateFailsClosedWhenDecisionCannotBeRead(t *testing.T) {
+	registration := config.RepositoryRegistration{AuthorizedUsers: []string{"alice"}}
+	packet := SpecificationPacket{RepositoryConfig: config.RepositoryConfig{
+		TestPolicy: config.TestPolicy{AllowAutomatedObjections: true},
+	}}
+
+	service := &Service{deps: Dependencies{Comments: &pilotGateCommentReader{err: errors.New("unavailable")}}}
+	allowed, reason := service.automatedTestObjectionGate(context.Background(), registration, packet)
+	if allowed || reason == "" {
+		t.Fatalf("gate with comment reader error = allowed=%v reason=%q, want denied", allowed, reason)
+	}
+
+	service = &Service{}
+	allowed, reason = service.automatedTestObjectionGate(context.Background(), registration, packet)
+	if allowed || reason == "" {
+		t.Fatalf("gate without comment reader = allowed=%v reason=%q, want denied", allowed, reason)
+	}
+}
+
+// pilotGateCommentReader is the bounded comment reader used by pilot-gate
+// tests to model GitHub's stable issue-comment projection.
+type pilotGateCommentReader struct {
+	comments []github.Comment
+	err      error
+}
+
+// IssueComments returns the configured pilot decision comments.
+func (r *pilotGateCommentReader) IssueComments(context.Context, github.Repository, int) ([]github.Comment, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return append([]github.Comment(nil), r.comments...), nil
+}

--- a/internal/factory/test_stage.go
+++ b/internal/factory/test_stage.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -24,6 +25,10 @@ import (
 // testExemptionMarkerPrefix identifies the exact issue marker that authorizes
 // a human test-stage skip.
 const testExemptionMarkerPrefix = "<!-- factory-test-exemption:"
+
+// measuredPilotIssueNumber is the fixed evidence-gate issue named by the
+// objection-cycle specification.
+const measuredPilotIssueNumber = 26
 
 // testPolicyModeForRun returns the frozen test-policy mode used by status and
 // command projections. Invalid historical packets return the empty mode so a
@@ -346,6 +351,327 @@ func validateImplementationOwnedSignals(value report.Report, invocation store.In
 	return nil
 }
 
+// testRevisionPending reports whether the run is waiting for the test role to
+// answer an implementation objection. It is used by startup recovery to
+// allow the next invocation in the same bounded cycle.
+func testRevisionPending(run store.Run) bool {
+	return run.Stage == store.StageTest && run.Status == store.StatusActive && run.TestObjection != nil
+}
+
+// implementationTestObjection reports whether a completed implementation
+// handoff requests the protected test-stage objection route.
+func implementationTestObjection(value report.Report, invocation store.Invocation) bool {
+	return invocation.Role == workflow.RoleImplementation &&
+		invocation.Stage == store.StageImplementation &&
+		value.Outcome == report.OutcomeCompleted && value.Handoff != nil && len(value.Handoff.TestObjections) > 0
+}
+
+// validateImplementationTestObjection enforces the independent-test route and
+// bounded-cycle preconditions before an implementation report can redirect a
+// run away from implementation.
+func validateImplementationTestObjection(value report.Report, invocation store.Invocation, run store.Run, packet SpecificationPacket) error {
+	if !implementationTestObjection(value, invocation) {
+		return nil
+	}
+	if !independentTestStageDeclared(packet) || run.TestStageSkipped {
+		return errors.New("test objections require an active independent test stage")
+	}
+	if run.TestHandoff == nil || len(run.ProtectedTestPaths) == 0 {
+		return errors.New("test objections require a completed protected test handoff")
+	}
+	budget := run.TestRevisionBudget
+	if budget == 0 {
+		budget = packet.RepositoryConfig.RetryLimits.TestRevision
+	}
+	if budget <= 0 {
+		return errors.New("test objection revision budget must be positive")
+	}
+	if len(value.Handoff.TestObjections) != 1 {
+		return errors.New("implementation must submit exactly one test objection per report")
+	}
+	return nil
+}
+
+// automatedTestObjectionGate reads the authorized measured-pilot decision
+// before allowing an objection to start an automated revision. Configuration
+// alone cannot open this gate; an authorized maintainer must have recorded the
+// latest decision on issue #26.
+func (s *Service) automatedTestObjectionGate(ctx context.Context, registration config.RepositoryRegistration, packet SpecificationPacket) (bool, string) {
+	if !packet.RepositoryConfig.TestPolicy.AllowAutomatedObjections {
+		return false, "test objection recorded; automated revision is disabled pending measured-pilot authorization"
+	}
+	if s.deps.Comments == nil {
+		return false, "test objection recorded; issue #26 proceed decision could not be verified"
+	}
+	comments, err := s.deps.Comments.IssueComments(ctx, commandRepository(registration), measuredPilotIssueNumber)
+	if err != nil {
+		return false, "test objection recorded; issue #26 proceed decision could not be verified"
+	}
+	sort.SliceStable(comments, func(left, right int) bool {
+		if !comments[left].UpdatedAt.IsZero() && !comments[right].UpdatedAt.IsZero() && !comments[left].UpdatedAt.Equal(comments[right].UpdatedAt) {
+			return comments[left].UpdatedAt.Before(comments[right].UpdatedAt)
+		}
+		return compareCommentIDs(comments[left].ID, comments[right].ID) < 0
+	})
+	decision := ""
+	for _, comment := range comments {
+		if !authorizedCommentAuthor(registration.AuthorizedUsers, comment.Author) {
+			continue
+		}
+		if value, ok := measuredPilotDecision(comment.Body); ok {
+			decision = value
+		}
+	}
+	if decision != "proceed" {
+		return false, "test objection recorded; issue #26 has no authorized proceed decision"
+	}
+	return true, ""
+}
+
+// measuredPilotDecision extracts one exact decision line or machine-readable
+// marker from a pilot comment. Ordinary prose mentioning the word proceed is
+// intentionally not sufficient to authorize automation.
+func measuredPilotDecision(body string) (string, bool) {
+	const markerPrefix = "<!-- factory-pilot-decision:"
+	const markerSuffix = "-->"
+	for _, rawLine := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(rawLine)
+		lowerLine := strings.ToLower(line)
+		if strings.HasPrefix(lowerLine, markerPrefix) && strings.HasSuffix(lowerLine, markerSuffix) {
+			value := strings.TrimSpace(line[len(markerPrefix) : len(line)-len(markerSuffix)])
+			if decision, ok := normalizeMeasuredPilotDecision(value); ok {
+				return decision, true
+			}
+		}
+		line = strings.TrimSpace(strings.TrimLeft(line, "-*# "))
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 || !strings.EqualFold(strings.TrimSpace(parts[0]), "decision") {
+			continue
+		}
+		if decision, ok := normalizeMeasuredPilotDecision(parts[1]); ok {
+			return decision, true
+		}
+	}
+	return "", false
+}
+
+// normalizeMeasuredPilotDecision keeps the pilot decision vocabulary closed
+// and strips only presentation backticks around a decision value.
+func normalizeMeasuredPilotDecision(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	value = strings.Trim(value, "`")
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "proceed", "revise and repeat", "stop":
+		return value, true
+	default:
+		return "", false
+	}
+}
+
+// projectImplementationTestObjection moves a validated implementation
+// objection to the test stage and freezes the dirty implementation paths that
+// the resumed test role must treat as pre-existing context.
+func projectImplementationTestObjection(previous store.Run, value report.Report, invocation store.Invocation, packet SpecificationPacket, observed gitadapter.WorktreeState, automated bool, automationReason string) (store.Run, error) {
+	if err := validateImplementationTestObjection(value, invocation, previous, packet); err != nil {
+		return store.Run{}, err
+	}
+	next := previous
+	budget := next.TestRevisionBudget
+	if budget == 0 {
+		budget = packet.RepositoryConfig.RetryLimits.TestRevision
+	}
+	if budget <= 0 {
+		return store.Run{}, errors.New("test objection revision budget must be positive")
+	}
+	next.TestRevisionBudget = budget
+	if next.TestInvocationID == "" {
+		return store.Run{}, errors.New("test objection has no original test invocation")
+	}
+	objection := value.Handoff.TestObjections[0]
+	disputeKey := testObjectionDisputeKey(objection)
+	if !testRevisionHistoryMatchesDispute(next.TestRevisionHistory, disputeKey) {
+		next.TestRevisionAttempts = 0
+		next.TestRevisionHistory = nil
+	}
+	next.TestObjection = &store.TestObjection{
+		Test:         objection.Test,
+		Claim:        objection.Claim,
+		Evidence:     objection.Evidence,
+		InvocationID: next.TestInvocationID,
+	}
+	basePaths, err := protectedTestPathsForCheckpoint(previous.Worktree, observed.ChangedPaths)
+	if err != nil {
+		return store.Run{}, fmt.Errorf("record test objection worktree context: %w", err)
+	}
+	next.TestRevisionBaseChangedPaths = basePaths
+	next.RoleHandoff = roleHandoffFromReport(*value.Handoff)
+	next.ImplementationHandoff = next.RoleHandoff
+	next.PendingQuestions = nil
+	next.ClarificationCommentID = ""
+	next.ClarificationNotificationSent = false
+	next.ActiveInvocationID = ""
+	next.TestStageSkipped = false
+	if !automated {
+		next.Stage = store.StageTest
+		next.Status = store.StatusWaitingForHuman
+		if strings.TrimSpace(automationReason) == "" {
+			automationReason = "test objection recorded; automated revision is disabled pending measured-pilot authorization"
+		}
+		next.LifecycleReason = automationReason
+		return next, nil
+	}
+	if next.TestRevisionAttempts >= budget {
+		next.Stage = store.StageTest
+		next.Status = store.StatusWaitingForHuman
+		next.LifecycleReason = fmt.Sprintf("test objection submitted after %d revision attempts; waiting for human disposition", next.TestRevisionAttempts)
+		return next, nil
+	}
+	next.TestRevisionAttempts++
+	next.TestRevisionHistory = append(next.TestRevisionHistory, store.TestRevision{
+		Attempt:    next.TestRevisionAttempts,
+		Outcome:    store.TestRevisionPending,
+		DisputeKey: disputeKey,
+	})
+	next.Stage = store.StageTest
+	next.Status = store.StatusActive
+	next.LifecycleReason = fmt.Sprintf("implementation test objection pending test revision %d/%d", next.TestRevisionAttempts, budget)
+	return next, nil
+}
+
+// testObjectionDisputeKey identifies the behavioral claim under dispute while
+// allowing updated evidence to accompany a later cycle for the same claim.
+func testObjectionDisputeKey(objection report.TestObjection) string {
+	value := strings.TrimSpace(objection.Test) + "\x00" + strings.TrimSpace(objection.Claim)
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:])
+}
+
+// testRevisionHistoryMatchesDispute reports whether retained cycles belong to
+// the same test claim. Empty keys are legacy history and start a fresh dispute.
+func testRevisionHistoryMatchesDispute(history []store.TestRevision, disputeKey string) bool {
+	if len(history) == 0 || strings.TrimSpace(disputeKey) == "" {
+		return len(history) == 0
+	}
+	for _, revision := range history {
+		if revision.DisputeKey == "" || revision.DisputeKey != disputeKey {
+			return false
+		}
+	}
+	return true
+}
+
+// finishImplementationTestObjection starts the bounded test-role response or
+// publishes the human pause when no revision budget remains.
+func (s *Service) finishImplementationTestObjection(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, invocation *store.Invocation, value report.Report) (AgentResult, error) {
+	if _, journaled := runStore.(PendingEffectStore); !journaled {
+		if err := s.stopRunWorker(ctx, run.ID); err != nil {
+			return AgentResult{}, err
+		}
+	}
+	if run.Status == store.StatusWaitingForHuman {
+		if err := s.notifyWorkspace(ctx, registration, "factory test objection waiting", run.LifecycleReason); err != nil {
+			return AgentResult{}, err
+		}
+		return AgentResult{Invocation: *invocation, Report: value}, nil
+	}
+	if run.Status != store.StatusActive || run.Stage != store.StageTest {
+		return AgentResult{}, fmt.Errorf("test objection did not enter an active test stage: %s/%s", run.Stage, run.Status)
+	}
+	if _, err := s.startAgentWithStore(ctx, registration, runStore, run, AgentRequest{
+		RunID:        run.ID,
+		Role:         workflow.RoleTest,
+		Stage:        store.StageTest,
+		testRevision: true,
+	}); err != nil {
+		return AgentResult{}, fmt.Errorf("resume original test session for objection: %w", err)
+	}
+	return AgentResult{Invocation: *invocation, Report: value}, nil
+}
+
+// testRevisionChangedPaths returns paths newly changed after an implementation
+// objection. Existing implementation changes remain in the worktree while the
+// test role revises only its owned files.
+func testRevisionChangedPaths(state gitadapter.WorktreeState, base []store.ProtectedTestPath) ([]string, error) {
+	baseSet := make(map[string]struct{}, len(base))
+	for _, path := range base {
+		clean, err := cleanTestPath(path.Path)
+		if err != nil {
+			return nil, err
+		}
+		baseSet[clean] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(state.ChangedPaths))
+	changed := make([]string, 0, len(state.ChangedPaths))
+	for _, path := range state.ChangedPaths {
+		clean, err := cleanTestPath(path)
+		if err != nil {
+			return nil, err
+		}
+		if _, alreadyDirty := baseSet[clean]; alreadyDirty {
+			continue
+		}
+		if _, duplicate := seen[clean]; duplicate {
+			continue
+		}
+		seen[clean] = struct{}{}
+		changed = append(changed, clean)
+	}
+	sort.Strings(changed)
+	return changed, nil
+}
+
+// validateTestRevisionBasePaths verifies that implementation changes present
+// when an objection was submitted are byte-for-byte unchanged while the test
+// role owns the resumed session.
+func validateTestRevisionBasePaths(worktree string, base []store.ProtectedTestPath) error {
+	for _, path := range base {
+		current, err := testPathDigest(worktree, path.Path)
+		if err != nil {
+			return fmt.Errorf("inspect test-revision base path %q: %w", path.Path, err)
+		}
+		if current != path.SHA256 {
+			return fmt.Errorf("test revision changed pre-existing path %q", path.Path)
+		}
+	}
+	return nil
+}
+
+// mergeProtectedTestPaths refreshes hashes for the original protected tests
+// and any files changed by an accepted revision.
+func mergeProtectedTestPaths(worktree string, previous []store.ProtectedTestPath, changed []string) ([]store.ProtectedTestPath, error) {
+	paths := make(map[string]struct{}, len(previous)+len(changed))
+	for _, value := range previous {
+		paths[value.Path] = struct{}{}
+	}
+	for _, path := range changed {
+		clean, err := cleanTestPath(path)
+		if err != nil {
+			return nil, err
+		}
+		paths[clean] = struct{}{}
+	}
+	ordered := make([]string, 0, len(paths))
+	for path := range paths {
+		ordered = append(ordered, path)
+	}
+	sort.Strings(ordered)
+	return protectedTestPathsForCheckpoint(worktree, ordered)
+}
+
+// setTestRevisionOutcome replaces the pending history entry for an attempt,
+// or appends one when recovering a legacy run without that entry.
+func setTestRevisionOutcome(history []store.TestRevision, attempt int, outcome store.TestRevisionOutcome) []store.TestRevision {
+	updated := append([]store.TestRevision(nil), history...)
+	for index := range updated {
+		if updated[index].Attempt == attempt {
+			updated[index].Outcome = outcome
+			return updated
+		}
+	}
+	return append(updated, store.TestRevision{Attempt: attempt, Outcome: outcome})
+}
+
 // isUnverifiableTestReport identifies a completed test envelope whose identity
 // is trustworthy enough to enter the required human-disposition path after
 // payload validation fails.
@@ -473,6 +799,9 @@ func (s *Service) acceptTestStageReport(ctx context.Context, registration config
 	_, ok := runStore.(InvocationStore)
 	if !ok {
 		return AgentResult{}, errors.New("operational store does not support visible invocations")
+	}
+	if run.TestObjection != nil {
+		return s.acceptTestRevisionReport(ctx, registration, runStore, run, invocation, value, state)
 	}
 	if err := validateTestChangedPaths(state.ChangedPaths, decodeTestPolicy(run.SpecificationPacket)); err != nil {
 		if stopErr := s.stopRunWorker(ctx, run.ID); stopErr != nil {
@@ -631,6 +960,251 @@ func (s *Service) acceptTestStageReport(ctx context.Context, registration config
 		return AgentResult{}, fmt.Errorf("launch next role after test handoff: %w", err)
 	}
 	return AgentResult{Invocation: *invocation, Report: value}, nil
+}
+
+// acceptTestRevisionReport handles the test role's response to one
+// implementation objection. Revisions are independently red-verified and
+// checkpointed before the implementation role can resume.
+func (s *Service) acceptTestRevisionReport(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, invocation *store.Invocation, value report.Report, state gitadapter.WorktreeState) (AgentResult, error) {
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return AgentResult{}, fmt.Errorf("decode specification packet for test revision: %w", err)
+	}
+	if err := validateTestRevisionBasePaths(run.Worktree, run.TestRevisionBaseChangedPaths); err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, err.Error())
+	}
+	if value.Outcome == report.OutcomeNeedsClarification {
+		previous := *run
+		run.Status = store.StatusWaitingForHuman
+		run.Stage = store.StageTest
+		run.PendingQuestions = pendingQuestionsFromReport(value.Questions)
+		run.ClarificationCommentID = ""
+		run.ClarificationNotificationSent = false
+		run.LifecycleReason = "test role requested clarification during objection revision"
+		run.Revision = previous.Revision + 1
+		run.UpdatedAt = s.deps.Now().UTC()
+		if err := s.persistAgentRunState(ctx, registration, runStore, previous, *run); err != nil {
+			return AgentResult{}, fmt.Errorf("persist test objection clarification: %w", err)
+		}
+		published, err := s.ensureClarificationPublication(ctx, registration, runStore, *run)
+		if err != nil {
+			return AgentResult{}, err
+		}
+		*run = published
+		return AgentResult{Invocation: *invocation, Report: value}, nil
+	}
+	if value.Outcome == report.OutcomeCannotProceed {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "test role cannot respond to implementation objection")
+	}
+	if value.TestObjectionResponse == nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "test objection response is missing")
+	}
+	newPaths, err := testRevisionChangedPaths(state, run.TestRevisionBaseChangedPaths)
+	if err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test worktree paths could not be verified")
+	}
+	if err := validateTestChangedPaths(newPaths, packet.RepositoryConfig.TestPolicy); err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "test objection revision changed a non-test path")
+	}
+	if value.TestObjectionResponse.Decision == report.TestObjectionRejected {
+		if len(newPaths) != 0 {
+			return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "rejected test objection changed the worktree")
+		}
+		reason := "test role rejected implementation objection"
+		if strings.TrimSpace(value.TestObjectionResponse.Reason) != "" {
+			reason += ": " + value.TestObjectionResponse.Reason
+		}
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionRejected, reason)
+	}
+	if value.TestObjectionResponse.Decision != report.TestObjectionAccepted {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "test objection response decision could not be verified")
+	}
+	if value.TestHandoff == nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "accepted test objection has no revised test handoff")
+	}
+	if len(newPaths) == 0 {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "accepted test objection did not revise a test path")
+	}
+	if s.deps.Worker == nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised red-test worker is unavailable")
+	}
+	result, commandErr := s.deps.Worker.RunCommand(ctx, worker.CommandRequest{
+		RunID:             run.ID,
+		Command:           value.TestHandoff.FocusedTestCommand,
+		EnvironmentPolicy: worker.EnvironmentPolicyRole,
+		Role:              workflow.RoleTest,
+	})
+	stopErr := s.stopRunWorker(ctx, run.ID)
+	output := result.Stdout + "\n" + result.Stderr
+	if commandErr != nil || stopErr != nil || result.ExitCode == 0 || !strings.Contains(output, value.TestHandoff.ExpectedFailureReason) {
+		if stopErr != nil && commandErr == nil {
+			commandErr = stopErr
+		}
+		reason := "revised focused red-test verification is disputed or unverifiable"
+		if commandErr != nil {
+			reason = "revised focused red-test verification could not be completed"
+		} else if result.ExitCode != 0 && !strings.Contains(output, value.TestHandoff.ExpectedFailureReason) {
+			reason = "revised focused red-test output did not contain the expected failure reason"
+		}
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, reason)
+	}
+	inspector := s.worktreeInspector()
+	if inspector == nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised red-test worktree inspection is unavailable")
+	}
+	verifiedState, err := inspector.Inspect(ctx, run.Worktree)
+	if err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised red-test worktree inspection failed")
+	}
+	if verifiedState.HeadSHA != run.CheckpointSHA {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test-stage checkpoint changed during red-test verification")
+	}
+	if err := validateTestRevisionBasePaths(run.Worktree, run.TestRevisionBaseChangedPaths); err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised red-test changed pre-existing implementation work")
+	}
+	newPaths, err = testRevisionChangedPaths(verifiedState, run.TestRevisionBaseChangedPaths)
+	if err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised red-test worktree paths could not be verified")
+	}
+	if err := validateTestChangedPaths(newPaths, packet.RepositoryConfig.TestPolicy); err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test-stage path ownership dispute")
+	}
+	if len(newPaths) == 0 {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test handoff has no changed test path")
+	}
+	protected, err := mergeProtectedTestPaths(run.Worktree, run.ProtectedTestPaths, newPaths)
+	if err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised protected test paths could not be verified")
+	}
+	workspace := s.gitWorkspace()
+	if workspace == nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test checkpoint workspace is unavailable")
+	}
+	checkpointRequest := gitadapter.CheckpointRequest{
+		RunID:        run.ID,
+		WorktreePath: run.Worktree,
+		ParentSHA:    run.CheckpointSHA,
+		Kind:         gitadapter.CheckpointKindTest,
+		Paths:        append([]string(nil), newPaths...),
+		Message:      "verified revised focused test is red",
+	}
+	previous := *run
+	handoff := convertTestHandoff(*value.TestHandoff)
+	next := *run
+	next.TestHandoff = &handoff
+	next.TestObjection = nil
+	next.TestRevisionBaseChangedPaths = nil
+	next.TestRevisionHistory = setTestRevisionOutcome(next.TestRevisionHistory, next.TestRevisionAttempts, store.TestRevisionAccepted)
+	next.TestInvocationID = invocation.ID
+	next.ProtectedTestPaths = protected
+	next.SpecificationReview = nil
+	transition, transitionErr := workflow.DefaultRegistry().ResolveReportTransition(store.StageTest, report.OutcomeCompleted)
+	if transitionErr != nil {
+		return AgentResult{}, transitionErr
+	}
+	next.Stage = transition.Stage
+	next.Status = transition.Status
+	next.PendingQuestions = nil
+	next.ClarificationCommentID = ""
+	next.ClarificationNotificationSent = false
+	next.LifecycleReason = fmt.Sprintf("test objection accepted; revised protected handoff ready for implementation (revision %d/%d)", next.TestRevisionAttempts, next.TestRevisionBudget)
+	next.Revision = previous.Revision + 1
+	next.UpdatedAt = s.deps.Now().UTC()
+	checkpoint := gitadapter.CheckpointResult{}
+	if _, journaled := runStore.(PendingEffectStore); journaled {
+		repository := commandRepository(registration)
+		issue, issueErr := s.deps.GitHub.Issue(ctx, repository, run.IssueNumber)
+		if issueErr != nil {
+			return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test checkpoint issue context could not be read")
+		}
+		issue = ensureIssueIdentity(issue, packet.Issue, run.IssueNumber)
+		checkpoint, next, err = s.checkpointAndPersistWithEffect(ctx, runStore, workspace, checkpointRequest, repository, issue, previous, next)
+	} else {
+		checkpoint, err = workspace.CreateCheckpoint(ctx, checkpointRequest)
+	}
+	if err != nil {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test checkpoint could not be created")
+	}
+	if !github.ValidCommitSHA(checkpoint.SHA) {
+		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test checkpoint returned an invalid commit identity")
+	}
+	if _, journaled := runStore.(PendingEffectStore); !journaled {
+		next.TestCheckpointSHA = checkpoint.SHA
+		next.CheckpointSHA = checkpoint.SHA
+		if err := s.persistAgentRunState(ctx, registration, runStore, previous, next); err != nil {
+			return AgentResult{}, fmt.Errorf("persist revised test handoff: %w", err)
+		}
+	}
+	*run = next
+	nextRole, nextRoleDeclared := workflow.DefaultRegistry().RoleForRunStage(next.Stage)
+	if !nextRoleDeclared {
+		return AgentResult{}, fmt.Errorf("no role is declared for revised test handoff stage %q", next.Stage)
+	}
+	if _, err := s.startAgentWithStore(ctx, registration, runStore, run, AgentRequest{RunID: run.ID, Role: nextRole.Name, Stage: nextRole.Stage}); err != nil {
+		return AgentResult{}, fmt.Errorf("launch implementation after revised test handoff: %w", err)
+	}
+	return AgentResult{Invocation: *invocation, Report: value}, nil
+}
+
+// pauseTestRevisionForHuman records a bounded objection-cycle outcome and
+// leaves the implementation changes available for explicit human review.
+func (s *Service) pauseTestRevisionForHuman(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, invocation *store.Invocation, value report.Report, outcome store.TestRevisionOutcome, reason string) (AgentResult, error) {
+	if err := s.stopRunWorker(ctx, run.ID); err != nil {
+		return AgentResult{}, err
+	}
+	previous := *run
+	run.Stage = store.StageTest
+	run.Status = store.StatusWaitingForHuman
+	run.ActiveInvocationID = ""
+	run.PendingQuestions = nil
+	run.TestRevisionHistory = setTestRevisionOutcome(run.TestRevisionHistory, run.TestRevisionAttempts, outcome)
+	run.LifecycleReason = reason
+	run.UpdatedAt = s.deps.Now().UTC()
+	run.Revision = previous.Revision + 1
+	if err := s.persistAgentRunState(ctx, registration, runStore, previous, *run); err != nil {
+		return AgentResult{}, fmt.Errorf("persist test objection human pause: %w", err)
+	}
+	if err := s.notifyWorkspace(ctx, registration, "factory test objection waiting", run.ID+" is waiting for human test-objection disposition"); err != nil {
+		return AgentResult{}, err
+	}
+	return AgentResult{Invocation: *invocation, Report: value}, nil
+}
+
+// pauseUnverifiableTestRevisionReport converts a structurally invalid but
+// identity-bound revision report into a durable human pause before the normal
+// result-acceptance effect can mark its invocation complete.
+func (s *Service) pauseUnverifiableTestRevisionReport(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run *store.Run, invocation *store.Invocation, value report.Report) (AgentResult, error) {
+	if err := s.stopRunWorker(ctx, run.ID); err != nil {
+		return AgentResult{}, err
+	}
+	if invocation.NativeSessionID != "" {
+		_, harnessRuntime, err := s.ensureAgentRuntime(registration.Cmux.SocketPath, config.Harness(invocation.Harness))
+		if err != nil {
+			return AgentResult{}, fmt.Errorf("ensure agent runtime for unverifiable test revision: %w", err)
+		}
+		if err := harnessRuntime.Finish(ctx, harness.Session{
+			InvocationID:    invocation.ID,
+			NativeSessionID: invocation.NativeSessionID,
+			Surface:         invocationSurface(*invocation),
+		}); err != nil {
+			return AgentResult{}, fmt.Errorf("finish unverifiable test revision session: %w", err)
+		}
+	}
+	invocation.Status = store.InvocationStatusWaitingForHuman
+	invocation.UpdatedAt = s.deps.Now().UTC()
+	invocationStore, ok := runStore.(InvocationStore)
+	if !ok {
+		return AgentResult{}, errors.New("operational store does not support test revision invocation persistence")
+	}
+	if err := invocationStore.SaveInvocation(ctx, *invocation); err != nil {
+		return AgentResult{}, fmt.Errorf("persist unverifiable test revision invocation: %w", err)
+	}
+	if recorder, ok := runStore.(evaluationRecorder); ok {
+		if err := recorder.RecordEvaluationEscalation(ctx, run.ID, store.EvaluationEscalationTestDispute); err != nil {
+			return AgentResult{}, fmt.Errorf("record test objection verification dispute: %w", err)
+		}
+	}
+	return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "test objection revision report is unverifiable")
 }
 
 // pauseUnverifiableTestReport stops the visible test execution before placing

--- a/internal/factory/test_stage_test.go
+++ b/internal/factory/test_stage_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,6 +178,460 @@ func TestTestStageAcceptsVerifiedRedTestsAndLaunchesImplementation(t *testing.T)
 	if got := storeRuntime.invocations[implementation.ID].Status; got != store.InvocationStatusActive {
 		t.Fatalf("protected-path invocation status = %q, want active after rejection", got)
 	}
+}
+
+// pilotDecisionComments supplies the authorized measured-pilot decision used
+// by the objection-cycle fixture without contacting GitHub.
+type pilotDecisionComments struct {
+	comments []github.Comment
+}
+
+// IssueComments returns the fixture's immutable pilot-decision comments.
+func (r *pilotDecisionComments) IssueComments(context.Context, github.Repository, int) ([]github.Comment, error) {
+	return append([]github.Comment(nil), r.comments...), nil
+}
+
+// TestImplementationObjectionResumesTheOriginalTestSession verifies the
+// bounded objection loop: implementation submits evidence without touching a
+// protected test, the original native test session resumes, and a revised red
+// test unlocks implementation again.
+func TestImplementationObjectionResumesTheOriginalTestSession(t *testing.T) {
+	service, storeRuntime, workerRuntime, harnessRuntime, implementation, workspace := newObjectionCycleFixture(t)
+	run := *storeRuntime.current
+	workspace.state.HeadSHA = run.CheckpointSHA
+	workspace.state.ChangedPaths = []string{"internal/factory/agent.go"}
+	implementationReport := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  implementation.ID,
+		RunID:         implementation.RunID,
+		Harness:       implementation.Harness,
+		Role:          "implementation",
+		Stage:         "implementation",
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "implementation found the protected assertion too narrow",
+		Handoff: &report.Handoff{
+			ChangeSummary:          "implementation change with a test objection",
+			AcceptanceMapping:      []report.AcceptanceMapping{{Criterion: "behavior", Evidence: "implementation evidence"}},
+			ProductionFilesChanged: []string{"internal/factory/agent.go"},
+			FocusedCommands:        []string{"go test ./internal/factory"},
+			TestObjections: []report.TestObjection{{
+				Test:     "internal/factory/agent_test.go:TestBehavior",
+				Claim:    "the test requires an obsolete internal detail",
+				Evidence: "equivalent public behavior passes with the implementation change",
+			}},
+		},
+		NativeSessionID: "implementation-session",
+		ReportedAt:      time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(implementation.ResultDirectory, implementation.ID, implementationReport); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() objection error = %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: implementation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() objection error = %v", err)
+	}
+	if storeRuntime.current.Stage != store.StageTest || storeRuntime.current.Status != store.StatusActive || storeRuntime.current.TestRevisionAttempts != 1 || storeRuntime.current.TestObjection == nil {
+		t.Fatalf("objection projection = %#v, want active test revision 1", storeRuntime.current)
+	}
+	if len(storeRuntime.github.editedComments) == 0 {
+		t.Fatal("objection transition did not update the status comment")
+	}
+	statusComment := storeRuntime.github.editedComments[len(storeRuntime.github.editedComments)-1].body
+	for _, expected := range []string{"- attempts: 1/2", "- remaining: 1", "- outcomes: 1=pending", "- current test: `internal/factory/agent_test.go:TestBehavior`"} {
+		if !strings.Contains(statusComment, expected) {
+			t.Fatalf("objection status comment = %q, want %q", statusComment, expected)
+		}
+	}
+	if len(harnessRuntime.resumes) != 1 || harnessRuntime.resumes[0].ResumeSessionID != "test-session" {
+		t.Fatalf("native resumes = %#v, want original test session", harnessRuntime.resumes)
+	}
+	if !strings.Contains(harnessRuntime.resumes[0].Prompt, "the test requires an obsolete internal detail") || !strings.Contains(harnessRuntime.resumes[0].Prompt, "revision attempt 1 of 2") {
+		t.Fatalf("resumed test prompt = %q, want objection and budget context", harnessRuntime.resumes[0].Prompt)
+	}
+	revision := storeRuntime.invocations["inv-revision-invocation"]
+	if revision.Status != store.InvocationStatusActive || revision.Role != "test" {
+		t.Fatalf("revision invocation = %#v, want active test invocation", revision)
+	}
+	workspace.state.ChangedPaths = []string{"internal/factory/agent.go", "internal/factory/agent_test.go"}
+	workerRuntime.results = append(workerRuntime.results, worker.CommandResult{ExitCode: 1, Stdout: "expected revised behavior assertion"})
+	revisionReport := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  revision.ID,
+		RunID:         revision.RunID,
+		Harness:       revision.Harness,
+		Role:          "test",
+		Stage:         "test",
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "test accepted the objection and revised the assertion",
+		TestObjectionResponse: &report.TestObjectionResponse{
+			Decision: report.TestObjectionAccepted,
+			Reason:   "the public behavior is the stable contract",
+		},
+		TestHandoff: &report.TestHandoff{
+			AcceptanceCoverage:    []report.AcceptanceMapping{{Criterion: "behavior", Evidence: "revised focused test"}},
+			ChangedFiles:          []string{"internal/factory/agent_test.go"},
+			FocusedTestCommand:    "go test ./internal/factory -run TestBehavior",
+			ExpectedFailureReason: "expected revised behavior assertion",
+			ObservedFailureEvidence: []report.Evidence{{
+				Kind: "exit_code", Detail: "focused command exited with code 1",
+			}},
+		},
+		NativeSessionID: "session-repaired",
+		ReportedAt:      time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(revision.ResultDirectory, revision.ID, revisionReport); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() revision error = %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: revision.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() revision error = %v", err)
+	}
+	if storeRuntime.current.Stage != store.StageImplementation || storeRuntime.current.Status != store.StatusActive || storeRuntime.current.TestObjection != nil || storeRuntime.current.TestRevisionAttempts != 1 || len(storeRuntime.current.TestRevisionHistory) != 1 || storeRuntime.current.TestRevisionHistory[0].Outcome != store.TestRevisionAccepted {
+		t.Fatalf("revised handoff projection = %#v, want active implementation with accepted cycle", storeRuntime.current)
+	}
+	if len(workerRuntime.starts) < 4 || workerRuntime.starts[len(workerRuntime.starts)-1].Role != "implementation" {
+		t.Fatalf("worker starts = %#v, want implementation after revised handoff", workerRuntime.starts)
+	}
+}
+
+// TestImplementationObjectionCanBeRejectedByTheTestRole verifies a test role
+// may reject a dispute with reasoning while preserving the implementation
+// changes for explicit human disposition.
+func TestImplementationObjectionCanBeRejectedByTheTestRole(t *testing.T) {
+	service, storeRuntime, workerRuntime, harnessRuntime, implementation, workspace := newObjectionCycleFixture(t)
+	run := *storeRuntime.current
+	workspace.state.HeadSHA = run.CheckpointSHA
+	workspace.state.ChangedPaths = []string{"internal/factory/agent.go"}
+	implementationReport := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  implementation.ID,
+		RunID:         implementation.RunID,
+		Harness:       implementation.Harness,
+		Role:          "implementation",
+		Stage:         "implementation",
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "implementation challenged the protected assertion",
+		Handoff: &report.Handoff{
+			ChangeSummary:          "implementation change with a test objection",
+			AcceptanceMapping:      []report.AcceptanceMapping{{Criterion: "behavior", Evidence: "implementation evidence"}},
+			ProductionFilesChanged: []string{"internal/factory/agent.go"},
+			FocusedCommands:        []string{"go test ./internal/factory"},
+			TestObjections: []report.TestObjection{{
+				Test:     "internal/factory/agent_test.go:TestBehavior",
+				Claim:    "the assertion is too narrow",
+				Evidence: "the frozen behavior remains required",
+			}},
+		},
+		NativeSessionID: "implementation-session",
+		ReportedAt:      time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(implementation.ResultDirectory, implementation.ID, implementationReport); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() objection error = %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: implementation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() objection error = %v", err)
+	}
+	revision := storeRuntime.invocations["inv-revision-invocation"]
+	workspace.state.ChangedPaths = []string{"internal/factory/agent.go"}
+	startsBeforeRejection := len(workerRuntime.starts)
+	revisionReport := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  revision.ID,
+		RunID:         revision.RunID,
+		Harness:       revision.Harness,
+		Role:          "test",
+		Stage:         "test",
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "test role confirms the protected assertion",
+		TestObjectionResponse: &report.TestObjectionResponse{
+			Decision: report.TestObjectionRejected,
+			Reason:   "the frozen behavior is still the required contract",
+		},
+		NativeSessionID: revision.NativeSessionID,
+		ReportedAt:      time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(revision.ResultDirectory, revision.ID, revisionReport); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() rejection error = %v", err)
+	}
+	accepted, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: revision.ID})
+	if err != nil {
+		t.Fatalf("AcceptAgentReport() rejection error = %v", err)
+	}
+	if accepted.Invocation.Status != store.InvocationStatusCompleted || storeRuntime.current.Status != store.StatusWaitingForHuman || storeRuntime.current.Stage != store.StageTest {
+		t.Fatalf("rejected objection projection = invocation %#v run %#v, want completed invocation and waiting human/test", accepted.Invocation, storeRuntime.current)
+	}
+	if storeRuntime.current.TestObjection == nil || storeRuntime.current.TestRevisionAttempts != 1 || len(storeRuntime.current.TestRevisionHistory) != 1 || storeRuntime.current.TestRevisionHistory[0].Outcome != store.TestRevisionRejected {
+		t.Fatalf("rejected objection history = %#v, want one rejected attempt with preserved objection", storeRuntime.current)
+	}
+	if !strings.Contains(storeRuntime.current.LifecycleReason, "the frozen behavior is still the required contract") {
+		t.Fatalf("rejected objection reason = %q, want test reasoning", storeRuntime.current.LifecycleReason)
+	}
+	if len(harnessRuntime.resumes) != 1 || len(workerRuntime.starts) != startsBeforeRejection {
+		t.Fatalf("rejected objection effects = resumes=%d starts=%d (before=%d), want one native resume and no implementation relaunch", len(harnessRuntime.resumes), len(workerRuntime.starts), startsBeforeRejection)
+	}
+	if len(storeRuntime.github.editedComments) == 0 || !strings.Contains(storeRuntime.github.editedComments[len(storeRuntime.github.editedComments)-1].body, "1=rejected") {
+		t.Fatalf("rejected objection status = %#v, want recorded outcome", storeRuntime.github.editedComments)
+	}
+}
+
+// TestImplementationObjectionEscalatesAfterTwoRevisionAttempts verifies the
+// coordinator never starts a third test revision after the bounded budget is
+// exhausted.
+func TestImplementationObjectionEscalatesAfterTwoRevisionAttempts(t *testing.T) {
+	service, storeRuntime, workerRuntime, harnessRuntime, implementation, workspace := newObjectionCycleFixture(t)
+	run := *storeRuntime.current
+	writeReport := func(invocation store.Invocation, value report.Report) {
+		t.Helper()
+		if _, err := report.WriteAtomicForInvocation(invocation.ResultDirectory, invocation.ID, value); err != nil {
+			t.Fatalf("WriteAtomicForInvocation(%s) error = %v", invocation.ID, err)
+		}
+	}
+	implementationObjection := func(invocation store.Invocation, attempt int) report.Report {
+		return report.Report{
+			SchemaVersion: report.SchemaVersion,
+			InvocationID:  invocation.ID,
+			RunID:         invocation.RunID,
+			Harness:       invocation.Harness,
+			Role:          "implementation",
+			Stage:         "implementation",
+			Outcome:       report.OutcomeCompleted,
+			Summary:       "implementation challenged the protected assertion",
+			Handoff: &report.Handoff{
+				ChangeSummary:          "implementation change with a test objection",
+				AcceptanceMapping:      []report.AcceptanceMapping{{Criterion: "behavior", Evidence: "implementation evidence"}},
+				ProductionFilesChanged: []string{"internal/factory/agent.go"},
+				FocusedCommands:        []string{"go test ./internal/factory"},
+				TestObjections: []report.TestObjection{{
+					Test:     "internal/factory/agent_test.go:TestBehavior",
+					Claim:    "the assertion is too narrow",
+					Evidence: "the frozen behavior remains required",
+				}},
+			},
+			NativeSessionID: fmt.Sprintf("implementation-session-%d", attempt),
+			ReportedAt:      time.Now().UTC(),
+		}
+	}
+	revisedTest := func(invocation store.Invocation, attempt int) report.Report {
+		reason := fmt.Sprintf("expected revised behavior assertion %d", attempt)
+		return report.Report{
+			SchemaVersion: report.SchemaVersion,
+			InvocationID:  invocation.ID,
+			RunID:         invocation.RunID,
+			Harness:       invocation.Harness,
+			Role:          "test",
+			Stage:         "test",
+			Outcome:       report.OutcomeCompleted,
+			Summary:       "test accepted the objection and revised the assertion",
+			TestObjectionResponse: &report.TestObjectionResponse{
+				Decision: report.TestObjectionAccepted,
+				Reason:   "the public behavior is the stable contract",
+			},
+			TestHandoff: &report.TestHandoff{
+				AcceptanceCoverage:    []report.AcceptanceMapping{{Criterion: "behavior", Evidence: "revised focused test"}},
+				ChangedFiles:          []string{"internal/factory/agent_test.go"},
+				FocusedTestCommand:    "go test ./internal/factory -run TestBehavior",
+				ExpectedFailureReason: reason,
+				ObservedFailureEvidence: []report.Evidence{{
+					Kind: "exit_code", Detail: "focused command exited with code 1",
+				}},
+			},
+			NativeSessionID: "session-repaired",
+			ReportedAt:      time.Now().UTC(),
+		}
+	}
+
+	currentImplementation := implementation
+	for attempt := 1; attempt <= 2; attempt++ {
+		run = *storeRuntime.current
+		workspace.state.HeadSHA = run.CheckpointSHA
+		workspace.state.ChangedPaths = []string{"internal/factory/agent.go"}
+		writeReport(currentImplementation, implementationObjection(currentImplementation, attempt))
+		if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: currentImplementation.ID}); err != nil {
+			t.Fatalf("AcceptAgentReport() objection %d error = %v", attempt, err)
+		}
+		if storeRuntime.current.Stage != store.StageTest || storeRuntime.current.Status != store.StatusActive || storeRuntime.current.TestRevisionAttempts != attempt || storeRuntime.current.TestObjection == nil {
+			t.Fatalf("objection %d projection = %#v, want active test revision", attempt, storeRuntime.current)
+		}
+		revisionID := "inv-revision-invocation"
+		if attempt == 2 {
+			revisionID = "inv-revision-invocation-2"
+		}
+		revision := storeRuntime.invocations[revisionID]
+		workspace.state.ChangedPaths = []string{"internal/factory/agent.go", "internal/factory/agent_test.go"}
+		workerRuntime.results = append(workerRuntime.results, worker.CommandResult{ExitCode: 1, Stdout: fmt.Sprintf("expected revised behavior assertion %d", attempt)})
+		writeReport(revision, revisedTest(revision, attempt))
+		if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: revision.ID}); err != nil {
+			t.Fatalf("AcceptAgentReport() revision %d error = %v", attempt, err)
+		}
+		if storeRuntime.current.Stage != store.StageImplementation || storeRuntime.current.Status != store.StatusActive || len(storeRuntime.current.TestRevisionHistory) != attempt || storeRuntime.current.TestRevisionHistory[attempt-1].Outcome != store.TestRevisionAccepted {
+			t.Fatalf("revision %d projection = %#v, want accepted implementation handoff", attempt, storeRuntime.current)
+		}
+		if attempt == 1 {
+			currentImplementation = storeRuntime.invocations["inv-implementation-after-revision"]
+		} else {
+			currentImplementation = storeRuntime.invocations["inv-implementation-after-revision-2"]
+		}
+	}
+
+	run = *storeRuntime.current
+	workspace.state.HeadSHA = run.CheckpointSHA
+	workspace.state.ChangedPaths = []string{"internal/factory/agent.go"}
+	startsBeforeEscalation := len(workerRuntime.starts)
+	thirdObjection := implementationObjection(currentImplementation, 3)
+	writeReport(currentImplementation, thirdObjection)
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: currentImplementation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() third objection error = %v", err)
+	}
+	if storeRuntime.current.Stage != store.StageTest || storeRuntime.current.Status != store.StatusWaitingForHuman || storeRuntime.current.TestRevisionAttempts != 2 || storeRuntime.current.TestRevisionBudget != 2 || storeRuntime.current.TestObjection == nil {
+		t.Fatalf("third objection projection = %#v, want waiting human after budget exhaustion", storeRuntime.current)
+	}
+	if len(storeRuntime.current.TestRevisionHistory) != 2 || storeRuntime.current.TestRevisionHistory[0].Outcome != store.TestRevisionAccepted || storeRuntime.current.TestRevisionHistory[1].Outcome != store.TestRevisionAccepted {
+		t.Fatalf("third objection history = %#v, want two accepted attempts", storeRuntime.current.TestRevisionHistory)
+	}
+	if !strings.Contains(storeRuntime.current.LifecycleReason, "after 2 revision attempts") {
+		t.Fatalf("third objection reason = %q, want bounded escalation", storeRuntime.current.LifecycleReason)
+	}
+	if len(harnessRuntime.resumes) != 2 || len(workerRuntime.starts) != startsBeforeEscalation {
+		t.Fatalf("third objection effects = resumes=%d starts=%d (before=%d), want no third revision", len(harnessRuntime.resumes), len(workerRuntime.starts), startsBeforeEscalation)
+	}
+}
+
+// TestImplementationObjectionWaitsForMeasuredPilotAuthorization verifies the
+// pre-pilot fail-closed path preserves the objection for human disposition and
+// never starts a second test session.
+func TestImplementationObjectionWaitsForMeasuredPilotAuthorization(t *testing.T) {
+	service, storeRuntime, workerRuntime, harnessRuntime, implementation, workspace := newObjectionCycleFixtureWith(t, false)
+	run := *storeRuntime.current
+	workspace.state.HeadSHA = run.CheckpointSHA
+	workspace.state.ChangedPaths = []string{"internal/factory/agent.go"}
+	value := report.Report{
+		SchemaVersion: report.SchemaVersion, InvocationID: implementation.ID, RunID: implementation.RunID,
+		Harness: implementation.Harness, Role: "implementation", Stage: "implementation", Outcome: report.OutcomeCompleted,
+		Summary: "implementation found a test dispute",
+		Handoff: &report.Handoff{
+			ChangeSummary: "implementation change", AcceptanceMapping: []report.AcceptanceMapping{{Criterion: "behavior", Evidence: "focused test"}},
+			ProductionFilesChanged: []string{"internal/factory/agent.go"}, FocusedCommands: []string{"go test ./internal/factory"},
+			TestObjections: []report.TestObjection{{Test: "internal/factory/agent_test.go:TestBehavior", Claim: "the assertion is too narrow", Evidence: "public behavior is correct"}},
+		},
+		NativeSessionID: "implementation-session", ReportedAt: time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(implementation.ResultDirectory, implementation.ID, value); err != nil {
+		t.Fatal(err)
+	}
+	startsBeforeObjection := len(workerRuntime.starts)
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: implementation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() error = %v", err)
+	}
+	if storeRuntime.current.Status != store.StatusWaitingForHuman || storeRuntime.current.TestObjection == nil || storeRuntime.current.TestRevisionAttempts != 0 {
+		t.Fatalf("run after pre-pilot objection = %#v, want waiting with preserved objection", storeRuntime.current)
+	}
+	if len(storeRuntime.github.editedComments) == 0 || !strings.Contains(storeRuntime.github.editedComments[len(storeRuntime.github.editedComments)-1].body, "automated revision is disabled pending measured-pilot authorization") {
+		t.Fatalf("pre-pilot status comment = %#v, want measured-pilot pause reason", storeRuntime.github.editedComments)
+	}
+	if len(harnessRuntime.resumes) != 0 || len(workerRuntime.starts) != startsBeforeObjection {
+		t.Fatalf("pre-pilot effects = resumes=%d worker starts=%d, want no resume and no new worker", len(harnessRuntime.resumes), len(workerRuntime.starts)-startsBeforeObjection)
+	}
+}
+
+// newObjectionCycleFixture creates a required independent test run through a
+// verified red handoff and returns its active implementation invocation.
+func newObjectionCycleFixture(t *testing.T) (*factory.Service, *agentRunStore, *agentWorker, *agentHarness, store.Invocation, *testStageWorkspace) {
+	return newObjectionCycleFixtureWith(t, true)
+}
+
+// newObjectionCycleFixtureWith creates the objection-cycle fixture with an
+// explicit evidence-gate setting for testing both enabled and pre-pilot paths.
+func newObjectionCycleFixtureWith(t *testing.T, allowAutomatedObjections bool) (*factory.Service, *agentRunStore, *agentWorker, *agentHarness, store.Invocation, *testStageWorkspace) {
+	t.Helper()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(worktreePath, "internal", "factory"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreePath, "internal", "factory", "agent_test.go"), []byte("package factory_test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy := validRepositoryConfig()
+	policy.TestPolicy.AllowAutomatedObjections = allowAutomatedObjections
+	policy.RoleHarnessDefaults["test"] = config.HarnessCodex
+	policy.ModelOptions["test"] = []string{"gpt-5"}
+	storeRuntime := &agentRunStore{runs: map[string]store.Run{}, invocations: map[string]store.Invocation{}, gateResults: map[string][]store.GateResult{}}
+	workerRuntime := &agentWorker{results: []worker.CommandResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 1, Stdout: "expected behavior assertion"}}}
+	terminalRuntime := &agentTerminal{}
+	harnessRuntime := &agentHarness{}
+	githubRuntime := &fakeGitHub{issueValue: github.Issue{Number: 13, Title: "Test objection", State: "open", Labels: []string{github.LabelAgentReady}}}
+	workspace := &testStageWorkspace{
+		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-objection", Worktree: worktreePath},
+		state:     gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-objection", HeadSHA: factoryGateCheckpoint},
+	}
+	storeRuntime.github = githubRuntime
+	storeRuntime.worktree = &inspectingWorktree{fakeWorktree: fakeWorktree{workspace: workspace.workspace}, state: workspace.state}
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path:                 repositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		AuthorizedUsers:      []string{"alice"},
+		Cmux:                 config.CmuxConfig{ControlWorkspace: "factory-control"},
+		OperationalDataPath:  filepath.Join(root, "state", "factory.db"),
+		RepositoryConfigPath: filepath.Join(repositoryPath, config.RepositoryConfigFileName),
+	}}}
+	ids := []string{"run-objection", "test-invocation", "implementation-invocation", "revision-invocation", "implementation-after-revision", "revision-invocation-2", "implementation-after-revision-2"}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config:         &fakeConfig{value: host},
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return storeRuntime, nil },
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		GitHub:         githubRuntime,
+		Comments:       &pilotDecisionComments{comments: []github.Comment{{Author: "alice", Body: "Decision: proceed"}}},
+		CommitStatuses: &gateStatuses{},
+		Worktree:       workspace,
+		GitWorkspace:   workspace,
+		Worker:         workerRuntime,
+		Terminal:       terminalRuntime,
+		Harness:        harnessRuntime,
+		Now:            func() time.Time { return time.Date(2026, 8, 25, 10, 0, 0, 0, time.UTC) },
+		NewRunID: func() (string, error) {
+			if len(ids) == 0 {
+				return "", errors.New("objection-cycle id fixture exhausted")
+			}
+			id := ids[0]
+			ids = ids[1:]
+			return id, nil
+		},
+		Coordinator: "coordinator-test",
+	})
+	claimed, err := service.ClaimIssue(context.Background(), 13)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+	if _, err := service.RunBaseline(context.Background(), factory.BaselineRequest{RunID: claimed.Run.ID}); err != nil {
+		t.Fatalf("RunBaseline() error = %v", err)
+	}
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() test error = %v", err)
+	}
+	workspace.state.ChangedPaths = []string{"internal/factory/agent_test.go"}
+	value := report.Report{
+		SchemaVersion: report.SchemaVersion, InvocationID: launch.Invocation.ID, RunID: launch.Invocation.RunID,
+		Harness: launch.Invocation.Harness, Role: "test", Stage: "test", Outcome: report.OutcomeCompleted,
+		Summary: "focused behavior test is red on base",
+		TestHandoff: &report.TestHandoff{
+			AcceptanceCoverage: []report.AcceptanceMapping{{Criterion: "behavior", Evidence: "focused test"}},
+			ChangedFiles:       []string{"internal/factory/agent_test.go"}, FocusedTestCommand: "go test ./internal/factory -run TestBehavior",
+			ExpectedFailureReason: "expected behavior assertion", ObservedFailureEvidence: []report.Evidence{{Kind: "exit_code", Detail: "focused command exited with code 1"}},
+		}, NativeSessionID: "test-session", ReportedAt: time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, value); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() initial test error = %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: claimed.Run.ID, InvocationID: launch.Invocation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() initial test error = %v", err)
+	}
+	return service, storeRuntime, workerRuntime, harnessRuntime, storeRuntime.invocations["inv-implementation-invocation"], workspace
 }
 
 // TestTestStagePausesAnUnverifiableCompletedReportForHumanDisposition verifies

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -54,6 +54,13 @@ type Request struct {
 	// TestHandoff is the accepted test-stage transfer packet shown to
 	// implementation, when available.
 	TestHandoff *store.TestHandoff
+	// TestObjection is the current implementation dispute shown to a resumed
+	// test role, when an objection cycle is active.
+	TestObjection *store.TestObjection
+	// TestRevisionAttempt is the one-based objection cycle being reviewed.
+	TestRevisionAttempt int
+	// TestRevisionBudget is the frozen objection-cycle ceiling.
+	TestRevisionBudget int
 	// ProtectedTestPaths identifies test files implementation must preserve.
 	ProtectedTestPaths []store.ProtectedTestPath
 	// TestExemption carries a provisional technical exemption to later review.
@@ -192,6 +199,23 @@ Test-stage ownership:
 			}
 			testContext += "- Treat the accepted design as the interface under test; it does not replace the frozen specification packet.\n"
 		}
+		if request.TestObjection != nil {
+			objection, err := marshalHandoff(request.TestObjection)
+			if err != nil {
+				return "", fmt.Errorf("encode test objection: %w", err)
+			}
+			testContext += fmt.Sprintf(`
+Test-objection revision:
+- This is objection revision attempt %d of %d.
+- Resume the original test session and inspect the current implementation in the mounted worktree before deciding.
+- The implementation role is not allowed to edit protected tests; decide whether the objection is valid from the current code and the frozen specification.
+- If accepted, edit only behavioral tests or authorized test infrastructure, rerun the focused red command, and report with --objection-decision accepted --objection-reason ... plus the revised test handoff.
+- If rejected, leave the worktree unchanged and report with --objection-decision rejected --objection-reason ...; the coordinator will escalate the dispute to a human.
+- Do not weaken the test merely to accommodate an implementation that violates the frozen behavior.
+Current objection (coordinator-owned):
+%s
+`, request.TestRevisionAttempt, request.TestRevisionBudget, objection)
+		}
 	} else if implementationOwnsTDD && definition.Kind == workflow.RoleKindHandoff && request.Role == workflow.RoleImplementation {
 		testContext = `
 Implementation-owned TDD:
@@ -209,7 +233,7 @@ Implementation-owned TDD:
 		if err != nil {
 			return "", fmt.Errorf("encode test handoff context: %w", err)
 		}
-		testContext = fmt.Sprintf("\nProtected test-stage handoff (coordinator-owned):\n%s\n- Do not edit any protected test path or change its recorded content.\n", data)
+		testContext = fmt.Sprintf("\nProtected test-stage handoff (coordinator-owned):\n%s\n- Do not edit any protected test path or change its recorded content.\n- If a protected test is incorrect, submit a structured objection with --test-objection test|claim|evidence; never edit the protected test.\n", data)
 	}
 	reviewContext := ""
 	if definition.Kind == workflow.RoleKindReview {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -39,6 +39,7 @@ const (
 	maxQuestions          = 32
 	maxEvidenceEntries    = 32
 	maxEvaluationSignals  = 32
+	maxTestObjections     = 8
 	// maxTestFiles bounds changed test and test-infrastructure paths in one handoff.
 	maxTestFiles = 256
 	// maxUncoveredCriteria bounds criteria the test role explicitly leaves open.
@@ -81,6 +82,44 @@ type Handoff struct {
 	FocusedCommands []string `json:"focused_commands"`
 	// KnownLimitations records limitations that remain visible to later stages.
 	KnownLimitations []string `json:"known_limitations,omitempty"`
+	// TestObjections contains structured disputes about protected test-stage
+	// behavior. The coordinator routes these back to the test role instead of
+	// permitting the implementation role to edit protected tests.
+	TestObjections []TestObjection `json:"test_objections,omitempty"`
+}
+
+// TestObjection identifies one protected test claim that the implementation
+// role believes is incorrect, together with bounded observable evidence.
+type TestObjection struct {
+	// Test identifies the disputed test by path, name, or both.
+	Test string `json:"test"`
+	// Claim states the behavioral assertion the test makes.
+	Claim string `json:"claim"`
+	// Evidence identifies observable implementation evidence supporting the
+	// objection.
+	Evidence string `json:"evidence"`
+}
+
+// TestObjectionDecision is the bounded response vocabulary for a test role
+// reviewing an implementation objection.
+type TestObjectionDecision string
+
+const (
+	// TestObjectionAccepted means the test role accepts the objection and has
+	// revised the test-stage evidence.
+	TestObjectionAccepted TestObjectionDecision = "accepted"
+	// TestObjectionRejected means the test role rejects the objection and leaves
+	// the dispute for human disposition.
+	TestObjectionRejected TestObjectionDecision = "rejected"
+)
+
+// TestObjectionResponse records the test role's bounded decision about the
+// current implementation objection.
+type TestObjectionResponse struct {
+	// Decision is accepted or rejected.
+	Decision TestObjectionDecision `json:"decision"`
+	// Reason explains the decision in observable terms.
+	Reason string `json:"reason"`
 }
 
 // TestHandoff contains the bounded evidence needed to transfer a test-stage
@@ -284,6 +323,10 @@ type Report struct {
 	TestHandoff *TestHandoff `json:"test_handoff,omitempty"`
 	// ReviewHandoff is required for a completed specification-review outcome.
 	ReviewHandoff *ReviewHandoff `json:"review_handoff,omitempty"`
+	// TestObjectionResponse is required when a test-stage invocation is
+	// reviewing an active implementation objection. A rejected response need
+	// not contain a revised test handoff.
+	TestObjectionResponse *TestObjectionResponse `json:"test_objection_response,omitempty"`
 	// Questions are required only for a clarification outcome.
 	Questions []Question `json:"questions,omitempty"`
 	// Evidence is required only for a cannot-proceed outcome.
@@ -535,9 +578,23 @@ func Validate(value Report, context ValidationContext) error {
 	case OutcomeCompleted:
 		if isTestReportForContext(value, context) {
 			if value.Handoff != nil || value.ReviewHandoff != nil {
-				return errors.New("test completed report must contain only a test handoff")
+				return errors.New("test completed report must contain only a test handoff or objection response")
 			}
-			if value.TestHandoff == nil {
+			if value.TestObjectionResponse != nil {
+				if err := validateTestObjectionResponse(*value.TestObjectionResponse); err != nil {
+					return err
+				}
+				if value.TestObjectionResponse.Decision == TestObjectionAccepted {
+					if value.TestHandoff == nil {
+						return errors.New("accepted test objection requires a revised test handoff")
+					}
+					if err := validateTestHandoff(*value.TestHandoff, context); err != nil {
+						return err
+					}
+				} else if value.TestHandoff != nil {
+					return errors.New("rejected test objection must not contain a test handoff")
+				}
+			} else if value.TestHandoff == nil {
 				if !hasExemption(value.Exemptions, ExemptionTechnical) {
 					return errors.New("completed test report requires a test handoff")
 				}
@@ -547,6 +604,9 @@ func Validate(value Report, context ValidationContext) error {
 		} else if isReviewReportForContext(value, context) {
 			if value.Handoff != nil || value.TestHandoff != nil {
 				return errors.New("review completed report must contain only a review handoff")
+			}
+			if value.TestObjectionResponse != nil {
+				return errors.New("review completed report must not contain a test objection response")
 			}
 			if value.ReviewHandoff == nil {
 				return errors.New("completed review report requires a review handoff")
@@ -558,7 +618,7 @@ func Validate(value Report, context ValidationContext) error {
 			if value.Handoff == nil {
 				return errors.New("completed report requires a handoff")
 			}
-			if value.TestHandoff != nil || value.ReviewHandoff != nil {
+			if value.TestHandoff != nil || value.ReviewHandoff != nil || value.TestObjectionResponse != nil {
 				return errors.New("implementation completed report must not contain test or review handoff")
 			}
 			if err := validateHandoff(*value.Handoff, context); err != nil {
@@ -572,7 +632,7 @@ func Validate(value Report, context ValidationContext) error {
 		if len(value.Questions) == 0 {
 			return errors.New("needs_clarification report requires at least one question")
 		}
-		if value.Handoff != nil || value.TestHandoff != nil || value.ReviewHandoff != nil || len(value.Evidence) != 0 {
+		if value.Handoff != nil || value.TestHandoff != nil || value.ReviewHandoff != nil || value.TestObjectionResponse != nil || len(value.Evidence) != 0 {
 			return errors.New("needs_clarification report must contain only questions")
 		}
 		if err := validateQuestions(value.Questions); err != nil {
@@ -582,7 +642,7 @@ func Validate(value Report, context ValidationContext) error {
 		if len(value.Evidence) == 0 {
 			return errors.New("cannot_proceed report requires evidence")
 		}
-		if value.Handoff != nil || value.TestHandoff != nil || value.ReviewHandoff != nil || len(value.Questions) != 0 {
+		if value.Handoff != nil || value.TestHandoff != nil || value.ReviewHandoff != nil || value.TestObjectionResponse != nil || len(value.Questions) != 0 {
 			return errors.New("cannot_proceed report must contain only evidence")
 		}
 		if err := validateEvidence(value.Evidence); err != nil {
@@ -748,6 +808,43 @@ func validateHandoff(value Handoff, context ValidationContext) error {
 		if err := validateText(fmt.Sprintf("known_limitations[%d]", index), limitation, maxTextRunes, true); err != nil {
 			return err
 		}
+	}
+	if len(value.TestObjections) > maxTestObjections {
+		return fmt.Errorf("test_objections exceeds %d entries", maxTestObjections)
+	}
+	seenTests := make(map[string]struct{}, len(value.TestObjections))
+	for index, objection := range value.TestObjections {
+		if err := validateText(fmt.Sprintf("test_objections[%d].test", index), objection.Test, maxPathRunes, true); err != nil {
+			return err
+		}
+		if err := validateText(fmt.Sprintf("test_objections[%d].claim", index), objection.Claim, maxTextRunes, true); err != nil {
+			return err
+		}
+		if err := validateText(fmt.Sprintf("test_objections[%d].evidence", index), objection.Evidence, maxTextRunes, true); err != nil {
+			return err
+		}
+		key := strings.TrimSpace(objection.Test)
+		if _, exists := seenTests[key]; exists {
+			return fmt.Errorf("test_objections[%d].test %q is duplicated", index, objection.Test)
+		}
+		seenTests[key] = struct{}{}
+	}
+	return nil
+}
+
+// validateTestObjectionResponse checks the bounded decision returned by the
+// test role without assuming whether the coordinator has an active objection.
+func validateTestObjectionResponse(value TestObjectionResponse) error {
+	switch value.Decision {
+	case TestObjectionAccepted, TestObjectionRejected:
+	default:
+		return fmt.Errorf("unsupported test objection decision %q", value.Decision)
+	}
+	if strings.TrimSpace(value.Reason) == "" {
+		return errors.New("test objection response requires a reason")
+	}
+	if err := validateText("test_objection_response.reason", value.Reason, maxTextRunes, false); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -316,6 +316,52 @@ func TestValidateRejectsAReviewHandoffForTestCompletion(t *testing.T) {
 	}
 }
 
+// TestValidateAcceptsTheStructuredTestObjectionProtocol verifies an
+// implementation objection and both bounded test-role response shapes remain
+// strict report-level contracts.
+func TestValidateAcceptsTheStructuredTestObjectionProtocol(t *testing.T) {
+	implementation := completedReport()
+	implementation.Handoff.TestObjections = []report.TestObjection{{
+		Test:     "internal/factory/agent_test.go:TestBehavior",
+		Claim:    "the assertion over-specifies an implementation detail",
+		Evidence: "the public behavior is correct while the assertion fails",
+	}}
+	if err := report.Validate(implementation, report.ValidationContext{InvocationID: "inv-1", RunID: "run-1", Harness: "codex", Role: "implementation", Stage: "implementation"}); err != nil {
+		t.Fatalf("Validate(implementation objection) error = %v", err)
+	}
+
+	accepted := testStageReport()
+	accepted.TestObjectionResponse = &report.TestObjectionResponse{Decision: report.TestObjectionAccepted, Reason: "the public contract is stable"}
+	if err := report.Validate(accepted, report.ValidationContext{InvocationID: "inv-test", RunID: "run-test", Harness: "codex", Role: "test", Stage: "test", WorktreeObserved: true, ObservedChanges: accepted.TestHandoff.ChangedFiles}); err != nil {
+		t.Fatalf("Validate(accepted objection) error = %v", err)
+	}
+
+	rejected := testStageReport()
+	rejected.TestHandoff = nil
+	rejected.TestObjectionResponse = &report.TestObjectionResponse{Decision: report.TestObjectionRejected, Reason: "the frozen specification requires this behavior"}
+	if err := report.Validate(rejected, report.ValidationContext{InvocationID: "inv-test", RunID: "run-test", Harness: "codex", Role: "test", Stage: "test"}); err != nil {
+		t.Fatalf("Validate(rejected objection) error = %v", err)
+	}
+}
+
+// TestValidateRejectsMalformedTestObjectionResponses verifies unknown
+// decisions and unexplained objection responses cannot reach the coordinator.
+func TestValidateRejectsMalformedTestObjectionResponses(t *testing.T) {
+	for name, response := range map[string]report.TestObjectionResponse{
+		"unknown decision":          {Decision: "maybe", Reason: "unclear"},
+		"missing acceptance reason": {Decision: report.TestObjectionAccepted},
+		"missing rejection reason":  {Decision: report.TestObjectionRejected},
+	} {
+		t.Run(name, func(t *testing.T) {
+			value := testStageReport()
+			value.TestObjectionResponse = &response
+			if err := report.Validate(value, report.ValidationContext{InvocationID: "inv-test", RunID: "run-test", Harness: "codex", Role: "test", Stage: "test"}); err == nil {
+				t.Fatal("Validate() accepted malformed objection response")
+			}
+		})
+	}
+}
+
 // TestValidateAcceptsACompleteSpecificationReview verifies a review binds its
 // findings to the exact immutable checkpoint and preserves advisory findings.
 func TestValidateAcceptsACompleteSpecificationReview(t *testing.T) {

--- a/internal/reportcli/reportcli.go
+++ b/internal/reportcli/reportcli.go
@@ -60,6 +60,8 @@ func Run(request Request) int {
 	flags.Var(&focusedCommands, "focused-command", "focused command run; may be repeated")
 	limitations := stringList{}
 	flags.Var(&limitations, "known-limitation", "known limitation; may be repeated")
+	testObjections := testObjectionList{}
+	flags.Var(&testObjections, "test-objection", "test|claim|evidence; may be repeated")
 	testFiles := stringList{}
 	flags.Var(&testFiles, "test-file", "repository-relative test file; may be repeated")
 	infrastructureFiles := stringList{}
@@ -70,6 +72,8 @@ func Run(request Request) int {
 	flags.Var(&observedFailures, "observed-failure", "red-test evidence kind=detail; may be repeated")
 	uncoveredCriteria := stringList{}
 	flags.Var(&uncoveredCriteria, "uncovered-criterion", "acceptance criterion not covered by this test handoff; may be repeated")
+	objectionDecision := flags.String("objection-decision", "", "accepted or rejected response to the current test objection")
+	objectionReason := flags.String("objection-reason", "", "observable reason for the test objection response")
 	findings := reviewFindingList{}
 	flags.Var(&findings, "finding", "review finding location|claim|evidence|severity|category|resolution|owner; may be repeated")
 	questions := pairList{}
@@ -183,12 +187,19 @@ func Run(request Request) int {
 			value.Handoff = ensureHandoff(value.Handoff)
 			value.Handoff.AcceptanceMapping = append(value.Handoff.AcceptanceMapping, report.AcceptanceMapping{Criterion: pair.Key, Evidence: pair.Value})
 		}
-		if *changeSummary != "" || len(productionFiles) > 0 || len(focusedCommands) > 0 || len(limitations) > 0 {
+		if *changeSummary != "" || len(productionFiles) > 0 || len(focusedCommands) > 0 || len(limitations) > 0 || len(testObjections) > 0 {
 			value.Handoff = ensureHandoff(value.Handoff)
 			value.Handoff.ChangeSummary = *changeSummary
 			value.Handoff.ProductionFilesChanged = append([]string(nil), productionFiles...)
 			value.Handoff.FocusedCommands = append([]string(nil), focusedCommands...)
 			value.Handoff.KnownLimitations = append([]string(nil), limitations...)
+			value.Handoff.TestObjections = append([]report.TestObjection(nil), testObjections...)
+		}
+	}
+	if identity["role"] == "test" && identity["stage"] == "test" && (*objectionDecision != "" || *objectionReason != "") {
+		value.TestObjectionResponse = &report.TestObjectionResponse{
+			Decision: report.TestObjectionDecision(*objectionDecision),
+			Reason:   *objectionReason,
 		}
 	}
 	for _, pair := range questions {
@@ -268,6 +279,34 @@ func (value *stringList) Set(input string) error {
 		return errors.New("value must not be empty")
 	}
 	*value = append(*value, input)
+	return nil
+}
+
+// testObjectionList collects the three bounded fields required to challenge a
+// protected test from the implementation handoff.
+type testObjectionList []report.TestObjection
+
+// String renders the compact test|claim|evidence flag form.
+func (value *testObjectionList) String() string {
+	parts := make([]string, 0, len(*value))
+	for _, objection := range *value {
+		parts = append(parts, strings.Join([]string{objection.Test, objection.Claim, objection.Evidence}, "|"))
+	}
+	return strings.Join(parts, ",")
+}
+
+// Set parses one test|claim|evidence objection without shell interpretation.
+func (value *testObjectionList) Set(input string) error {
+	parts := strings.SplitN(input, "|", 3)
+	if len(parts) != 3 {
+		return errors.New("value must use test|claim|evidence form")
+	}
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			return errors.New("test objection fields must not be empty")
+		}
+	}
+	*value = append(*value, report.TestObjection{Test: parts[0], Claim: parts[1], Evidence: parts[2]})
 	return nil
 }
 

--- a/internal/reportcli/reportcli_test.go
+++ b/internal/reportcli/reportcli_test.go
@@ -145,6 +145,57 @@ func TestRunWritesTheTestStageHandoff(t *testing.T) {
 	}
 }
 
+// TestRunWritesTestObjectionsAndResponses verifies the worker-facing report
+// command exposes the structured implementation dispute protocol.
+func TestRunWritesTestObjectionsAndResponses(t *testing.T) {
+	implementationDirectory := t.TempDir()
+	var implementationErrors bytes.Buffer
+	status := reportcli.Run(reportcli.Request{
+		Args: []string{
+			"--outcome", "completed", "--summary", "implementation dispute",
+			"--change-summary", "implemented public behavior", "--acceptance", "behavior=focused test",
+			"--production-file", "internal/factory/agent.go", "--focused-command", "go test ./internal/factory",
+			"--test-objection", "internal/factory/agent_test.go:TestBehavior|the assertion is too narrow|public behavior passes while the assertion fails",
+		},
+		Environment: map[string]string{
+			"FACTORY_INVOCATION_ID": "inv-implementation", "FACTORY_RUN_ID": "run-1", "FACTORY_HARNESS": "codex",
+			"FACTORY_ROLE": "implementation", "FACTORY_STAGE": "implementation", "FACTORY_RESULT_DIR": implementationDirectory,
+		},
+		Output: &bytes.Buffer{}, ErrorsOutput: &implementationErrors,
+	})
+	if status != 0 {
+		t.Fatalf("implementation Run() status = %d, stderr = %s", status, implementationErrors.String())
+	}
+	implementation, err := report.Read(implementationDirectory + "/report.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if implementation.Handoff == nil || len(implementation.Handoff.TestObjections) != 1 || implementation.Handoff.TestObjections[0].Claim == "" {
+		t.Fatalf("implementation handoff = %#v, want one structured objection", implementation.Handoff)
+	}
+
+	testDirectory := t.TempDir()
+	var testErrors bytes.Buffer
+	status = reportcli.Run(reportcli.Request{
+		Args: []string{"--outcome", "completed", "--summary", "objection accepted", "--objection-decision", "accepted", "--objection-reason", "the public contract is correct", "--acceptance", "behavior=revised focused test", "--test-file", "internal/factory/agent_test.go", "--focused-test-command", "go test ./internal/factory -run TestBehavior", "--expected-failure-reason", "expected behavior assertion", "--observed-failure", "exit_code=1"},
+		Environment: map[string]string{
+			"FACTORY_INVOCATION_ID": "inv-test", "FACTORY_RUN_ID": "run-1", "FACTORY_HARNESS": "codex",
+			"FACTORY_ROLE": "test", "FACTORY_STAGE": "test", "FACTORY_RESULT_DIR": testDirectory,
+		},
+		Output: &bytes.Buffer{}, ErrorsOutput: &testErrors,
+	})
+	if status != 0 {
+		t.Fatalf("test Run() status = %d, stderr = %s", status, testErrors.String())
+	}
+	testReport, err := report.Read(testDirectory + "/report.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if testReport.TestObjectionResponse == nil || testReport.TestObjectionResponse.Decision != report.TestObjectionAccepted || testReport.TestHandoff == nil {
+		t.Fatalf("test report = %#v, want accepted objection response and revised handoff", testReport)
+	}
+}
+
 // TestRunWritesTheSpecificationReviewFindingContract verifies repeated review
 // flags bind complete findings to the coordinator-provided checkpoint.
 func TestRunWritesTheSpecificationReviewFindingContract(t *testing.T) {

--- a/internal/store/cleanup.go
+++ b/internal/store/cleanup.go
@@ -253,7 +253,10 @@ func (s *Store) cleanupRun(ctx context.Context, runID string) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
-		       test_handoff, implementation_handoff, specification_review,
+		       test_handoff, test_invocation_id, test_revision_attempts,
+		       test_revision_budget, test_revision_history, test_objection,
+		       test_revision_base_changed_paths,
+		       implementation_handoff, specification_review,
 		       test_exemption, protected_test_paths, test_stage_skipped,
 		       active_invocation_id,
 		       image_digest, coordinator, status_comment_id,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,11 @@ import (
 )
 
 // CurrentSchemaVersion is the supported operational-store schema version.
-const CurrentSchemaVersion = 26
+const CurrentSchemaVersion = 27
+
+// MaxTestRevisionAttempts is the hard safety ceiling for automated
+// implementation-versus-test objection cycles.
+const MaxTestRevisionAttempts = 2
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -215,6 +219,49 @@ type TestFailureEvidence struct {
 	Detail string `json:"detail"`
 }
 
+// TestObjection is the durable implementation claim that a protected test is
+// incorrect. InvocationID is coordinator-owned and records which original
+// test session must receive the objection on resume.
+type TestObjection struct {
+	// Test identifies the disputed test by path, name, or both.
+	Test string `json:"test"`
+	// Claim states the behavioral assertion the test makes.
+	Claim string `json:"claim"`
+	// Evidence identifies observable implementation evidence supporting the
+	// objection.
+	Evidence string `json:"evidence"`
+	// InvocationID identifies the original test invocation to resume.
+	InvocationID string `json:"invocation_id,omitempty"`
+}
+
+// TestRevisionOutcome is the bounded status of one objection cycle.
+type TestRevisionOutcome string
+
+const (
+	// TestRevisionPending means the test role has not answered the objection.
+	TestRevisionPending TestRevisionOutcome = "pending"
+	// TestRevisionAccepted means the test role accepted and revised the test.
+	TestRevisionAccepted TestRevisionOutcome = "accepted"
+	// TestRevisionRejected means the test role rejected the objection.
+	TestRevisionRejected TestRevisionOutcome = "rejected"
+	// TestRevisionVerificationFailed means the revised test did not reproduce
+	// the expected red failure under coordinator verification.
+	TestRevisionVerificationFailed TestRevisionOutcome = "verification_failed"
+	// TestRevisionEscalated means the bounded revision budget was exhausted.
+	TestRevisionEscalated TestRevisionOutcome = "escalated"
+)
+
+// TestRevision records one bounded objection cycle and its latest outcome.
+type TestRevision struct {
+	// Attempt is the one-based cycle number.
+	Attempt int `json:"attempt"`
+	// Outcome is pending, accepted, rejected, verification_failed, or escalated.
+	Outcome TestRevisionOutcome `json:"outcome"`
+	// DisputeKey groups revision cycles that address the same test claim while
+	// allowing a later, distinct objection to receive its own two-cycle budget.
+	DisputeKey string `json:"dispute_key,omitempty"`
+}
+
 // TestHandoff is the durable test-stage transfer packet for implementation.
 type TestHandoff struct {
 	// AcceptanceCoverage maps acceptance criteria to test evidence.
@@ -265,6 +312,9 @@ type RoleHandoff struct {
 	FocusedCommands []string `json:"focused_commands"`
 	// KnownLimitations carries bounded visible limitations.
 	KnownLimitations []string `json:"known_limitations,omitempty"`
+	// TestObjections contains structured disputes about protected test-stage
+	// behavior.
+	TestObjections []TestObjection `json:"test_objections,omitempty"`
 }
 
 // ImplementationHandoff is the legacy name retained for callers and persisted
@@ -324,6 +374,23 @@ type Run struct {
 	TestCheckpointSHA string
 	// TestHandoff is the accepted structured test-stage transfer packet.
 	TestHandoff *TestHandoff
+	// TestInvocationID identifies the latest test invocation whose native
+	// session should receive a future implementation objection.
+	TestInvocationID string
+	// TestRevisionAttempts is the number of objection cycles started.
+	TestRevisionAttempts int
+	// TestRevisionBudget is the frozen maximum number of objection cycles.
+	TestRevisionBudget int
+	// TestRevisionHistory records bounded objection outcomes for status and
+	// recovery projection.
+	TestRevisionHistory []TestRevision
+	// TestObjection is the current implementation objection awaiting a test
+	// role response. It is cleared after an accepted revision.
+	TestObjection *TestObjection
+	// TestRevisionBaseChangedPaths records implementation changes already in
+	// the worktree when the current objection was submitted, including their
+	// content identity so a resumed test role cannot alter them silently.
+	TestRevisionBaseChangedPaths []ProtectedTestPath
 	// RoleHandoff is the accepted role transfer packet.
 	RoleHandoff *RoleHandoff
 	// ImplementationHandoff is the legacy compatibility projection of
@@ -646,7 +713,10 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
-		       test_handoff, implementation_handoff, specification_review,
+		       test_handoff, test_invocation_id, test_revision_attempts,
+		       test_revision_budget, test_revision_history, test_objection,
+		       test_revision_base_changed_paths,
+		       implementation_handoff, specification_review,
 		       test_exemption, protected_test_paths, test_stage_skipped,
 		       active_invocation_id,
 		       image_digest, coordinator, status_comment_id,
@@ -671,7 +741,10 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
 		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
-		       test_handoff, implementation_handoff, specification_review,
+		       test_handoff, test_invocation_id, test_revision_attempts,
+		       test_revision_budget, test_revision_history, test_objection,
+		       test_revision_base_changed_paths,
+		       implementation_handoff, specification_review,
 		       test_exemption, protected_test_paths, test_stage_skipped,
 		       active_invocation_id,
 		       image_digest, coordinator, status_comment_id,
@@ -694,6 +767,7 @@ func scanRun(row *sql.Row) (*Run, error) {
 	var run Run
 	var baseCheckpointSHA, testCheckpointSHA string
 	var testHandoffJSON, roleHandoffJSON, specificationReviewJSON string
+	var testRevisionHistoryJSON, testObjectionJSON, testRevisionBaseChangedPathsJSON string
 	var testExemptionJSON, protectedTestPathsJSON string
 	var pendingQuestionsJSON, clarificationCommentID, terminalAt, createdAt, updatedAt string
 	var clarificationNotificationSent bool
@@ -710,6 +784,12 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&baseCheckpointSHA,
 		&testCheckpointSHA,
 		&testHandoffJSON,
+		&run.TestInvocationID,
+		&run.TestRevisionAttempts,
+		&run.TestRevisionBudget,
+		&testRevisionHistoryJSON,
+		&testObjectionJSON,
+		&testRevisionBaseChangedPathsJSON,
 		&roleHandoffJSON,
 		&specificationReviewJSON,
 		&testExemptionJSON,
@@ -761,6 +841,22 @@ func scanRun(row *sql.Row) (*Run, error) {
 		run.TestHandoff = &TestHandoff{}
 		if err := json.Unmarshal([]byte(testHandoffJSON), run.TestHandoff); err != nil {
 			return nil, fmt.Errorf("decode test handoff: %w", err)
+		}
+	}
+	if testRevisionHistoryJSON != "" {
+		if err := json.Unmarshal([]byte(testRevisionHistoryJSON), &run.TestRevisionHistory); err != nil {
+			return nil, fmt.Errorf("decode test revision history: %w", err)
+		}
+	}
+	if testObjectionJSON != "" {
+		run.TestObjection = &TestObjection{}
+		if err := json.Unmarshal([]byte(testObjectionJSON), run.TestObjection); err != nil {
+			return nil, fmt.Errorf("decode test objection: %w", err)
+		}
+	}
+	if testRevisionBaseChangedPathsJSON != "" {
+		if err := json.Unmarshal([]byte(testRevisionBaseChangedPathsJSON), &run.TestRevisionBaseChangedPaths); err != nil {
+			return nil, fmt.Errorf("decode test revision base changed paths: %w", err)
 		}
 	}
 	if roleHandoffJSON != "" {
@@ -1021,6 +1117,18 @@ func normalizeRun(run Run) (Run, error) {
 	if run.CheckRepairPendingAttempt != 0 && run.CheckRepairPendingAttempt != run.CheckRepairAttempts+1 {
 		return Run{}, errors.New("run pending check-repair attempt must be the next attempt")
 	}
+	if run.TestRevisionAttempts < 0 {
+		return Run{}, errors.New("run test-revision attempts must not be negative")
+	}
+	if run.TestRevisionBudget < 0 {
+		return Run{}, errors.New("run test-revision budget must not be negative")
+	}
+	if run.TestRevisionBudget > MaxTestRevisionAttempts {
+		return Run{}, fmt.Errorf("run test-revision budget must not exceed %d", MaxTestRevisionAttempts)
+	}
+	if run.TestRevisionAttempts > run.TestRevisionBudget {
+		return Run{}, errors.New("run test-revision attempts must not exceed budget")
+	}
 	if strings.ContainsAny(run.ClarificationCommentID, "\x00\r\n") {
 		return Run{}, errors.New("run clarification comment id contains a control character")
 	}
@@ -1085,6 +1193,69 @@ func validateTestProjection(run Run) error {
 			}
 		}
 	}
+	if run.TestInvocationID != "" && !safeQuestionIdentifier(run.TestInvocationID) {
+		return errors.New("run test invocation id is unsafe")
+	}
+	if len(run.TestRevisionHistory) > MaxTestRevisionAttempts {
+		return fmt.Errorf("run test revision history exceeds %d entries", MaxTestRevisionAttempts)
+	}
+	seenAttempts := make(map[int]struct{}, len(run.TestRevisionHistory))
+	disputeKey := ""
+	for index, revision := range run.TestRevisionHistory {
+		if revision.Attempt < 1 || revision.Attempt > run.TestRevisionBudget {
+			return fmt.Errorf("run test revision history entry %d has an invalid attempt", index)
+		}
+		if _, exists := seenAttempts[revision.Attempt]; exists {
+			return fmt.Errorf("run test revision history attempt %d is duplicated", revision.Attempt)
+		}
+		seenAttempts[revision.Attempt] = struct{}{}
+		if revision.DisputeKey != "" {
+			if len(revision.DisputeKey) != 64 || !isLowerHex(revision.DisputeKey) {
+				return fmt.Errorf("run test revision history entry %d has an invalid dispute key", index)
+			}
+			if disputeKey == "" {
+				disputeKey = revision.DisputeKey
+			} else if disputeKey != revision.DisputeKey {
+				return errors.New("run test revision history must contain one dispute key")
+			}
+		}
+		switch revision.Outcome {
+		case TestRevisionPending, TestRevisionAccepted, TestRevisionRejected, TestRevisionVerificationFailed, TestRevisionEscalated:
+		default:
+			return fmt.Errorf("unsupported test revision outcome %q", revision.Outcome)
+		}
+	}
+	if len(run.TestRevisionBaseChangedPaths) > 256 {
+		return errors.New("run test revision base changed paths exceed 256 entries")
+	}
+	seenBasePaths := make(map[string]struct{}, len(run.TestRevisionBaseChangedPaths))
+	for index, path := range run.TestRevisionBaseChangedPaths {
+		if err := validateStoreRelativePath(path.Path); err != nil {
+			return fmt.Errorf("run test revision base changed path %d: %w", index, err)
+		}
+		if len(path.SHA256) != 64 || !isLowerHex(path.SHA256) {
+			return fmt.Errorf("run test revision base changed path %q has an invalid SHA256", path.Path)
+		}
+		if _, exists := seenBasePaths[path.Path]; exists {
+			return fmt.Errorf("run test revision base changed path %q is duplicated", path.Path)
+		}
+		seenBasePaths[path.Path] = struct{}{}
+	}
+	if run.TestObjection != nil {
+		for field, value := range map[string]string{
+			"test": run.TestObjection.Test, "claim": run.TestObjection.Claim, "evidence": run.TestObjection.Evidence,
+		} {
+			if strings.TrimSpace(value) == "" || strings.ContainsAny(value, "\x00\r\n") {
+				return fmt.Errorf("test objection %s is required and must be single-line", field)
+			}
+		}
+		if strings.TrimSpace(run.TestObjection.InvocationID) == "" {
+			return errors.New("test objection invocation id is required")
+		}
+		if !safeQuestionIdentifier(run.TestObjection.InvocationID) {
+			return errors.New("test objection invocation id is unsafe")
+		}
+	}
 	roleHandoff := roleHandoffForRun(run)
 	if roleHandoff != nil {
 		if strings.TrimSpace(roleHandoff.ChangeSummary) == "" || strings.ContainsAny(roleHandoff.ChangeSummary, "\x00\r\n") {
@@ -1101,6 +1272,15 @@ func validateTestProjection(run Run) error {
 		for _, path := range roleHandoff.ProductionFilesChanged {
 			if err := validateStoreRelativePath(path); err != nil {
 				return fmt.Errorf("role handoff changed path: %w", err)
+			}
+		}
+		for index, objection := range roleHandoff.TestObjections {
+			for field, value := range map[string]string{
+				"test": objection.Test, "claim": objection.Claim, "evidence": objection.Evidence,
+			} {
+				if strings.TrimSpace(value) == "" || strings.ContainsAny(value, "\x00\r\n") {
+					return fmt.Errorf("role handoff test objection %d %s is required and must be single-line", index, field)
+				}
 			}
 		}
 	}
@@ -1226,6 +1406,43 @@ func testHandoffJSON(value *TestHandoff) string {
 	return string(data)
 }
 
+// testRevisionHistoryJSON serializes the bounded objection-cycle history.
+func testRevisionHistoryJSON(values []TestRevision) string {
+	if values == nil {
+		return "[]"
+	}
+	data, err := json.Marshal(values)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
+}
+
+// testObjectionJSON serializes a nullable current objection.
+func testObjectionJSON(value *TestObjection) string {
+	if value == nil {
+		return ""
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// testRevisionBaseChangedPathsJSON serializes paths and content identities
+// already dirty when an implementation objection was submitted.
+func testRevisionBaseChangedPathsJSON(values []ProtectedTestPath) string {
+	if values == nil {
+		return "[]"
+	}
+	data, err := json.Marshal(values)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
+}
+
 // roleHandoffJSON serializes a nullable role handoff.
 func roleHandoffJSON(value *RoleHandoff) string {
 	if value == nil {
@@ -1298,6 +1515,12 @@ func runValues(run Run) []any {
 		run.BaseCheckpointSHA,
 		run.TestCheckpointSHA,
 		testHandoffJSON(run.TestHandoff),
+		run.TestInvocationID,
+		run.TestRevisionAttempts,
+		run.TestRevisionBudget,
+		testRevisionHistoryJSON(run.TestRevisionHistory),
+		testObjectionJSON(run.TestObjection),
+		testRevisionBaseChangedPathsJSON(run.TestRevisionBaseChangedPaths),
 		roleHandoffJSON(roleHandoffForRun(run)),
 		specificationReviewJSON(run.SpecificationReview),
 		testExemptionJSON(run.TestExemption),
@@ -1345,7 +1568,10 @@ const saveRunStatement = `
 		INSERT INTO operational_runs (
 			id, repository_path, issue_number, stage, status, branch, worktree,
 			checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
-			test_handoff, implementation_handoff, specification_review,
+			test_handoff, test_invocation_id, test_revision_attempts,
+			test_revision_budget, test_revision_history, test_objection,
+			test_revision_base_changed_paths, implementation_handoff,
+			specification_review,
 			test_exemption, protected_test_paths, test_stage_skipped,
 			active_invocation_id,
 			image_digest, coordinator, status_comment_id,
@@ -1361,7 +1587,8 @@ const saveRunStatement = `
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?
 		)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
@@ -1374,6 +1601,12 @@ const saveRunStatement = `
 			base_checkpoint_sha = excluded.base_checkpoint_sha,
 			test_checkpoint_sha = excluded.test_checkpoint_sha,
 			test_handoff = excluded.test_handoff,
+			test_invocation_id = excluded.test_invocation_id,
+			test_revision_attempts = excluded.test_revision_attempts,
+			test_revision_budget = excluded.test_revision_budget,
+			test_revision_history = excluded.test_revision_history,
+			test_objection = excluded.test_objection,
+			test_revision_base_changed_paths = excluded.test_revision_base_changed_paths,
 			implementation_handoff = excluded.implementation_handoff,
 			specification_review = excluded.specification_review,
 			test_exemption = excluded.test_exemption,
@@ -1409,7 +1642,10 @@ const saveRunIfRevisionStatement = `
 		UPDATE operational_runs SET
 			repository_path = ?, issue_number = ?, stage = ?, status = ?, branch = ?, worktree = ?,
 			checkpoint_sha = ?, base_checkpoint_sha = ?, test_checkpoint_sha = ?,
-			test_handoff = ?, implementation_handoff = ?, specification_review = ?,
+			test_handoff = ?, test_invocation_id = ?, test_revision_attempts = ?,
+			test_revision_budget = ?, test_revision_history = ?, test_objection = ?,
+			test_revision_base_changed_paths = ?, implementation_handoff = ?,
+			specification_review = ?,
 			test_exemption = ?, protected_test_paths = ?, test_stage_skipped = ?,
 			active_invocation_id = ?,
 			image_digest = ?, coordinator = ?, status_comment_id = ?,
@@ -2406,6 +2642,19 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 		case 26:
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN active_invocation_id TEXT NOT NULL DEFAULT ''"); err != nil {
 				return fmt.Errorf("apply store migration 26: %w", err)
+			}
+		case 27:
+			for _, statement := range []string{
+				"ALTER TABLE operational_runs ADD COLUMN test_invocation_id TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN test_revision_attempts INTEGER NOT NULL DEFAULT 0",
+				"ALTER TABLE operational_runs ADD COLUMN test_revision_budget INTEGER NOT NULL DEFAULT 0",
+				"ALTER TABLE operational_runs ADD COLUMN test_revision_history TEXT NOT NULL DEFAULT '[]'",
+				"ALTER TABLE operational_runs ADD COLUMN test_objection TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN test_revision_base_changed_paths TEXT NOT NULL DEFAULT '[]'",
+			} {
+				if _, err := tx.ExecContext(ctx, statement); err != nil {
+					return fmt.Errorf("apply store migration 27: %w", err)
+				}
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -515,6 +515,51 @@ func TestRunPersistsTheProtectedTestHandoffProjection(t *testing.T) {
 	}
 }
 
+// TestRunPersistsTheTestObjectionProjection verifies an objection, its native
+// test-session identity, bounded history, and pre-existing worktree hashes
+// survive a SQLite restart.
+func TestRunPersistsTheTestObjectionProjection(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := store.Run{
+		ID:                           "run-objection-projection",
+		RepositoryPath:               "/work/repository",
+		Stage:                        store.StageTest,
+		Status:                       store.StatusActive,
+		CheckpointSHA:                strings.Repeat("b", 64),
+		TestInvocationID:             "inv-test",
+		TestRevisionAttempts:         1,
+		TestRevisionBudget:           2,
+		TestRevisionHistory:          []store.TestRevision{{Attempt: 1, Outcome: store.TestRevisionPending}},
+		TestObjection:                &store.TestObjection{Test: "internal/factory/agent_test.go:TestBehavior", Claim: "the assertion is too narrow", Evidence: "public behavior is correct", InvocationID: "inv-test"},
+		TestRevisionBaseChangedPaths: []store.ProtectedTestPath{{Path: "internal/factory/agent.go", SHA256: strings.Repeat("c", 64)}},
+	}
+	if err := opened.SaveRun(context.Background(), want); err != nil {
+		_ = opened.Close()
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentRun() error = %v", err)
+	}
+	if got == nil || got.TestInvocationID != want.TestInvocationID || got.TestRevisionAttempts != 1 || got.TestRevisionBudget != 2 || len(got.TestRevisionHistory) != 1 || got.TestObjection == nil || got.TestObjection.Claim != want.TestObjection.Claim || len(got.TestRevisionBaseChangedPaths) != 1 || got.TestRevisionBaseChangedPaths[0].SHA256 != strings.Repeat("c", 64) {
+		t.Fatalf("CurrentRun() = %#v, want persisted objection projection", got)
+	}
+}
+
 // TestRunPersistsImplementationAndSpecificationReviewProjections verifies the
 // reviewer packet's durable handoffs survive the schema-20 restart boundary.
 func TestRunPersistsImplementationAndSpecificationReviewProjections(t *testing.T) {


### PR DESCRIPTION
Closes #13

## Summary
- Add structured implementation objections with protected-test ownership enforcement.
- Gate automated cycles on the measured-pilot authorization and latest authorized #26 decision.
- Resume the original native test session, support accepted/rejected responses, independently verify revised red tests, and cap each dispute at two cycles.
- Persist objection state, hashes, invocation identity, outcomes, status projections, CLI flags, prompts, docs, and migration coverage.

## Verification
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured process for raising and reviewing implementation objections to protected tests.
  * Added support for accepting or rejecting objections, independently verifying revised tests, and escalating unresolved disputes.
  * Added CLI options for submitting objections and recording test-stage decisions.

* **Configuration**
  * Added an automated-objection setting, disabled by default.
  * Limited automated test revisions to two attempts.

* **Documentation**
  * Documented the objection workflow, configuration, reporting, and decision requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->