### PR TITLE
Stop replaying issue commands from before claim

### DIFF
--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -270,11 +270,11 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 }
 
 // claimCommentWatermark captures the latest existing issue comment before a
-// run can receive commands. A missing reader preserves claim-only embedders;
-// the default GitHub client supplies the reader used by command polling.
+// run can receive commands. Every claimed run accepts commands, so the reader
+// must be available before the claim creates any durable or external effects.
 func (s *Service) claimCommentWatermark(ctx context.Context, repository github.Repository, issueNumber int) (string, error) {
 	if s.deps.Comments == nil {
-		return "", nil
+		return "", errors.New("GitHub comment reader is required to establish the command cutoff before claim")
 	}
 	comments, err := s.deps.Comments.IssueComments(ctx, repository, issueNumber)
 	if err != nil {

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -188,6 +188,10 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 	if err != nil {
 		return IssueResult{}, fmt.Errorf("validate frozen issue route for #%d: %w", issueNumber, err)
 	}
+	processedCommentID, err := s.claimCommentWatermark(ctx, repository, issueNumber)
+	if err != nil {
+		return IssueResult{}, err
+	}
 
 	runID, err := s.deps.NewRunID()
 	if err != nil {
@@ -237,6 +241,7 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 		CheckRepairBudget:   repositoryConfig.RetryLimits.CheckRepair,
 		ReviewRepairBudget:  repositoryConfig.RetryLimits.ReviewRepair,
 		TestRevisionBudget:  testRevisionBudget,
+		ProcessedCommentID:  processedCommentID,
 		SpecificationPacket: string(packetData),
 		CreatedAt:           startedAt,
 		UpdatedAt:           startedAt,
@@ -262,6 +267,29 @@ func (s *Service) ClaimIssue(ctx context.Context, issueNumber int) (IssueResult,
 		return IssueResult{}, cleanupWorkspace(failureErr)
 	}
 	return IssueResult{Run: run, Packet: packet}, nil
+}
+
+// claimCommentWatermark captures the latest existing issue comment before a
+// run can receive commands. A missing reader preserves claim-only embedders;
+// the default GitHub client supplies the reader used by command polling.
+func (s *Service) claimCommentWatermark(ctx context.Context, repository github.Repository, issueNumber int) (string, error) {
+	if s.deps.Comments == nil {
+		return "", nil
+	}
+	comments, err := s.deps.Comments.IssueComments(ctx, repository, issueNumber)
+	if err != nil {
+		return "", fmt.Errorf("list comments on issue #%d before claim: %w", issueNumber, err)
+	}
+	latestCommentID := ""
+	for _, comment := range comments {
+		if strings.TrimSpace(comment.ID) == "" {
+			continue
+		}
+		if latestCommentID == "" || compareGitHubIDs(latestCommentID, comment.ID) < 0 {
+			latestCommentID = comment.ID
+		}
+	}
+	return latestCommentID, nil
 }
 
 // testRevisionBudgetForPacket returns a revision ceiling only for runs that

--- a/internal/factory/claim_comment_internal_test.go
+++ b/internal/factory/claim_comment_internal_test.go
@@ -1,0 +1,20 @@
+package factory
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/github"
+)
+
+// TestClaimCommentWatermarkFailsClosedWithoutCommentReader verifies a claim
+// cannot proceed without the command cutoff reader required by every run.
+func TestClaimCommentWatermarkFailsClosedWithoutCommentReader(t *testing.T) {
+	t.Parallel()
+
+	_, err := (&Service{}).claimCommentWatermark(context.Background(), github.Repository{}, 42)
+	if err == nil || !strings.Contains(err.Error(), "comment reader is required") {
+		t.Fatalf("claimCommentWatermark() error = %v, want missing comment-reader failure", err)
+	}
+}

--- a/internal/factory/claim_test.go
+++ b/internal/factory/claim_test.go
@@ -93,6 +93,87 @@ func TestIssueClaimsAnEligibleIssueWithAFrozenPacketAndOneStatusComment(t *testi
 	}
 }
 
