### PR TITLE
Accept a rolled-back invocation as recovery history

### DIFF
--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -480,6 +480,14 @@ func (s *Service) inspectInvocationProjectionSingle(ctx context.Context, diagnos
 	}
 	invocationID = active.ID
 	diagnosis.InvocationExists = true
+	if invocationProjectionNeverEstablished(*active) {
+		// The launch boundary rolled this invocation back before it recorded any
+		// external identity, so no worker, terminal, or harness projection was
+		// ever created for it. Its empty identities are the durable result of a
+		// completed rollback rather than restart drift, and comparing them with
+		// live projections would block every later start permanently.
+		return
+	}
 	hasNativeSession := strings.TrimSpace(active.NativeSessionID) != ""
 	if !hasNativeSession {
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{
@@ -708,6 +716,19 @@ func workerProjectionExpectedStopped(run store.Run, invocation store.Invocation)
 		return false
 	}
 	return run.Stage == store.StageReady || run.Stage == store.StageCheck || run.Status == store.StatusWaitingForHuman
+}
+
+// invocationProjectionNeverEstablished reports that a historical invocation was
+// rolled back at the launch boundary before it recorded a native session or a
+// workspace. Such an invocation owns no external projection to compare, so the
+// coordinator must read its empty identities as recorded history rather than as
+// an infrastructure discrepancy. An active invocation is always compared,
+// because a live agent with no persisted identity is genuine drift.
+func invocationProjectionNeverEstablished(invocation store.Invocation) bool {
+	if invocation.Status == store.InvocationStatusActive {
+		return false
+	}
+	return strings.TrimSpace(invocation.NativeSessionID) == "" && strings.TrimSpace(invocation.WorkspaceID) == ""
 }
 
 // terminalInvocationProjectionExpectedStopped reports the coordinator-owned

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -722,13 +722,11 @@ func workerProjectionExpectedStopped(run store.Run, invocation store.Invocation)
 // rolled back at the launch boundary before it recorded a native session or a
 // workspace. Such an invocation owns no external projection to compare, so the
 // coordinator must read its empty identities as recorded history rather than as
-// an infrastructure discrepancy. An active invocation is always compared,
-// because a live agent with no persisted identity is genuine drift.
+// an infrastructure discrepancy. Only the cannot-proceed status records that
+// rollback; every other status is compared so missing identities remain drift.
 func invocationProjectionNeverEstablished(invocation store.Invocation) bool {
-	if invocation.Status == store.InvocationStatusActive {
-		return false
-	}
-	return strings.TrimSpace(invocation.NativeSessionID) == "" && strings.TrimSpace(invocation.WorkspaceID) == ""
+	return invocation.Status == store.InvocationStatusCannotProceed &&
+		strings.TrimSpace(invocation.NativeSessionID) == "" && strings.TrimSpace(invocation.WorkspaceID) == ""
 }
 
 // terminalInvocationProjectionExpectedStopped reports the coordinator-owned

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -487,6 +487,75 @@ func TestRecoveryAcceptsAnUninspectableSessionAtAHumanWaitingBoundary(t *testing
 	}
 }
 
