### PR TITLE
Accept a partially rolled-back invocation as recovery history

### DIFF
--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -481,11 +481,12 @@ func (s *Service) inspectInvocationProjectionSingle(ctx context.Context, diagnos
 	invocationID = active.ID
 	diagnosis.InvocationExists = true
 	if invocationProjectionNeverEstablished(*active) {
-		// The launch boundary rolled this invocation back before it recorded any
-		// external identity, so no worker, terminal, or harness projection was
-		// ever created for it. Its empty identities are the durable result of a
-		// completed rollback rather than restart drift, and comparing them with
-		// live projections would block every later start permanently.
+		// The launch boundary rolled this invocation back before its agent
+		// started, so it owns no live worker, terminal, or harness projection.
+		// Any workspace or surface it had already reserved was torn down by the
+		// same rollback. Its identities are the durable result of that completed
+		// rollback rather than restart drift, and comparing them with live
+		// projections would block every later start permanently.
 		return
 	}
 	hasNativeSession := strings.TrimSpace(active.NativeSessionID) != ""
@@ -719,14 +720,17 @@ func workerProjectionExpectedStopped(run store.Run, invocation store.Invocation)
 }
 
 // invocationProjectionNeverEstablished reports that a historical invocation was
-// rolled back at the launch boundary before it recorded a native session or a
-// workspace. Such an invocation owns no external projection to compare, so the
-// coordinator must read its empty identities as recorded history rather than as
-// an infrastructure discrepancy. Only the cannot-proceed status records that
-// rollback; every other status is compared so missing identities remain drift.
+// rolled back at the launch boundary before its agent ever started. The native
+// session identifier is the anchor of every live projection, so a rolled-back
+// invocation without one owns no worker, terminal, or harness state to compare,
+// whether or not it had already reserved a workspace or a surface: the rollback
+// stops the worker and closes the surface it created. The coordinator must read
+// those identities as recorded history rather than as an infrastructure
+// discrepancy. Only the cannot-proceed status records that rollback; every other
+// status is compared so missing identities remain drift.
 func invocationProjectionNeverEstablished(invocation store.Invocation) bool {
 	return invocation.Status == store.InvocationStatusCannotProceed &&
-		strings.TrimSpace(invocation.NativeSessionID) == "" && strings.TrimSpace(invocation.WorkspaceID) == ""
+		strings.TrimSpace(invocation.NativeSessionID) == ""
 }
 
 // terminalInvocationProjectionExpectedStopped reports the coordinator-owned

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -548,10 +548,23 @@ func TestInvocationProjectionNeverEstablishedRequiresCannotProceed(t *testing.T)
 			want: false,
 		},
 		{
-			name: "cannot proceed with a workspace",
+			// A rollback that reached workspace reservation still tore down
+			// everything it built, so a reserved workspace is not evidence of a
+			// live projection.
+			name: "cannot proceed with a reserved workspace and no session",
 			invocation: store.Invocation{
 				Status:      store.InvocationStatusCannotProceed,
 				WorkspaceID: "workspace-1",
+			},
+			want: true,
+		},
+		{
+			name: "cannot proceed with a surface and a native session",
+			invocation: store.Invocation{
+				Status:          store.InvocationStatusCannotProceed,
+				NativeSessionID: "session-1",
+				WorkspaceID:     "workspace-1",
+				RoleSurfaceID:   "surface-1",
 			},
 			want: false,
 		},
@@ -563,6 +576,41 @@ func TestInvocationProjectionNeverEstablishedRequiresCannotProceed(t *testing.T)
 				t.Errorf("invocationProjectionNeverEstablished() = %t, want %t", got, test.want)
 			}
 		})
