### PR TITLE
Refresh worker Git metadata for post-checkpoint reviews

### DIFF
--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -693,7 +693,8 @@ func gitMetadataProjectionPath(runID, worktreePath string) string {
 // remotes, commands, or host paths. It rejects symbolic links and other
 // non-regular entries.
 func copyGitMetadata(source, destination string) error {
-	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+	managedFiles := make(map[string]struct{})
+	if err := filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -724,10 +725,45 @@ func copyGitMetadata(source, destination string) error {
 		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
 			return fmt.Errorf("unsupported git metadata entry %q", relative)
 		}
+		managedFiles[relative] = struct{}{}
 		if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
 			return err
 		}
 		return copyGitMetadataFile(path, target, 0o640)
+	}); err != nil {
+		return err
+	}
+	return removeStaleGitMetadataFiles(destination, managedFiles)
+}
+
+// removeStaleGitMetadataFiles removes projected regular metadata files that
+// are no longer present in the current permitted source set. Directories and
+// excluded paths remain outside this reconciliation step.
+func removeStaleGitMetadataFiles(destination string, managedFiles map[string]struct{}) error {
+	return filepath.WalkDir(destination, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(destination, path)
+		if err != nil {
+			return err
+		}
+		if relative == "." {
+			return nil
+		}
+		if skipGitMetadata(relative, entry.IsDir()) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if _, ok := managedFiles[relative]; ok {
+			return nil
+		}
+		return os.Remove(path)
 	})
 }
 

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -610,11 +610,12 @@ func suiteErrHasBlockingFailure(suite gate.SuiteResult) bool {
 }
 
 // prepareGitMetadataProjection creates or reuses a sanitized Git metadata
