### PR TITLE
Read factory commands in the unattended polling loop

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,8 +84,10 @@ _Avoid_: Docker API
 The persistent coordinator's bounded pass that drives one claimed run through
 baseline, its route-selected stages, result acceptance, the exact-checkpoint
 gates, the bounded check-repair loop, the push, and one draft pull request
-without an operator running a stage-driving command. It stops at the first
-human or infrastructure waiting state.
+without an operator running a stage-driving command. Each pass also applies
+the structured commands an operator left on the run's issue or draft pull
+request, so no comment needs a command-polling CLI invocation either. It
+stops at the first human or infrastructure waiting state.
 _Avoid_: Autonomous agent, agent-driven workflow, auto-merge
 
 **Run activity**:

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -577,10 +577,9 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 	if _, ok := runStore.(InvocationStore); !ok {
 		return run, nil
 	}
-	// A run still at claim has no frozen baseline yet, so the coordinator's
-	// progression pass owns the next transition. Launching a role here would
-	// fail the baseline gate that only the claim stage can produce.
-	if run.Stage == store.StageClaim {
+	// The coordinator's progression pass owns the baseline, so a run that has
+	// not passed it yet must not launch a role here.
+	if awaitingBaseline(run) {
 		return run, nil
 	}
 	request := normalizeAgentRequest(agentRequestForRun(run))
@@ -599,14 +598,19 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 	return run, nil
 }
 