+	}
+}
+
+// TestRecoveryAcceptsAPartiallyRolledBackInvocation verifies that a launch
+// rolled back after it had already reserved a workspace and a role surface is
+// still read as history. The rollback closes the surface it created, so cmux
+// reports that surface as missing; treating that as drift deadlocks every
+// later start exactly as an empty identity does.
+func TestRecoveryAcceptsAPartiallyRolledBackInvocation(t *testing.T) {
+	now := time.Unix(6, 0).UTC()
+	run := store.Run{ID: "run-partial-rollback", Stage: store.StageImplementation, Status: store.StatusWaitingForHuman}
+	invocation := store.Invocation{
+		ID: "inv-partial-rollback", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		WorkspaceID: "workspace-partial-rollback", RoleSurfaceID: "surface-partial-rollback",
+		Status:    store.InvocationStatusCannotProceed,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	// The workspace survives because later roles reuse it; only the surface the
+	// rollback closed is gone.
+	terminalRuntime := &journalRecoveryTerminal{inspection: terminal.WorkspaceInspection{
+		Exists: true, WorkspaceID: terminal.WorkspaceID(invocation.WorkspaceID),
+	}}
+	service := &Service{deps: Dependencies{
+		Worker:   &journalRecoveryWorker{inspection: worker.Inspection{}},
+		Terminal: terminalRuntime,
+		Harness:  &journalRecoveryHarness{},
+	}}
+	baseStore := &repairLaunchStore{run: run, invocations: map[string]store.Invocation{invocation.ID: invocation}}
+	runStore := &terminalProjectionStore{repairLaunchStore: baseStore}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+
+	service.inspectInvocationProjection(context.Background(), &diagnosis, config.RepositoryRegistration{}, runStore, run)
+	if len(diagnosis.Discrepancies) != 0 {
+		t.Fatalf("recovery discrepancies = %#v, want partial rollback accepted as history", diagnosis.Discrepancies)
 	}
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #102, which fixed this deadlock too narrowly.

`run-de1e2e3f` (issue #12) reached the implementation stage, then the launch failed:

```
launch codex implementation agent: discover Codex native session:
native harness session was not discovered before the deadline: context deadline exceeded
```

Codex did not persist a rollout file within the 60s discovery window (`harness.go:140`), so the deferred rollback in `agent_launch.go` fired. This launch failed **later** than the one in #102 — it had already reserved the run workspace and created its role surface — so the rollback stopped the worker and **closed the surface it had created**, leaving `role_surface_id` persisted and pointing at a surface that no longer exists.

Startup reconciliation then reported:

```
native session.identity  expected="persisted native session identifier"  observed="empty"
cmux.role surface        expected="6CDD697B-..."                        observed="missing"
```

Both are artifacts of a *completed* rollback, not drift. #102 required `WorkspaceID` to be empty as well, so the guard did not apply and the run deadlocked exactly as before: `factory start` aborts, `factory reconcile` re-derives it, `/factory retry` is rejected at `waiting_for_human`.

## Change

Key the allowance on the native session identifier alone, still bounded to `cannot_proceed`:

```go
func invocationProjectionNeverEstablished(invocation store.Invocation) bool {
	return invocation.Status == store.InvocationStatusCannotProceed &&
		strings.TrimSpace(invocation.NativeSessionID) == ""
}
```

The native session is the anchor of every live projection — worker, terminal surface, and harness session all hang off an invocation whose agent actually started. Without one, the invocation never started and owns nothing live to compare, whether or not it reserved a workspace first. `cannot_proceed` still bounds this to the launch-rollback boundary; a `cannot_proceed` invocation from a blocking agent report (`agent.go:752`) has a native session and is unaffected.

The dropped `WorkspaceID` condition costs nothing real: the run workspace is shared and reused by later roles, so a live invocation still verifies it.

## Verification

- New test reproduces both discrepancies from the affected database; fails without the fix.
- The `cannot proceed with a workspace` case in the table test from #102 asserted the behavior this bug disproves, so it is flipped to `want: true` with a comment. A new case pins that a `cannot_proceed` invocation *with* a session and surface is still compared.
- `gofmt`, `go vet`, full `go test ./...` pass.
- Against the live database: `sources=disagree` with both discrepancies → **`sources=agree`** with none.

## Follow-up, not in this PR

The rollback leaves `role_surface_id` persisted while deliberately closing that surface. Clearing torn-down identities at the write side would make the stored state self-consistent, but it would not help rows already written, so the read-side invariant is the durable fix.

Separately, the launch failure itself has now happened twice and is nowhere logged — the coordinator keeps no log file, so the cause is only visible in the lifecycle reason after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACfrat7V4yqp8sbZCRCvxa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery handling for rolled-back invocations that never established a native session.
  * Prevented historical, partially rolled-back invocations from being incorrectly reported as recovery discrepancies.
  * Continued to flag active projection drift when a native session and surface remain present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->