-// projection for a run. It copies history and refs without copying repository
-// configuration, remotes, hooks, or other files that could carry credentials or
-// host paths. The projection is stable for the run so a reused worker keeps the
-// same mounted metadata after a coordinator restart. It returns the projection
-// path or an error if the inputs or projection are invalid.
+// projection for a run. It copies or refreshes history and refs without copying
+// repository configuration, remotes, hooks, or other files that could carry
+// credentials or host paths. The projection is stable for the run so a reused
+// worker keeps the same mounted metadata after a coordinator restart. It
+// returns the projection path or an error if the inputs or projection are
+// invalid.
 func prepareGitMetadataProjection(runID, repositoryPath, worktreePath string) (string, error) {
 	if strings.TrimSpace(runID) == "" || filepath.Base(runID) != runID || runID == "." || runID == ".." || strings.ContainsAny(runID, `/\`) {
 		return "", fmt.Errorf("run id %q cannot name a git metadata projection", runID)
@@ -644,6 +645,9 @@ func prepareGitMetadataProjection(runID, repositoryPath, worktreePath string) (s
 			return "", fmt.Errorf("git metadata projection %q contains forbidden configuration", projection)
 		} else if !errors.Is(statErr, os.ErrNotExist) {
 			return "", fmt.Errorf("inspect git metadata projection configuration: %w", statErr)
+		}
+		if err := copyGitMetadata(source, projection); err != nil {
+			return "", fmt.Errorf("refresh git metadata: %w", err)
 		}
 		if err := overlayWorktreeGitState(worktreePath, projection); err != nil {
 			return "", fmt.Errorf("refresh git metadata projection: %w", err)
@@ -784,25 +788,33 @@ func skipGitMetadata(relative string, directory bool) bool {
 	return base == "config" || base == "config.worktree" || base == "FETCH_HEAD" || base == "alternates"
 }
 
-// copyGitMetadataFile streams one regular Git metadata file into the projection
-// while preserving the specified non-secret permission bits.
+// copyGitMetadataFile streams one regular Git metadata file into a temporary
+// sibling and atomically replaces the projection entry while preserving the
+// specified non-secret permission bits.
 func copyGitMetadataFile(source, destination string, mode fs.FileMode) error {
 	input, err := os.Open(source)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = input.Close() }()
-	if err := os.Chmod(destination, 0o600); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	temporary, err := os.CreateTemp(filepath.Dir(destination), "."+filepath.Base(destination)+".tmp-")
 	if err != nil {
 		return err
 	}
-	_, copyErr := io.Copy(output, input)
-	chmodErr := output.Chmod(mode)
-	closeErr := output.Close()
-	return errors.Join(copyErr, chmodErr, closeErr)
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if _, err := io.Copy(temporary, input); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Chmod(mode); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, destination)
 }
 
 // overlayWorktreeGitState copies the run worktree's HEAD and index from its

--- a/internal/factory/git_projection_test.go
+++ b/internal/factory/git_projection_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
 // TestPrepareGitMetadataProjectionRefreshesCheckpointObjects verifies a
@@ -70,7 +72,7 @@ func TestPrepareGitMetadataProjectionRefreshesCheckpointObjects(t *testing.T) {
 		t.Fatalf("repeated projection = %q, want stable path %q", repeatedProjection, projection)
 	}
 
-	command := exec.Command("git", "diff", "--no-ext-diff", "--binary", "--unified=80", baseSHA, checkpointSHA, "--", ".")
+	command := exec.CommandContext(t.Context(), "git", "diff", "--no-ext-diff", "--binary", "--unified=80", baseSHA, checkpointSHA, "--", ".")
 	command.Dir = worktreePath
 	command.Env = projectionTestGitEnvironment(
 		"GIT_DIR="+refreshedProjection,
@@ -85,11 +87,62 @@ func TestPrepareGitMetadataProjectionRefreshesCheckpointObjects(t *testing.T) {
 	}
 }
 
+// TestPrepareGitMetadataProjectionRemovesDeletedLooseRef verifies that a
+// refreshed projection does not leave a deleted source ref visible to commands
+// run through the Docker worker adapter.
+func TestPrepareGitMetadataProjectionRemovesDeletedLooseRef(t *testing.T) {
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktrees", "run-deleted-ref")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runProjectionTestGit(t, repositoryPath, "init", "-b", "main")
+	runProjectionTestGit(t, repositoryPath, "config", "user.email", "factory@example.test")
+	runProjectionTestGit(t, repositoryPath, "config", "user.name", "Factory Test")
+	if err := os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runProjectionTestGit(t, repositoryPath, "add", "README.md")
+	runProjectionTestGit(t, repositoryPath, "commit", "-m", "base")
+	runProjectionTestGit(t, repositoryPath, "update-ref", "refs/heads/deleted", "HEAD")
+	runProjectionTestGit(t, repositoryPath, "worktree", "add", "-b", "factory/run-deleted-ref", worktreePath)
+
+	projection, err := prepareGitMetadataProjection("run-deleted-ref", repositoryPath, worktreePath)
+	if err != nil {
+		t.Fatalf("prepare initial Git metadata projection: %v", err)
+	}
+	projectedRef := filepath.Join(projection, "refs", "heads", "deleted")
+	if _, err := os.Stat(projectedRef); err != nil {
+		t.Fatalf("inspect initially projected loose ref: %v", err)
+	}
+
+	runProjectionTestGit(t, repositoryPath, "update-ref", "-d", "refs/heads/deleted")
+	if _, err := prepareGitMetadataProjection("run-deleted-ref", repositoryPath, worktreePath); err != nil {
+		t.Fatalf("refresh Git metadata projection after ref deletion: %v", err)
+	}
+
+	runtime := &worker.DockerRuntime{DockerBinary: writeProjectionDockerStub(t, projection, worktreePath)}
+	result, err := runtime.RunCommand(t.Context(), worker.CommandRequest{
+		RunID:             "run-deleted-ref",
+		Command:           "git show-ref --verify refs/heads/deleted",
+		EnvironmentPolicy: worker.EnvironmentPolicyClean,
+		Role:              "gate",
+	})
+	if err != nil {
+		t.Fatalf("DockerRuntime.RunCommand() error = %v", err)
+	}
+	if result.ExitCode == 0 {
+		t.Fatalf("git show-ref verified deleted loose ref from refreshed projection: %#v", result)
+	}
+}
+
 // runProjectionTestGit runs one isolated Git command with system and global
 // configuration disabled so the regression exercises only the projected data.
 func runProjectionTestGit(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
-	command := exec.Command("git", arguments...)
+	command := exec.CommandContext(t.Context(), "git", arguments...)
 	command.Dir = directory
 	command.Env = projectionTestGitEnvironment()
 	output, err := command.CombinedOutput()
@@ -97,6 +150,44 @@ func runProjectionTestGit(t *testing.T, directory string, arguments ...string) s
 		t.Fatalf("git %s: %v\n%s", strings.Join(arguments, " "), err, output)
 	}
 	return strings.TrimSpace(string(output))
+}
+
+// writeProjectionDockerStub creates the narrow Docker CLI surface needed to
+// run a worker command against host-side projection fixtures without a daemon.
+func writeProjectionDockerStub(t *testing.T, projection, worktree string) string {
+	t.Helper()
+	stub := filepath.Join(t.TempDir(), "docker-stub")
+	script := `#!/bin/sh
+set -eu
+if [ "${1:-}" = "container" ] && [ "${2:-}" = "inspect" ]; then
+  printf 'true\tprojection-test-image\n'
+  exit 0
+fi
+if [ "${1:-}" = "exec" ]; then
+  while [ "$#" -gt 0 ] && [ "$1" != "/bin/sh" ]; do
+    shift
+  done
+  if [ "$#" -lt 3 ] || [ "$2" != "-c" ]; then
+    echo "malformed worker command" >&2
+    exit 125
+  fi
+  shift 2
+  GIT_DIR="$PROJECTION_TEST_GIT_DIR" \
+  GIT_WORK_TREE="$PROJECTION_TEST_GIT_WORK_TREE" \
+  GIT_CONFIG_NOSYSTEM=1 \
+  GIT_CONFIG_GLOBAL=/dev/null \
+  GIT_CONFIG_SYSTEM=/dev/null \
+  exec /bin/sh -c "$1"
+fi
+echo "unsupported Docker invocation" >&2
+exit 125
+`
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PROJECTION_TEST_GIT_DIR", projection)
+	t.Setenv("PROJECTION_TEST_GIT_WORK_TREE", worktree)
+	return stub
 }
 
 // projectionTestGitEnvironment returns the isolated Git environment used by

--- a/internal/factory/git_projection_test.go
+++ b/internal/factory/git_projection_test.go
@@ -1,0 +1,110 @@
+package factory
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPrepareGitMetadataProjectionRefreshesCheckpointObjects verifies a
+// checkpoint committed after projection creation is available to the worker's
+// exact review diff command.
+func TestPrepareGitMetadataProjectionRefreshesCheckpointObjects(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktrees", "run-refresh")
+	if err := os.MkdirAll(repositoryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runProjectionTestGit(t, repositoryPath, "init", "-b", "main")
+	runProjectionTestGit(t, repositoryPath, "config", "user.email", "factory@example.test")
+	runProjectionTestGit(t, repositoryPath, "config", "user.name", "Factory Test")
+	if err := os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runProjectionTestGit(t, repositoryPath, "add", "README.md")
+	runProjectionTestGit(t, repositoryPath, "commit", "-m", "base")
+	baseSHA := runProjectionTestGit(t, repositoryPath, "rev-parse", "HEAD")
+	runProjectionTestGit(t, repositoryPath, "worktree", "add", "-b", "factory/run-refresh", worktreePath)
+
+	projection, err := prepareGitMetadataProjection("run-refresh", repositoryPath, worktreePath)
+	if err != nil {
+		t.Fatalf("prepare initial Git metadata projection: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git", "remotes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "remotes", "origin"), []byte("URL https://user:secret@example.invalid/project.git\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreePath, "checkpoint.txt"), []byte("checkpoint\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runProjectionTestGit(t, worktreePath, "add", "checkpoint.txt")
+	runProjectionTestGit(t, worktreePath, "commit", "-m", "checkpoint")
+	checkpointSHA := runProjectionTestGit(t, worktreePath, "rev-parse", "HEAD")
+
+	refreshedProjection, err := prepareGitMetadataProjection("run-refresh", repositoryPath, worktreePath)
+	if err != nil {
+		t.Fatalf("refresh Git metadata projection: %v", err)
+	}
+	if refreshedProjection != projection {
+		t.Fatalf("refreshed projection = %q, want stable path %q", refreshedProjection, projection)
+	}
+	for _, forbidden := range []string{"config", "remotes"} {
+		if _, err := os.Stat(filepath.Join(refreshedProjection, forbidden)); !os.IsNotExist(err) {
+			t.Fatalf("refreshed projection contains forbidden %q: %v", forbidden, err)
+		}
+	}
+	repeatedProjection, err := prepareGitMetadataProjection("run-refresh", repositoryPath, worktreePath)
+	if err != nil {
+		t.Fatalf("repeat Git metadata projection refresh: %v", err)
+	}
+	if repeatedProjection != projection {
+		t.Fatalf("repeated projection = %q, want stable path %q", repeatedProjection, projection)
+	}
+
+	command := exec.Command("git", "diff", "--no-ext-diff", "--binary", "--unified=80", baseSHA, checkpointSHA, "--", ".")
+	command.Dir = worktreePath
+	command.Env = projectionTestGitEnvironment(
+		"GIT_DIR="+refreshedProjection,
+		"GIT_WORK_TREE="+worktreePath,
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("worker-style review diff: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "diff --git a/checkpoint.txt b/checkpoint.txt") {
+		t.Fatalf("worker-style review diff = %q, want checkpoint change", output)
+	}
+}
+
+// runProjectionTestGit runs one isolated Git command with system and global
+// configuration disabled so the regression exercises only the projected data.
+func runProjectionTestGit(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	command.Env = projectionTestGitEnvironment()
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(arguments, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// projectionTestGitEnvironment returns the isolated Git environment used by
+// both repository setup commands and the worker-style review command.
+func projectionTestGitEnvironment(extra ...string) []string {
+	return append(append([]string(nil), os.Environ()...), append([]string{
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	}, extra...)...)
+}


### PR DESCRIPTION
Fixes #98

## Summary
- Refresh the existing sanitized Git metadata projection so post-projection checkpoint objects reach workers.
- Atomically replace projected metadata files while preserving configuration, remote, symlink, and non-regular-entry exclusions.
- Add a real-Git regression covering a checkpoint created after projection creation and repeated refreshes.

## Verification
- GOCACHE=/tmp/sw-factory-go-build make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git metadata projection refreshes to preserve existing projection paths while reflecting the latest checkpoint changes.
  * File updates are now applied more safely, reducing the risk of incomplete or corrupted projection files.
  * Refreshed projections continue to exclude restricted metadata.

* **Tests**
  * Added regression coverage for projection refreshes, checkpoint visibility, stable paths, and metadata exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->