### PR TITLE
Drive unattended review repair and terminal queue continuation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,10 +93,11 @@ after a terminal pull-request outcome.
 _Avoid_: Autonomous agent, agent-driven workflow, auto-merge
 
 **Human repair packet**:
-The coordinator-owned repair context built from one submitted
-`CHANGES_REQUESTED` review by an authorized maintainer, holding the completed
-review body and its inline findings. It is not one of the bounded factory
-repair rounds and never consumes the review-repair budget.
+The coordinator-owned repair context built from one or more applicable
+`CHANGES_REQUESTED` reviews by authorized maintainers, holding their completed
+review bodies and inline findings. Concurrent applicable reviews form one
+packet outside the bounded factory repair rounds and never consume the
+review-repair budget.
 _Avoid_: Comment command, review reply, advisory feedback
 
 **Review watermark**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,7 +10,9 @@ _Avoid_: Job, task, workflow instance
 
 **GitHub lifecycle observation**:
 One coordinator read of the tracked issue and pull request that can identify
-successful merge completion or an unmerged closure requiring cancellation.
+successful merge completion, an unmerged closure requiring cancellation, or a
+newly submitted authorized review requesting changes. Lifecycle is always read
+before any repair, readiness, or infrastructure work.
 _Avoid_: Screen scrape, hidden workflow transition
 
 **Specification packet**:
@@ -83,10 +85,32 @@ _Avoid_: Docker API
 **Unattended progression**:
 The persistent coordinator's bounded pass that drives one claimed run through
 baseline, its route-selected stages, result acceptance, the exact-checkpoint
-gates, the bounded check-repair loop, the push, and one draft pull request
-without an operator running a stage-driving command. It stops at the first
-human or infrastructure waiting state.
+gates, the bounded check-repair loop, the push, one draft pull request, the
+independent review round, the bounded review-repair loop, and pull-request
+readiness without an operator running a stage-driving command. It stops at the
+first human or infrastructure waiting state, and it resumes the issue queue
+after a terminal pull-request outcome.
 _Avoid_: Autonomous agent, agent-driven workflow, auto-merge
+
+**Human repair packet**:
+The coordinator-owned repair context built from one submitted
+`CHANGES_REQUESTED` review by an authorized maintainer, holding the completed
+review body and its inline findings. It is not one of the bounded factory
+repair rounds and never consumes the review-repair budget.
+_Avoid_: Comment command, review reply, advisory feedback
+
+**Review watermark**:
+The persisted identity of the last human review a run applied. It makes
+repeated polling and a coordinator restart unable to apply the same review
+twice.
+_Avoid_: Comment watermark, last poll time
+
+**Queue release**:
+The terminal transition of the active run - a merged pull request completes it
+and an unmerged closure cancels it - that ends the one-active-run constraint
+and lets the same coordinator process claim the next oldest eligible issue.
+Waiting-for-human and retryable-infrastructure states never release it.
+_Avoid_: Cleanup, retention, restart
 
 **Run activity**:
 The published distinction between an active run whose next transition the

--- a/README.md
+++ b/README.md
@@ -1206,11 +1206,12 @@ without any stage-driving command.
 
 ### Human review as a repair trigger
 
-A submitted GitHub review with the <code>CHANGES_REQUESTED</code> decision from
-a user in <code>authorized_users</code> is a progression event. The coordinator
-consumes that one completed review as a single human repair packet holding its
-review body and every inline comment, returns the pull request to draft when it
-was already ready, and resumes implementation from the current checkpoint. All
+One or more submitted GitHub reviews with the <code>CHANGES_REQUESTED</code>
+decision from users in <code>authorized_users</code> are a progression event.
+The coordinator combines all concurrent applicable reviews before one repair
+flow begins, consuming them as a single human repair packet holding every
+review body and inline comment. It returns the pull request to draft when it was
+already ready and resumes implementation from the current checkpoint. All
 downstream results for the superseded checkpoint are invalidated, so every gate
 and both fresh reviewers must pass again before the pull request can become
 ready a second time.

--- a/README.md
+++ b/README.md
@@ -1216,7 +1216,8 @@ and both fresh reviewers must pass again before the pull request can become
 ready a second time.
 
 A human-requested repair is not one of the bounded factory repair rounds and