+// TestIssueClaimScopesCommandsToTheRunStart verifies pre-claim commands are
+// ignored while a command posted after claim remains available exactly once.
+func TestIssueClaimScopesCommandsToTheRunStart(t *testing.T) {
+	t.Parallel()
+
+	issue := github.Issue{
+		Number: 42,
+		Title:  "Scope commands to the claimed run",
+		State:  "open",
+		Labels: []string{github.LabelAgentReady},
+	}
+	oldCommand := github.Comment{ID: "100", Author: "alice", Body: "/factory cancel"}
+	latestHistory := github.Comment{ID: "102", Author: "alice", Body: "historical discussion"}
+	newCommand := github.Comment{ID: "103", Author: "alice", Body: "/factory status"}
+	githubAdapter := &fakeGitHub{issueValue: issue, comments: []github.Comment{latestHistory, oldCommand}}
+	service := newClaimService(githubAdapter, &fakeWorktree{workspace: gitadapter.Workspace{
+		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
+	}}, &fakeRunStore{}, validRepositoryConfig())
+
+	claimed, err := service.ClaimIssue(context.Background(), issue.Number)
+	if err != nil {
+		t.Fatalf("ClaimIssue() error = %v", err)
+	}
+	if claimed.Run.ProcessedCommentID != latestHistory.ID {
+		t.Fatalf("claim watermark = %q, want latest pre-claim comment %q", claimed.Run.ProcessedCommentID, latestHistory.ID)
+	}
+
+	githubAdapter.comments = append(githubAdapter.comments, newCommand)
+	first, err := service.PollCommands(context.Background(), factory.CommandPollRequest{RunID: claimed.Run.ID})
+	if err != nil {
+		t.Fatalf("first PollCommands() error = %v", err)
+	}
+	if len(first) != 2 || first[0].Outcome != factory.CommandReplayed || first[1].Outcome != factory.CommandAccepted {
+		t.Fatalf("first PollCommands() = %#v, want one replayed pre-claim and one accepted post-claim command", first)
+	}
+	if first[1].Run.Status != store.StatusActive || first[1].Run.LastCommandName != "status" {
+		t.Fatalf("post-claim command run = %#v, want active status projection", first[1].Run)
+	}
+	if len(githubAdapter.replacedLabels) != 1 || githubAdapter.replacedLabels[0] != github.LabelAgentRunning {
+		t.Fatalf("label mutations = %#v, want the claim label only", githubAdapter.replacedLabels)
+	}
+	if len(githubAdapter.editedComments) != 1 {
+		t.Fatalf("status comment edits = %d, want one post-claim command edit", len(githubAdapter.editedComments))
+	}
+
+	second, err := service.PollCommands(context.Background(), factory.CommandPollRequest{RunID: claimed.Run.ID})
+	if err != nil {
+		t.Fatalf("second PollCommands() error = %v", err)
+	}
+	if len(second) != 2 || second[0].Outcome != factory.CommandReplayed || second[1].Outcome != factory.CommandReplayed {
+		t.Fatalf("second PollCommands() = %#v, want both comments replayed", second)
+	}
+	if len(githubAdapter.editedComments) != 1 {
+		t.Fatalf("status comment edits after replay = %d, want no duplicate edit", len(githubAdapter.editedComments))
+	}
+}
+
+// TestIssueClaimFailsClosedWhenCommentHistoryCannotBeRead verifies the claim
+// does not create a run when it cannot establish the command cutoff.
+func TestIssueClaimFailsClosedWhenCommentHistoryCannotBeRead(t *testing.T) {
+	t.Parallel()
+
+	githubAdapter := &fakeGitHub{
+		issueValue:  github.Issue{Number: 42, State: "open", Labels: []string{github.LabelAgentReady}},
+		commentsErr: errors.New("GitHub comments unavailable"),
+	}
+	worktree := &fakeWorktree{workspace: gitadapter.Workspace{
+		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
+	}}
+	runStore := &fakeRunStore{}
+	service := newClaimService(githubAdapter, worktree, runStore, validRepositoryConfig())
+
+	_, err := service.ClaimIssue(context.Background(), 42)
+	if err == nil || !strings.Contains(err.Error(), "before claim") || !strings.Contains(err.Error(), "GitHub comments unavailable") {
+		t.Fatalf("ClaimIssue() error = %v, want comment-cutoff failure", err)
+	}
+	if worktree.called || len(runStore.saved) != 0 || len(githubAdapter.replacedLabels) != 0 || len(githubAdapter.createdComments) != 0 {
+		t.Fatalf("claim effects = workspace=%t/runs=%d/labels=%d/comments=%d, want none", worktree.called, len(runStore.saved), len(githubAdapter.replacedLabels), len(githubAdapter.createdComments))
+	}
+}
+
 // TestIssueRefusesClosedOrUnauthorizedIssuesBeforeCreatingAWorkspace verifies
 // eligibility is checked before any host or GitHub mutation.
 func TestIssueRefusesClosedOrUnauthorizedIssuesBeforeCreatingAWorkspace(t *testing.T) {
@@ -446,6 +527,10 @@ type fakeGitHub struct {
 	createCommentErr error
 	statusComment    github.Comment
 	findCommentCalls int
+	// comments contains the issue history returned to command polling.
+	comments []github.Comment
+	// commentsErr simulates a failure while establishing the claim cutoff.
+	commentsErr error
 }
 
 // Issue returns the configured issue snapshot.
@@ -490,6 +575,14 @@ func (f *fakeGitHub) FindStatusComment(_ context.Context, _ github.Repository, _
 func (f *fakeGitHub) EditIssueComment(_ context.Context, _ github.Repository, id, body string) error {
 	f.editedComments = append(f.editedComments, editedComment{id: id, body: body})
 	return nil
+}
+
+// IssueComments returns the issue comments visible to command polling.
+func (f *fakeGitHub) IssueComments(context.Context, github.Repository, int) ([]github.Comment, error) {
+	if f.commentsErr != nil {
+		return nil, f.commentsErr
+	}
+	return append([]github.Comment(nil), f.comments...), nil
 }
 
 // editedComment records one status-comment edit.

--- a/internal/factory/continuation_test.go
+++ b/internal/factory/continuation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 	"github.com/Stevie1704/sw-factory/internal/workflow"
 )
@@ -243,7 +244,7 @@ type continuationFixture struct {
 	reviews         *continuationReviews
 	statuses        *gateStatuses
 	lease           *pollingLease
-	terminal        *agentTerminal
+	terminal        *continuationTerminal
 	harness         *continuationHarness
 	operationalPath string
 	configPath      string
@@ -300,12 +301,18 @@ func newContinuationFixture(t *testing.T) *continuationFixture {
 		statuses:            &gateStatuses{},
 		clock:               monotonicClock(time.Date(2026, 8, 29, 9, 0, 0, 0, time.UTC)),
 		lease:               &pollingLease{},
-		terminal:            &agentTerminal{},
+		terminal:            &continuationTerminal{agentTerminal: &agentTerminal{}},
 		operationalPath:     filepath.Join(root, "state", "factory.db"),
 		firstRunID:          "run-continuation",
 		checkpointsReviewed: map[string]struct{}{},
 	}
 	fixture.harness = &continuationHarness{fixture: fixture}
+	fixture.terminal.onNotify = func() {
+		run := fixture.latestRun(t)
+		if run != nil && store.IsTerminalStatus(run.Status) {
+			fixture.recordTerminalRun(*run)
+		}
+	}
 
 	registration := config.RepositoryRegistration{
 		Path:                 repositoryPath,
@@ -323,6 +330,7 @@ func newContinuationFixture(t *testing.T) *continuationFixture {
 			LoadRepository:     func(string) (config.RepositoryConfig, error) { return policy, nil },
 			GitHub:             fixture.commands,
 			IssuePoller:        fixture.commands,
+			Comments:           emptyCommentReader{},
 			Lease:              fixture.lease,
 			PullRequests:       fixture.pullRequests,
 			PullRequestReviews: fixture.reviews,
@@ -349,6 +357,33 @@ func newContinuationFixture(t *testing.T) *continuationFixture {
 func (f *continuationFixture) restart() *factory.Service {
 	f.service = factory.NewWithDependencies(f.configPath, f.dependencies())
 	return f.service
+}
+
+// emptyCommentReader keeps unattended continuation tests in the normal
+// command-enabled mode without introducing command traffic into the fixture.
+type emptyCommentReader struct{}
+
+// IssueComments returns no human commands for the continuation fixture.
+func (emptyCommentReader) IssueComments(context.Context, github.Repository, int) ([]github.Comment, error) {
+	return nil, nil
+}
+
+// continuationTerminal records the terminal state before the same polling
+// pass can claim the next queued issue.
+type continuationTerminal struct {
+	*agentTerminal
+	onNotify func()
+}
+
+// Notify records the terminal notification and captures the persisted state.
+func (t *continuationTerminal) Notify(ctx context.Context, notification terminal.Notification) error {
+	if err := t.agentTerminal.Notify(ctx, notification); err != nil {
+		return err
+	}
+	if t.onNotify != nil {
+		t.onNotify()
+	}
+	return nil
 }
 
 // monotonicClock returns a strictly increasing coordinator clock, so the

--- a/internal/factory/polling_test.go
+++ b/internal/factory/polling_test.go
@@ -171,10 +171,10 @@ func TestStartUsesTransportBackoffWithoutChangingRunState(t *testing.T) {
 	}
 }
 
-// TestStartAppliesQueuedIssueCommands verifies the unattended loop reads the
-// structured /factory comments of the run it already reconciled, instead of
-// waiting for an operator to run the `factory poll` command by hand.
-func TestStartAppliesQueuedIssueCommands(t *testing.T) {
+// TestStartAppliesIssueCommandsPostedAfterClaim verifies the unattended loop
+// applies a command posted after claim while ignoring an older command that
+// remains in the issue's comment history.
+func TestStartAppliesIssueCommandsPostedAfterClaim(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -183,7 +183,13 @@ func TestStartAppliesQueuedIssueCommands(t *testing.T) {
 	runStore := &fakeRunStore{}
 	var cancel context.CancelFunc
 	comments := &pollingCommentReader{
-		comments: []github.Comment{{ID: "15", Author: "alice", Body: "/factory status"}},
+		commentBatches: [][]github.Comment{
+			{{ID: "14", Author: "alice", Body: "/factory cancel"}},
+			{
+				{ID: "14", Author: "alice", Body: "/factory cancel"},
+				{ID: "15", Author: "alice", Body: "/factory status"},
+			},
+		},
 		onList: func(call int) {
 			if call >= 2 {
 				cancel()
@@ -204,7 +210,10 @@ func TestStartAppliesQueuedIssueCommands(t *testing.T) {
 		t.Fatal("comment listings = 0, want the polling loop to read issue commands")
 	}
 	if !savedCommandWatermark(runStore.saved, "15", "status") {
-		t.Fatalf("saved runs = %#v, want the status command applied with its watermark", runStore.saved)
+		t.Fatalf("saved runs = %#v, want the post-claim status command applied with its watermark", runStore.saved)
+	}
+	if strings.Contains(githubAdapter.lastLabelMutation, github.LabelAgentCancelled) {
+		t.Fatal("the pre-claim cancel command changed the run state")
 	}
 }
 
@@ -220,9 +229,9 @@ func TestStartBacksOffCommandTransportFailures(t *testing.T) {
 	runStore := &fakeRunStore{}
 	var cancel context.CancelFunc
 	comments := &pollingCommentReader{
-		listErrors: []error{errors.New("GitHub comment transport unavailable")},
+		listErrors: []error{nil, errors.New("GitHub comment transport unavailable")},
 		onList: func(call int) {
-			if call >= 2 {
+			if call >= 3 {
 				cancel()
 			}
 		},
@@ -237,11 +246,11 @@ func TestStartBacksOffCommandTransportFailures(t *testing.T) {
 	if err := service.Start(ctx); err != nil {
 		t.Fatalf("Start() error = %v, want the loop to survive a command transport failure", err)
 	}
-	if comments.calls != 2 {
-		t.Fatalf("comment listings = %d, want one retry after transport backoff", comments.calls)
+	if comments.calls != 3 {
+		t.Fatalf("comment listings = %d, want one retry after command transport backoff", comments.calls)
 	}
-	if gap := comments.times[1].Sub(comments.times[0]); gap < 20*time.Millisecond {
-		t.Fatalf("command retry gap = %s, want the configured backoff before the second command poll", gap)
+	if gap := comments.times[2].Sub(comments.times[1]); gap < 20*time.Millisecond {
+		t.Fatalf("command retry gap = %s, want the configured backoff before the retry", gap)
 	}
 	if savedCommandWatermark(runStore.saved, "15", "status") {
 		t.Fatal("a queued command was applied although every comment listing failed")
@@ -262,7 +271,11 @@ func savedCommandWatermark(saved []store.Run, commentID, command string) bool {
 // pollingCommentReader supplies structured command comments to the polling
 // loop with controllable transport failures.
 type pollingCommentReader struct {
-	comments   []github.Comment
+	// comments is the fallback history returned after commentBatches are used.
+	comments []github.Comment
+	// commentBatches supplies one deterministic history for each list call.
+	commentBatches [][]github.Comment
+	// listErrors supplies deterministic failures for successive list calls.
 	listErrors []error
 	calls      int
 	times      []time.Time
@@ -281,7 +294,12 @@ func (r *pollingCommentReader) IssueComments(context.Context, github.Repository,
 	if len(r.listErrors) > 0 {
 		err := r.listErrors[0]
 		r.listErrors = r.listErrors[1:]
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
+	}
+	if r.calls <= len(r.commentBatches) {
+		return append([]github.Comment(nil), r.commentBatches[r.calls-1]...), nil
 	}
 	return append([]github.Comment(nil), r.comments...), nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -543,7 +543,8 @@ type Run struct {
 	// prevention and persisted supervision updates.
 	Revision int64
 	// ProcessedCommentID is the highest processed GitHub comment watermark for
-	// this run. Editing that comment must never execute it again.
+	// this run. Claim initializes it to the latest pre-claim issue comment so
+	// historical commands cannot execute against the new run.
 	ProcessedCommentID string
 	// ProcessedCommentRevision records the run revision at which the watermark
 	// was persisted, making the watermark tuple restart-safe and auditable.


### PR DESCRIPTION
Closes #99. Initialize each run's issue-comment watermark from the latest comment visible at claim time, deliberately retire pre-claim queued commands, and fail closed when the cutoff cannot be established. Updated regression coverage verifies pre-claim cancel commands are ignored and post-claim commands are applied exactly once. Verification: make check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New runs now ignore issue commands posted before the run was claimed.
  * Commands posted after claiming continue to be processed normally.
  * Runs fail safely when comment history cannot be retrieved, preventing unintended command execution.
  * Improved handling of comment history and retry scenarios during polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->