### PR TITLE
Unblock the verified test stage

### DIFF
--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -638,6 +638,13 @@ func (s *Service) inspectInvocationProjectionSingle(ctx context.Context, diagnos
 	if !hasNativeSession {
 		return
 	}
+	if expectedStopped {
+		// A human-waiting boundary intentionally finishes the harness session
+		// and stops the worker. The native session cannot be inspected without
+		// a running worker, so its absence is the expected projection here
+		// rather than a discrepancy that must block the coordinator.
+		return
+	}
 	if inspector, ok := harnessRuntime.(harness.NativeSessionInspector); ok {
 		observed, providerErr := inspector.NativeSessionID(ctx, harness.NativeSessionRequest{RunID: run.ID, WorkerID: workerIDForInvocation(*active), Harness: active.Harness})
 		if providerErr != nil {

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -448,6 +448,45 @@ func TestRecoveryAcceptsAStoppedWorkerAfterReadiness(t *testing.T) {
 	}
 }
 
+// TestRecoveryAcceptsAnUninspectableSessionAtAHumanWaitingBoundary verifies
+// that a run paused for human disposition, whose worker the pause deliberately
+// stopped, does not report a native-session discrepancy. Such a discrepancy is
+// not recoverable and would block the coordinator from starting at all.
+func TestRecoveryAcceptsAnUninspectableSessionAtAHumanWaitingBoundary(t *testing.T) {
+	now := time.Unix(3, 0).UTC()
+	run := store.Run{ID: "run-human-waiting-session", Stage: store.StageTest, Status: store.StatusWaitingForHuman}
+	invocation := store.Invocation{
+		ID: "inv-human-waiting-session", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "test", Stage: store.StageTest,
+		NativeSessionID: "session-human-waiting", WorkspaceID: "workspace-human-waiting",
+		ImplementationSurfaceID: "surface-human-waiting", RoleSurfaceID: "surface-human-waiting",
+		Status:    store.InvocationStatusWaitingForHuman,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	workerRuntime := &journalRecoveryWorker{inspection: worker.Inspection{}}
+	terminalRuntime := &journalRecoveryTerminal{inspection: terminal.WorkspaceInspection{
+		Exists: true, WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID),
+		Surfaces: []terminal.Surface{
+			{ID: terminal.SurfaceID(invocation.RoleSurfaceID), WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID)},
+		},
+	}}
+	service := &Service{deps: Dependencies{
+		Worker: workerRuntime, Terminal: terminalRuntime,
+		Harness: &journalRecoveryHarness{
+			nativeSessionID:  invocation.NativeSessionID,
+			nativeSessionErr: errors.New(`worker "run-human-waiting-session" is not running`),
+		},
+	}}
+	baseStore := &repairLaunchStore{run: run, invocations: map[string]store.Invocation{invocation.ID: invocation}}
+	runStore := &terminalProjectionStore{repairLaunchStore: baseStore}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+
+	service.inspectInvocationProjection(context.Background(), &diagnosis, config.RepositoryRegistration{}, runStore, run)
+	if len(diagnosis.Discrepancies) != 0 {
+		t.Fatalf("recovery discrepancies = %#v, want stopped session accepted while waiting for human", diagnosis.Discrepancies)
+	}
+}
+
 // TestPollLifecycleCompletesAMergedRunBeforeRecovery verifies that a deleted
 // remote branch and historical worker projection cannot block the public
 // lifecycle seam from recording an already-merged pull request.
@@ -936,6 +975,7 @@ var _ terminal.WorkspaceInspector = (*journalRecoveryTerminal)(nil)
 // calls so the startup test can detect duplicate continuation.
 type journalRecoveryHarness struct {
 	nativeSessionID     string
+	nativeSessionErr    error
 	resumeCalls         int
 	failResumeOnce      bool
 	resumeErr           error
@@ -971,6 +1011,9 @@ func (*journalRecoveryHarness) Finish(context.Context, harness.Session) error { 
 
 // NativeSessionID returns the stable native session projection.
 func (h *journalRecoveryHarness) NativeSessionID(context.Context, harness.NativeSessionRequest) (string, error) {
+	if h.nativeSessionErr != nil {
+		return "", h.nativeSessionErr
+	}
 	return h.nativeSessionID, nil
 }
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -211,7 +211,10 @@ Test-stage ownership:
 - Add tests that fail for the expected behavior reason on the frozen base implementation, then run the focused command.
 - Exercise the highest practical observable interface that can prove the frozen acceptance criteria.
 - Do not prescribe private implementation structure that the criteria do not require; a test must not name internal helpers, fields, or call sequences an equivalent implementation could change.
-- Report the changed test files, acceptance coverage, focused command, expected failure reason, and observed red evidence.
+- Report through factory-report with the test-role flags only: --test-file <path>, --acceptance <criterion>=<evidence>, --focused-test-command <command>, --expected-failure-reason <text>, --observed-failure <kind>=<detail>, and --infrastructure-file <path> when authorized test infrastructure changed. Every <...> is a placeholder to replace with a real value, never a literal.
+- Do not use the implementation flags --change-summary, --production-file, or --focused-command. A test report that carries an implementation handoff is rejected as unverifiable and stops the run.
+- The coordinator reruns --focused-test-command and requires --expected-failure-reason to appear literally in that output, as a plain substring match on the bytes the command prints.
+- Choose a short, distinctive --expected-failure-reason that contains no quotes and no backslashes, and copy it exactly as the command printed it. Do not add shell or JSON escaping, and do not double a backslash. A mismatch of one character stops the run and no retry follows.
 - A technical exemption is provisional and must include a bounded reason for later review.
 `
 		testContext += fmt.Sprintf("- Frozen additional test scope: %s\n", string(scope))

--- a/internal/workflow/registry.go
+++ b/internal/workflow/registry.go
@@ -25,7 +25,7 @@ const (
 	RoleStandardsReview = "standards_review"
 
 	// PromptVersionTest identifies the immutable test-role prompt.
-	PromptVersionTest = "test-v1"
+	PromptVersionTest = "test-v2"
 	// PromptVersionImplementation identifies the immutable implementation prompt.
 	PromptVersionImplementation = "implementation-v1"
 	// PromptVersionArchitecture identifies the immutable architecture prompt.


### PR DESCRIPTION
## Summary

Two independent defects stopped every run that reached the verified test stage. Found while diagnosing why `sw-factory-test` had not produced a pull request since the test stage landed in `454dccc`.

## 1. A parked run made the coordinator refuse to start

`factory start` failed outright whenever any run sat in `waiting_for_human`:

```
error: reconcile persisted run at startup: recovery infrastructure discrepancy:
  run "run-9cecdd0e-..." is waiting for human reconciliation:
  native session.identity expected="01a053e4-..."
  observed="worker \"run-9cecdd0e-...\" is not running"
```

`pauseTestForHuman` deliberately finishes the harness session and stops the worker, but `inspectInvocationProjection` still asked the harness adapter for the native session identity. The adapter cannot inspect a session whose worker is gone, and its error was recorded as a **non-recoverable** infrastructure discrepancy — so `reconcileRegisteredRun` failed and `Service.Start` returned an error.

The worker existence and lifecycle checks directly above already suppress this case through `workerProjectionExpectedStopped`. Only the session inspection did not consult it. This adds the same guard, mirroring the `terminalInvocationProjectionExpectedStopped` early return a few lines up.

Regression test `TestRecoveryAcceptsAnUninspectableSessionAtAHumanWaitingBoundary` reproduces the production discrepancy exactly — same source, field, and observed string. Verified failing without the guard and passing with it.

## 2. The test-stage prompt never named the report flags

The prompt asked for the changed test files, acceptance coverage, focused command, expected failure reason, and observed red evidence — but never said which `factory-report` flags carry them. Agents used the implementation flags, producing a report with a `handoff` instead of a `test_handoff`. `report.Validate` rejects that, `isUnverifiableTestReport` matches, and the run parks as an unverifiable red-test report after the worker is already destroyed.

The prompt now names the test-role flags, forbids the implementation flags, and explains that the coordinator reruns the focused command and matches the expected failure reason as a plain substring of its output.

Two further corrections came from watching real runs fail:

- An agent submitted a literal `kind=detail` as its observed-failure evidence, copying the flag's usage text. Placeholders are now written `<kind>=<detail>` with an explicit note that every `<...>` is to be replaced.
- An agent reported `want "Hello, Ada!\\nHello, Grace!"` where the command printed `want "Hello, Ada!\nHello, Grace!"`. One extra backslash, `strings.Contains` misses, and the run parks with no retry. The prompt now asks for a short reason free of quotes and backslashes, copied exactly as printed, with no added escaping.

`PromptVersionTest` moves to `test-v2`, since the constant documents the prompt as immutable per version.

## Verification

`gofmt` clean, `go vet` clean, 798 tests pass.

End to end against `sw-factory-test` issue #9, with a worker image rebuilt from current source: the test stage produced its first accepted `test_handoff`, red verification passed, implementation completed, all four gates passed, and draft PR #14 opened with working code.

## Known remaining blocker, not addressed here

That run then parked at `draft_pr`:

```
start specification reviewer: capture exact review diff exited with code 128
  -> fatal: bad object 16008cd65e5d90f14d8ae7430240946faa05455e
```

`ensureGitMetadataProjection` copies the object database once at creation. Later calls take the existing-projection branch and `overlayWorktreeGitState`, which copies only `HEAD` and `index`. Checkpoints the coordinator commits on the host afterwards are never projected, so `captureReviewDiff` cannot resolve them inside the worker and no run can reach a completed pull request.

Left out deliberately: the fix widens what crosses `copyGitMetadata`, which excludes config, remotes, and symlinks on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phdrrpkry9engS45cjWgwB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery handling for runs paused while waiting for human input, avoiding false infrastructure discrepancies when the native session is unavailable.

* **Tests**
  * Added coverage for recovery at human-waiting boundaries with an uninspectable session.

* **Documentation**
  * Clarified test-report requirements, including required report flags and exact failure-marker validation.
  * Updated the test prompt version to reflect these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->