-never consumes the <code>review_repair</code> budget.
+never consumes the <code>review_repair</code> budget. The editable status
+comment names the review that triggered it under the review-repair cycle.
 
 These do not start work: an unsubmitted review draft, an ordinary issue or
 pull-request comment, a <code>COMMENTED</code> review, an approval, a dismissed

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ repository. The deeper contracts live in
 - [Recovery and authentication](#recovery-and-authentication)
 - [Persistent polling](#persistent-polling)
   - [Unattended claim-to-draft-PR progression](#unattended-claim-to-draft-pr-progression)
+  - [Unattended review, repair, and readiness](#unattended-review-repair-and-readiness)
+  - [Human review as a repair trigger](#human-review-as-a-repair-trigger)
+  - [Terminal outcomes and queue continuation](#terminal-outcomes-and-queue-continuation)
+  - [States that intentionally pause progression](#states-that-intentionally-pause-progression)
 - [Evaluation and cleanup](#evaluation-and-cleanup)
 - [Security and data boundaries](#security-and-data-boundaries)
 - [Command reference](#command-reference)
@@ -560,8 +564,10 @@ model.
 ## Run an issue from start to draft PR
 
 Routine operation needs one command: <code>factory start</code> claims the
-oldest eligible issue and drives it to a draft pull request without any further
-CLI step. See [Persistent polling](#persistent-polling).
+oldest eligible issue, drives it to a draft pull request, runs both independent
+reviews and their bounded repair loop, marks the pull request ready, and claims
+the next issue after a human merges or closes it - all without a further CLI
+step. See [Persistent polling](#persistent-polling).
 
 The one-shot commands below perform the same boundaries one at a time. Use them
 for diagnosis or a deliberately manual run; they are the clearest way to see
@@ -1166,14 +1172,6 @@ no agent may choose, skip, or redefine one.
 6. A coherent checkpoint that passes every gate is pushed and receives one
    draft pull request.
 
-Progression stops in its defined waiting state, and publishes the reason in the
-editable status comment, for a clarification request, a policy rejection, an
-exhausted retry budget, a harness rate limit, an authentication failure, an
-invocation that requires <code>factory attach</code>, or an ambiguous recovery.
-The concurrent isolated reviews remain a deliberate step; unattended
-progression ends at the draft pull request or while either review awaits human
-action.
-
 Repeated polling and a coordinator restart are safe. Every transition runs
 through the same durable effect journal as the one-shot commands, so a second
 pass reconciles pending effects instead of creating a second invocation,
@@ -1181,6 +1179,84 @@ checkpoint, push, comment, status, or pull request. The supervisor also
 observes a tracked issue or pull request before restart reconciliation when no
 effect is pending, which lets an already-merged or closed target enter its
 terminal state even after GitHub deletes the run branch.
+
+### Unattended review, repair, and readiness
+
+The draft pull request is not the end of the routine path. When the frozen
+packet declares both independent review roles, the coordinator continues
+without any stage-driving command.
+
+1. It launches the specification reviewer and the standards reviewer for the
+   same immutable checkpoint. Launching is serialized; the two sessions then
+   run concurrently in their own workers, homes, and result directories, and
+   neither reviewer ever sees the other's findings.
+2. When both reviewers have reported for the exact current checkpoint, their
+   blocking findings are combined into one implementation repair packet. A
+   finding that names the test role still reaches it through the existing
+   structured objection protocol; implementation never edits a protected test.
+3. The repair produces a new checkpoint, which reruns every configured gate and
+   both reviewers in fresh sessions. No gate result and no review result
+   survives a code change, because both are keyed by the exact commit.
+4. A materially repeated blocker escalates immediately, even with budget left,
+   and an exhausted <code>review_repair</code> budget escalates too. Both enter
+   the waiting-for-human state instead of looping.
+5. When the final checkpoint passes every gate and neither reviewer reports a
+   blocker, the coordinator synchronizes the target if configured, removes the
+   draft flag, and waits. The factory never approves and never merges.
+
+### Human review as a repair trigger
+
+A submitted GitHub review with the <code>CHANGES_REQUESTED</code> decision from
+a user in <code>authorized_users</code> is a progression event. The coordinator
+consumes that one completed review as a single human repair packet holding its
+review body and every inline comment, returns the pull request to draft when it
+was already ready, and resumes implementation from the current checkpoint. All
+downstream results for the superseded checkpoint are invalidated, so every gate
+and both fresh reviewers must pass again before the pull request can become
+ready a second time.
+
+A human-requested repair is not one of the bounded factory repair rounds and
+never consumes the <code>review_repair</code> budget.
+
+These do not start work: an unsubmitted review draft, an ordinary issue or
+pull-request comment, a <code>COMMENTED</code> review, an approval, a dismissed
+decision, and any review from a user outside <code>authorized_users</code>.
+
+The applied review identity is persisted as a watermark on the run, so repeated
+polling and a coordinator restart cannot apply the same review twice.
+
+### Terminal outcomes and queue continuation
+
+The coordinator observes the tracked pull request before it applies any
+transition, so a terminal disposition always wins over further work.
+
+| Observation                        | Outcome                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------- |
+| Pull request merged                | The run completes and records the merge commit.                                  |
+| Pull request closed without merge  | The run is cancelled; its branch, worktree, worker, and artifacts are retained.  |
+| Issue closed                       | The run is cancelled the same way.                                               |
+
+Either terminal outcome releases the one-active-run constraint. The same
+<code>factory start</code> process then claims the next oldest eligible issue
+without waiting for a full polling interval and without an operator restart.
+Retention is unchanged: cleanup stays an explicit, separate seven-day
+operation.
+
+### States that intentionally pause progression
+
+A non-terminal waiting state keeps the run active and suppresses new claims, so
+the queue stays blocked until a person or infrastructure resolves it. The
+reason is published in the editable status comment.
+
+| Pause                                   | Who resolves it                                     |
+| --------------------------------------- | --------------------------------------------------- |
+| Clarification request                   | An authorized <code>/factory answer</code> comment.  |
+| Ready pull request awaiting disposition | A human merge or close.                              |
+| Repeated blocker or exhausted budget    | A human decision on the finding.                     |
+| Policy rejection                        | An authorized command or an issue change.            |
+| Harness rate limit or expired auth      | Harness infrastructure; the coordinator retries.     |
+| Invocation needing <code>factory attach</code> | An operator attaching the resumed session.    |
+| Ambiguous recovery discrepancy          | A human reconciliation decision.                     |
 
 ### Activity in status output
 
@@ -1203,7 +1279,9 @@ editable status comment publish a separate activity value:
 available for diagnosis and deliberate manual operation. They are not part of
 routine unattended progression. Likewise, <code>factory poll</code> is the
 explicit one-shot command for issue/PR lifecycle observation and structured
-GitHub command handling.
+GitHub command handling. It does not consume human reviews: the
+<code>CHANGES_REQUESTED</code> repair trigger belongs to the persistent
+coordinator.
 
 ## Evaluation and cleanup
 
@@ -1345,7 +1423,7 @@ supported by the installed binary.
 | <code>factory register</code>               | Register the one repository, GitHub identity, authorized users, polling settings, cmux settings, auth sources, repository policy path, and SQLite path.           |
 | <code>factory bootstrap-labels</code>       | Create the six factory-owned GitHub labels explicitly and idempotently.                                                                                           |
 | <code>factory doctor</code>                 | Run the complete startup diagnosis and print every problem/action.                                                                                                |
-| <code>factory start</code>                  | Run the persistent queue/lease supervisor and drive each claimed run to its draft pull request.                                                                    |
+| <code>factory start</code>                  | Run the persistent queue/lease supervisor, drive each claimed run through review, repair, and readiness, and continue with the next issue after a terminal outcome. |
 | <code>factory stop</code>                   | Stop a running supervisor without cancelling the active run.                                                                                                      |
 | <code>factory issue [--issue N] N</code>    | Diagnostic: claim one issue and run its baseline. The number may be positional or supplied with <code>--issue</code>, but not both.                               |
 | <code>factory agent</code>                  | Diagnostic: start the active stage's visible role, or select a validated role/stage/harness/model/reasoning override.                                             |

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -535,8 +535,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		run.Stage = stage
 	}
 	run.Status = store.StatusActive
-	if reviewRepair {
-		// The reservation is now consumed by a visible invocation.
+	if consumesBoundedRepairRound(reviewRepair, run.ReviewRepairPacket) {
 		run.ReviewRepairAttempts = run.ReviewRepairPacket.Attempt
 		run.ReviewRepairPendingAttempt = 0
 		run.ReviewRepairHistory = reviewRepairHistoryWithOutcome(run.ReviewRepairHistory, run.ReviewRepairPacket.Attempt, store.ReviewRepairStarted, run.ReviewRepairPacket)

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -536,6 +536,8 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	}
 	run.Status = store.StatusActive
 	if reviewRepair {
+		// The reservation is now consumed by a visible invocation.
+		run.ReviewRepairAttempts = run.ReviewRepairPacket.Attempt
 		run.ReviewRepairPendingAttempt = 0
 		run.ReviewRepairHistory = reviewRepairHistoryWithOutcome(run.ReviewRepairHistory, run.ReviewRepairPacket.Attempt, store.ReviewRepairStarted, run.ReviewRepairPacket)
 	}

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -1107,6 +1107,9 @@ func reviewRepairStatusComment(run store.Run) string {
 	if run.ReviewRepairPendingAttempt > 0 {
 		result += fmt.Sprintf("- pending: attempt %d\n", run.ReviewRepairPendingAttempt)
 	}
+	if packet := run.ReviewRepairPacket; packet != nil && packet.Source == store.ReviewRepairSourceHuman {
+		result += fmt.Sprintf("- human review: %s (does not consume the budget)\n", safeStatusCommentValue(packet.ReviewID))
+	}
 	if len(run.ReviewRepairHistory) > 0 {
 		outcomes := make([]string, 0, len(run.ReviewRepairHistory))
 		for _, attempt := range run.ReviewRepairHistory {

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -180,7 +180,7 @@ func (s *Service) handleRecognizedCommand(ctx context.Context, registration conf
 		}
 		*run = updated
 	}
-	if commentAlreadyProcessed(run.ProcessedCommentID, request.Comment.ID) {
+	if githubIDAlreadyProcessed(run.ProcessedCommentID, request.Comment.ID) {
 		return CommandResult{Outcome: CommandReplayed, Command: parsed.Command, Run: *run}, nil
 	}
 	if !authorizedCommentAuthor(registration.AuthorizedUsers, request.Comment.Author) {
@@ -894,7 +894,7 @@ func (s *Service) PollCommands(ctx context.Context, request CommandPollRequest) 
 		}
 	}
 	sort.SliceStable(comments, func(left, right int) bool {
-		return compareCommentIDs(comments[left].comment.ID, comments[right].comment.ID) < 0
+		return compareGitHubIDs(comments[left].comment.ID, comments[right].comment.ID) < 0
 	})
 	results := make([]CommandResult, 0)
 	currentRun := *run
@@ -1150,9 +1150,10 @@ func authorizedCommentAuthor(authorized []string, author string) bool {
 	return false
 }
 
-// commentAlreadyProcessed checks the persisted numeric GitHub watermark and
-// falls back to identity equality for synthetic or nonnumeric test IDs.
-func commentAlreadyProcessed(processed, current string) bool {
+// githubIDAlreadyProcessed checks a persisted numeric GitHub watermark, such
+// as a processed comment or an applied review, and falls back to identity
+// equality for synthetic or nonnumeric test IDs.
+func githubIDAlreadyProcessed(processed, current string) bool {
 	if strings.TrimSpace(processed) == "" || strings.TrimSpace(current) == "" {
 		return false
 	}
@@ -1167,9 +1168,10 @@ func commentAlreadyProcessed(processed, current string) bool {
 	return false
 }
 
-// compareCommentIDs sorts numeric GitHub IDs numerically and keeps other IDs
-// deterministic without allowing a human-readable message to control flow.
-func compareCommentIDs(left, right string) int {
+// compareGitHubIDs orders numeric GitHub identities numerically and keeps
+// other identities deterministic without allowing a human-readable message to
+// control flow.
+func compareGitHubIDs(left, right string) int {
 	leftID, leftErr := strconv.ParseUint(left, 10, 64)
 	rightID, rightErr := strconv.ParseUint(right, 10, 64)
 	if leftErr == nil && rightErr == nil {

--- a/internal/factory/continuation_test.go
+++ b/internal/factory/continuation_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 // TestStartTraversesReviewRepairHumanRepairReadinessAndMergeBeforeTheNextClaim
-// is the end-to-end proof for autonomous review repair and terminal queue
+// is the end-to-end proof for unattended review repair and terminal queue
 // continuation. One `factory start` process queues two eligible issues and
 // drives the first through the draft pull request, both independent reviews, a
 // blocking agent finding, an authorized human `CHANGES_REQUESTED` repair,
@@ -58,12 +58,7 @@ func TestStartTraversesReviewRepairHumanRepairReadinessAndMergeBeforeTheNextClai
 	if first.MergeCommitSHA != continuationMergeSHA {
 		t.Fatalf("first run merge commit = %q, want the observed merge commit", first.MergeCommitSHA)
 	}
-	if !fixture.pullRequests.wasReady {
-		t.Fatal("pull request never left draft, so readiness was never reached")
-	}
-	if fixture.pullRequests.merges != 0 {
-		t.Fatal("the factory merged its own pull request")
-	}
+	fixture.assertDraftRoundTrip(t)
 	if first.ProcessedReviewID != "4001" {
 		t.Fatalf("review watermark = %q, want the applied GitHub review identity", first.ProcessedReviewID)
 	}
@@ -102,6 +97,63 @@ func TestStartCancelsAnUnmergedClosedPullRequestAndClaimsTheNextIssue(t *testing
 	fixture.assertNextIssueClaimed(t)
 }
 
+// TestRestartDoesNotReapplyAnAlreadyConsumedHumanReview proves the persisted
+// review watermark survives a coordinator process boundary: a restarted
+// coordinator re-reads the same submitted review and must not start a second
+// repair, a second review round, or a second readiness change for it.
+func TestRestartDoesNotReapplyAnAlreadyConsumedHumanReview(t *testing.T) {
+	t.Parallel()
+
+	fixture := newContinuationFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	fixture.driveTerminalOutcome(t, cancel, func() { cancel() })
+
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	applied := fixture.harness.roleStarts()
+	draftTransitions := len(fixture.pullRequests.draftTransitions())
+	reads := fixture.reviews.readCount()
+	if watermark := fixture.appliedReviewID(t); watermark != "4001" {
+		t.Fatalf("review watermark = %q, want the applied review", watermark)
+	}
+
+	restarted, restartCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer restartCancel()
+	ticks := 0
+	fixture.lease.onRenew = func(github.Lease) {
+		if ticks++; ticks >= 4 {
+			restartCancel()
+		}
+	}
+	if err := fixture.restart().Start(restarted); err != nil {
+		t.Fatalf("restarted Start() error = %v", err)
+	}
+
+	if got := fixture.harness.roleStarts(); len(got) != len(applied) {
+		t.Fatalf("invocations after restart = %d, want the %d from before the restart", len(got), len(applied))
+	}
+	if got := len(fixture.pullRequests.draftTransitions()); got != draftTransitions {
+		t.Fatalf("readiness changes after restart = %d, want the %d from before the restart", got, draftTransitions)
+	}
+	// Without this the assertions above would pass for a coordinator that
+	// never looked at the review again.
+	if fixture.reviews.readCount() <= reads {
+		t.Fatal("the restarted coordinator never re-read the submitted review")
+	}
+}
+
+// appliedReviewID reads the review watermark the coordinator persisted.
+func (f *continuationFixture) appliedReviewID(t *testing.T) string {
+	t.Helper()
+	run := f.latestRun(t)
+	if run == nil {
+		t.Fatal("no persisted run")
+	}
+	return run.ProcessedReviewID
+}
+
 // assertUnattendedReviewRepairHappened checks the evidence that both review
 // loops ran without a stage-driving CLI command: two full review rounds per
 // checkpoint, one agent repair, and one human repair.
@@ -122,11 +174,60 @@ func (f *continuationFixture) assertUnattendedReviewRepairHappened(t *testing.T)
 	}
 	// The submitted review stays visible to every later poll, so a second
 	// repair here would mean the watermark failed to make it replay-safe.
-	if f.reviews.reads < 2 {
-		t.Fatalf("review polls = %d, want the submitted review to be observed again after it was applied", f.reviews.reads)
+	if f.reviews.readCount() < 2 {
+		t.Fatalf("review polls = %d, want the submitted review to be observed again after it was applied", f.reviews.readCount())
 	}
 	if !f.humanRepairPacketSeen {
 		t.Fatal("no implementation invocation received the human review repair packet")
+	}
+	// The human repair must not advance, reset, or record a bounded factory
+	// round; only the one agent-found blocker consumed the budget.
+	terminal := f.firstTerminalRun(t)
+	if terminal.ReviewRepairAttempts != 1 {
+		t.Fatalf("factory review-repair attempts = %d, want only the one agent-found repair", terminal.ReviewRepairAttempts)
+	}
+	if len(terminal.ReviewRepairHistory) != 1 || terminal.ReviewRepairHistory[0].Attempt != 1 {
+		t.Fatalf("review-repair history = %#v, want one bounded factory round", terminal.ReviewRepairHistory)
+	}
+	f.assertGatesReranPerCheckpoint(t)
+}
+
+// assertDraftRoundTrip proves the pull request became ready, was returned to
+// draft for the human repair, and became ready again only after the repaired
+// checkpoint passed everything.
+func (f *continuationFixture) assertDraftRoundTrip(t *testing.T) {
+	t.Helper()
+	want := []bool{false, true, false}
+	got := f.pullRequests.draftTransitions()
+	if len(got) != len(want) {
+		t.Fatalf("draft transitions = %v, want ready, back to draft for the human repair, then ready again", got)
+	}
+	for index, draft := range want {
+		if got[index] != draft {
+			t.Fatalf("draft transitions = %v, want %v", got, want)
+		}
+	}
+}
+
+// assertGatesReranPerCheckpoint proves no gate result survived a code change:
+// every checkpoint the run produced has its own published gate status, and
+// both reviewers reported against that same exact checkpoint.
+func (f *continuationFixture) assertGatesReranPerCheckpoint(t *testing.T) {
+	t.Helper()
+	published := map[string]map[string]bool{}
+	for _, status := range f.statuses.values {
+		if published[status.SHA] == nil {
+			published[status.SHA] = map[string]bool{}
+		}
+		published[status.SHA][status.Context] = true
+	}
+	wanted := []string{"factory/gate/test", factory.SpecificationReviewStatusContext, factory.StandardsReviewStatusContext}
+	for _, checkpoint := range []string{implementationCheckpoint, firstRepairCheckpoint, secondRepairCheckpoint} {
+		for _, context := range wanted {
+			if !published[checkpoint][context] {
+				t.Fatalf("checkpoint %s is missing the %s status; published = %v", checkpoint[:6], context, published[checkpoint])
+			}
+		}
 	}
 }
 
@@ -140,10 +241,14 @@ type continuationFixture struct {
 	workspace       *unattendedWorkspace
 	pullRequests    *continuationPullRequests
 	reviews         *continuationReviews
+	statuses        *gateStatuses
 	lease           *pollingLease
 	terminal        *agentTerminal
 	harness         *continuationHarness
 	operationalPath string
+	configPath      string
+	clock           func() time.Time
+	dependencies    func() factory.Dependencies
 
 	mu                    sync.Mutex
 	terminalRun           *store.Run
@@ -185,13 +290,15 @@ func newContinuationFixture(t *testing.T) *continuationFixture {
 	}}
 	fixture := &continuationFixture{
 		commands: newContinuationGitHub([]github.Issue{
-			{Number: 7, Title: "Drive the review loops", Body: "Implement autonomous review repair.", State: "open", Labels: []string{github.LabelAgentReady}},
+			{Number: 7, Title: "Drive the review loops", Body: "Implement unattended review repair.", State: "open", Labels: []string{github.LabelAgentReady}},
 			{Number: 9, Title: "Wait for the queue", Body: "Implement the next queued change.", State: "open", Labels: []string{github.LabelAgentReady}},
 		}),
 		worker:              &unattendedWorker{},
 		workspace:           workspace,
 		pullRequests:        newContinuationPullRequests(workspace),
 		reviews:             &continuationReviews{},
+		statuses:            &gateStatuses{},
+		clock:               monotonicClock(time.Date(2026, 8, 29, 9, 0, 0, 0, time.UTC)),
 		lease:               &pollingLease{},
 		terminal:            &agentTerminal{},
 		operationalPath:     filepath.Join(root, "state", "factory.db"),
@@ -208,29 +315,40 @@ func newContinuationFixture(t *testing.T) *continuationFixture {
 		OperationalDataPath:  fixture.operationalPath,
 		RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
 	}
-	fixture.service = factory.NewWithDependencies(filepath.Join(root, "config.yaml"), factory.Dependencies{
-		Config:             &fakeConfig{value: config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{registration}}},
-		OpenStore:          func(ctx context.Context, path string) (factory.OperationalStore, error) { return store.Open(ctx, path) },
-		LoadRepository:     func(string) (config.RepositoryConfig, error) { return policy, nil },
-		GitHub:             fixture.commands,
-		IssuePoller:        fixture.commands,
-		Lease:              fixture.lease,
-		PullRequests:       fixture.pullRequests,
-		PullRequestReviews: fixture.reviews,
-		CommitStatuses:     &gateStatuses{},
-		Worktree:           fixture.workspace,
-		GitWorkspace:       fixture.workspace,
-		Worker:             fixture.worker,
-		Terminal:           fixture.terminal,
-		Harness:            fixture.harness,
-		Now:                monotonicClock(time.Date(2026, 8, 29, 9, 0, 0, 0, time.UTC)),
-		NewRunID:           newSequentialRunID(fixture.firstRunID),
-		Coordinator:        "coordinator-test",
-		StartupDiagnosis: func(context.Context) (factory.DoctorResult, error) {
-			return factory.DoctorResult{Report: doctor.Report{Results: []doctor.Result{doctor.Success("startup")}}}, nil
-		},
-	})
+	fixture.configPath = filepath.Join(root, "config.yaml")
+	fixture.dependencies = func() factory.Dependencies {
+		return factory.Dependencies{
+			Config:             &fakeConfig{value: config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{registration}}},
+			OpenStore:          func(ctx context.Context, path string) (factory.OperationalStore, error) { return store.Open(ctx, path) },
+			LoadRepository:     func(string) (config.RepositoryConfig, error) { return policy, nil },
+			GitHub:             fixture.commands,
+			IssuePoller:        fixture.commands,
+			Lease:              fixture.lease,
+			PullRequests:       fixture.pullRequests,
+			PullRequestReviews: fixture.reviews,
+			CommitStatuses:     fixture.statuses,
+			Worktree:           fixture.workspace,
+			GitWorkspace:       fixture.workspace,
+			Worker:             fixture.worker,
+			Terminal:           fixture.terminal,
+			Harness:            fixture.harness,
+			Now:                fixture.clock,
+			NewRunID:           newSequentialRunID(fixture.firstRunID),
+			Coordinator:        "coordinator-test",
+			StartupDiagnosis: func(context.Context) (factory.DoctorResult, error) {
+				return factory.DoctorResult{Report: doctor.Report{Results: []doctor.Result{doctor.Success("startup")}}}, nil
+			},
+		}
+	}
+	fixture.service = factory.NewWithDependencies(fixture.configPath, fixture.dependencies())
 	return fixture
+}
+
+// restart models a coordinator process boundary: a fresh service opens the
+// same operational store and adapters with no in-memory continuity.
+func (f *continuationFixture) restart() *factory.Service {
+	f.service = factory.NewWithDependencies(f.configPath, f.dependencies())
+	return f.service
 }
 
 // monotonicClock returns a strictly increasing coordinator clock, so the
@@ -589,11 +707,10 @@ func (g *continuationGitHub) EditIssueComment(_ context.Context, _ github.Reposi
 // continuationPullRequests keeps one tracked pull request whose head follows
 // the pushed checkpoint and whose terminal disposition the test controls.
 type continuationPullRequests struct {
-	mu        sync.Mutex
-	workspace *unattendedWorkspace
-	current   github.PullRequest
-	wasReady  bool
-	merges    int
+	mu           sync.Mutex
+	workspace    *unattendedWorkspace
+	current      github.PullRequest
+	draftChanges []bool
 }
 
 // newContinuationPullRequests binds the fake to the pushed-checkpoint source.
@@ -646,10 +763,16 @@ func (p *continuationPullRequests) SetPullRequestDraft(_ context.Context, _ gith
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.current.Draft = draft
-	if !draft {
-		p.wasReady = true
-	}
+	p.draftChanges = append(p.draftChanges, draft)
 	return p.projection(), nil
+}
+
+// draftTransitions returns every explicit readiness change the coordinator
+// requested, in order. `false` means the pull request became ready.
+func (p *continuationPullRequests) draftTransitions() []bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]bool(nil), p.draftChanges...)
 }
 
 // merge applies the human merge the factory is never allowed to perform.
@@ -684,6 +807,13 @@ func (r *continuationReviews) PullRequestReviews(context.Context, github.Reposit
 		r.reads++
 	}
 	return append([]github.PullRequestReview(nil), r.reviews...), nil
+}
+
+// readCount reports how many polls observed a non-empty review list.
+func (r *continuationReviews) readCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.reads
 }
 
 // submit records one newly submitted review.

--- a/internal/factory/continuation_test.go
+++ b/internal/factory/continuation_test.go
@@ -1,0 +1,702 @@
+package factory_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/doctor"
+	"github.com/Stevie1704/sw-factory/internal/factory"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/worker"
+	"github.com/Stevie1704/sw-factory/internal/workflow"
+)
+
+// The continuation fixture advances the checkpoint once per implementation
+// round so every repair produces a genuinely new exact subject for the gates
+// and both reviewers.
+const (
+	firstRepairCheckpoint  = "1111111111111111111111111111111111111111111111111111111111111111"
+	secondRepairCheckpoint = "2222222222222222222222222222222222222222222222222222222222222222"
+	continuationMergeSHA   = "3333333333333333333333333333333333333333333333333333333333333333"
+)
+
+// TestStartTraversesReviewRepairHumanRepairReadinessAndMergeBeforeTheNextClaim
+// is the end-to-end proof for autonomous review repair and terminal queue
+// continuation. One `factory start` process queues two eligible issues and
+// drives the first through the draft pull request, both independent reviews, a
+// blocking agent finding, an authorized human `CHANGES_REQUESTED` repair,
+// readiness, and merge, and only then claims the second issue.
+func TestStartTraversesReviewRepairHumanRepairReadinessAndMergeBeforeTheNextClaim(t *testing.T) {
+	t.Parallel()
+
+	fixture := newContinuationFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	fixture.driveTerminalOutcome(t, cancel, func() { fixture.pullRequests.merge(continuationMergeSHA) })
+
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	fixture.assertUnattendedReviewRepairHappened(t)
+
+	first := fixture.firstTerminalRun(t)
+	if first.Status != store.StatusComplete {
+		t.Fatalf("first run status = %q, want complete after the merge", first.Status)
+	}
+	if first.MergeCommitSHA != continuationMergeSHA {
+		t.Fatalf("first run merge commit = %q, want the observed merge commit", first.MergeCommitSHA)
+	}
+	if !fixture.pullRequests.wasReady {
+		t.Fatal("pull request never left draft, so readiness was never reached")
+	}
+	if fixture.pullRequests.merges != 0 {
+		t.Fatal("the factory merged its own pull request")
+	}
+	if first.ProcessedReviewID != "4001" {
+		t.Fatalf("review watermark = %q, want the applied GitHub review identity", first.ProcessedReviewID)
+	}
+	if first.ProcessedReviewRevision == 0 {
+		t.Fatal("review watermark has no run revision, so it is not restart-auditable")
+	}
+
+	fixture.assertNextIssueClaimed(t)
+}
+
+// TestStartCancelsAnUnmergedClosedPullRequestAndClaimsTheNextIssue proves that
+// closing the pull request without merging cancels the active run, retains its
+// artifacts, releases the queue, and lets the same coordinator continue.
+func TestStartCancelsAnUnmergedClosedPullRequestAndClaimsTheNextIssue(t *testing.T) {
+	t.Parallel()
+
+	fixture := newContinuationFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	fixture.driveTerminalOutcome(t, cancel, fixture.pullRequests.closeWithoutMerge)
+
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	first := fixture.firstTerminalRun(t)
+	if first.Status != store.StatusCancelled {
+		t.Fatalf("first run status = %q, want cancelled after the unmerged close", first.Status)
+	}
+	if first.MergeCommitSHA != "" {
+		t.Fatalf("cancelled run merge commit = %q, want none", first.MergeCommitSHA)
+	}
+	if first.Branch == "" || first.Worktree == "" {
+		t.Fatalf("cancelled run lost its retained artifacts: %#v", first)
+	}
+	fixture.assertNextIssueClaimed(t)
+}
+
+// assertUnattendedReviewRepairHappened checks the evidence that both review
+// loops ran without a stage-driving CLI command: two full review rounds per
+// checkpoint, one agent repair, and one human repair.
+func (f *continuationFixture) assertUnattendedReviewRepairHappened(t *testing.T) {
+	t.Helper()
+	roles := map[string]int{}
+	for _, start := range f.harness.roleStarts() {
+		roles[start]++
+	}
+	if roles[workflow.RoleImplementation] != 3 {
+		t.Fatalf("implementation invocations = %d, want the first pass plus the agent and human repairs", roles[workflow.RoleImplementation])
+	}
+	if roles[workflow.RoleSpecificationReview] != 3 || roles[workflow.RoleStandardsReview] != 3 {
+		t.Fatalf("review invocations = spec %d standards %d, want three fresh rounds each", roles[workflow.RoleSpecificationReview], roles[workflow.RoleStandardsReview])
+	}
+	if f.reviewedCheckpoints() != 3 {
+		t.Fatalf("reviewed checkpoints = %d, want one review round per exact checkpoint", f.reviewedCheckpoints())
+	}
+	// The submitted review stays visible to every later poll, so a second
+	// repair here would mean the watermark failed to make it replay-safe.
+	if f.reviews.reads < 2 {
+		t.Fatalf("review polls = %d, want the submitted review to be observed again after it was applied", f.reviews.reads)
+	}
+	if !f.humanRepairPacketSeen {
+		t.Fatal("no implementation invocation received the human review repair packet")
+	}
+}
+
+// continuationFixture assembles one repository whose harness answers each
+// role, whose pull request can be reviewed and terminalized, and whose queue
+// holds two eligible issues.
+type continuationFixture struct {
+	service         *factory.Service
+	commands        *continuationGitHub
+	worker          *unattendedWorker
+	workspace       *unattendedWorkspace
+	pullRequests    *continuationPullRequests
+	reviews         *continuationReviews
+	lease           *pollingLease
+	terminal        *agentTerminal
+	harness         *continuationHarness
+	operationalPath string
+
+	mu                    sync.Mutex
+	terminalRun           *store.Run
+	firstRunID            string
+	blockingReviewServed  bool
+	humanRepairPacketSeen bool
+	checkpointsReviewed   map[string]struct{}
+}
+
+// newContinuationFixture builds an advisory-policy repository that declares
+// both independent reviewers and queues two eligible issues.
+func newContinuationFixture(t *testing.T) *continuationFixture {
+	t.Helper()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-continuation\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := validRepositoryConfig()
+	policy.TestPolicy = config.TestPolicy{Mode: config.TestModeAdvisory}
+	policy.RoleHarnessDefaults[workflow.RoleSpecificationReview] = config.HarnessCodex
+	policy.RoleHarnessDefaults[workflow.RoleStandardsReview] = config.HarnessCodex
+	policy.ModelOptions[workflow.RoleSpecificationReview] = []string{"gpt-5"}
+	policy.ModelOptions[workflow.RoleStandardsReview] = []string{"gpt-5"}
+
+	workspace := &unattendedWorkspace{draftGitWorkspace: &draftGitWorkspace{
+		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-continuation", Worktree: worktreePath},
+		state:     gitadapter.WorktreeState{RepositoryPath: repositoryPath, Branch: "factory/run-continuation", HeadSHA: factoryGateCheckpoint},
+		// One distinct checkpoint per implementation round.
+		checkpointSHAs: []string{implementationCheckpoint, firstRepairCheckpoint, secondRepairCheckpoint},
+	}}
+	fixture := &continuationFixture{
+		commands: newContinuationGitHub([]github.Issue{
+			{Number: 7, Title: "Drive the review loops", Body: "Implement autonomous review repair.", State: "open", Labels: []string{github.LabelAgentReady}},
+			{Number: 9, Title: "Wait for the queue", Body: "Implement the next queued change.", State: "open", Labels: []string{github.LabelAgentReady}},
+		}),
+		worker:              &unattendedWorker{},
+		workspace:           workspace,
+		pullRequests:        newContinuationPullRequests(workspace),
+		reviews:             &continuationReviews{},
+		lease:               &pollingLease{},
+		terminal:            &agentTerminal{},
+		operationalPath:     filepath.Join(root, "state", "factory.db"),
+		firstRunID:          "run-continuation",
+		checkpointsReviewed: map[string]struct{}{},
+	}
+	fixture.harness = &continuationHarness{fixture: fixture}
+
+	registration := config.RepositoryRegistration{
+		Path:                 repositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		AuthorizedUsers:      []string{"alice"},
+		Polling:              config.PollingConfig{Interval: "1ms", Backoff: "1ms"},
+		OperationalDataPath:  fixture.operationalPath,
+		RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+	}
+	fixture.service = factory.NewWithDependencies(filepath.Join(root, "config.yaml"), factory.Dependencies{
+		Config:             &fakeConfig{value: config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{registration}}},
+		OpenStore:          func(ctx context.Context, path string) (factory.OperationalStore, error) { return store.Open(ctx, path) },
+		LoadRepository:     func(string) (config.RepositoryConfig, error) { return policy, nil },
+		GitHub:             fixture.commands,
+		IssuePoller:        fixture.commands,
+		Lease:              fixture.lease,
+		PullRequests:       fixture.pullRequests,
+		PullRequestReviews: fixture.reviews,
+		CommitStatuses:     &gateStatuses{},
+		Worktree:           fixture.workspace,
+		GitWorkspace:       fixture.workspace,
+		Worker:             fixture.worker,
+		Terminal:           fixture.terminal,
+		Harness:            fixture.harness,
+		Now:                monotonicClock(time.Date(2026, 8, 29, 9, 0, 0, 0, time.UTC)),
+		NewRunID:           newSequentialRunID(fixture.firstRunID),
+		Coordinator:        "coordinator-test",
+		StartupDiagnosis: func(context.Context) (factory.DoctorResult, error) {
+			return factory.DoctorResult{Report: doctor.Report{Results: []doctor.Result{doctor.Success("startup")}}}, nil
+		},
+	})
+	return fixture
+}
+
+// monotonicClock returns a strictly increasing coordinator clock, so the
+// newest persisted run is unambiguous once a second run exists.
+func monotonicClock(start time.Time) func() time.Time {
+	var ticks int64
+	var mu sync.Mutex
+	return func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		ticks++
+		return start.Add(time.Duration(ticks) * time.Second)
+	}
+}
+
+// driveTerminalOutcome supplies the two human actions the factory must never
+// take itself. It submits one authorized `CHANGES_REQUESTED` review the first
+// time the pull request becomes ready, applies the terminal disposition the
+// second time, and stops the coordinator once the next issue is claimed.
+func (f *continuationFixture) driveTerminalOutcome(t *testing.T, cancel context.CancelFunc, terminalAction func()) {
+	t.Helper()
+	humanReviewSubmitted := false
+	repairObserved := false
+	terminalApplied := false
+	f.lease.onRenew = func(github.Lease) {
+		run := f.latestRun(t)
+		switch {
+		case run == nil:
+			return
+		case run.IssueNumber == 9:
+			cancel()
+		case store.IsTerminalStatus(run.Status):
+			f.recordTerminalRun(*run)
+		case run.Stage != store.StageReady:
+			return
+		case !humanReviewSubmitted:
+			humanReviewSubmitted = true
+			f.reviews.submit(github.PullRequestReview{
+				ID: "4001", Author: "alice", State: github.PullRequestReviewChangesRequested,
+				Body: "the retry budget must be read from the frozen packet", SubmittedAt: time.Date(2026, 8, 29, 9, 30, 0, 0, time.UTC),
+				Comments: []github.PullRequestReviewComment{
+					{Path: "internal/factory/polling.go", Line: 42, Body: "this branch never releases the queue"},
+				},
+			})
+		case !repairObserved:
+			// Hold the pull request ready for one further observation, so the
+			// already-applied review is polled again and must not repeat.
+			repairObserved = true
+		case !terminalApplied:
+			terminalApplied = true
+			terminalAction()
+		}
+	}
+}
+
+// recordTerminalRun snapshots the first run once GitHub terminalized it, while
+// it is still the newest persisted run.
+func (f *continuationFixture) recordTerminalRun(run store.Run) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.terminalRun == nil {
+		f.terminalRun = &run
+	}
+}
+
+// latestRun reads the newest persisted run, or nil before the first claim.
+func (f *continuationFixture) latestRun(t *testing.T) *store.Run {
+	t.Helper()
+	opened, err := store.Open(context.Background(), f.operationalPath)
+	if err != nil {
+		t.Fatalf("open operational store: %v", err)
+	}
+	defer func() { _ = opened.Close() }()
+	run, err := opened.LatestRun(context.Background())
+	if err != nil {
+		t.Fatalf("read latest run: %v", err)
+	}
+	return run
+}
+
+// firstTerminalRun returns the snapshot of the first run taken when the
+// coordinator observed its terminal GitHub disposition.
+func (f *continuationFixture) firstTerminalRun(t *testing.T) store.Run {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.terminalRun == nil {
+		t.Fatal("the first run never reached a terminal state")
+	}
+	return *f.terminalRun
+}
+
+// assertNextIssueClaimed proves the released queue let the same coordinator
+// claim the next oldest eligible issue.
+func (f *continuationFixture) assertNextIssueClaimed(t *testing.T) {
+	t.Helper()
+	opened, err := store.Open(context.Background(), f.operationalPath)
+	if err != nil {
+		t.Fatalf("open operational store: %v", err)
+	}
+	defer func() { _ = opened.Close() }()
+	run, err := opened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("read current run: %v", err)
+	}
+	if run == nil {
+		t.Fatal("no run was claimed after the terminal outcome released the queue")
+	}
+	if run.IssueNumber != 9 {
+		t.Fatalf("claimed issue = #%d, want the next oldest eligible issue #9", run.IssueNumber)
+	}
+}
+
+// reviewedCheckpoints counts the distinct exact checkpoints a reviewer saw.
+func (f *continuationFixture) reviewedCheckpoints() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.checkpointsReviewed)
+}
+
+// continuationHarness answers implementation and review invocations with the
+// structured results one full review-repair traversal requires.
+type continuationHarness struct {
+	agentHarness
+	fixture *continuationFixture
+
+	mu     sync.Mutex
+	starts []harness.StartRequest
+}
+
+// roleStarts returns the role of every launched invocation.
+func (h *continuationHarness) roleStarts() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	roles := make([]string, 0, len(h.starts))
+	for _, start := range h.starts {
+		roles = append(roles, start.Role)
+	}
+	return roles
+}
+
+// Start records the launch and writes the role's structured report.
+func (h *continuationHarness) Start(ctx context.Context, request harness.StartRequest) (harness.Session, error) {
+	session, err := h.agentHarness.Start(ctx, request)
+	if err != nil {
+		return session, err
+	}
+	return session, h.answer(request, session)
+}
+
+// Resume answers a natively resumed session with the same report contract.
+func (h *continuationHarness) Resume(ctx context.Context, request harness.StartRequest) (harness.Session, error) {
+	session, err := h.agentHarness.Resume(ctx, request)
+	if err != nil {
+		return session, err
+	}
+	return session, h.answer(request, session)
+}
+
+// answer writes one role-appropriate structured report into the mounted result
+// directory, standing in for an interactive session that finished its work.
+func (h *continuationHarness) answer(request harness.StartRequest, session harness.Session) error {
+	h.mu.Lock()
+	h.starts = append(h.starts, request)
+	h.mu.Unlock()
+	value, ok := h.fixture.reportFor(request)
+	if !ok {
+		// The second run's invocation stays executing, which keeps the proof
+		// focused on the first run's traversal.
+		return nil
+	}
+	if session.NativeSessionID != "" {
+		value.NativeSessionID = session.NativeSessionID
+	}
+	_, err := report.WriteAtomicForInvocation(h.fixture.worker.resultPath, request.InvocationID, value)
+	return err
+}
+
+// reportFor selects the structured result for one launched invocation.
+func (f *continuationFixture) reportFor(request harness.StartRequest) (report.Report, bool) {
+	if request.RunID != f.firstRunID {
+		return report.Report{}, false
+	}
+	base := report.Report{
+		SchemaVersion:   report.SchemaVersion,
+		InvocationID:    request.InvocationID,
+		RunID:           request.RunID,
+		Harness:         string(config.HarnessCodex),
+		Role:            request.Role,
+		Stage:           request.Stage,
+		Outcome:         report.OutcomeCompleted,
+		Summary:         "completed the assigned role",
+		NativeSessionID: "session-" + request.Role,
+		ReportedAt:      time.Date(2026, 8, 29, 9, 5, 0, 0, time.UTC),
+	}
+	switch request.Role {
+	case workflow.RoleImplementation:
+		f.observeImplementationPacket(request)
+		f.workspace.state.ChangedPaths = []string{"internal/factory/polling.go"}
+		base.Handoff = &report.Handoff{
+			ChangeSummary:          "implemented the queued change",
+			AcceptanceMapping:      []report.AcceptanceMapping{{Criterion: "queue continuation", Evidence: "internal/factory/polling.go"}},
+			ProductionFilesChanged: []string{"internal/factory/polling.go"},
+			FocusedCommands:        []string{"go test ./internal/factory"},
+		}
+		return base, true
+	case workflow.RoleSpecificationReview, workflow.RoleStandardsReview:
+		base.ReviewHandoff = &report.ReviewHandoff{ReviewedSHA: f.observeReviewedCheckpoint(request)}
+		if request.Role == workflow.RoleSpecificationReview && f.serveBlockingFinding() {
+			base.ReviewHandoff.Findings = []report.ReviewFinding{{
+				Location:            "internal/factory/polling.go:17",
+				Claim:               "the terminal outcome never releases the queue",
+				Evidence:            "no test covers the released queue",
+				Severity:            report.ReviewSeverityBlocker,
+				Category:            report.ReviewCategoryCorrectness,
+				SuggestedResolution: "release queue ownership on the terminal transition",
+				SuggestedOwner:      workflow.RoleImplementation,
+			}}
+		}
+		return base, true
+	default:
+		return report.Report{}, false
+	}
+}
+
+// observeImplementationPacket records whether the human repair packet reached
+// an implementation invocation.
+func (f *continuationFixture) observeImplementationPacket(request harness.StartRequest) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if strings.Contains(request.Prompt, string(store.ReviewRepairSourceHuman)) && strings.Contains(request.Prompt, "4001") {
+		f.humanRepairPacketSeen = true
+	}
+}
+
+// observeReviewedCheckpoint records the exact checkpoint one reviewer saw and
+// returns it as the reviewed SHA.
+func (f *continuationFixture) observeReviewedCheckpoint(request harness.StartRequest) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	checkpoint := f.workspace.state.HeadSHA
+	f.checkpointsReviewed[checkpoint] = struct{}{}
+	_ = request
+	return checkpoint
+}
+
+// serveBlockingFinding returns true exactly once, so the first review round
+// produces one agent-found blocker and later rounds pass.
+func (f *continuationFixture) serveBlockingFinding() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.blockingReviewServed {
+		return false
+	}
+	f.blockingReviewServed = true
+	return true
+}
+
+// continuationGitHub serves a two-issue queue whose claimed issues leave the
+// eligible set, and keeps one recoverable status comment per issue.
+type continuationGitHub struct {
+	mu       sync.Mutex
+	issues   map[int]github.Issue
+	order    []int
+	comments map[string]github.Comment
+	nextID   int
+}
+
+// newContinuationGitHub indexes the configured queue by issue number.
+func newContinuationGitHub(issues []github.Issue) *continuationGitHub {
+	value := &continuationGitHub{issues: map[int]github.Issue{}, comments: map[string]github.Comment{}}
+	for _, issue := range issues {
+		value.issues[issue.Number] = issue
+		value.order = append(value.order, issue.Number)
+	}
+	return value
+}
+
+// ListEligibleIssues returns the open issues that still carry the queue label.
+func (g *continuationGitHub) ListEligibleIssues(context.Context, github.Repository) ([]github.Issue, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	eligible := make([]github.Issue, 0, len(g.order))
+	for _, number := range g.order {
+		issue := g.issues[number]
+		for _, label := range issue.Labels {
+			if label == github.LabelAgentReady {
+				eligible = append(eligible, issue)
+				break
+			}
+		}
+	}
+	return eligible, nil
+}
+
+// Issue returns the current projection of one issue.
+func (g *continuationGitHub) Issue(_ context.Context, _ github.Repository, number int) (github.Issue, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	issue, ok := g.issues[number]
+	if !ok {
+		return github.Issue{}, fmt.Errorf("issue #%d is not configured", number)
+	}
+	return issue, nil
+}
+
+// CreateLabel accepts the label bootstrap without recording it.
+func (g *continuationGitHub) CreateLabel(context.Context, github.Repository, github.Label) error {
+	return nil
+}
+
+// ReplaceIssueLabels applies the complete label set to one issue, which also
+// removes it from the eligible queue when the coordinator claims it.
+func (g *continuationGitHub) ReplaceIssueLabels(_ context.Context, _ github.Repository, number int, labels []string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	issue := g.issues[number]
+	issue.Labels = append([]string(nil), labels...)
+	g.issues[number] = issue
+	return nil
+}
+
+// CreateIssueComment stores one recoverable comment per marker.
+func (g *continuationGitHub) CreateIssueComment(_ context.Context, _ github.Repository, _ int, body string) (github.Comment, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.nextID++
+	comment := github.Comment{ID: fmt.Sprintf("comment-%d", g.nextID), Body: body}
+	g.comments[comment.ID] = comment
+	return comment, nil
+}
+
+// FindStatusComment recovers the comment whose body carries the marker.
+func (g *continuationGitHub) FindStatusComment(_ context.Context, _ github.Repository, _ int, marker string) (github.Comment, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for _, comment := range g.comments {
+		if strings.Contains(comment.Body, marker) {
+			return comment, nil
+		}
+	}
+	return github.Comment{}, nil
+}
+
+// EditIssueComment keeps the recoverable comment body current.
+func (g *continuationGitHub) EditIssueComment(_ context.Context, _ github.Repository, id, body string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	comment := g.comments[id]
+	comment.ID = id
+	comment.Body = body
+	g.comments[id] = comment
+	return nil
+}
+
+// continuationPullRequests keeps one tracked pull request whose head follows
+// the pushed checkpoint and whose terminal disposition the test controls.
+type continuationPullRequests struct {
+	mu        sync.Mutex
+	workspace *unattendedWorkspace
+	current   github.PullRequest
+	wasReady  bool
+	merges    int
+}
+
+// newContinuationPullRequests binds the fake to the pushed-checkpoint source.
+func newContinuationPullRequests(workspace *unattendedWorkspace) *continuationPullRequests {
+	return &continuationPullRequests{workspace: workspace}
+}
+
+// FindPullRequest returns the tracked pull request with its published head.
+func (p *continuationPullRequests) FindPullRequest(context.Context, github.Repository, string, string) (github.PullRequest, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.projection(), nil
+}
+
+// projection renders the current pull request with the last pushed head.
+func (p *continuationPullRequests) projection() github.PullRequest {
+	value := p.current
+	if value.Number == 0 {
+		return github.PullRequest{}
+	}
+	if pushed := p.workspace.pushedSHAs; len(pushed) > 0 && !value.Merged {
+		value.HeadSHA = pushed[len(pushed)-1]
+	}
+	return value
+}
+
+// CreatePullRequest creates the one tracked draft pull request.
+func (p *continuationPullRequests) CreatePullRequest(_ context.Context, _ github.Repository, request github.PullRequestRequest) (github.PullRequest, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.current = github.PullRequest{
+		Number: 17, URL: "https://github.com/example/project/pull/17",
+		Title: request.Title, Body: request.Body, State: "open", Draft: request.Draft,
+		HeadBranch: request.HeadBranch, BaseBranch: request.BaseBranch,
+	}
+	return p.projection(), nil
+}
+
+// UpdatePullRequest replaces the generated title and body.
+func (p *continuationPullRequests) UpdatePullRequest(_ context.Context, _ github.Repository, _ int, request github.PullRequestRequest) (github.PullRequest, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.current.Title = request.Title
+	p.current.Body = request.Body
+	return p.projection(), nil
+}
+
+// SetPullRequestDraft applies the explicit readiness transition.
+func (p *continuationPullRequests) SetPullRequestDraft(_ context.Context, _ github.Repository, _ int, draft bool) (github.PullRequest, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.current.Draft = draft
+	if !draft {
+		p.wasReady = true
+	}
+	return p.projection(), nil
+}
+
+// merge applies the human merge the factory is never allowed to perform.
+func (p *continuationPullRequests) merge(mergeCommitSHA string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.current.Merged = true
+	p.current.State = "closed"
+	p.current.MergeCommitSHA = mergeCommitSHA
+}
+
+// closeWithoutMerge applies the human close that cancels the run.
+func (p *continuationPullRequests) closeWithoutMerge() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.current.State = "closed"
+}
+
+// continuationReviews serves the completed human reviews of the tracked pull
+// request.
+type continuationReviews struct {
+	mu      sync.Mutex
+	reviews []github.PullRequestReview
+	reads   int
+}
+
+// PullRequestReviews returns every submitted review.
+func (r *continuationReviews) PullRequestReviews(context.Context, github.Repository, int) ([]github.PullRequestReview, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.reviews) > 0 {
+		r.reads++
+	}
+	return append([]github.PullRequestReview(nil), r.reviews...), nil
+}
+
+// submit records one newly submitted review.
+func (r *continuationReviews) submit(review github.PullRequestReview) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reviews = append(r.reviews, review)
+}
+
+var _ github.Client = (*continuationGitHub)(nil)
+var _ github.IssuePoller = (*continuationGitHub)(nil)
+var _ github.PullRequestClient = (*continuationPullRequests)(nil)
+var _ github.PullRequestDraftClient = (*continuationPullRequests)(nil)
+var _ github.PullRequestReviewReader = (*continuationReviews)(nil)
+var _ harness.Runtime = (*continuationHarness)(nil)
+var _ worker.WorkerRuntime = (*unattendedWorker)(nil)

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -150,6 +150,9 @@ type Dependencies struct {
 	GitWorkspace gitadapter.GitWorkspace
 	// PullRequests owns idempotent draft pull-request discovery and mutation.
 	PullRequests github.PullRequestClient
+	// PullRequestReviews lists completed human reviews of a tracked pull
+	// request. It is read-only: the factory never submits or dismisses one.
+	PullRequestReviews github.PullRequestReviewReader
 	// Comments lists issue and pull-request comments for command polling.
 	Comments github.CommentReader
 	Worker   worker.WorkerRuntime
@@ -323,6 +326,11 @@ func NewWithDependencies(configPath string, dependencies Dependencies) *Service 
 	if dependencies.PullRequests == nil {
 		if client, ok := dependencies.GitHub.(github.PullRequestClient); ok {
 			dependencies.PullRequests = client
+		}
+	}
+	if dependencies.PullRequestReviews == nil {
+		if reader, ok := dependencies.GitHub.(github.PullRequestReviewReader); ok {
+			dependencies.PullRequestReviews = reader
 		}
 	}
 	if dependencies.Comments == nil {

--- a/internal/factory/human_review.go
+++ b/internal/factory/human_review.go
@@ -3,6 +3,7 @@ package factory
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
@@ -34,57 +35,65 @@ func (s *Service) pullRequestReviewReader() github.PullRequestReviewReader {
 
 // consumeHumanReview applies at most one newly submitted `CHANGES_REQUESTED`
 // review from an authorized maintainer as a single implementation repair
-// packet. It reports whether it changed durable run state.
+// packet.
 //
 // Only a completed review decision is a progression event. An unsubmitted
 // draft, an ordinary comment, a `COMMENTED` review, an approval, a dismissed
 // decision, and a review from an unauthorized user are all read and ignored.
-func (s *Service) consumeHumanReview(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, bool, error) {
+func (s *Service) consumeHumanReview(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) error {
 	if !humanReviewEligible(run) {
-		return run, false, nil
+		return nil
 	}
 	reader := s.pullRequestReviewReader()
 	if reader == nil {
-		return run, false, nil
+		return nil
 	}
 	active, supported, err := activeInvocationsForRun(ctx, runStore, run.ID)
 	if err != nil {
-		return run, false, fmt.Errorf("look up active invocations before human review: %w", err)
+		return fmt.Errorf("look up active invocations before human review: %w", err)
 	}
 	if !supported || len(active) > 0 {
 		// A human review must never interrupt a harness session that can still
 		// write a structured result for the current checkpoint.
-		return run, false, nil
+		return nil
 	}
-	repository := commandRepository(registration)
-	reviews, err := reader.PullRequestReviews(ctx, repository, run.PullRequestNumber)
+	reviews, err := reader.PullRequestReviews(ctx, commandRepository(registration), run.PullRequestNumber)
 	if err != nil {
-		return run, false, fmt.Errorf("read reviews for pull request #%d: %w", run.PullRequestNumber, err)
+		return fmt.Errorf("read reviews for pull request #%d: %w", run.PullRequestNumber, err)
 	}
-	review, found := newestApplicableHumanReview(reviews, registration.AuthorizedUsers, run.ProcessedReviewID)
-	if !found {
-		return run, false, nil
+	applicable := applicableHumanReviews(reviews, registration.AuthorizedUsers, run.ProcessedReviewID)
+	if len(applicable) == 0 {
+		return nil
 	}
-	findings := humanRepairFindings(run, review)
+	findings := make([]store.ReviewRepairFinding, 0, len(applicable))
+	for _, review := range applicable {
+		findings = append(findings, humanRepairFindings(run, review)...)
+	}
 	if len(findings) == 0 {
-		return run, false, nil
+		return nil
 	}
+	return s.applyHumanRepair(ctx, registration, runStore, run, applicable, findings)
+}
 
-	// Return the pull request to draft before the durable transition. The
-	// watermark only advances with that transition, so an interrupted pass
-	// repeats an idempotent draft change instead of losing the review.
+// applyHumanRepair returns the pull request to draft, resumes implementation
+// from the current checkpoint, and persists the review watermark.
+//
+// The draft change comes first and is idempotent, while the watermark advances
+// only with the durable transition. An interrupted pass therefore repeats the
+// draft change instead of losing the review.
+func (s *Service) applyHumanRepair(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, applicable []github.PullRequestReview, findings []store.ReviewRepairFinding) error {
 	if err := s.returnPullRequestToDraft(ctx, registration, run); err != nil {
-		return run, false, err
+		return err
 	}
-
+	watermark := applicable[len(applicable)-1].ID
 	next := run
 	next.Stage = store.StageImplementation
 	next.Status = store.StatusActive
-	next.LifecycleReason = fmt.Sprintf("authorized human review %s requested changes; resuming implementation from checkpoint %s", review.ID, run.CheckpointSHA)
+	next.LifecycleReason = fmt.Sprintf("authorized human review %s requested changes; resuming implementation from checkpoint %s", watermark, run.CheckpointSHA)
 	next.ReviewRepairPacket = &store.ReviewRepairPacket{
 		Version:       1,
 		Source:        store.ReviewRepairSourceHuman,
-		ReviewID:      review.ID,
+		ReviewID:      watermark,
 		RunID:         run.ID,
 		CheckpointSHA: run.CheckpointSHA,
 		Budget:        run.ReviewRepairBudget,
@@ -96,20 +105,20 @@ func (s *Service) consumeHumanReview(ctx context.Context, registration config.Re
 	next.StandardsReview = nil
 	next.ReviewRepairPendingAttempt = 0
 	next.ReadyNotificationSent = false
+	// An outstanding reviewer question was asked about the superseded
+	// checkpoint, and the maintainer has now given direction for it. Clearing
+	// it matches how a factory repair round supersedes the same question.
 	next.PendingQuestions = nil
 	next.ClarificationCommentID = ""
 	next.ClarificationNotificationSent = false
-	next.ProcessedReviewID = review.ID
+	next.ProcessedReviewID = watermark
 	next.Revision = run.Revision + 1
 	next.ProcessedReviewRevision = next.Revision
 	next.UpdatedAt = s.deps.Now().UTC()
 	if err := s.persistAgentRunState(ctx, registration, runStore, run, next); err != nil {
-		return run, false, fmt.Errorf("persist human review repair state: %w", err)
+		return fmt.Errorf("persist human review repair state: %w", err)
 	}
-	if current, currentErr := runStore.CurrentRun(ctx); currentErr == nil && current != nil {
-		next = *current
-	}
-	return next, true, nil
+	return nil
 }
 
 // humanReviewEligible reports whether the run has a tracked pull request whose
@@ -129,12 +138,15 @@ func humanReviewEligible(run store.Run) bool {
 	}
 }
 
-// newestApplicableHumanReview selects the single newest submitted
-// `CHANGES_REQUESTED` review from an authorized maintainer that the persisted
-// watermark has not already applied.
-func newestApplicableHumanReview(reviews []github.PullRequestReview, authorized []string, watermark string) (github.PullRequestReview, bool) {
-	selected := github.PullRequestReview{}
-	found := false
+// applicableHumanReviews returns every submitted `CHANGES_REQUESTED` review
+// from an authorized maintainer that the persisted watermark has not already
+// applied, oldest identity first.
+//
+// Two maintainers can request changes between two polls. Returning all of them
+// lets one repair packet carry every outstanding instruction, so advancing the
+// watermark to the newest identity cannot discard an older unapplied review.
+func applicableHumanReviews(reviews []github.PullRequestReview, authorized []string, watermark string) []github.PullRequestReview {
+	applicable := make([]github.PullRequestReview, 0, len(reviews))
 	for _, review := range reviews {
 		if review.State != github.PullRequestReviewChangesRequested {
 			continue
@@ -145,16 +157,15 @@ func newestApplicableHumanReview(reviews []github.PullRequestReview, authorized 
 		if !authorizedCommentAuthor(authorized, review.Author) {
 			continue
 		}
-		if commentAlreadyProcessed(watermark, review.ID) {
+		if githubIDAlreadyProcessed(watermark, review.ID) {
 			continue
 		}
-		if found && compareCommentIDs(review.ID, selected.ID) <= 0 {
-			continue
-		}
-		selected = review
-		found = true
+		applicable = append(applicable, review)
 	}
-	return selected, found
+	sort.SliceStable(applicable, func(left, right int) bool {
+		return compareGitHubIDs(applicable[left].ID, applicable[right].ID) < 0
+	})
+	return applicable
 }
 
 // humanRepairFindings converts one completed review into blocking findings.

--- a/internal/factory/human_review.go
+++ b/internal/factory/human_review.go
@@ -1,0 +1,232 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/workflow"
+)
+
+// humanReviewCategory classifies every human repair instruction. An authorized
+// maintainer's requested change is authoritative product intent, so it uses the
+// declared specification category rather than widening the closed vocabulary.
+const humanReviewCategory = report.ReviewCategorySpecification
+
+// humanReviewerRole names the reviewer that produced a human repair packet.
+// It is deliberately not a workflow role: no invocation, prompt, or stage
+// belongs to it, and it exists only to preserve finding provenance.
+const humanReviewerRole = "human"
+
+// pullRequestReviewReader resolves the read-only review seam without widening
+// the pull-request mutation authority of the other GitHub clients.
+func (s *Service) pullRequestReviewReader() github.PullRequestReviewReader {
+	if s.deps.PullRequestReviews != nil {
+		return s.deps.PullRequestReviews
+	}
+	reader, _ := s.deps.GitHub.(github.PullRequestReviewReader)
+	return reader
+}
+
+// consumeHumanReview applies at most one newly submitted `CHANGES_REQUESTED`
+// review from an authorized maintainer as a single implementation repair
+// packet. It reports whether it changed durable run state.
+//
+// Only a completed review decision is a progression event. An unsubmitted
+// draft, an ordinary comment, a `COMMENTED` review, an approval, a dismissed
+// decision, and a review from an unauthorized user are all read and ignored.
+func (s *Service) consumeHumanReview(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run) (store.Run, bool, error) {
+	if !humanReviewEligible(run) {
+		return run, false, nil
+	}
+	reader := s.pullRequestReviewReader()
+	if reader == nil {
+		return run, false, nil
+	}
+	active, supported, err := activeInvocationsForRun(ctx, runStore, run.ID)
+	if err != nil {
+		return run, false, fmt.Errorf("look up active invocations before human review: %w", err)
+	}
+	if !supported || len(active) > 0 {
+		// A human review must never interrupt a harness session that can still
+		// write a structured result for the current checkpoint.
+		return run, false, nil
+	}
+	repository := commandRepository(registration)
+	reviews, err := reader.PullRequestReviews(ctx, repository, run.PullRequestNumber)
+	if err != nil {
+		return run, false, fmt.Errorf("read reviews for pull request #%d: %w", run.PullRequestNumber, err)
+	}
+	review, found := newestApplicableHumanReview(reviews, registration.AuthorizedUsers, run.ProcessedReviewID)
+	if !found {
+		return run, false, nil
+	}
+	findings := humanRepairFindings(run, review)
+	if len(findings) == 0 {
+		return run, false, nil
+	}
+
+	// Return the pull request to draft before the durable transition. The
+	// watermark only advances with that transition, so an interrupted pass
+	// repeats an idempotent draft change instead of losing the review.
+	if err := s.returnPullRequestToDraft(ctx, registration, run); err != nil {
+		return run, false, err
+	}
+
+	next := run
+	next.Stage = store.StageImplementation
+	next.Status = store.StatusActive
+	next.LifecycleReason = fmt.Sprintf("authorized human review %s requested changes; resuming implementation from checkpoint %s", review.ID, run.CheckpointSHA)
+	next.ReviewRepairPacket = &store.ReviewRepairPacket{
+		Version:       1,
+		Source:        store.ReviewRepairSourceHuman,
+		ReviewID:      review.ID,
+		RunID:         run.ID,
+		CheckpointSHA: run.CheckpointSHA,
+		Budget:        run.ReviewRepairBudget,
+		Findings:      findings,
+	}
+	// The reviewed checkpoint is superseded, so every result derived from it
+	// stops being evidence for readiness.
+	next.SpecificationReview = nil
+	next.StandardsReview = nil
+	next.ReviewRepairPendingAttempt = 0
+	next.ReadyNotificationSent = false
+	next.PendingQuestions = nil
+	next.ClarificationCommentID = ""
+	next.ClarificationNotificationSent = false
+	next.ProcessedReviewID = review.ID
+	next.Revision = run.Revision + 1
+	next.ProcessedReviewRevision = next.Revision
+	next.UpdatedAt = s.deps.Now().UTC()
+	if err := s.persistAgentRunState(ctx, registration, runStore, run, next); err != nil {
+		return run, false, fmt.Errorf("persist human review repair state: %w", err)
+	}
+	if current, currentErr := runStore.CurrentRun(ctx); currentErr == nil && current != nil {
+		next = *current
+	}
+	return next, true, nil
+}
+
+// humanReviewEligible reports whether the run has a tracked pull request whose
+// completed reviews can still change the outcome of the run.
+func humanReviewEligible(run store.Run) bool {
+	if run.PullRequestNumber == 0 || store.IsTerminalStatus(run.Status) {
+		return false
+	}
+	if run.Status != store.StatusActive && run.Status != store.StatusWaitingForHuman {
+		return false
+	}
+	switch run.Stage {
+	case store.StageDraftPR, store.StageReview, store.StageReady:
+		return true
+	default:
+		return false
+	}
+}
+
+// newestApplicableHumanReview selects the single newest submitted
+// `CHANGES_REQUESTED` review from an authorized maintainer that the persisted
+// watermark has not already applied.
+func newestApplicableHumanReview(reviews []github.PullRequestReview, authorized []string, watermark string) (github.PullRequestReview, bool) {
+	selected := github.PullRequestReview{}
+	found := false
+	for _, review := range reviews {
+		if review.State != github.PullRequestReviewChangesRequested {
+			continue
+		}
+		if review.SubmittedAt.IsZero() || strings.TrimSpace(review.ID) == "" {
+			continue
+		}
+		if !authorizedCommentAuthor(authorized, review.Author) {
+			continue
+		}
+		if commentAlreadyProcessed(watermark, review.ID) {
+			continue
+		}
+		if found && compareCommentIDs(review.ID, selected.ID) <= 0 {
+			continue
+		}
+		selected = review
+		found = true
+	}
+	return selected, found
+}
+
+// humanRepairFindings converts one completed review into blocking findings.
+// The review body is one finding and every inline comment is another, so the
+// implementation role receives the complete human instruction.
+func humanRepairFindings(run store.Run, review github.PullRequestReview) []store.ReviewRepairFinding {
+	findings := make([]store.ReviewRepairFinding, 0, len(review.Comments)+1)
+	if body := strings.TrimSpace(review.Body); body != "" {
+		findings = append(findings, humanRepairFinding(fmt.Sprintf("pull request #%d", run.PullRequestNumber), body, review))
+	}
+	for _, comment := range review.Comments {
+		claim := strings.TrimSpace(comment.Body)
+		if claim == "" {
+			continue
+		}
+		findings = append(findings, humanRepairFinding(humanReviewLocation(comment), claim, review))
+	}
+	return findings
+}
+
+// humanRepairFinding renders one human instruction in the existing review
+// finding contract. Implementation always owns the repair: a human comment on
+// a protected test still reaches the test role through the objection protocol
+// only when a factory reviewer assigns that ownership.
+func humanRepairFinding(location, claim string, review github.PullRequestReview) store.ReviewRepairFinding {
+	return store.ReviewRepairFinding{
+		ReviewerRole: humanReviewerRole,
+		Finding: store.ReviewFinding{
+			Location:            location,
+			Claim:               claim,
+			Evidence:            fmt.Sprintf("GitHub review %s submitted by %s", review.ID, review.Author),
+			Severity:            string(report.ReviewSeverityBlocker),
+			Category:            string(humanReviewCategory),
+			SuggestedResolution: claim,
+			SuggestedOwner:      workflow.RoleImplementation,
+		},
+	}
+}
+
+// humanReviewLocation renders the repository-relative anchor of one inline
+// review comment in the same shape reviewers use for their own findings.
+func humanReviewLocation(comment github.PullRequestReviewComment) string {
+	path := strings.TrimSpace(comment.Path)
+	if path == "" {
+		return "pull request diff"
+	}
+	if comment.Line > 0 {
+		return fmt.Sprintf("%s:%d", path, comment.Line)
+	}
+	return path
+}
+
+// returnPullRequestToDraft removes readiness before implementation resumes, so
+// a pull request awaiting human merge cannot be merged mid-repair. It is a
+// no-op for a pull request that is already a draft.
+func (s *Service) returnPullRequestToDraft(ctx context.Context, registration config.RepositoryRegistration, run store.Run) error {
+	pullRequest, found, err := s.trackedPullRequest(ctx, registration, run)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("tracked pull request #%d was not found before human repair", run.PullRequestNumber)
+	}
+	if pullRequest.Draft {
+		return nil
+	}
+	reverted, err := s.setPullRequestDraft(ctx, commandRepository(registration), pullRequest, true)
+	if err != nil {
+		return err
+	}
+	if !reverted.Draft {
+		return fmt.Errorf("pull request #%d remained ready before human repair", pullRequest.Number)
+	}
+	return nil
+}

--- a/internal/factory/human_review_internal_test.go
+++ b/internal/factory/human_review_internal_test.go
@@ -1,0 +1,158 @@
+package factory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/workflow"
+)
+
+// submittedAt is one non-zero submission time shared by the review fixtures.
+var submittedAt = time.Date(2026, 8, 29, 9, 30, 0, 0, time.UTC)
+
+// TestNewestApplicableHumanReviewAcceptsOnlyAnAuthorizedCompletedDecision
+// proves that only a submitted `CHANGES_REQUESTED` review from an authorized
+// maintainer starts work, and that the persisted watermark makes repeated
+// polling replay-safe.
+func TestNewestApplicableHumanReviewAcceptsOnlyAnAuthorizedCompletedDecision(t *testing.T) {
+	t.Parallel()
+
+	authorized := []string{"alice", "bob"}
+	changesRequested := github.PullRequestReview{
+		ID: "40", Author: "alice", State: github.PullRequestReviewChangesRequested,
+		Body: "restore the deleted validation", SubmittedAt: submittedAt,
+	}
+	tests := []struct {
+		name      string
+		reviews   []github.PullRequestReview
+		watermark string
+		wantID    string
+	}{
+		{
+			name:    "authorized changes requested",
+			reviews: []github.PullRequestReview{changesRequested},
+			wantID:  "40",
+		},
+		{
+			name: "newest authorized decision wins",
+			reviews: []github.PullRequestReview{
+				changesRequested,
+				{ID: "41", Author: "bob", State: github.PullRequestReviewChangesRequested, Body: "and rename the flag", SubmittedAt: submittedAt},
+			},
+			wantID: "41",
+		},
+		{
+			name:      "already applied review is skipped",
+			reviews:   []github.PullRequestReview{changesRequested},
+			watermark: "40",
+		},
+		{
+			name:      "older review below the watermark is skipped",
+			reviews:   []github.PullRequestReview{changesRequested},
+			watermark: "55",
+		},
+		{
+			name:    "unauthorized author is ignored",
+			reviews: []github.PullRequestReview{{ID: "42", Author: "mallory", State: github.PullRequestReviewChangesRequested, Body: "rewrite it", SubmittedAt: submittedAt}},
+		},
+		{
+			name:    "commented review is ignored",
+			reviews: []github.PullRequestReview{{ID: "43", Author: "alice", State: github.PullRequestReviewCommented, Body: "looks interesting", SubmittedAt: submittedAt}},
+		},
+		{
+			name:    "approval is ignored",
+			reviews: []github.PullRequestReview{{ID: "44", Author: "alice", State: github.PullRequestReviewApproved, Body: "ship it", SubmittedAt: submittedAt}},
+		},
+		{
+			name:    "dismissed decision is ignored",
+			reviews: []github.PullRequestReview{{ID: "45", Author: "alice", State: github.PullRequestReviewDismissed, Body: "withdrawn", SubmittedAt: submittedAt}},
+		},
+		{
+			name:    "unsubmitted draft is ignored",
+			reviews: []github.PullRequestReview{{ID: "46", Author: "alice", State: github.PullRequestReviewChangesRequested, Body: "still drafting"}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			selected, found := newestApplicableHumanReview(test.reviews, authorized, test.watermark)
+			if found != (test.wantID != "") {
+				t.Fatalf("found = %t, want %t", found, test.wantID != "")
+			}
+			if found && selected.ID != test.wantID {
+				t.Fatalf("selected review = %q, want %q", selected.ID, test.wantID)
+			}
+		})
+	}
+}
+
+// TestHumanRepairFindingsCarryTheBodyAndEveryInlineComment verifies that one
+// completed review becomes a single implementation-owned repair packet holding
+// the review body and its file-anchored findings.
+func TestHumanRepairFindingsCarryTheBodyAndEveryInlineComment(t *testing.T) {
+	t.Parallel()
+
+	review := github.PullRequestReview{
+		ID: "40", Author: "alice", State: github.PullRequestReviewChangesRequested,
+		Body: "restore the deleted validation", SubmittedAt: submittedAt,
+		Comments: []github.PullRequestReviewComment{
+			{Path: "internal/factory/review.go", Line: 42, Body: "this branch cannot be reached"},
+			{Path: "internal/factory/gate.go", Body: "no line anchor here"},
+			{Path: "internal/factory/lock.go", Line: 7, Body: "   "},
+		},
+	}
+	findings := humanRepairFindings(store.Run{PullRequestNumber: 17}, review)
+	if len(findings) != 3 {
+		t.Fatalf("findings = %d, want the body and the two non-empty inline comments", len(findings))
+	}
+	wantLocations := []string{"pull request #17", "internal/factory/review.go:42", "internal/factory/gate.go"}
+	for index, finding := range findings {
+		if finding.Finding.Location != wantLocations[index] {
+			t.Fatalf("finding %d location = %q, want %q", index, finding.Finding.Location, wantLocations[index])
+		}
+		if finding.ReviewerRole != humanReviewerRole {
+			t.Fatalf("finding %d reviewer = %q, want %q", index, finding.ReviewerRole, humanReviewerRole)
+		}
+		if finding.Finding.SuggestedOwner != workflow.RoleImplementation {
+			t.Fatalf("finding %d owner = %q, want implementation", index, finding.Finding.SuggestedOwner)
+		}
+		if finding.Finding.Severity != string(report.ReviewSeverityBlocker) {
+			t.Fatalf("finding %d severity = %q, want blocker", index, finding.Finding.Severity)
+		}
+		if !reviewFindingBlocks(finding.Finding) {
+			t.Fatalf("finding %d does not block readiness", index)
+		}
+	}
+}
+
+// TestHumanReviewEligibleCoversOnlyRunsWithAPendingPullRequestDecision
+// verifies that the coordinator reads reviews exactly while a tracked pull
+// request can still change the outcome of the run.
+func TestHumanReviewEligibleCoversOnlyRunsWithAPendingPullRequestDecision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  store.Run
+		want bool
+	}{
+		{name: "review stage", run: store.Run{PullRequestNumber: 17, Stage: store.StageReview, Status: store.StatusActive}, want: true},
+		{name: "ready stage awaiting merge", run: store.Run{PullRequestNumber: 17, Stage: store.StageReady, Status: store.StatusWaitingForHuman}, want: true},
+		{name: "draft pull request", run: store.Run{PullRequestNumber: 17, Stage: store.StageDraftPR, Status: store.StatusActive}, want: true},
+		{name: "no pull request yet", run: store.Run{Stage: store.StageImplementation, Status: store.StatusActive}},
+		{name: "implementation already resumed", run: store.Run{PullRequestNumber: 17, Stage: store.StageImplementation, Status: store.StatusActive}},
+		{name: "merged run", run: store.Run{PullRequestNumber: 17, Stage: store.StageReady, Status: store.StatusComplete}},
+		{name: "cancelled run", run: store.Run{PullRequestNumber: 17, Stage: store.StageReady, Status: store.StatusCancelled}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := humanReviewEligible(test.run); got != test.want {
+				t.Fatalf("humanReviewEligible = %t, want %t", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/factory/human_review_internal_test.go
+++ b/internal/factory/human_review_internal_test.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -13,11 +14,11 @@ import (
 // submittedAt is one non-zero submission time shared by the review fixtures.
 var submittedAt = time.Date(2026, 8, 29, 9, 30, 0, 0, time.UTC)
 
-// TestNewestApplicableHumanReviewAcceptsOnlyAnAuthorizedCompletedDecision
-// proves that only a submitted `CHANGES_REQUESTED` review from an authorized
-// maintainer starts work, and that the persisted watermark makes repeated
-// polling replay-safe.
-func TestNewestApplicableHumanReviewAcceptsOnlyAnAuthorizedCompletedDecision(t *testing.T) {
+// TestApplicableHumanReviewsAcceptOnlyAuthorizedCompletedDecisions proves that
+// only a submitted `CHANGES_REQUESTED` review from an authorized maintainer
+// starts work, that concurrent decisions are all carried, and that the
+// persisted watermark makes repeated polling replay-safe.
+func TestApplicableHumanReviewsAcceptOnlyAuthorizedCompletedDecisions(t *testing.T) {
 	t.Parallel()
 
 	authorized := []string{"alice", "bob"}
@@ -29,20 +30,29 @@ func TestNewestApplicableHumanReviewAcceptsOnlyAnAuthorizedCompletedDecision(t *
 		name      string
 		reviews   []github.PullRequestReview
 		watermark string
-		wantID    string
+		wantIDs   []string
 	}{
 		{
 			name:    "authorized changes requested",
 			reviews: []github.PullRequestReview{changesRequested},
-			wantID:  "40",
+			wantIDs: []string{"40"},
 		},
 		{
-			name: "newest authorized decision wins",
+			name: "concurrent authorized decisions are all carried, oldest first",
+			reviews: []github.PullRequestReview{
+				{ID: "41", Author: "bob", State: github.PullRequestReviewChangesRequested, Body: "and rename the flag", SubmittedAt: submittedAt},
+				changesRequested,
+			},
+			wantIDs: []string{"40", "41"},
+		},
+		{
+			name: "watermark keeps only the unapplied decision",
 			reviews: []github.PullRequestReview{
 				changesRequested,
 				{ID: "41", Author: "bob", State: github.PullRequestReviewChangesRequested, Body: "and rename the flag", SubmittedAt: submittedAt},
 			},
-			wantID: "41",
+			watermark: "40",
+			wantIDs:   []string{"41"},
 		},
 		{
 			name:      "already applied review is skipped",
@@ -78,12 +88,14 @@ func TestNewestApplicableHumanReviewAcceptsOnlyAnAuthorizedCompletedDecision(t *
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			selected, found := newestApplicableHumanReview(test.reviews, authorized, test.watermark)
-			if found != (test.wantID != "") {
-				t.Fatalf("found = %t, want %t", found, test.wantID != "")
+			applicable := applicableHumanReviews(test.reviews, authorized, test.watermark)
+			if len(applicable) != len(test.wantIDs) {
+				t.Fatalf("applicable reviews = %d, want %d", len(applicable), len(test.wantIDs))
 			}
-			if found && selected.ID != test.wantID {
-				t.Fatalf("selected review = %q, want %q", selected.ID, test.wantID)
+			for index, review := range applicable {
+				if review.ID != test.wantIDs[index] {
+					t.Fatalf("applicable review %d = %q, want %q", index, review.ID, test.wantIDs[index])
+				}
 			}
 		})
 	}
@@ -125,6 +137,60 @@ func TestHumanRepairFindingsCarryTheBodyAndEveryInlineComment(t *testing.T) {
 		if !reviewFindingBlocks(finding.Finding) {
 			t.Fatalf("finding %d does not block readiness", index)
 		}
+	}
+}
+
+// TestStatusCommentPublishesTheUnbudgetedHumanRepair verifies an operator can
+// see that a human review, not a factory reviewer, requested the current
+// repair, and that it does not consume the bounded repair budget.
+func TestStatusCommentPublishesTheUnbudgetedHumanRepair(t *testing.T) {
+	t.Parallel()
+
+	run := store.Run{
+		ID:                 "run-human",
+		ReviewRepairBudget: 2,
+		ReviewRepairPacket: &store.ReviewRepairPacket{
+			Version: 1, Source: store.ReviewRepairSourceHuman, ReviewID: "4001",
+			RunID: "run-human", Budget: 2,
+		},
+	}
+	body := reviewRepairStatusComment(run)
+	if !strings.Contains(body, "- human review: 4001 (does not consume the budget)") {
+		t.Fatalf("status comment = %q, want the published human repair trigger", body)
+	}
+	if !strings.Contains(body, "- attempts: 0/2") {
+		t.Fatalf("status comment = %q, want an unchanged factory repair budget", body)
+	}
+}
+
+// TestConsumesBoundedRepairRoundExcludesHumanRequestedRepair verifies that only
+// a factory packet consumes a reserved repair round. Every implementation
+// launch that carries a packet reaches this rule, including the test-stage
+// handoff, so a human review must not reset an exhausted repair budget.
+func TestConsumesBoundedRepairRoundExcludesHumanRequestedRepair(t *testing.T) {
+	t.Parallel()
+
+	factoryPacket := &store.ReviewRepairPacket{Version: 1, Attempt: 2, Budget: 2}
+	humanPacket := &store.ReviewRepairPacket{Version: 1, Source: store.ReviewRepairSourceHuman, ReviewID: "4001", Budget: 2}
+	tests := []struct {
+		name         string
+		reviewRepair bool
+		packet       *store.ReviewRepairPacket
+		want         bool
+	}{
+		{name: "factory packet on a repair launch", reviewRepair: true, packet: factoryPacket, want: true},
+		{name: "legacy packet without a source", reviewRepair: true, packet: &store.ReviewRepairPacket{Version: 1, Attempt: 1, Budget: 2}, want: true},
+		{name: "human packet on a repair launch", reviewRepair: true, packet: humanPacket},
+		{name: "factory packet on an ordinary launch", packet: factoryPacket},
+		{name: "no packet", reviewRepair: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := consumesBoundedRepairRound(test.reviewRepair, test.packet); got != test.want {
+				t.Fatalf("consumesBoundedRepairRound = %t, want %t", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -194,11 +194,12 @@ func (s *Service) Start(ctx context.Context) error {
 				continue
 			}
 			consecutiveProgressionFailures = 0
-			if progression.Outcome == progressionTerminal || progression.Outcome == progressionIdle {
-				// The run this pass owned reached a terminal state, which
-				// releases the one-active-run constraint. Observe the queue
-				// again without waiting a full interval so the next oldest
-				// eligible issue starts promptly.
+			// A run this pass drove into a terminal state releases the
+			// one-active-run constraint. Observe the queue again without
+			// waiting a full interval so the next oldest eligible issue starts
+			// promptly. An idle pass that performed no transition is not a
+			// release, so it keeps the ordinary interval.
+			if progression.Outcome == progressionTerminal || (progression.Outcome == progressionIdle && progression.Steps > 0) {
 				leaseRunID = ""
 				delay = 0
 			}

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -179,8 +179,10 @@ func (s *Service) Start(ctx context.Context) error {
 			return err
 		}
 		leaseRunID = result.Run.ID
+		delay = interval
 		if result.Outcome == PollClaimed || result.Outcome == PollActiveRun {
-			if _, err := s.driveRun(pollContext, registration); err != nil {
+			progression, err := s.driveRun(pollContext, registration)
+			if err != nil {
 				if pollingContextDone(err) {
 					return nil
 				}
@@ -192,8 +194,15 @@ func (s *Service) Start(ctx context.Context) error {
 				continue
 			}
 			consecutiveProgressionFailures = 0
+			if progression.Outcome == progressionTerminal || progression.Outcome == progressionIdle {
+				// The run this pass owned reached a terminal state, which
+				// releases the one-active-run constraint. Observe the queue
+				// again without waiting a full interval so the next oldest
+				// eligible issue starts promptly.
+				leaseRunID = ""
+				delay = 0
+			}
 		}
-		delay = interval
 	}
 }
 

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -52,6 +52,9 @@ type progressionResult struct {
 	Steps int
 	// Reason is the operator-facing explanation of Outcome.
 	Reason string
+	// Step names the transition that stopped the pass. It is used in the
+	// published waiting reason and defaults to an unexplained stall.
+	Step string
 }
 
 // progressionState is one consistent read of the run and the invocation it
@@ -81,6 +84,16 @@ type progressionState struct {
 // creating a second invocation, checkpoint, push, comment, or pull request.
 func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRegistration) (progressionResult, error) {
 	result := progressionResult{Outcome: progressionIdle}
+	if err := s.observePullRequestEvents(ctx, registration); err != nil {
+		if pollingContextDone(err) || ctx.Err() != nil {
+			return result, err
+		}
+		state, readErr := s.readProgressionState(ctx, registration)
+		if readErr != nil || state.Run == nil {
+			return result, errors.Join(err, readErr)
+		}
+		return s.stopProgressionAfterFailure(ctx, registration, *state.Run, "observe pull-request events", err, result.Steps)
+	}
 	for result.Steps < maxProgressionSteps {
 		if err := ctx.Err(); err != nil {
 			return result, err
@@ -128,6 +141,51 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 	})
 }
 
+// observePullRequestEvents makes one bounded GitHub observation for a run that
+// already has a tracked pull request, before the pass applies any coordinator
+// transition. Pull-request lifecycle is observed first, because a merged or
+// closed pull request ends the run and must not be followed by repair,
+// readiness, or infrastructure work. A pending durable effect defers both
+// observations to reconciliation, which owns the unresolved mutation.
+func (s *Service) observePullRequestEvents(ctx context.Context, registration config.RepositoryRegistration) error {
+	s.commandMu.Lock()
+	defer s.commandMu.Unlock()
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return fmt.Errorf("open operational store to observe pull-request events: %w", err)
+	}
+	defer func() { _ = opened.Close() }()
+	runStore, ok := opened.(RunStore)
+	if !ok {
+		return nil
+	}
+	run, err := runStore.CurrentRun(ctx)
+	if err != nil {
+		return fmt.Errorf("read run to observe pull-request events: %w", err)
+	}
+	if run == nil || run.PullRequestNumber == 0 {
+		return nil
+	}
+	if journal, journaled := runStore.(PendingEffectStore); journaled {
+		pending, pendingErr := journal.PendingEffect(ctx, run.ID)
+		if pendingErr != nil {
+			return fmt.Errorf("read pending effect before pull-request observation: %w", pendingErr)
+		}
+		if pending != nil {
+			return nil
+		}
+	}
+	lifecycle, err := s.observeLifecycle(ctx, registration, runStore, run)
+	if err != nil {
+		return err
+	}
+	if lifecycle.Outcome != LifecycleUnchanged || store.IsTerminalStatus(lifecycle.Run.Status) {
+		return nil
+	}
+	_, _, err = s.consumeHumanReview(ctx, registration, runStore, *run)
+	return err
+}
+
 // progressionAction is one coordinator-owned transition selected from durable
 // run state. The coordinator, never an agent, chooses it.
 type progressionAction struct {
@@ -173,6 +231,13 @@ func (s *Service) progressionStep(state progressionState) (progressionAction, *p
 			_, err := s.StartAgent(ctx, AgentRequest{RunID: run.ID, Role: definition.Name, Stage: definition.Stage})
 			return err
 		}}, nil
+	}
+	if reviewReadinessSettled(run) {
+		return progressionAction{}, &progressionResult{
+			Outcome: progressionWaiting,
+			Step:    "pull-request readiness",
+			Reason:  fmt.Sprintf("pull request #%d is ready and waiting for human disposition", run.PullRequestNumber),
+		}
 	}
 	if reviewReadinessEligible(run) {
 		return progressionAction{name: "finalize pull-request readiness", action: func(ctx context.Context) error {
@@ -445,7 +510,11 @@ func (s *Service) publishProgressionStop(ctx context.Context, registration confi
 	if stop.Outcome != progressionWaiting || run.Status != store.StatusActive {
 		return stop, nil
 	}
-	paused, err := s.pauseProgression(ctx, registration, run, "stall", errors.New(stop.Reason))
+	step := stop.Step
+	if step == "" {
+		step = "stall"
+	}
+	paused, err := s.pauseProgression(ctx, registration, run, step, errors.New(stop.Reason))
 	if err != nil {
 		return stop, err
 	}

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -182,8 +182,7 @@ func (s *Service) observePullRequestEvents(ctx context.Context, registration con
 	if lifecycle.Outcome != LifecycleUnchanged || store.IsTerminalStatus(lifecycle.Run.Status) {
 		return nil
 	}
-	_, _, err = s.consumeHumanReview(ctx, registration, runStore, *run)
-	return err
+	return s.consumeHumanReview(ctx, registration, runStore, lifecycle.Run)
 }
 
 // progressionAction is one coordinator-owned transition selected from durable

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -84,7 +84,8 @@ type progressionState struct {
 // creating a second invocation, checkpoint, push, comment, or pull request.
 func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRegistration) (progressionResult, error) {
 	result := progressionResult{Outcome: progressionIdle}
-	if err := s.observePullRequestEvents(ctx, registration); err != nil {
+	lifecycle, err := s.observePullRequestEvents(ctx, registration)
+	if err != nil {
 		if pollingContextDone(err) || ctx.Err() != nil {
 			return result, err
 		}
@@ -93,6 +94,9 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 			return result, errors.Join(err, readErr)
 		}
 		return s.stopProgressionAfterFailure(ctx, registration, *state.Run, "observe pull-request events", err, result.Steps)
+	}
+	if lifecycle.Outcome == LifecycleCompleted || lifecycle.Outcome == LifecycleCancelled {
+		return progressionResult{Outcome: progressionTerminal, Run: lifecycle.Run, Reason: lifecycle.Reason}, nil
 	}
 	for result.Steps < maxProgressionSteps {
 		if err := ctx.Err(); err != nil {
@@ -147,42 +151,42 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 // closed pull request ends the run and must not be followed by repair,
 // readiness, or infrastructure work. A pending durable effect defers both
 // observations to reconciliation, which owns the unresolved mutation.
-func (s *Service) observePullRequestEvents(ctx context.Context, registration config.RepositoryRegistration) error {
+func (s *Service) observePullRequestEvents(ctx context.Context, registration config.RepositoryRegistration) (LifecycleResult, error) {
 	s.commandMu.Lock()
 	defer s.commandMu.Unlock()
 	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
 	if err != nil {
-		return fmt.Errorf("open operational store to observe pull-request events: %w", err)
+		return LifecycleResult{}, fmt.Errorf("open operational store to observe pull-request events: %w", err)
 	}
 	defer func() { _ = opened.Close() }()
 	runStore, ok := opened.(RunStore)
 	if !ok {
-		return nil
+		return LifecycleResult{Outcome: LifecycleUnchanged}, nil
 	}
 	run, err := runStore.CurrentRun(ctx)
 	if err != nil {
-		return fmt.Errorf("read run to observe pull-request events: %w", err)
+		return LifecycleResult{}, fmt.Errorf("read run to observe pull-request events: %w", err)
 	}
 	if run == nil || run.PullRequestNumber == 0 {
-		return nil
+		return LifecycleResult{Outcome: LifecycleUnchanged}, nil
 	}
 	if journal, journaled := runStore.(PendingEffectStore); journaled {
 		pending, pendingErr := journal.PendingEffect(ctx, run.ID)
 		if pendingErr != nil {
-			return fmt.Errorf("read pending effect before pull-request observation: %w", pendingErr)
+			return LifecycleResult{}, fmt.Errorf("read pending effect before pull-request observation: %w", pendingErr)
 		}
 		if pending != nil {
-			return nil
+			return LifecycleResult{Outcome: LifecycleUnchanged}, nil
 		}
 	}
 	lifecycle, err := s.observeLifecycle(ctx, registration, runStore, run)
 	if err != nil {
-		return err
+		return lifecycle, err
 	}
 	if lifecycle.Outcome != LifecycleUnchanged || store.IsTerminalStatus(lifecycle.Run.Status) {
-		return nil
+		return lifecycle, nil
 	}
-	return s.consumeHumanReview(ctx, registration, runStore, lifecycle.Run)
+	return lifecycle, s.consumeHumanReview(ctx, registration, runStore, lifecycle.Run)
 }
 
 // progressionAction is one coordinator-owned transition selected from durable

--- a/internal/factory/readiness.go
+++ b/internal/factory/readiness.go
@@ -23,6 +23,14 @@ func reviewReadinessEligible(run store.Run) bool {
 	return reviewRoundComplete(run) && !reviewHasBlockingResult(run)
 }
 
+// reviewReadinessSettled reports whether the final readiness boundary is
+// already complete for the current checkpoint. Retrying it then cannot change
+// anything, so unattended progression must publish the human disposition it is
+// waiting for instead of reporting a stalled transition.
+func reviewReadinessSettled(run store.Run) bool {
+	return run.Stage == store.StageReady && run.ReadyNotificationSent && reviewReadinessEligible(run)
+}
+
 // finalizeReviewReadiness performs the final target synchronization, explicit
 // PR readiness transition, durable ready state, and operator notification.
 // A target change returns the run to checks so every gate and reviewer starts

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -466,6 +466,35 @@ func TestPollLifecycleCompletesAMergedRunBeforeRecovery(t *testing.T) {
 	}
 }
 
+// TestDriveRunPropagatesTerminalLifecycleOutcomes verifies that lifecycle
+// observations release the queue through the progression result consumed by
+// the persistent polling loop.
+func TestDriveRunPropagatesTerminalLifecycleOutcomes(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		merged  bool
+		outcome LifecycleOutcome
+		status  store.Status
+	}{
+		{name: "completed", merged: true, outcome: LifecycleCompleted, status: store.StatusComplete},
+		{name: "cancelled", outcome: LifecycleCancelled, status: store.StatusCancelled},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newDraftPRRecoveryFixture(t, "run-drive-"+test.name, 19, test.merged, "")
+			if !test.merged {
+				fixture.github.pullRequest.State = "closed"
+			}
+			result, err := fixture.lifecycleService().driveRun(context.Background(), fixture.host.Repositories[0])
+			if err != nil {
+				t.Fatalf("driveRun() error = %v", err)
+			}
+			if result.Outcome != progressionTerminal || result.Run.Status != test.status {
+				t.Fatalf("driveRun() result = %#v, want terminal %s lifecycle outcome", result, test.outcome)
+			}
+		})
+	}
+}
+
 // TestStartCompletesAMergedRunBeforeRecovery verifies the persistent
 // supervisor records an already-merged pull request before startup
 // reconciliation can reject its deleted remote branch.

--- a/internal/factory/review_repair.go
+++ b/internal/factory/review_repair.go
@@ -98,6 +98,16 @@ func decideReviewRepair(run store.Run, findings []store.ReviewRepairFinding) rev
 	return decision
 }
 
+// consumesBoundedRepairRound reports whether one implementation launch consumes
+// a reserved factory repair round.
+//
+// Only a factory packet reserves a round. A human-requested repair carries no
+// attempt number, so recording it would reset the bounded budget and let every
+// `CHANGES_REQUESTED` review revive an exhausted repair allowance.
+func consumesBoundedRepairRound(reviewRepair bool, packet *store.ReviewRepairPacket) bool {
+	return reviewRepair && packet != nil && packet.Source != store.ReviewRepairSourceHuman
+}
+
 // reviewRepairRemaining returns a non-negative budget remainder.
 func reviewRepairRemaining(budget, attempts int) int {
 	if budget <= attempts {

--- a/internal/factory/review_repair.go
+++ b/internal/factory/review_repair.go
@@ -506,7 +506,9 @@ func (s *Service) routeReviewRepair(ctx context.Context, registration config.Rep
 		next.Stage = store.StageImplementation
 		next.Status = store.StatusActive
 		next.LifecycleReason = fmt.Sprintf("blocking review findings routed to implementation repair attempt %d of %d", decision.Attempt, run.ReviewRepairBudget)
-		next.ReviewRepairAttempts = decision.Attempt
+		// Reserve the round without consuming it. The attempt count advances
+		// only when the visible implementation invocation actually launches,
+		// so an interrupted launch stays distinguishable from a used attempt.
 		next.ReviewRepairPendingAttempt = decision.Attempt
 		next.ReviewRepairPacket = packet
 		next.ReviewRepairHistory = reviewRepairHistoryWithOutcome(run.ReviewRepairHistory, decision.Attempt, store.ReviewRepairPending, packet)

--- a/internal/factory/test_stage.go
+++ b/internal/factory/test_stage.go
@@ -411,7 +411,7 @@ func (s *Service) automatedTestObjectionGate(ctx context.Context, registration c
 		if !comments[left].UpdatedAt.IsZero() && !comments[right].UpdatedAt.IsZero() && !comments[left].UpdatedAt.Equal(comments[right].UpdatedAt) {
 			return comments[left].UpdatedAt.Before(comments[right].UpdatedAt)
 		}
-		return compareCommentIDs(comments[left].ID, comments[right].ID) < 0
+		return compareGitHubIDs(comments[left].ID, comments[right].ID) < 0
 	})
 	decision := ""
 	for _, comment := range comments {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -221,6 +221,61 @@ type PullRequestClient interface {
 	UpdatePullRequest(context.Context, Repository, int, PullRequestRequest) (PullRequest, error)
 }
 
+// PullRequestReviewState is the bounded GitHub review decision vocabulary.
+// Only a submitted review carries one; an unsubmitted draft is `PENDING`.
+type PullRequestReviewState string
+
+const (
+	// PullRequestReviewPending is an unsubmitted review draft. It is visible
+	// only to its author and must never start factory work.
+	PullRequestReviewPending PullRequestReviewState = "PENDING"
+	// PullRequestReviewCommented is a submitted review without a decision.
+	PullRequestReviewCommented PullRequestReviewState = "COMMENTED"
+	// PullRequestReviewApproved is a submitted approval.
+	PullRequestReviewApproved PullRequestReviewState = "APPROVED"
+	// PullRequestReviewChangesRequested is the only review decision the
+	// coordinator treats as a progression event.
+	PullRequestReviewChangesRequested PullRequestReviewState = "CHANGES_REQUESTED"
+	// PullRequestReviewDismissed is a decision a maintainer later withdrew.
+	PullRequestReviewDismissed PullRequestReviewState = "DISMISSED"
+)
+
+// PullRequestReviewComment is one inline, file-anchored review finding.
+type PullRequestReviewComment struct {
+	// Path is the repository-relative file the reviewer annotated.
+	Path string
+	// Line is the annotated line in the file, or zero when GitHub reports none.
+	Line int
+	// Body is the reviewer's complete comment text.
+	Body string
+}
+
+// PullRequestReview is one completed human review of a tracked pull request.
+type PullRequestReview struct {
+	// ID is the immutable GitHub review identity used as a replay watermark.
+	ID string
+	// Author is the GitHub login that submitted the review.
+	Author string
+	// State is the submitted review decision.
+	State PullRequestReviewState
+	// Body is the completed review summary text.
+	Body string
+	// URL is the browser URL for operator supervision.
+	URL string
+	// SubmittedAt is the submission time. It is the zero value while GitHub
+	// still holds the review as an unsubmitted draft.
+	SubmittedAt time.Time
+	// Comments contains the review's inline findings in GitHub order.
+	Comments []PullRequestReviewComment
+}
+
+// PullRequestReviewReader is the read-only seam for observing completed human
+// reviews. It is separate from the mutation clients because the factory never
+// submits, approves, dismisses, or merges a review.
+type PullRequestReviewReader interface {
+	PullRequestReviews(context.Context, Repository, int) ([]PullRequestReview, error)
+}
+
 // PullRequestDraftClient owns the explicit draft/readiness mutation for an
 // existing pull request. Keeping it separate prevents body updates from
 // accidentally changing merge readiness.
@@ -601,25 +656,19 @@ func (c *GhClient) ListCommitStatuses(ctx context.Context, repository Repository
 	if err != nil {
 		return nil, fmt.Errorf("list commit statuses for %s: %w", sha, err)
 	}
-	var pages [][]commitStatusResponse
-	if err := json.Unmarshal(output, &pages); err != nil {
-		var flat []commitStatusResponse
-		if flatErr := json.Unmarshal(output, &flat); flatErr != nil {
-			return nil, fmt.Errorf("decode commit statuses for %s: %w", sha, flatErr)
-		}
-		pages = [][]commitStatusResponse{flat}
+	responses, err := decodeJSONPages[commitStatusResponse](output)
+	if err != nil {
+		return nil, fmt.Errorf("decode commit statuses for %s: %w", sha, err)
 	}
-	statuses := make([]CommitStatus, 0)
-	for _, page := range pages {
-		for _, response := range page {
-			statuses = append(statuses, CommitStatus{
-				SHA:         sha,
-				State:       CommitStatusState(response.State),
-				Context:     response.Context,
-				Description: response.Description,
-				TargetURL:   response.TargetURL,
-			})
-		}
+	statuses := make([]CommitStatus, 0, len(responses))
+	for _, response := range responses {
+		statuses = append(statuses, CommitStatus{
+			SHA:         sha,
+			State:       CommitStatusState(response.State),
+			Context:     response.Context,
+			Description: response.Description,
+			TargetURL:   response.TargetURL,
+		})
 	}
 	return statuses, nil
 }
@@ -837,19 +886,7 @@ func (r pullRequestResponse) pullRequest() PullRequest {
 // decodePullRequestList accepts both gh --slurp pagination output and a plain
 // single-page array, which keeps the adapter tolerant of test and CLI modes.
 func decodePullRequestList(output []byte) ([]pullRequestResponse, error) {
-	var pages [][]pullRequestResponse
-	if err := json.Unmarshal(output, &pages); err == nil {
-		result := make([]pullRequestResponse, 0)
-		for _, page := range pages {
-			result = append(result, page...)
-		}
-		return result, nil
-	}
-	var singlePage []pullRequestResponse
-	if err := json.Unmarshal(output, &singlePage); err != nil {
-		return nil, err
-	}
-	return singlePage, nil
+	return decodeJSONPages[pullRequestResponse](output)
 }
 
 // validatePullRequestBranches rejects values that could alter an API request
@@ -876,4 +913,125 @@ func validatePullRequestRequest(request PullRequestRequest) error {
 		return errors.New("pull request body contains a NUL byte")
 	}
 	return nil
+}
+
+// pullRequestReviewResponse is the GitHub pull-request review subset the
+// coordinator needs to recognize one completed human review.
+type pullRequestReviewResponse struct {
+	ID          int64      `json:"id"`
+	Body        string     `json:"body"`
+	State       string     `json:"state"`
+	SubmittedAt *time.Time `json:"submitted_at"`
+	HTMLURL     string     `json:"html_url"`
+	User        struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+// review converts the GitHub response shape into the coordinator-neutral
+// review model. A review GitHub has not submitted has no submission time, and
+// the coordinator uses that absence to ignore an incomplete draft.
+func (r pullRequestReviewResponse) review() PullRequestReview {
+	value := PullRequestReview{
+		ID:       fmt.Sprint(r.ID),
+		Author:   r.User.Login,
+		State:    PullRequestReviewState(strings.ToUpper(strings.TrimSpace(r.State))),
+		Body:     r.Body,
+		URL:      r.HTMLURL,
+		Comments: []PullRequestReviewComment{},
+	}
+	if r.SubmittedAt != nil {
+		value.SubmittedAt = *r.SubmittedAt
+	}
+	return value
+}
+
+// pullRequestReviewCommentResponse is the inline review-comment subset used to
+// carry a human reviewer's file-anchored findings into a repair packet.
+type pullRequestReviewCommentResponse struct {
+	Path     string `json:"path"`
+	Line     int    `json:"line"`
+	Position int    `json:"position"`
+	Body     string `json:"body"`
+}
+
+// comment converts one inline review comment into the neutral model, keeping
+// the newer `line` anchor and falling back to the legacy diff position.
+func (r pullRequestReviewCommentResponse) comment() PullRequestReviewComment {
+	line := r.Line
+	if line == 0 {
+		line = r.Position
+	}
+	return PullRequestReviewComment{Path: r.Path, Line: line, Body: r.Body}
+}
+
+// PullRequestReviews lists every submitted review for one pull request,
+// including the inline comments of the reviews that carry them. It is
+// read-only: the factory never submits, approves, or dismisses a review.
+func (c *GhClient) PullRequestReviews(ctx context.Context, repository Repository, number int) ([]PullRequestReview, error) {
+	if number <= 0 {
+		return nil, errors.New("pull request number must be positive")
+	}
+	output, err := c.callBytes(ctx, []string{
+		"api", fmt.Sprintf("repos/%s/pulls/%d/reviews", repository.String(), number),
+		"--method", "GET", "--paginate", "--slurp",
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list reviews for pull request #%d: %w", number, err)
+	}
+	responses, err := decodeJSONPages[pullRequestReviewResponse](output)
+	if err != nil {
+		return nil, fmt.Errorf("decode reviews for pull request #%d: %w", number, err)
+	}
+	reviews := make([]PullRequestReview, 0, len(responses))
+	for _, response := range responses {
+		review := response.review()
+		if review.State == PullRequestReviewChangesRequested {
+			comments, commentErr := c.pullRequestReviewComments(ctx, repository, number, response.ID)
+			if commentErr != nil {
+				return nil, commentErr
+			}
+			review.Comments = comments
+		}
+		reviews = append(reviews, review)
+	}
+	return reviews, nil
+}
+
+// pullRequestReviewComments lists the inline findings of one review.
+func (c *GhClient) pullRequestReviewComments(ctx context.Context, repository Repository, number int, reviewID int64) ([]PullRequestReviewComment, error) {
+	output, err := c.callBytes(ctx, []string{
+		"api", fmt.Sprintf("repos/%s/pulls/%d/reviews/%d/comments", repository.String(), number, reviewID),
+		"--method", "GET", "--paginate", "--slurp",
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list inline comments for review %d: %w", reviewID, err)
+	}
+	responses, err := decodeJSONPages[pullRequestReviewCommentResponse](output)
+	if err != nil {
+		return nil, fmt.Errorf("decode inline comments for review %d: %w", reviewID, err)
+	}
+	comments := make([]PullRequestReviewComment, 0, len(responses))
+	for _, response := range responses {
+		comments = append(comments, response.comment())
+	}
+	return comments, nil
+}
+
+// decodeJSONPages accepts both gh --slurp pagination output and a plain
+// single-page array, which keeps the adapter tolerant of test and CLI modes.
+func decodeJSONPages[T any](output []byte) ([]T, error) {
+	var pages [][]T
+	if err := json.Unmarshal(output, &pages); err == nil {
+		result := make([]T, 0)
+		for _, page := range pages {
+			result = append(result, page...)
+		}
+		return result, nil
+	}
+	var singlePage []T
+	if err := json.Unmarshal(output, &singlePage); err != nil {
+		return nil, err
+	}
+	return singlePage, nil
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -541,7 +541,7 @@ func (c *GhClient) FindPullRequest(ctx context.Context, repository Repository, h
 	if err != nil {
 		return PullRequest{}, fmt.Errorf("find pull request for %q: %w", headBranch, err)
 	}
-	responses, err := decodePullRequestList(output)
+	responses, err := decodeJSONPages[pullRequestResponse](output)
 	if err != nil {
 		return PullRequest{}, fmt.Errorf("decode pull requests for %q: %w", headBranch, err)
 	}
@@ -881,12 +881,6 @@ func (r pullRequestResponse) pullRequest() PullRequest {
 		State: r.State, Draft: r.Draft, Merged: r.Merged || r.MergedAt != nil,
 		MergeCommitSHA: r.MergeCommitSHA, HeadBranch: r.Head.Ref, HeadSHA: r.Head.SHA, BaseBranch: r.Base.Ref,
 	}
-}
-
-// decodePullRequestList accepts both gh --slurp pagination output and a plain
-// single-page array, which keeps the adapter tolerant of test and CLI modes.
-func decodePullRequestList(output []byte) ([]pullRequestResponse, error) {
-	return decodeJSONPages[pullRequestResponse](output)
 }
 
 // validatePullRequestBranches rejects values that could alter an API request

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -420,3 +420,49 @@ func hasArgs(args []string, wanted ...string) bool {
 	}
 	return true
 }
+
+// TestGhClientReadsCompletedPullRequestReviews verifies the read-only review
+// seam decodes submitted decisions, keeps an unsubmitted draft recognizable,
+// and fetches inline comments only for a changes-requested decision.
+func TestGhClientReadsCompletedPullRequestReviews(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeCommandRunner{outputs: [][]byte{
+		[]byte(`[[{"id":4001,"body":"restore the validation","state":"CHANGES_REQUESTED","submitted_at":"2026-08-29T09:30:00Z","html_url":"https://github.com/example/project/pull/17#pullrequestreview-4001","user":{"login":"alice"}},` +
+			`{"id":4002,"body":"looks interesting","state":"COMMENTED","submitted_at":"2026-08-29T09:31:00Z","user":{"login":"bob"}},` +
+			`{"id":4003,"body":"still drafting","state":"PENDING","user":{"login":"alice"}}]]`),
+		[]byte(`[[{"path":"internal/factory/polling.go","line":42,"body":"this branch never releases the queue"},` +
+			`{"path":"internal/factory/gate.go","position":9,"body":"legacy diff anchor"}]]`),
+	}}
+	client := &github.GhClient{Runner: runner}
+
+	reviews, err := client.PullRequestReviews(context.Background(), github.Repository{Owner: "example", Name: "project"}, 17)
+	if err != nil {
+		t.Fatalf("PullRequestReviews() error = %v", err)
+	}
+	if len(reviews) != 3 {
+		t.Fatalf("reviews = %d, want every listed review", len(reviews))
+	}
+	changes := reviews[0]
+	if changes.ID != "4001" || changes.Author != "alice" || changes.State != github.PullRequestReviewChangesRequested {
+		t.Fatalf("first review = %#v, want the authorized changes-requested decision", changes)
+	}
+	if changes.SubmittedAt.IsZero() || changes.Body != "restore the validation" {
+		t.Fatalf("first review = %#v, want the submitted body and time", changes)
+	}
+	if len(changes.Comments) != 2 || changes.Comments[0].Line != 42 || changes.Comments[1].Line != 9 {
+		t.Fatalf("inline comments = %#v, want the line anchor and the legacy position fallback", changes.Comments)
+	}
+	if len(reviews[1].Comments) != 0 {
+		t.Fatal("a commented review triggered an inline-comment request")
+	}
+	if !reviews[2].SubmittedAt.IsZero() || reviews[2].State != github.PullRequestReviewPending {
+		t.Fatalf("draft review = %#v, want an unsubmitted pending decision", reviews[2])
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("gh calls = %d, want the review list and one inline-comment list", len(runner.calls))
+	}
+	if !containsArgs(runner.calls[1].args, "api", "repos/example/project/pulls/17/reviews/4001/comments") {
+		t.Fatalf("inline comment call = %#v, want the changes-requested review only", runner.calls[1].args)
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -179,16 +179,20 @@ Check-repair context:
 		if err != nil {
 			return "", fmt.Errorf("encode review-repair packet: %w", err)
 		}
+		scope := fmt.Sprintf("This is bounded review-repair attempt %d of %d for the exact checkpoint that produced the findings.", request.ReviewRepair.Attempt, request.ReviewRepair.Budget)
+		if request.ReviewRepair.Source == store.ReviewRepairSourceHuman {
+			scope = fmt.Sprintf("An authorized maintainer requested changes in GitHub review %s against the exact current checkpoint. It does not consume the bounded factory review-repair budget.", request.ReviewRepair.ReviewID)
+		}
 		repairContext += fmt.Sprintf(`
 Review-repair context:
-- This is bounded review-repair attempt %d of %d for the exact checkpoint that produced the findings.
+- %s
 - Read the coordinator-supplied review-repair packet in /invocation/specification.json.
 - Repair production behavior for implementation-owned findings and do not edit protected tests.
 - When a finding names the test role as suggested owner, submit a structured test objection through the existing report protocol; never edit that test directly.
 - Preserve the frozen specification and deterministic gates; do not dismiss a finding without observable evidence.
 Review-repair packet (coordinator-owned):
 %s
-`, request.ReviewRepair.Attempt, request.ReviewRepair.Budget, data)
+`, scope, data)
 	}
 	version := definition.PromptVersion
 	testContext := ""

--- a/internal/store/cleanup.go
+++ b/internal/store/cleanup.go
@@ -265,6 +265,7 @@ func (s *Store) cleanupRun(ctx context.Context, runID string) (*Run, error) {
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent, ready_notification_sent,
 		       revision, processed_comment_id, processed_comment_revision,
+		       processed_review_id, processed_review_revision,
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override, check_repair_attempts, check_repair_budget,
 		       check_repair_pending_attempt,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CurrentSchemaVersion is the supported operational-store schema version.
-const CurrentSchemaVersion = 30
+const CurrentSchemaVersion = 31
 
 // MaxTestRevisionAttempts is the hard safety ceiling for automated
 // implementation-versus-test objection cycles.
@@ -378,11 +378,31 @@ type ReviewRepairFinding struct {
 	Finding ReviewFinding `json:"finding"`
 }
 
+// ReviewRepairSource identifies who produced the blocking findings in one
+// repair packet. An empty value is the factory reviewers, which keeps packets
+// written before human-review repair readable.
+type ReviewRepairSource string
+
+const (
+	// ReviewRepairSourceFactory means the independent factory reviewers
+	// produced the findings and the bounded repair budget applies.
+	ReviewRepairSourceFactory ReviewRepairSource = "factory"
+	// ReviewRepairSourceHuman means an authorized maintainer requested the
+	// changes through a completed GitHub review.
+	ReviewRepairSourceHuman ReviewRepairSource = "human"
+)
+
 // ReviewRepairPacket is the coordinator-owned combined blocking-review packet
 // mounted in the implementation repair invocation.
 type ReviewRepairPacket struct {
 	// Version identifies this packet shape.
 	Version int `json:"version"`
+	// Source identifies who requested the repair. It is empty for packets
+	// written before human-requested repair existed, which means factory.
+	Source ReviewRepairSource `json:"source,omitempty"`
+	// ReviewID is the GitHub review identity of a human repair packet. It is
+	// empty for a factory packet.
+	ReviewID string `json:"review_id,omitempty"`
 	// RunID identifies the owning factory run.
 	RunID string `json:"run_id"`
 	// CheckpointSHA identifies the exact checkpoint that produced the findings.
@@ -528,6 +548,13 @@ type Run struct {
 	// ProcessedCommentRevision records the run revision at which the watermark
 	// was persisted, making the watermark tuple restart-safe and auditable.
 	ProcessedCommentRevision int64
+	// ProcessedReviewID is the highest applied GitHub pull-request review
+	// watermark for this run. Repeated polling and a coordinator restart must
+	// never apply the same completed human review twice.
+	ProcessedReviewID string
+	// ProcessedReviewRevision records the run revision at which the review
+	// watermark was persisted, making the tuple restart-safe and auditable.
+	ProcessedReviewRevision int64
 	// LastCommandName is the last recognized structured command kind.
 	LastCommandName string
 	// LastCommandOutcome is accepted, rejected, or replayed for the last command.
@@ -818,6 +845,7 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent, ready_notification_sent,
 		       revision, processed_comment_id, processed_comment_revision,
+		       processed_review_id, processed_review_revision,
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override, check_repair_attempts, check_repair_budget,
 		       check_repair_pending_attempt,
@@ -848,6 +876,7 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent, ready_notification_sent,
 		       revision, processed_comment_id, processed_comment_revision,
+		       processed_review_id, processed_review_revision,
 		       last_command_name, last_command_outcome, last_command_message,
 		       harness_override, check_repair_attempts, check_repair_budget,
 		       check_repair_pending_attempt,
@@ -914,6 +943,8 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&run.Revision,
 		&run.ProcessedCommentID,
 		&run.ProcessedCommentRevision,
+		&run.ProcessedReviewID,
+		&run.ProcessedReviewRevision,
 		&run.LastCommandName,
 		&run.LastCommandOutcome,
 		&run.LastCommandMessage,
@@ -1537,8 +1568,23 @@ func validateReviewRepairProjection(run Run) error {
 		if packet.Version <= 0 || packet.RunID != run.ID || !validGateCheckpointSHA(packet.CheckpointSHA) {
 			return errors.New("review repair packet identity is invalid")
 		}
-		if packet.Attempt < 1 || packet.Attempt > run.ReviewRepairBudget || packet.Budget != run.ReviewRepairBudget {
-			return errors.New("review repair packet budget or attempt is invalid")
+		if packet.Budget != run.ReviewRepairBudget {
+			return errors.New("review repair packet budget is invalid")
+		}
+		switch packet.Source {
+		case ReviewRepairSourceHuman:
+			// A human-requested repair is not one of the bounded factory
+			// rounds, so it carries no attempt number and never exhausts the
+			// budget. Its GitHub review identity is what makes it replayable.
+			if packet.Attempt != 0 || strings.TrimSpace(packet.ReviewID) == "" {
+				return errors.New("human review repair packet must identify its GitHub review and carry no attempt")
+			}
+		case "", ReviewRepairSourceFactory:
+			if packet.Attempt < 1 || packet.Attempt > run.ReviewRepairBudget || packet.ReviewID != "" {
+				return errors.New("factory review repair packet attempt is invalid")
+			}
+		default:
+			return fmt.Errorf("unsupported review repair source %q", packet.Source)
 		}
 		if len(packet.Findings) == 0 || len(packet.Findings) > 256 {
 			return errors.New("review repair packet findings must contain one to 256 entries")
@@ -1892,6 +1938,8 @@ func runValues(run Run) []any {
 		run.Revision,
 		run.ProcessedCommentID,
 		run.ProcessedCommentRevision,
+		run.ProcessedReviewID,
+		run.ProcessedReviewRevision,
 		run.LastCommandName,
 		run.LastCommandOutcome,
 		run.LastCommandMessage,
@@ -1934,7 +1982,8 @@ const saveRunStatement = `
 			pull_request_number, pull_request_url, merge_commit_sha, lifecycle_reason,
 			lifecycle_notification_sent, ready_notification_sent,
 			revision, processed_comment_id,
-			processed_comment_revision, last_command_name, last_command_outcome,
+			processed_comment_revision, processed_review_id, processed_review_revision,
+			last_command_name, last_command_outcome,
 			last_command_message, harness_override, check_repair_attempts,
 			check_repair_budget, check_repair_pending_attempt, specification_packet,
 			pending_questions, clarification_comment_id,
@@ -1945,7 +1994,7 @@ const saveRunStatement = `
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?, ?
 		)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
@@ -1989,6 +2038,8 @@ const saveRunStatement = `
 			revision = excluded.revision,
 			processed_comment_id = excluded.processed_comment_id,
 			processed_comment_revision = excluded.processed_comment_revision,
+			processed_review_id = excluded.processed_review_id,
+			processed_review_revision = excluded.processed_review_revision,
 			last_command_name = excluded.last_command_name,
 			last_command_outcome = excluded.last_command_outcome,
 			last_command_message = excluded.last_command_message,
@@ -2019,7 +2070,8 @@ const saveRunIfRevisionStatement = `
 			pull_request_number = ?, pull_request_url = ?, merge_commit_sha = ?, lifecycle_reason = ?,
 			lifecycle_notification_sent = ?, ready_notification_sent = ?,
 			revision = ?, processed_comment_id = ?,
-			processed_comment_revision = ?, last_command_name = ?, last_command_outcome = ?,
+			processed_comment_revision = ?, processed_review_id = ?, processed_review_revision = ?,
+			last_command_name = ?, last_command_outcome = ?,
 			last_command_message = ?, harness_override = ?, check_repair_attempts = ?,
 			check_repair_budget = ?, check_repair_pending_attempt = ?, specification_packet = ?,
 			pending_questions = ?, clarification_comment_id = ?,
@@ -3143,6 +3195,15 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 		case 30:
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN ready_notification_sent INTEGER NOT NULL DEFAULT 0"); err != nil {
 				return fmt.Errorf("apply store migration 30: %w", err)
+			}
+		case 31:
+			for _, statement := range []string{
+				"ALTER TABLE operational_runs ADD COLUMN processed_review_id TEXT NOT NULL DEFAULT ''",
+				"ALTER TABLE operational_runs ADD COLUMN processed_review_revision INTEGER NOT NULL DEFAULT 0",
+			} {
+				if _, err := tx.ExecContext(ctx, statement); err != nil {
+					return fmt.Errorf("apply store migration 31: %w", err)
+				}
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1242,3 +1242,69 @@ func TestLatestRunIncludesTerminalState(t *testing.T) {
 		t.Fatalf("LatestRun() = %#v, want terminal run %#v", got, wanted)
 	}
 }
+
+// TestStorePersistsTheHumanReviewWatermarkAndPacket verifies the replay-safe
+// GitHub review identity and the unbounded human repair packet survive a
+// coordinator restart, and that the packet still rejects a missing identity.
+func TestStorePersistsTheHumanReviewWatermarkAndPacket(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	finding := store.ReviewRepairFinding{ReviewerRole: "human", Finding: store.ReviewFinding{
+		Location: "internal/factory/polling.go:42", Claim: "this branch never releases the queue",
+		Evidence: "GitHub review 4001 submitted by alice", Severity: "blocker", Category: "specification",
+		SuggestedResolution: "release queue ownership on the terminal transition", SuggestedOwner: "implementation",
+	}}
+	run := store.Run{
+		ID:                      "run-human-review",
+		RepositoryPath:          "/work/repository",
+		Stage:                   store.StageImplementation,
+		Status:                  store.StatusActive,
+		ReviewRepairBudget:      2,
+		ProcessedReviewID:       "4001",
+		ProcessedReviewRevision: 7,
+		Revision:                7,
+		ReviewRepairPacket: &store.ReviewRepairPacket{
+			Version: 1, Source: store.ReviewRepairSourceHuman, ReviewID: "4001",
+			RunID: "run-human-review", CheckpointSHA: strings.Repeat("b", 64), Budget: 2,
+			Findings: []store.ReviewRepairFinding{finding},
+		},
+		CheckpointSHA: strings.Repeat("b", 64),
+		CreatedAt:     time.Unix(100, 0).UTC(), UpdatedAt: time.Unix(200, 0).UTC(),
+	}
+	if err := opened.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	reopened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("reopen error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentRun() error = %v", err)
+	}
+	if got == nil || got.ProcessedReviewID != "4001" || got.ProcessedReviewRevision != 7 {
+		t.Fatalf("CurrentRun() = %#v, want the persisted human review watermark", got)
+	}
+	if got.ReviewRepairPacket == nil || got.ReviewRepairPacket.Source != store.ReviewRepairSourceHuman || got.ReviewRepairPacket.ReviewID != "4001" {
+		t.Fatalf("CurrentRun() packet = %#v, want the human repair packet", got.ReviewRepairPacket)
+	}
+
+	anonymous := run
+	anonymous.ID = "run-anonymous-human-review"
+	packet := *run.ReviewRepairPacket
+	packet.RunID = anonymous.ID
+	packet.ReviewID = ""
+	anonymous.ReviewRepairPacket = &packet
+	if err := reopened.SaveRun(context.Background(), anonymous); err == nil || !strings.Contains(err.Error(), "must identify its GitHub review") {
+		t.Fatalf("SaveRun() error = %v, want a refusal of an unidentified human repair packet", err)
+	}
+}


### PR DESCRIPTION
Closes #86.

## Summary

Extends the persistent coordinator past the draft pull request so it drives the configured review, repair, readiness, and terminal lifecycle without routine operator commands, then returns to the issue queue.

- **Human review as a repair trigger.** A submitted `CHANGES_REQUESTED` review from a user in `authorized_users` becomes one implementation repair packet holding the review body and every inline comment. The pull request returns to draft, implementation resumes from the current checkpoint, and every result derived from the superseded checkpoint is invalidated. Drafts, ordinary comments, `COMMENTED` reviews, approvals, dismissals, and unauthorized authors are read and ignored. A human repair is not a bounded factory round and never consumes the `review_repair` budget.
- **Replay safety.** The applied review identity is persisted as a watermark (`processed_review_id`, migration 31), so repeated polling and a coordinator restart cannot apply the same review twice. Concurrent reviews from two maintainers are combined into one packet rather than the newest silently winning.
- **Terminal queue continuation.** `driveRun` observes pull-request lifecycle before any coordinator transition, so a merge or an unmerged close always wins over further work. Either outcome releases the one-active-run constraint and the same `factory start` process claims the next oldest eligible issue without waiting a full interval.
- **Read-only review seam.** New `github.PullRequestReviewReader` backed by `gh api`. The factory still never submits, approves, dismisses, or merges a review.

## Defects found while proving the traversal

Both surfaced only once the loop ran against the real SQLite store, which the existing #17 tests do not use:

- The review-repair reservation set `ReviewRepairAttempts` and `ReviewRepairPendingAttempt` to the same round, which the store rejects (`pending review-repair attempt must be the next attempt`). Review repair could not persist at all. Now the attempt advances when the visible invocation launches, matching check-repair.
- A ready pull request re-ran its own readiness boundary every pass and was published as a coordinator *stall*. It now publishes the human disposition it is actually waiting for.

## Contract impact

- **Operational store**: migration 31 adds two columns. Forward-only; existing runs default to an empty watermark.
- **`ReviewRepairPacket`**: gains optional `source` and `review_id`. An absent source means factory, so packets written before this change stay readable. Validation now rejects a human packet with no review identity and a factory packet with a review identity.
- **Role prompt**: the review-repair block reads differently for a human packet — it names the review instead of an attempt number.
- **No configuration change.** The trigger reuses the existing `authorized_users` list.

## Test plan

- `make check` and `go test -race` on `internal/factory`, `internal/store`, `internal/github`, `internal/prompt`.
- `TestStartTraversesReviewRepairHumanRepairReadinessAndMergeBeforeTheNextClaim` — two queued issues; the first traverses draft PR, an agent-found blocker, an authorized `CHANGES_REQUESTED` repair, readiness, and merge before the second is claimed. Asserts three fresh review rounds against three distinct checkpoints, gate and both reviewer statuses per checkpoint, the ready → draft → ready round trip, and that the human repair left the factory budget at one attempt.
- `TestStartCancelsAnUnmergedClosedPullRequestAndClaimsTheNextIssue` — close-without-merge cancels, retains artifacts, and continues.
- `TestRestartDoesNotReapplyAnAlreadyConsumedHumanReview` — a restarted coordinator re-reads the same review and starts no second repair.
- Unit coverage for review selection, finding conversion, the bounded-round rule, the status projection, the store round trip, and the `gh` review decoder.

## Reviewer notes

- `internal/factory/human_review.go` is the new seam; `observePullRequestEvents` in `progression.go` is where it and lifecycle hook into the loop.
- `factory poll` deliberately does **not** consume human reviews — the trigger belongs to the persistent coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrDRfPTNz7htCGCEbaFmdr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `factory start` now continues runs through automated review, repair, readiness, and terminal pull-request outcomes.
  - Authorized human “changes requested” reviews can trigger implementation repairs, including review details and inline comments.
  - Runs resume safely after interruptions without reprocessing the same review.
  - Completed or cancelled pull requests release the queue so subsequent work can continue.

- **Documentation**
  - Updated command guidance and lifecycle documentation, including intentional pauses and `factory poll` limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->