+// awaitingBaseline reports whether a run has not yet passed its frozen
+// baseline suite. Only the claim stage runs that suite, so a packet change
+// must leave such a run there: a post-baseline stage it jumped to could never
+// satisfy the baseline gate and would wedge the run permanently.
+func awaitingBaseline(run store.Run) bool {
+	return run.Stage == store.StageClaim
+}
+
 // packetResumeStageForPacket preserves test ownership when a configured test
 // stage receives a new specification packet, including refreshes initiated
 // after implementation has already started.
 func packetResumeStageForPacket(run store.Run, packet SpecificationPacket) store.Stage {
-	// Only the claim stage runs the frozen baseline suite, so a run that has
-	// not left it must stay there. A jump to a post-baseline stage can never
-	// satisfy the baseline gate and wedges the run permanently.
-	if run.Stage == store.StageClaim {
+	if awaitingBaseline(run) {
 		return store.StageClaim
 	}
 	if entry := postBaselineStage(packet); entry != store.StageTest {
@@ -644,10 +648,15 @@ func resetTestProjectionForPacketChange(run *store.Run, packet SpecificationPack
 	run.TestCheckpointSHA = ""
 	run.TestExemption = nil
 	run.TestStageSkipped = false
-	// A run still at claim keeps the baseline as its next step; the entry
-	// stage is selected by the healthy baseline result, not by the packet
-	// change itself.
-	if run.Stage == store.StageClaim {
+	// The healthy baseline result selects the entry stage, not the packet
+	// change itself. A packet the baseline could never leave still parks
+	// visibly, because advanceAfterBaseline rejects it after every pass.
+	if awaitingBaseline(*run) {
+		if !testRolePolicySatisfied(packet) {
+			run.Status = store.StatusWaitingForHuman
+			run.LifecycleReason = "frozen repository packet lacks the mandatory test-stage role policy"
+			return
+		}
 		run.Status = store.StatusActive
 		run.LifecycleReason = "specification packet changed; baseline restarted"
 		return

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -577,6 +577,12 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 	if _, ok := runStore.(InvocationStore); !ok {
 		return run, nil
 	}
+	// A run still at claim has no frozen baseline yet, so the coordinator's
+	// progression pass owns the next transition. Launching a role here would
+	// fail the baseline gate that only the claim stage can produce.
+	if run.Stage == store.StageClaim {
+		return run, nil
+	}
 	request := normalizeAgentRequest(agentRequestForRun(run))
 	if err := validateAgentRequest(request); err != nil {
 		return run, err
@@ -597,6 +603,12 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 // stage receives a new specification packet, including refreshes initiated
 // after implementation has already started.
 func packetResumeStageForPacket(run store.Run, packet SpecificationPacket) store.Stage {
+	// Only the claim stage runs the frozen baseline suite, so a run that has
+	// not left it must stay there. A jump to a post-baseline stage can never
+	// satisfy the baseline gate and wedges the run permanently.
+	if run.Stage == store.StageClaim {
+		return store.StageClaim
+	}
 	if entry := postBaselineStage(packet); entry != store.StageTest {
 		return entry
 	}
@@ -632,6 +644,14 @@ func resetTestProjectionForPacketChange(run *store.Run, packet SpecificationPack
 	run.TestCheckpointSHA = ""
 	run.TestExemption = nil
 	run.TestStageSkipped = false
+	// A run still at claim keeps the baseline as its next step; the entry
+	// stage is selected by the healthy baseline result, not by the packet
+	// change itself.
+	if run.Stage == store.StageClaim {
+		run.Status = store.StatusActive
+		run.LifecycleReason = "specification packet changed; baseline restarted"
+		return
+	}
 	if entry := postBaselineStage(packet); entry != store.StageTest {
 		run.Stage = entry
 		run.Status = store.StatusActive
@@ -887,7 +907,7 @@ func (s *Service) PollCommands(ctx context.Context, request CommandPollRequest) 
 	for _, target := range targets {
 		listed, listErr := s.deps.Comments.IssueComments(ctx, repository, target)
 		if listErr != nil {
-			return nil, listErr
+			return nil, &pollingTransportError{err: fmt.Errorf("list comments for #%d: %w", target, listErr)}
 		}
 		for _, comment := range listed {
 			comments = append(comments, polledComment{target: target, comment: comment})

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -592,6 +592,36 @@ func TestHandleCommandAnswerKeepsAClaimStageRunAtClaim(t *testing.T) {
 	}
 }
 
+// TestHandleCommandRefreshParksAClaimStageRunWithoutATestRolePolicy verifies
+// a packet the baseline could never leave still parks visibly at claim. The
+// post-baseline transition rejects such a packet on every pass, so an active
+// run would fail unattended progression instead of asking for a human.
+func TestHandleCommandRefreshParksAClaimStageRunWithoutATestRolePolicy(t *testing.T) {
+	t.Parallel()
+
+	// commandRun freezes a packet whose role harness defaults omit the test
+	// role, which is exactly the mandatory policy the test stage requires.
+	run := commandRun(t, store.StatusActive)
+	run.Stage = store.StageClaim
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandInvocationRunStore{commandRunStore: &commandRunStore{current: &run, latest: &run}}
+	service := newCommandServiceWithStore(runStore, githubAdapter, nil)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 42,
+		Comment:     github.Comment{ID: "22", Author: "alice", Body: "/factory refresh"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Run.Stage != store.StageClaim || result.Run.Status != store.StatusWaitingForHuman {
+		t.Fatalf("run = stage %q status %q, want a claim-stage run waiting for a human", result.Run.Stage, result.Run.Status)
+	}
+	if !strings.Contains(result.Run.LifecycleReason, "mandatory test-stage role policy") {
+		t.Fatalf("lifecycle reason = %q, want the missing test-role policy", result.Run.LifecycleReason)
+	}
+}
+
 // claimStageCommandRun creates a run that was claimed but has not yet passed
 // its frozen baseline suite. Its packet declares the complete test-stage
 // policy, so only the missing baseline can block a post-baseline stage.
@@ -613,6 +643,18 @@ func claimStageCommandRun(t *testing.T, status store.Status) store.Run {
 type commandInvocationRunStore struct {
 	*commandRunStore
 	invocations []store.Invocation
+}
+
+// SaveGateResults satisfies the baseline gate seam; a claim-stage run has no
+// baseline results to retain.
+func (s *commandInvocationRunStore) SaveGateResults(context.Context, []store.GateResult) error {
+	return nil
+}
+
+// GateResults reports the empty baseline projection of a run that has not yet
+// run its frozen suite, so a post-baseline stage cannot satisfy the gate.
+func (s *commandInvocationRunStore) GateResults(context.Context, string, store.GatePhase, string) ([]store.GateResult, error) {
+	return nil, nil
 }
 
 // SaveInvocation records a launched invocation for resumption assertions.

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -317,11 +317,18 @@ func commandHost() config.HostConfig {
 
 // newCommandService builds a service at the public command seam.
 func newCommandService(runStore *commandRunStore, githubAdapter *commandGitHub, comments github.CommentReader) *factory.Service {
+	return newCommandServiceWithStore(runStore, githubAdapter, comments)
+}
+
+// newCommandServiceWithStore builds the same command seam over any operational
+// store, letting a test add the optional persistence seams it needs.
+func newCommandServiceWithStore(runStore factory.OperationalStore, githubAdapter *commandGitHub, comments github.CommentReader) *factory.Service {
 	dependencies := factory.Dependencies{
 		Config:    commandConfig{host: commandHost()},
 		OpenStore: func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
 		GitHub:    githubAdapter,
 		Comments:  comments,
+		Terminal:  &lifecycleTerminal{},
 		Now:       func() time.Time { return time.Date(2026, 8, 23, 10, 11, 12, 0, time.UTC) },
 	}
 	return factory.NewWithDependencies("/host/config.yaml", dependencies)
@@ -526,4 +533,101 @@ func (g *commandGitHub) SetPullRequestDraft(_ context.Context, _ github.Reposito
 type commandEditedComment struct {
 	id   string
 	body string
+}
+
+// TestHandleCommandRefreshKeepsAClaimStageRunAtClaim verifies a refresh before
+// the frozen baseline ran leaves the run at claim. Only the claim stage runs
+// the baseline suite, so a jump to a post-baseline stage would wedge the run on
+// an incomplete baseline gate.
+func TestHandleCommandRefreshKeepsAClaimStageRunAtClaim(t *testing.T) {
+	t.Parallel()
+
+	run := claimStageCommandRun(t, store.StatusActive)
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentRunning}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandInvocationRunStore{commandRunStore: &commandRunStore{current: &run, latest: &run}}
+	service := newCommandServiceWithStore(runStore, githubAdapter, nil)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 42,
+		Comment:     github.Comment{ID: "20", Author: "alice", Body: "/factory refresh"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Stage != store.StageClaim || result.Run.Status != store.StatusActive {
+		t.Fatalf("result = %#v, want an accepted refresh that stays at the claim stage", result)
+	}
+	if len(runStore.invocations) != 0 {
+		t.Fatalf("invocations started = %#v, want none before the baseline ran", runStore.invocations)
+	}
+}
+
+// TestHandleCommandAnswerKeepsAClaimStageRunAtClaim verifies an answer that
+// arrives before the frozen baseline ran resumes the run at claim rather than
+// at a post-baseline stage it can never satisfy.
+func TestHandleCommandAnswerKeepsAClaimStageRunAtClaim(t *testing.T) {
+	t.Parallel()
+
+	run := claimStageCommandRun(t, store.StatusWaitingForHuman)
+	run.PendingQuestions = []store.PendingQuestion{{ID: "format", Prompt: "Which format should be used?"}}
+	githubAdapter := &commandGitHub{issue: github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentNeedsInput}}, statusComment: github.Comment{ID: "status-1"}}
+	runStore := &commandInvocationRunStore{commandRunStore: &commandRunStore{current: &run, latest: &run}}
+	service := newCommandServiceWithStore(runStore, githubAdapter, nil)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 42,
+		Comment:     github.Comment{ID: "21", Author: "alice", Body: "/factory answer format use the existing JSON format"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Stage != store.StageClaim || result.Run.Status != store.StatusActive {
+		t.Fatalf("result = %#v, want an accepted answer that stays at the claim stage", result)
+	}
+	if len(result.Run.PendingQuestions) != 0 {
+		t.Fatalf("pending questions = %#v, want the answered question removed", result.Run.PendingQuestions)
+	}
+	if len(runStore.invocations) != 0 {
+		t.Fatalf("invocations started = %#v, want none before the baseline ran", runStore.invocations)
+	}
+}
+
+// claimStageCommandRun creates a run that was claimed but has not yet passed
+// its frozen baseline suite. Its packet declares the complete test-stage
+// policy, so only the missing baseline can block a post-baseline stage.
+func claimStageCommandRun(t *testing.T, status store.Status) store.Run {
+	t.Helper()
+	packet, err := json.Marshal(factory.SpecificationPacket{Version: 1, RepositoryConfig: validRepositoryConfig()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := commandRun(t, status)
+	run.Stage = store.StageClaim
+	run.Worktree = "/worktree/run-command"
+	run.SpecificationPacket = string(packet)
+	return run
+}
+
+// commandInvocationRunStore adds the visible-invocation seam to the command
+// fixture so packet-change resumption takes its agent-launching path.
+type commandInvocationRunStore struct {
+	*commandRunStore
+	invocations []store.Invocation
+}
+
+// SaveInvocation records a launched invocation for resumption assertions.
+func (s *commandInvocationRunStore) SaveInvocation(_ context.Context, invocation store.Invocation) error {
+	s.invocations = append(s.invocations, invocation)
+	return nil
+}
+
+// Invocation returns a previously recorded invocation.
+func (s *commandInvocationRunStore) Invocation(_ context.Context, runID, invocationID string) (*store.Invocation, error) {
+	for index := range s.invocations {
+		if s.invocations[index].RunID == runID && s.invocations[index].ID == invocationID {
+			found := s.invocations[index]
+			return &found, nil
+		}
+	}
+	return nil, nil
 }

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -175,10 +175,11 @@ func (s *Service) Start(ctx context.Context) error {
 				delay = backoff
 				continue
 			}
-			// A command that cannot be applied is already visible as a
-			// rejection on its issue, and the next pass reads the same
-			// comments again. Keep observing the queue instead of stopping the
-			// coordinator over one operator comment.
+			// Every remaining command failure, from a rejected comment to an
+			// unreadable command store, leaves the run untouched and is
+			// retried by the next pass over the same comments. None of them
+			// may stop an unattended coordinator, so the queue observation
+			// below still runs.
 		}
 		result, err := s.pollOnce(pollContext, registration)
 		if err != nil {

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -166,6 +166,20 @@ func (s *Service) Start(ctx context.Context) error {
 			}
 			return err
 		}
+		if err := s.pollLoopCommands(pollContext); err != nil {
+			if pollingContextDone(err) {
+				return nil
+			}
+			var transportErr *pollingTransportError
+			if errors.As(err, &transportErr) {
+				delay = backoff
+				continue
+			}
+			// A command that cannot be applied is already visible as a
+			// rejection on its issue, and the next pass reads the same
+			// comments again. Keep observing the queue instead of stopping the
+			// coordinator over one operator comment.
+		}
 		result, err := s.pollOnce(pollContext, registration)
 		if err != nil {
 			if pollingContextDone(err) {
@@ -195,6 +209,24 @@ func (s *Service) Start(ctx context.Context) error {
 		}
 		delay = interval
 	}
+}
+
+// pollLoopCommands applies the structured /factory comments that appeared on
+// the reconciled run's issue and draft pull request. An absent run is the
+// ordinary idle case of an unattended coordinator, not a failure, so it
+// reports no error.
+func (s *Service) pollLoopCommands(ctx context.Context) error {
+	if s.deps.Comments == nil {
+		return nil
+	}
+	if _, err := s.PollCommands(ctx, CommandPollRequest{}); err != nil {
+		var rejection *PolicyRejection
+		if errors.As(err, &rejection) && rejection.Code == PolicyRejectionNoRun {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // reconcileRegisteredRun opens the operational store once after the polling

--- a/internal/factory/polling_test.go
+++ b/internal/factory/polling_test.go
@@ -32,7 +32,7 @@ func TestPollOnceClaimsTheOldestEligibleIssue(t *testing.T) {
 	runStore := &fakeRunStore{}
 	service := newPollingService(root, githubAdapter, githubAdapter, nil, runStore, &fakeWorktree{workspace: gitadapter.Workspace{
 		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
-	}})
+	}}, nil)
 
 	result, err := service.PollOnce(context.Background())
 	if err != nil {
@@ -59,7 +59,7 @@ func TestPollOnceDoesNotClaimWhileARunIsActive(t *testing.T) {
 	runStore := &fakeRunStore{saved: []store.Run{active}}
 	issues := []github.Issue{{Number: 7, State: "open", Labels: []string{github.LabelAgentReady}}}
 	githubAdapter := &pollingGitHub{fakeGitHub: &fakeGitHub{}, issues: issues}
-	service := newPollingService(root, githubAdapter, githubAdapter, nil, runStore, &fakeWorktree{})
+	service := newPollingService(root, githubAdapter, githubAdapter, nil, runStore, &fakeWorktree{}, nil)
 
 	result, err := service.PollOnce(context.Background())
 	if err != nil {
@@ -115,7 +115,7 @@ func TestStartPollsThenStopsWithoutCancellingTheActiveRun(t *testing.T) {
 	}}
 	service := newPollingService(root, githubAdapter, githubAdapter, lease, runStore, &fakeWorktree{workspace: gitadapter.Workspace{
 		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
-	}})
+	}}, nil)
 	ctx, stop := context.WithCancel(context.Background())
 	cancel = stop
 
@@ -152,7 +152,7 @@ func TestStartUsesTransportBackoffWithoutChangingRunState(t *testing.T) {
 	}}
 	lease := &pollingLease{}
 	runStore := &fakeRunStore{}
-	service := newPollingService(root, &fakeGitHub{}, reader, lease, runStore, &fakeWorktree{})
+	service := newPollingService(root, &fakeGitHub{}, reader, lease, runStore, &fakeWorktree{}, nil)
 	ctx, stop := context.WithCancel(context.Background())
 	cancel = stop
 	started := time.Now()
@@ -169,6 +169,122 @@ func TestStartUsesTransportBackoffWithoutChangingRunState(t *testing.T) {
 	if len(runStore.saved) != 0 {
 		t.Fatalf("runs saved after queue transport failures = %#v, want none", runStore.saved)
 	}
+}
+
+// TestStartAppliesQueuedIssueCommands verifies the unattended loop reads the
+// structured /factory comments of the run it already reconciled, instead of
+// waiting for an operator to run the `factory poll` command by hand.
+func TestStartAppliesQueuedIssueCommands(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	issues := []github.Issue{{Number: 7, Title: "claim me", State: "open", Labels: []string{github.LabelAgentReady}}}
+	githubAdapter := &pollingGitHub{fakeGitHub: &fakeGitHub{statusComment: github.Comment{ID: "status-1"}}, issues: issues}
+	runStore := &fakeRunStore{}
+	var cancel context.CancelFunc
+	comments := &pollingCommentReader{
+		comments: []github.Comment{{ID: "15", Author: "alice", Body: "/factory status"}},
+		onList: func(call int) {
+			if call >= 2 {
+				cancel()
+			}
+		},
+	}
+	service := newPollingService(root, githubAdapter, githubAdapter, &pollingLease{}, runStore, &fakeWorktree{workspace: gitadapter.Workspace{
+		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
+	}}, comments)
+	ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+	cancel = stop
+	defer stop()
+
+	if err := service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if comments.calls == 0 {
+		t.Fatal("comment listings = 0, want the polling loop to read issue commands")
+	}
+	if !savedCommandWatermark(runStore.saved, "15", "status") {
+		t.Fatalf("saved runs = %#v, want the status command applied with its watermark", runStore.saved)
+	}
+}
+
+// TestStartBacksOffCommandTransportFailures verifies a comment-listing failure
+// delays the next command poll by the configured backoff and never stops the
+// coordinator.
+func TestStartBacksOffCommandTransportFailures(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	issues := []github.Issue{{Number: 7, Title: "claim me", State: "open", Labels: []string{github.LabelAgentReady}}}
+	githubAdapter := &pollingGitHub{fakeGitHub: &fakeGitHub{statusComment: github.Comment{ID: "status-1"}}, issues: issues}
+	runStore := &fakeRunStore{}
+	var cancel context.CancelFunc
+	comments := &pollingCommentReader{
+		listErrors: []error{errors.New("GitHub comment transport unavailable")},
+		onList: func(call int) {
+			if call >= 2 {
+				cancel()
+			}
+		},
+	}
+	service := newPollingService(root, githubAdapter, githubAdapter, &pollingLease{}, runStore, &fakeWorktree{workspace: gitadapter.Workspace{
+		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
+	}}, comments)
+	ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+	cancel = stop
+	defer stop()
+
+	if err := service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v, want the loop to survive a command transport failure", err)
+	}
+	if comments.calls != 2 {
+		t.Fatalf("comment listings = %d, want one retry after transport backoff", comments.calls)
+	}
+	if gap := comments.times[1].Sub(comments.times[0]); gap < 20*time.Millisecond {
+		t.Fatalf("command retry gap = %s, want the configured backoff before the second command poll", gap)
+	}
+	if savedCommandWatermark(runStore.saved, "15", "status") {
+		t.Fatal("a command was applied although its comment listing failed")
+	}
+}
+
+// savedCommandWatermark reports whether any persisted run recorded the named
+// command against the supplied comment identifier.
+func savedCommandWatermark(saved []store.Run, commentID, command string) bool {
+	for _, run := range saved {
+		if run.ProcessedCommentID == commentID && run.LastCommandName == command {
+			return true
+		}
+	}
+	return false
+}
+
+// pollingCommentReader supplies structured command comments to the polling
+// loop with controllable transport failures.
+type pollingCommentReader struct {
+	comments   []github.Comment
+	listErrors []error
+	calls      int
+	times      []time.Time
+	onList     func(int)
+}
+
+// IssueComments records the listing time, runs the optional test hook, and
+// then replays the configured transport failure or comment set.
+func (r *pollingCommentReader) IssueComments(context.Context, github.Repository, int) ([]github.Comment, error) {
+	r.calls++
+	r.times = append(r.times, time.Now())
+	if r.onList != nil {
+		r.onList(r.calls)
+	}
+	if len(r.listErrors) > 0 {
+		err := r.listErrors[0]
+		r.listErrors = r.listErrors[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return append([]github.Comment(nil), r.comments...), nil
 }
 
 // pollingGitHub combines the existing claim fake with a deterministic issue
@@ -239,7 +355,7 @@ func (f *pollingLease) RenewLease(_ context.Context, _ github.Repository, lease 
 
 // newPollingService constructs a service with real queue/claim behavior and
 // isolated fakes for the external polling and lease adapters.
-func newPollingService(root string, githubAdapter github.Client, issuePoller github.IssuePoller, lease github.LeaseClient, runStore *fakeRunStore, worktree gitadapter.WorktreeManager) *factory.Service {
+func newPollingService(root string, githubAdapter github.Client, issuePoller github.IssuePoller, lease github.LeaseClient, runStore *fakeRunStore, worktree gitadapter.WorktreeManager, comments github.CommentReader) *factory.Service {
 	registration := config.RepositoryRegistration{
 		Path:                 filepath.Join(root, "repository"),
 		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
@@ -258,6 +374,8 @@ func newPollingService(root string, githubAdapter github.Client, issuePoller git
 		IssuePoller:    issuePoller,
 		Lease:          lease,
 		Worktree:       worktree,
+		Comments:       comments,
+		Terminal:       &lifecycleTerminal{},
 		Now: func() time.Time {
 			return time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 		},

--- a/internal/factory/polling_test.go
+++ b/internal/factory/polling_test.go
@@ -244,7 +244,7 @@ func TestStartBacksOffCommandTransportFailures(t *testing.T) {
 		t.Fatalf("command retry gap = %s, want the configured backoff before the second command poll", gap)
 	}
 	if savedCommandWatermark(runStore.saved, "15", "status") {
-		t.Fatal("a command was applied although its comment listing failed")
+		t.Fatal("a queued command was applied although every comment listing failed")
 	}
 }
 
@@ -270,7 +270,8 @@ type pollingCommentReader struct {
 }
 
 // IssueComments records the listing time, runs the optional test hook, and
-// then replays the configured transport failure or comment set.
+// then replays the next configured transport failure, or the comment set once
+// the failures are exhausted.
 func (r *pollingCommentReader) IssueComments(context.Context, github.Repository, int) ([]github.Comment, error) {
 	r.calls++
 	r.times = append(r.times, time.Now())
@@ -280,9 +281,7 @@ func (r *pollingCommentReader) IssueComments(context.Context, github.Repository,
 	if len(r.listErrors) > 0 {
 		err := r.listErrors[0]
 		r.listErrors = r.listErrors[1:]
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return append([]github.Comment(nil), r.comments...), nil
 }


### PR DESCRIPTION
## Summary

Two defects in the unattended coordinator.

**A. `/factory` commands were never read while polling.** `Service.Start`'s loop never called `PollCommands`, whose only caller was the `factory poll` CLI handler. An operator comment therefore did nothing until somebody ran that command by hand. The command poll is now wired in after `retryWaitingForHarness` and before `pollOnce`, so a command only reaches a run the coordinator has already reconciled.

**B. A packet change at the claim stage wedged the run.** `packetResumeStageForPacket` returned a post-baseline stage unconditionally, so `/factory refresh` or `/factory answer` on a run still at `store.StageClaim` moved it to test or implementation. Only the claim stage runs the frozen baseline suite, so such a run could never satisfy `ensureBaselineReady` and wedged permanently on `baseline gate results are incomplete: got 0, want N`.

## Changes

- `internal/factory/polling.go`: `pollLoopCommands` applies the run's structured comments each pass. An absent run is the ordinary idle case, not a failure. A transport failure backs off exactly like a failed queue read; no command failure stops the coordinator.
- `internal/factory/command.go`: the claim-stage rule is named once as `awaitingBaseline` and applied at all three sites that a packet change moves through — `packetResumeStageForPacket`, `resetTestProjectionForPacketChange`, and `resumeAfterPacketChange`, which must not launch a role before the baseline exists. A comment-listing failure is now a `*pollingTransportError`.
- A packet lacking the mandatory test-stage role policy still parks visibly at `waiting_for_human`. `advanceAfterBaseline` rejects such a packet on every pass, so leaving the run active would turn a human-wait into a progression failure loop.
- `CONTEXT.md`: the **Unattended progression** glossary entry now records that each pass also applies operator commands.

## Test plan

- `TestStartAppliesQueuedIssueCommands` — the loop applies a queued `/factory status` and persists its watermark. Without the wiring the comment reader is never called.
- `TestStartBacksOffCommandTransportFailures` — a failed comment listing retries after the configured backoff, applies no command, and never stops the loop.
- `TestHandleCommandRefreshKeepsAClaimStageRunAtClaim` and `TestHandleCommandAnswerKeepsAClaimStageRunAtClaim` — both reproduce `baseline gate results are incomplete: got 0, want 1` against the unfixed code.
- `TestHandleCommandRefreshParksAClaimStageRunWithoutATestRolePolicy` — guards the human-wait that the claim guard must not swallow.
- `make check` and `go test -race ./internal/factory/` pass.

## Contract impact

`PollCommands` now reports a comment-listing failure as `*pollingTransportError` instead of the bare adapter error. It unwraps to the same error, so `errors.Is`/`errors.As` callers are unaffected; only the `factory poll` CLI message gains a `list comments for #N:` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrDRfPTNz7htCGCEbaFmdr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The service now processes queued `/factory` commands before each polling cycle.
  - State-changing or completed actions trigger an immediate status recheck for faster updates.

- **Bug Fixes**
  - Temporary failures while reading commands are retried with backoff.
  - Invalid or unsupported commands no longer interrupt ongoing polling.
  - Runs remain at the claim stage when required policies or human input are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->