+// TestRecoveryAcceptsAnInvocationRolledBackBeforeLaunch verifies that an
+// invocation the launch boundary rolled back before it recorded any external
+// identity is read as history rather than as restart drift. Reporting its empty
+// identities would block every later start permanently, because no effect can
+// ever fill those columns.
+func TestRecoveryAcceptsAnInvocationRolledBackBeforeLaunch(t *testing.T) {
+	now := time.Unix(4, 0).UTC()
+	run := store.Run{ID: "run-rolled-back-launch", Stage: store.StageTest, Status: store.StatusWaitingForHuman}
+	invocation := store.Invocation{
+		ID: "inv-rolled-back-launch", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "test", Stage: store.StageTest,
+		Status:    store.InvocationStatusCannotProceed,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	service := &Service{deps: Dependencies{
+		Worker:   &journalRecoveryWorker{inspection: worker.Inspection{}},
+		Terminal: &journalRecoveryTerminal{},
+		Harness:  &journalRecoveryHarness{},
+	}}
+	baseStore := &repairLaunchStore{run: run, invocations: map[string]store.Invocation{invocation.ID: invocation}}
+	runStore := &terminalProjectionStore{repairLaunchStore: baseStore}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+
+	service.inspectInvocationProjection(context.Background(), &diagnosis, config.RepositoryRegistration{}, runStore, run)
+	if len(diagnosis.Discrepancies) != 0 {
+		t.Fatalf("recovery discrepancies = %#v, want rolled-back invocation accepted as history", diagnosis.Discrepancies)
+	}
+	if !diagnosis.InvocationExists {
+		t.Fatal("diagnosis.InvocationExists = false, want the rolled-back invocation reported as history")
+	}
+}
+
+// TestRecoveryReportsAnActiveInvocationWithoutIdentity verifies that the
+// rolled-back allowance does not weaken the live case: an active invocation
+// with no persisted identity is genuine drift and must still be reported.
+func TestRecoveryReportsAnActiveInvocationWithoutIdentity(t *testing.T) {
+	now := time.Unix(5, 0).UTC()
+	run := store.Run{ID: "run-active-without-identity", Stage: store.StageTest, Status: store.StatusActive}
+	invocation := store.Invocation{
+		ID: "inv-active-without-identity", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "test", Stage: store.StageTest,
+		Status:    store.InvocationStatusActive,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	service := &Service{deps: Dependencies{
+		Worker:   &journalRecoveryWorker{inspection: worker.Inspection{}},
+		Terminal: &journalRecoveryTerminal{},
+		Harness:  &journalRecoveryHarness{},
+	}}
+	baseStore := &repairLaunchStore{run: run, invocations: map[string]store.Invocation{invocation.ID: invocation}}
+	runStore := selectedActiveInvocationStore{OperationalStore: baseStore, active: invocation}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+
+	service.inspectInvocationProjectionSingle(context.Background(), &diagnosis, config.RepositoryRegistration{}, runStore, run)
+	nativeSession := false
+	workspace := false
+	for _, discrepancy := range diagnosis.Discrepancies {
+		if discrepancy.Source == "native session" && discrepancy.Field == "identity" {
+			nativeSession = true
+		}
+		if discrepancy.Source == "cmux" && discrepancy.Field == "workspace" {
+			workspace = true
+		}
+	}
+	if !nativeSession || !workspace {
+		t.Fatalf("recovery discrepancies = %#v, want native session and workspace drift for an active invocation", diagnosis.Discrepancies)
+	}
+}
+
 // TestPollLifecycleCompletesAMergedRunBeforeRecovery verifies that a deleted
 // remote branch and historical worker projection cannot block the public
 // lifecycle seam from recording an already-merged pull request.

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -519,6 +519,53 @@ func TestRecoveryAcceptsAnInvocationRolledBackBeforeLaunch(t *testing.T) {
 	}
 }
 
+func TestInvocationProjectionNeverEstablishedRequiresCannotProceed(t *testing.T) {
+	tests := []struct {
+		name       string
+		invocation store.Invocation
+		want       bool
+	}{
+		{
+			name: "cannot proceed with empty identities",
+			invocation: store.Invocation{
+				Status: store.InvocationStatusCannotProceed,
+			},
+			want: true,
+		},
+		{
+			name: "completed with empty identities",
+			invocation: store.Invocation{
+				Status: store.InvocationStatusCompleted,
+			},
+			want: false,
+		},
+		{
+			name: "cannot proceed with a native session",
+			invocation: store.Invocation{
+				Status:          store.InvocationStatusCannotProceed,
+				NativeSessionID: "session-1",
+			},
+			want: false,
+		},
+		{
+			name: "cannot proceed with a workspace",
+			invocation: store.Invocation{
+				Status:      store.InvocationStatusCannotProceed,
+				WorkspaceID: "workspace-1",
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := invocationProjectionNeverEstablished(test.invocation); got != test.want {
+				t.Errorf("invocationProjectionNeverEstablished() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 // TestRecoveryReportsAnActiveInvocationWithoutIdentity verifies that the
 // rolled-back allowance does not weaken the live case: an active invocation
 // with no persisted identity is genuine drift and must still be reported.


### PR DESCRIPTION
## Problem

`factory start` refuses to run and cannot recover:

```
error: reconcile persisted run at startup: recovery infrastructure discrepancy:
run "run-0f124cdf-9369-4a69-872d-db2dadbdf44d" is waiting for human reconciliation:
native session.identity expected="persisted native session identifier" observed="empty",
cmux.workspace expected="persisted workspace identity" observed="empty"
```

An agent launch failed between persisting the invocation row and recording the cmux workspace handles (`agent_launch.go:396-450`). The deferred rollback at `agent_launch.go:357` did its job: no pending effect existed, so it flipped the invocation to `cannot_proceed` and left `native_session_id` and `workspace_id` empty.

Startup reconciliation then read that rollback as infrastructure drift. `ActiveInvocation()` returns nil for a `cannot_proceed` row, so `inspectInvocationProjectionSingle` falls back to `LatestInvocation()` and applies **live-projection** identity expectations to a **historical, already-failed** invocation.

The result is a permanent deadlock — no effect can ever fill those two columns:

| Recovery path | Result |
|---|---|
| `factory start` | same error on every restart |
| `factory reconcile` | re-derives the identical diagnosis |
| `factory reconcile --abandon-effect` | N/A, `pending_effects` is empty |
| `/factory retry` | rejected, retry needs `failed`/`cancelled`, not `waiting_for_human` |

`pauseForRecovery` already returns early for a run it has previously paused (`recovery.go:1370`), but the caller at `recovery.go:1197` returns the typed error unconditionally regardless.

## Change

Skip the live comparison for a non-active invocation that recorded neither a native session nor a workspace. Such an invocation owns no external projection to compare against.

An **active** invocation is still compared: a live agent with no persisted identity is genuine drift. The guard is scoped to the `LatestInvocation` fallback path by its status check.

The rest of recovery is untouched. The run stays `waiting_for_human` and `ensureAgentStartup` returns without resuming anything (`claim.go:804`) — startup succeeds, polling begins, and the operator decides through the normal command path.

## Verification

- New regression test reproduces the exact two discrepancies from the affected database and fails without the fix.
- Second test pins the live case, so the allowance cannot silently widen.
- `gofmt`, `go vet`, and the full `go test ./...` suite pass.
- Built against the real stuck database: `factory status` goes from `sources=disagree` with both discrepancies to `sources=agree` with none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACfrat7V4yqp8sbZCRCvxa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery handling for invocations rolled back before launch, preventing false discrepancy reports.
  - Continued detecting recovery drift for active invocations missing required session or workspace identities.

- **Tests**
  - Added coverage for historical pre-launch rollbacks.
  - Added coverage for active identity-less invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->