### PR TITLE
Capture harness output when a session fails to launch or exits

### DIFF
--- a/internal/factory/agent_internal_test.go
+++ b/internal/factory/agent_internal_test.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"testing"
 
 	"github.com/Stevie1704/sw-factory/internal/prompt"
@@ -218,24 +220,24 @@ func TestValidatePersistedInvocationPacketRequiresReviewRepairContext(t *testing
 	}
 }
 
-// TestWriteLaunchFailureDiagnosticRecordsTheTranscript verifies that a failed
+// TestWriteHarnessFailureDiagnosticRecordsTheTranscript verifies that a failed
 // launch leaves a readable local diagnostic beside its invocation, since the
 // surface is closed and the worker stopped immediately afterwards.
-func TestWriteLaunchFailureDiagnosticRecordsTheTranscript(t *testing.T) {
+func TestWriteHarnessFailureDiagnosticRecordsTheTranscript(t *testing.T) {
 	root := t.TempDir()
 	observed := time.Date(2026, 8, 31, 8, 32, 55, 0, time.UTC)
 	cause := errors.New("discover Codex native session: deadline exceeded")
 	launchErr := &harness.LaunchFailure{Cause: cause, Transcript: "codex: stream error: 429 Too Many Requests"}
 
-	path := writeLaunchFailureDiagnostic(root, launchErr, observed)
-	if path != filepath.Join(root, launchFailureDiagnosticName) {
-		t.Fatalf("writeLaunchFailureDiagnostic() = %q, want the invocation-local diagnostic path", path)
+	path := writeHarnessFailureDiagnostic(root, "launch", launchErr, harness.LaunchTranscript(launchErr), observed)
+	if path != filepath.Join(root, harnessFailureDiagnosticName) {
+		t.Fatalf("writeHarnessFailureDiagnostic() = %q, want the invocation-local diagnostic path", path)
 	}
 	body, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile() error = %v, want the diagnostic written", err)
 	}
-	for _, want := range []string{"2026-08-31T08:32:55Z", cause.Error(), "codex: stream error: 429 Too Many Requests"} {
+	for _, want := range []string{"2026-08-31T08:32:55Z", "occasion: launch", cause.Error(), "codex: stream error: 429 Too Many Requests"} {
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("diagnostic = %q, want it to contain %q", string(body), want)
 		}
@@ -250,17 +252,94 @@ func TestWriteLaunchFailureDiagnosticRecordsTheTranscript(t *testing.T) {
 	}
 }
 
-// TestWriteLaunchFailureDiagnosticSkipsAnEmptyTranscript verifies that a launch
+// TestWriteHarnessFailureDiagnosticNamesTheOccasion verifies that a session
+// that exited after a successful launch is distinguishable from a launch that
+// never started. Claude Code assigns its own session identifier, so its failed
+// launches only ever reach this occasion.
+func TestWriteHarnessFailureDiagnosticNamesTheOccasion(t *testing.T) {
+	root := t.TempDir()
+	cause := errors.New("claude native session \"session-1\" exited before reporting")
+
+	path := writeHarnessFailureDiagnostic(root, "session exit", cause, "claude: invalid API key", time.Now().UTC())
+	if path == "" {
+		t.Fatal("writeHarnessFailureDiagnostic() = \"\", want a diagnostic path")
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	for _, want := range []string{"occasion: session exit", "exited before reporting", "claude: invalid API key"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("diagnostic = %q, want it to contain %q", string(body), want)
+		}
+	}
+}
+
+// TestWriteHarnessFailureDiagnosticSkipsAnEmptyTranscript verifies that a
 // failure carrying no captured output writes no file and reports no path, so
 // nothing points an operator at a diagnostic that does not exist.
-func TestWriteLaunchFailureDiagnosticSkipsAnEmptyTranscript(t *testing.T) {
+func TestWriteHarnessFailureDiagnosticSkipsAnEmptyTranscript(t *testing.T) {
 	root := t.TempDir()
 	launchErr := &harness.LaunchFailure{Cause: errors.New("discover Codex native session: deadline exceeded")}
 
-	if path := writeLaunchFailureDiagnostic(root, launchErr, time.Now().UTC()); path != "" {
-		t.Fatalf("writeLaunchFailureDiagnostic() = %q, want no path without a transcript", path)
+	if path := writeHarnessFailureDiagnostic(root, "launch", launchErr, harness.LaunchTranscript(launchErr), time.Now().UTC()); path != "" {
+		t.Fatalf("writeHarnessFailureDiagnostic() = %q, want no path without a transcript", path)
 	}
-	if _, err := os.Stat(filepath.Join(root, launchFailureDiagnosticName)); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(root, harnessFailureDiagnosticName)); !os.IsNotExist(err) {
 		t.Fatalf("Stat() error = %v, want no diagnostic file", err)
+	}
+}
+
+// readableRecoveryTerminal adds the optional surface-read capability to the
+// recovery terminal fake.
+type readableRecoveryTerminal struct {
+	*journalRecoveryTerminal
+	screen  string
+	readErr error
+	lines   int
+}
+
+// ReadSurface returns the fake surface output and records the requested bound.
+func (t *readableRecoveryTerminal) ReadSurface(_ context.Context, _ terminal.SurfaceID, lines int) (string, error) {
+	t.lines = lines
+	if t.readErr != nil {
+		return "", t.readErr
+	}
+	return t.screen, nil
+}
+
+// TestCaptureSurfaceTranscriptReadsABoundedSurface verifies the coordinator
+// captures a bounded transcript when the terminal adapter can read surfaces.
+func TestCaptureSurfaceTranscriptReadsABoundedSurface(t *testing.T) {
+	runtime := &readableRecoveryTerminal{journalRecoveryTerminal: &journalRecoveryTerminal{}, screen: "  claude: invalid API key  "}
+
+	if got := captureSurfaceTranscript(context.Background(), runtime, "surface-1"); got != "claude: invalid API key" {
+		t.Fatalf("captureSurfaceTranscript() = %q, want the trimmed surface output", got)
+	}
+	if runtime.lines != harnessTranscriptLines {
+		t.Fatalf("requested lines = %d, want the bounded transcript length %d", runtime.lines, harnessTranscriptLines)
+	}
+}
+
+// TestCaptureSurfaceTranscriptDegradesQuietly verifies that a capture failure
+// never propagates. The caller is already reporting a harness failure, and a
+// missing diagnostic must not replace it.
+func TestCaptureSurfaceTranscriptDegradesQuietly(t *testing.T) {
+	cases := map[string]struct {
+		runtime   terminal.TerminalRuntime
+		surfaceID terminal.SurfaceID
+	}{
+		"adapter cannot read surfaces": {runtime: &journalRecoveryTerminal{}, surfaceID: "surface-1"},
+		"invocation has no surface":    {runtime: &readableRecoveryTerminal{journalRecoveryTerminal: &journalRecoveryTerminal{}, screen: "output"}, surfaceID: ""},
+		"read fails": {runtime: &readableRecoveryTerminal{
+			journalRecoveryTerminal: &journalRecoveryTerminal{}, readErr: errors.New("surface is gone"),
+		}, surfaceID: "surface-1"},
+	}
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := captureSurfaceTranscript(context.Background(), test.runtime, test.surfaceID); got != "" {
+				t.Fatalf("captureSurfaceTranscript() = %q, want empty", got)
+			}
+		})
 	}
 }

--- a/internal/factory/agent_internal_test.go
+++ b/internal/factory/agent_internal_test.go
@@ -1,9 +1,13 @@
 package factory
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/harness"
 	"testing"
 
 	"github.com/Stevie1704/sw-factory/internal/prompt"
@@ -211,5 +215,52 @@ func TestValidatePersistedInvocationPacketRequiresReviewRepairContext(t *testing
 	}
 	if err := validatePersistedInvocationPacket(run, invocation, persisted); err == nil || !strings.Contains(err.Error(), "review-repair context") {
 		t.Fatalf("validatePersistedInvocationPacket() error = %v, want missing review-repair context refusal", err)
+	}
+}
+
+// TestWriteLaunchFailureDiagnosticRecordsTheTranscript verifies that a failed
+// launch leaves a readable local diagnostic beside its invocation, since the
+// surface is closed and the worker stopped immediately afterwards.
+func TestWriteLaunchFailureDiagnosticRecordsTheTranscript(t *testing.T) {
+	root := t.TempDir()
+	observed := time.Date(2026, 8, 31, 8, 32, 55, 0, time.UTC)
+	cause := errors.New("discover Codex native session: deadline exceeded")
+	launchErr := &harness.LaunchFailure{Cause: cause, Transcript: "codex: stream error: 429 Too Many Requests"}
+
+	path := writeLaunchFailureDiagnostic(root, launchErr, observed)
+	if path != filepath.Join(root, launchFailureDiagnosticName) {
+		t.Fatalf("writeLaunchFailureDiagnostic() = %q, want the invocation-local diagnostic path", path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v, want the diagnostic written", err)
+	}
+	for _, want := range []string{"2026-08-31T08:32:55Z", cause.Error(), "codex: stream error: 429 Too Many Requests"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("diagnostic = %q, want it to contain %q", string(body), want)
+		}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	// The transcript holds harness output, so it stays owner-readable only.
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("diagnostic mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+// TestWriteLaunchFailureDiagnosticSkipsAnEmptyTranscript verifies that a launch
+// failure carrying no captured output writes no file and reports no path, so
+// nothing points an operator at a diagnostic that does not exist.
+func TestWriteLaunchFailureDiagnosticSkipsAnEmptyTranscript(t *testing.T) {
+	root := t.TempDir()
+	launchErr := &harness.LaunchFailure{Cause: errors.New("discover Codex native session: deadline exceeded")}
+
+	if path := writeLaunchFailureDiagnostic(root, launchErr, time.Now().UTC()); path != "" {
+		t.Fatalf("writeLaunchFailureDiagnostic() = %q, want no path without a transcript", path)
+	}
+	if _, err := os.Stat(filepath.Join(root, launchFailureDiagnosticName)); !os.IsNotExist(err) {
+		t.Fatalf("Stat() error = %v, want no diagnostic file", err)
 	}
 }

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -234,7 +234,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	}
 	invocationID := "inv-" + runID
 	createdAt := s.deps.Now().UTC()
-	root := filepath.Join(filepath.Dir(run.Worktree), ".factory-agents", run.ID, invocationID)
+	root := invocationRoot(*run, invocationID)
 	packetDirectory := filepath.Join(root, "packet")
 	resultDirectory := filepath.Join(root, "results")
 	if err := os.MkdirAll(packetDirectory, 0o700); err != nil {
@@ -484,7 +484,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		// printed is written beside the invocation before either happens. The
 		// path travels with the error so every waiting projection names the
 		// diagnostic without carrying its content.
-		if diagnostic := writeLaunchFailureDiagnostic(root, err, s.deps.Now().UTC()); diagnostic != "" {
+		if diagnostic := writeHarnessFailureDiagnostic(root, "launch", err, harness.LaunchTranscript(err), s.deps.Now().UTC()); diagnostic != "" {
 			classified = fmt.Errorf("%w (launch diagnostic: %s)", classified, diagnostic)
 		}
 		if harness.IsRateLimited(classified) {
@@ -977,25 +977,55 @@ func credentialHarnessLabel(harnessName string) string {
 	}
 }
 
-// launchFailureDiagnosticName is the invocation-local file that records what a
-// failed harness launch printed before its surface was closed.
-const launchFailureDiagnosticName = "launch-failure.log"
+// harnessFailureDiagnosticName is the invocation-local file that records what a
+// harness printed before the coordinator tore its session down.
+const harnessFailureDiagnosticName = "harness-failure.log"
 
-// writeLaunchFailureDiagnostic records a failed launch beside its invocation
-// and returns the path it wrote, or an empty string when there was nothing to
-// record. The file stays on the coordinator host: it holds harness output,
-// which the operator-visible run projections deliberately exclude. Writing it
-// is best-effort, because losing a diagnostic must never mask the launch
-// failure the caller is already reporting.
-func writeLaunchFailureDiagnostic(invocationRoot string, launchErr error, observedAt time.Time) string {
-	transcript := harness.LaunchTranscript(launchErr)
+// harnessTranscriptLines bounds a diagnostic surface read, matching the bound
+// the harness adapter applies when it captures a failing launch.
+const harnessTranscriptLines = 200
+
+// writeHarnessFailureDiagnostic records what a harness printed beside its
+// invocation and returns the path it wrote, or an empty string when there was
+// nothing to record. The occasion names why the coordinator captured it, so a
+// launch that never started reads differently from a session that exited.
+//
+// The file stays on the coordinator host: it holds harness output, which the
+// operator-visible run projections deliberately exclude. Writing it is
+// best-effort, because losing a diagnostic must never mask the failure the
+// caller is already reporting.
+func writeHarnessFailureDiagnostic(invocationRoot, occasion string, cause error, transcript string, observedAt time.Time) string {
 	if strings.TrimSpace(invocationRoot) == "" || strings.TrimSpace(transcript) == "" {
 		return ""
 	}
-	path := filepath.Join(invocationRoot, launchFailureDiagnosticName)
-	body := fmt.Sprintf("observed at: %s\nlaunch error: %v\n\nsurface output:\n%s\n", observedAt.Format(time.RFC3339), launchErr, transcript)
+	path := filepath.Join(invocationRoot, harnessFailureDiagnosticName)
+	body := fmt.Sprintf("observed at: %s\noccasion: %s\ncause: %v\n\nsurface output:\n%s\n", observedAt.Format(time.RFC3339), occasion, cause, transcript)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		return ""
 	}
 	return path
+}
+
+// captureSurfaceTranscript reads a surface's recent output when the terminal
+// adapter exposes that capability. It is the coordinator-side counterpart to
+// the harness adapter's launch capture, used where the coordinator, not the
+// adapter, is the first to observe that a session is gone.
+func captureSurfaceTranscript(ctx context.Context, runtime terminal.TerminalRuntime, surfaceID terminal.SurfaceID) string {
+	reader, readable := runtime.(terminal.SurfaceReader)
+	if !readable || strings.TrimSpace(string(surfaceID)) == "" {
+		return ""
+	}
+	captureContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	transcript, err := reader.ReadSurface(captureContext, surfaceID, harnessTranscriptLines)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(transcript)
+}
+
+// invocationRoot returns the private per-invocation directory holding one
+// invocation's packet, results, and diagnostics.
+func invocationRoot(run store.Run, invocationID string) string {
+	return filepath.Join(filepath.Dir(run.Worktree), ".factory-agents", run.ID, invocationID)
 }

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -479,6 +479,14 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	}
 	if err != nil {
 		classified := harness.ClassifyError(err, string(policy.Harness))
+		// A launch failure is otherwise unrecoverable after the fact: the
+		// surface is closed and the worker stopped, so whatever the harness
+		// printed is written beside the invocation before either happens. The
+		// path travels with the error so every waiting projection names the
+		// diagnostic without carrying its content.
+		if diagnostic := writeLaunchFailureDiagnostic(root, err, s.deps.Now().UTC()); diagnostic != "" {
+			classified = fmt.Errorf("%w (launch diagnostic: %s)", classified, diagnostic)
+		}
 		if harness.IsRateLimited(classified) {
 			preserveInvocation = true
 			invocation.Status = store.InvocationStatusSuperseded
@@ -967,4 +975,27 @@ func credentialHarnessLabel(harnessName string) string {
 	default:
 		return "harness"
 	}
+}
+
+// launchFailureDiagnosticName is the invocation-local file that records what a
+// failed harness launch printed before its surface was closed.
+const launchFailureDiagnosticName = "launch-failure.log"
+
+// writeLaunchFailureDiagnostic records a failed launch beside its invocation
+// and returns the path it wrote, or an empty string when there was nothing to
+// record. The file stays on the coordinator host: it holds harness output,
+// which the operator-visible run projections deliberately exclude. Writing it
+// is best-effort, because losing a diagnostic must never mask the launch
+// failure the caller is already reporting.
+func writeLaunchFailureDiagnostic(invocationRoot string, launchErr error, observedAt time.Time) string {
+	transcript := harness.LaunchTranscript(launchErr)
+	if strings.TrimSpace(invocationRoot) == "" || strings.TrimSpace(transcript) == "" {
+		return ""
+	}
+	path := filepath.Join(invocationRoot, launchFailureDiagnosticName)
+	body := fmt.Sprintf("observed at: %s\nlaunch error: %v\n\nsurface output:\n%s\n", observedAt.Format(time.RFC3339), launchErr, transcript)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		return ""
+	}
+	return path
 }

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -517,10 +517,29 @@ func (s *Service) reconcileActiveHarnessLiveness(ctx context.Context, registrati
 		// is gone. Claude Code assigns its own session identifier, so a Claude
 		// launch that dies immediately is only ever observed here. Capture the
 		// surface before reconciliation stops the worker behind it.
-		s.recordSessionExitDiagnostic(ctx, registration, run, active)
-		_, _, _, reconcileErr := s.reconcileInterruptedRunWithMode(ctx, registration, runStore, run, true)
+		diagnostic := s.recordSessionExitDiagnostic(ctx, registration, run, active)
+		recovered, _, _, reconcileErr := s.reconcileInterruptedRunWithMode(ctx, registration, runStore, run, true)
 		if reconcileErr != nil {
+			if diagnostic != "" {
+				return fmt.Errorf("%w (session-exit diagnostic: %s)", reconcileErr, diagnostic)
+			}
 			return reconcileErr
+		}
+		if diagnostic != "" {
+			diagnosticReason := fmt.Sprintf("session-exit diagnostic: %s", diagnostic)
+			next := recovered
+			if strings.TrimSpace(next.LifecycleReason) == "" {
+				next.LifecycleReason = diagnosticReason
+			} else if !strings.Contains(next.LifecycleReason, diagnosticReason) {
+				next.LifecycleReason += "; " + diagnosticReason
+			}
+			if next.LifecycleReason != recovered.LifecycleReason {
+				next.Revision = recovered.Revision + 1
+				next.UpdatedAt = s.deps.Now().UTC()
+				if err := s.persistAgentRunState(ctx, registration, runStore, recovered, next); err != nil {
+					return fmt.Errorf("persist session-exit diagnostic projection %q: %w", diagnostic, err)
+				}
+			}
 		}
 		return nil
 	}
@@ -876,13 +895,14 @@ func (s *Service) resetStartupState() {
 // recordSessionExitDiagnostic captures what a harness printed before its
 // session ended and writes it beside the invocation. Without it an exited
 // session reports only that it exited, which is the same dead end a failed
-// launch used to reach.
-func (s *Service) recordSessionExitDiagnostic(ctx context.Context, registration config.RepositoryRegistration, run store.Run, invocation store.Invocation) {
+// launch used to reach. It returns only the local diagnostic path so callers
+// can expose that location without copying transcript contents into metadata.
+func (s *Service) recordSessionExitDiagnostic(ctx context.Context, registration config.RepositoryRegistration, run store.Run, invocation store.Invocation) string {
 	terminalRuntime := s.deps.Terminal
 	if terminalRuntime == nil {
 		terminalRuntime = terminal.NewCmuxRuntime(nil, registration.Cmux.SocketPath)
 	}
 	transcript := captureSurfaceTranscript(ctx, terminalRuntime, invocationSurface(invocation).ID)
 	cause := fmt.Errorf("%s native session %q exited before reporting", invocation.Harness, invocation.NativeSessionID)
-	writeHarnessFailureDiagnostic(invocationRoot(run, invocation.ID), "session exit", cause, transcript, s.deps.Now().UTC())
+	return writeHarnessFailureDiagnostic(invocationRoot(run, invocation.ID), "session exit", cause, transcript, s.deps.Now().UTC())
 }

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -513,6 +513,11 @@ func (s *Service) reconcileActiveHarnessLiveness(ctx context.Context, registrati
 		if running {
 			continue
 		}
+		// The coordinator, not the adapter, is the first to see that a session
+		// is gone. Claude Code assigns its own session identifier, so a Claude
+		// launch that dies immediately is only ever observed here. Capture the
+		// surface before reconciliation stops the worker behind it.
+		s.recordSessionExitDiagnostic(ctx, registration, run, active)
 		_, _, _, reconcileErr := s.reconcileInterruptedRunWithMode(ctx, registration, runStore, run, true)
 		if reconcileErr != nil {
 			return reconcileErr
@@ -866,4 +871,18 @@ func (s *Service) resetStartupState() {
 	defer s.startupMu.Unlock()
 	s.startupChecked = false
 	s.startupErr = nil
+}
+
+// recordSessionExitDiagnostic captures what a harness printed before its
+// session ended and writes it beside the invocation. Without it an exited
+// session reports only that it exited, which is the same dead end a failed
+// launch used to reach.
+func (s *Service) recordSessionExitDiagnostic(ctx context.Context, registration config.RepositoryRegistration, run store.Run, invocation store.Invocation) {
+	terminalRuntime := s.deps.Terminal
+	if terminalRuntime == nil {
+		terminalRuntime = terminal.NewCmuxRuntime(nil, registration.Cmux.SocketPath)
+	}
+	transcript := captureSurfaceTranscript(ctx, terminalRuntime, invocationSurface(invocation).ID)
+	cause := fmt.Errorf("%s native session %q exited before reporting", invocation.Harness, invocation.NativeSessionID)
+	writeHarnessFailureDiagnostic(invocationRoot(run, invocation.ID), "session exit", cause, transcript, s.deps.Now().UTC())
 }

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -319,7 +319,14 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 	githubRuntime.issue.Labels = []string{factoryLabelForStatus(activeRun.Status)}
 	githubRuntime.statusComment.Body = statusCommentBody(activeRun)
 	harnessRuntime.nativeSessionExited = true
-	if err := lossService.retryWaitingForHarness(ctx, registration); err != nil {
+	diagnosticRoot := invocationRoot(activeRun, invocation.ID)
+	if err := os.MkdirAll(diagnosticRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	transcript := "claude: session-exit-secret"
+	liveService := &Service{deps: service.deps}
+	liveService.deps.Terminal = &readableRecoveryTerminal{journalRecoveryTerminal: terminalRuntime, screen: transcript}
+	if err := liveService.retryWaitingForHarness(ctx, registration); err != nil {
 		t.Fatalf("live harness interruption recovery = %v", err)
 	}
 	if harnessRuntime.resumeCalls != 3 {
@@ -328,6 +335,13 @@ func TestJournaledStartupRecreatesALostWorkerAndResumesOnce(t *testing.T) {
 	liveRecovered, err := opened.CurrentRun(ctx)
 	if err != nil || liveRecovered == nil || liveRecovered.Status != store.StatusActive {
 		t.Fatalf("run after live harness recovery = %#v, error = %v; want active run", liveRecovered, err)
+	}
+	diagnosticPath := filepath.Join(diagnosticRoot, harnessFailureDiagnosticName)
+	if !strings.Contains(liveRecovered.LifecycleReason, diagnosticPath) {
+		t.Fatalf("live recovery reason = %q, want diagnostic path %q", liveRecovered.LifecycleReason, diagnosticPath)
+	}
+	if strings.Contains(liveRecovered.LifecycleReason, transcript) {
+		t.Fatalf("live recovery projection leaked transcript: %q", liveRecovered.LifecycleReason)
 	}
 
 	// A configured source that disappears before the next restart must pause

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -511,7 +511,7 @@ func (s *Service) startCheckRepair(ctx context.Context, registration config.Repo
 	}
 	invocationID := "inv-" + identifier
 	createdAt := s.deps.Now().UTC()
-	root := filepath.Join(filepath.Dir(run.Worktree), ".factory-agents", run.ID, invocationID)
+	root := invocationRoot(run, invocationID)
 	packetDirectory := filepath.Join(root, "packet")
 	resultDirectory := filepath.Join(root, "results")
 	if err := os.MkdirAll(packetDirectory, 0o700); err != nil {

--- a/internal/harness/codex.go
+++ b/internal/harness/codex.go
@@ -137,15 +137,19 @@ func (c *Codex) launch(ctx context.Context, request StartRequest) (Session, erro
 		if snapshotProvider != nil {
 			discovered, discoverErr := discoverNativeSession(ctx, snapshotProvider, baseline, worker.NativeSessionRequest{RunID: request.RunID, WorkerID: request.WorkerID, Harness: NameCodex})
 			if discoverErr != nil {
+				// Codex reports why it could not start on its surface, so the
+				// transcript is captured before the surface is closed.
+				failure := captureLaunchFailure(ctx, c.Terminal, surface.ID, fmt.Errorf("discover Codex native session: %w", discoverErr))
 				_ = c.Terminal.CloseSurface(ctx, surface.ID)
-				return Session{}, fmt.Errorf("discover Codex native session: %w", discoverErr)
+				return Session{}, failure
 			}
 			nativeSessionID = discovered
 		} else if provider, ok := c.Worker.(worker.NativeSessionProvider); ok {
 			discovered, discoverErr := provider.NativeSessionID(ctx, worker.NativeSessionRequest{RunID: request.RunID, WorkerID: request.WorkerID, Harness: NameCodex})
 			if discoverErr != nil {
+				failure := captureLaunchFailure(ctx, c.Terminal, surface.ID, fmt.Errorf("discover Codex native session: %w", discoverErr))
 				_ = c.Terminal.CloseSurface(ctx, surface.ID)
-				return Session{}, fmt.Errorf("discover Codex native session: %w", discoverErr)
+				return Session{}, failure
 			}
 			nativeSessionID = discovered
 		}

--- a/internal/harness/codex_test.go
+++ b/internal/harness/codex_test.go
@@ -162,6 +162,93 @@ func TestCodexDiscoveryFailureClosesTheSurface(t *testing.T) {
 	}
 }
 
+// TestCodexDiscoveryFailureCapturesTheSurfaceTranscript verifies that the
+// surface output diagnosing a failed launch is captured before the surface is
+// closed. Without it the cause is unrecoverable: the surface is gone and the
+// worker is stopped by the time anyone reads the run.
+func TestCodexDiscoveryFailureCapturesTheSurfaceTranscript(t *testing.T) {
+	workerRuntime := &snapshotWorker{fakeWorker: &fakeWorker{}, snapshots: [][]string{{"session-old"}}}
+	base := &fakeTerminal{
+		surface:    terminal.Surface{ID: "surface-implementation", WorkspaceID: "workspace-run", Name: "implementation"},
+		launchHook: workerRuntime.markSurfaceStarted,
+	}
+	terminalRuntime := &readableTerminal{fakeTerminal: base, screen: "codex: stream error: 429 Too Many Requests"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := harness.NewCodex(workerRuntime, terminalRuntime).Start(ctx, harness.StartRequest{
+		InvocationID: "inv-transcript",
+		RunID:        "run-1",
+		Role:         "implementation",
+		Stage:        "implementation",
+		WorkspaceID:  "workspace-run",
+		Surface:      base.surface,
+		Prompt:       "Start the implementation.",
+	})
+	if !errors.Is(err, harness.ErrNativeSessionUnavailable) {
+		t.Fatalf("Start() error = %v, want native-session-unavailable sentinel", err)
+	}
+	if got := harness.LaunchTranscript(err); got != terminalRuntime.screen {
+		t.Fatalf("LaunchTranscript() = %q, want %q", got, terminalRuntime.screen)
+	}
+	// Capture must happen while the surface still exists.
+	if terminalRuntime.readAfterClose {
+		t.Fatal("surface was read after it was closed, want capture before cleanup")
+	}
+	if base.closed != string(base.surface.ID) {
+		t.Fatalf("closed surface = %q, want %q", base.closed, base.surface.ID)
+	}
+}
+
+// TestCodexLaunchFailureKeepsTheTranscriptOutOfTheMessage verifies the captured
+// harness output never reaches Error(). That string is copied into the run
+// lifecycle reason and the GitHub status comment, which stay free of work
+// content.
+func TestCodexLaunchFailureKeepsTheTranscriptOutOfTheMessage(t *testing.T) {
+	workerRuntime := &snapshotWorker{fakeWorker: &fakeWorker{}, snapshots: [][]string{{"session-old"}}}
+	base := &fakeTerminal{
+		surface:    terminal.Surface{ID: "surface-implementation", WorkspaceID: "workspace-run", Name: "implementation"},
+		launchHook: workerRuntime.markSurfaceStarted,
+	}
+	terminalRuntime := &readableTerminal{fakeTerminal: base, screen: "secret-bearing agent output"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := harness.NewCodex(workerRuntime, terminalRuntime).Start(ctx, harness.StartRequest{
+		InvocationID: "inv-bounded", RunID: "run-1", Role: "implementation", Stage: "implementation",
+		WorkspaceID: "workspace-run", Surface: base.surface, Prompt: "Start the implementation.",
+	})
+	if err == nil {
+		t.Fatal("Start() error = nil, want a launch failure")
+	}
+	if strings.Contains(err.Error(), terminalRuntime.screen) {
+		t.Fatalf("Start() error = %q, want the transcript excluded from the message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "discover Codex native session") {
+		t.Fatalf("Start() error = %q, want the launch cause preserved", err.Error())
+	}
+}
+
+// TestCodexDiscoveryFailureSurvivesAnUnreadableSurface verifies that a terminal
+// adapter without the read capability still reports the launch failure itself.
+func TestCodexDiscoveryFailureSurvivesAnUnreadableSurface(t *testing.T) {
+	workerRuntime := &snapshotWorker{fakeWorker: &fakeWorker{}, snapshots: [][]string{{"session-old"}}}
+	terminalRuntime := &fakeTerminal{
+		surface:    terminal.Surface{ID: "surface-implementation", WorkspaceID: "workspace-run", Name: "implementation"},
+		launchHook: workerRuntime.markSurfaceStarted,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := harness.NewCodex(workerRuntime, terminalRuntime).Start(ctx, harness.StartRequest{
+		InvocationID: "inv-unreadable", RunID: "run-1", Role: "implementation", Stage: "implementation",
+		WorkspaceID: "workspace-run", Surface: terminalRuntime.surface, Prompt: "Start the implementation.",
+	})
+	if !errors.Is(err, harness.ErrNativeSessionUnavailable) {
+		t.Fatalf("Start() error = %v, want native-session-unavailable sentinel", err)
+	}
+	if got := harness.LaunchTranscript(err); got != "" {
+		t.Fatalf("LaunchTranscript() = %q, want empty for an unreadable surface", got)
+	}
+}
+
 // TestCodexLegacyDiscoveryFailureClosesTheSurface verifies cleanup also
 // covers runtimes that expose only the single-session lookup seam.
 func TestCodexLegacyDiscoveryFailureClosesTheSurface(t *testing.T) {
@@ -328,3 +415,24 @@ var _ worker.InteractiveRuntime = (*fakeWorker)(nil)
 var _ worker.NativeSessionSnapshotProvider = (*snapshotWorker)(nil)
 var _ worker.NativeSessionProvider = (*failingNativeSessionWorker)(nil)
 var _ terminal.TerminalRuntime = (*fakeTerminal)(nil)
+
+// readableTerminal adds the optional surface-read capability to the harness
+// terminal fake and records whether the read happened after cleanup.
+type readableTerminal struct {
+	*fakeTerminal
+	screen         string
+	readAfterClose bool
+}
+
+// ReadSurface returns the fake surface output and notes read-after-close.
+func (t *readableTerminal) ReadSurface(_ context.Context, _ terminal.SurfaceID, lines int) (string, error) {
+	if lines <= 0 {
+		return "", errors.New("surface line count must be greater than zero")
+	}
+	if t.closed != "" {
+		t.readAfterClose = true
+	}
+	return t.screen, nil
+}
+
+var _ terminal.SurfaceReader = (*readableTerminal)(nil)

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -145,7 +145,80 @@ const (
 	// nativeSessionDiscoveryMaxInterval keeps discovery responsive without
 	// repeatedly invoking the worker while the harness is still starting.
 	nativeSessionDiscoveryMaxInterval = 500 * time.Millisecond
+	// launchCaptureTimeout bounds the best-effort diagnostic read of a failing
+	// launch surface so capture never delays reporting the failure itself.
+	launchCaptureTimeout = 10 * time.Second
 )
+
+// launchTranscriptLines bounds the surface output captured when a launch
+// fails. It is large enough to hold a harness startup banner and its error,
+// and small enough to stay a readable diagnostic rather than a transcript.
+const launchTranscriptLines = 200
+
+// LaunchFailure reports a harness launch that failed after its surface existed,
+// carrying the output that surface was showing at the moment of failure.
+//
+// The transcript is deliberately absent from Error(). A launch error reaches
+// operator-visible projections such as the run lifecycle reason and the GitHub
+// status comment, which stay free of work content; the transcript belongs in
+// local diagnostics that only the operator running the coordinator can read.
+type LaunchFailure struct {
+	// Cause is the underlying launch failure.
+	Cause error
+	// Transcript is the captured surface output, empty when capture failed or
+	// the terminal adapter cannot read surfaces.
+	Transcript string
+}
+
+// Error returns the underlying cause without the captured transcript.
+func (e *LaunchFailure) Error() string {
+	if e == nil {
+		return "harness launch failed"
+	}
+	if e.Cause == nil {
+		return "harness launch failed"
+	}
+	return e.Cause.Error()
+}
+
+// Unwrap exposes the underlying cause so existing classification keeps working.
+func (e *LaunchFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// LaunchTranscript returns the surface output captured for a failed launch, or
+// an empty string when the error carries none.
+func LaunchTranscript(err error) string {
+	var failure *LaunchFailure
+	if !errors.As(err, &failure) || failure == nil {
+		return ""
+	}
+	return failure.Transcript
+}
+
+// captureLaunchFailure enriches a launch failure with the surface output that
+// diagnoses it. The surface is about to be closed by the caller, so this is the
+// only moment the harness's own error message is still readable. Capture is
+// best-effort: a diagnostic that cannot be read must never replace the failure
+// the caller is already reporting.
+func captureLaunchFailure(ctx context.Context, runtime terminal.TerminalRuntime, surfaceID terminal.SurfaceID, cause error) error {
+	reader, readable := runtime.(terminal.SurfaceReader)
+	if !readable || strings.TrimSpace(string(surfaceID)) == "" {
+		return &LaunchFailure{Cause: cause}
+	}
+	// The caller's context is commonly already past its deadline when a launch
+	// fails, so capture runs on its own bounded context.
+	captureContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), launchCaptureTimeout)
+	defer cancel()
+	transcript, err := reader.ReadSurface(captureContext, surfaceID, launchTranscriptLines)
+	if err != nil {
+		return &LaunchFailure{Cause: cause}
+	}
+	return &LaunchFailure{Cause: cause, Transcript: strings.TrimSpace(transcript)}
+}
 
 // ErrNativeSessionUnavailable reports that a fresh launch did not expose a
 // newly persisted native session before discovery timed out or was canceled.

--- a/internal/terminal/runtime.go
+++ b/internal/terminal/runtime.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -98,6 +99,13 @@ type WorkspaceInspection struct {
 // persisted cmux handles before a native session is resumed.
 type WorkspaceInspector interface {
 	InspectWorkspace(context.Context, WorkspaceID) (WorkspaceInspection, error)
+}
+
+// SurfaceReader is the optional adapter capability that reads a surface's
+// visible output. A launch that fails leaves its diagnosis only on the surface,
+// so callers capture that output before the failure path closes the surface.
+type SurfaceReader interface {
+	ReadSurface(context.Context, SurfaceID, int) (string, error)
 }
 
 // SurfaceRequest asks the adapter to create one additional terminal surface.
@@ -364,6 +372,28 @@ func (r *CmuxRuntime) CloseSurface(ctx context.Context, surfaceID SurfaceID) err
 		return fmt.Errorf("close terminal surface: %w", err)
 	}
 	return nil
+}
+
+// ReadSurface returns one surface's visible output and scrollback, bounded to
+// the requested number of lines.
+func (r *CmuxRuntime) ReadSurface(ctx context.Context, surfaceID SurfaceID, lines int) (string, error) {
+	if strings.TrimSpace(string(surfaceID)) == "" {
+		return "", errors.New("surface id is required")
+	}
+	if lines <= 0 {
+		return "", errors.New("surface line count must be greater than zero")
+	}
+	// Surface lookup is scoped to a workspace, so the owning workspace is
+	// resolved before the surface is read.
+	workspaceID, err := r.surfaceWorkspace(ctx, surfaceID)
+	if err != nil {
+		return "", err
+	}
+	output, err := r.run(ctx, []string{"read-screen", "--surface", string(surfaceID), "--workspace", string(workspaceID), "--scrollback", "--lines", strconv.Itoa(lines)}, nil)
+	if err != nil {
+		return "", fmt.Errorf("read terminal surface: %w", err)
+	}
+	return string(output), nil
 }
 
 // CloseWorkspace closes a workspace through the adapter lifecycle command.

--- a/internal/terminal/runtime_test.go
+++ b/internal/terminal/runtime_test.go
@@ -29,6 +29,44 @@ func treeResponse(workspaceID string, titledSurfaces map[string]string) string {
 	return `{"windows":[{"workspaces":[{"id":"` + workspaceID + `","panes":[` + strings.Join(panes, ",") + `]}]}]}`
 }
 
+// TestCmuxRuntimeReadsSurfaceScrollback verifies the adapter asks the terminal
+// for a surface's scrollback bounded to the requested line count. A failed
+// launch is diagnosable only from this output, so the request must include the
+// scrollback rather than just the visible screen.
+func TestCmuxRuntimeReadsSurfaceScrollback(t *testing.T) {
+	runner := &fakeRunner{tree: treeResponse(runWorkspaceID, map[string]string{"implementation": implementationSurface})}
+	runtime := terminal.NewCmuxRuntime(runner)
+
+	output, err := runtime.ReadSurface(context.Background(), implementationSurface, 200)
+	if err != nil {
+		t.Fatalf("ReadSurface() error = %v", err)
+	}
+	if strings.TrimSpace(output) != "OK" {
+		t.Fatalf("ReadSurface() = %q, want the terminal output", output)
+	}
+	joined := strings.Join(runner.calls, "\n")
+	for _, wanted := range []string{
+		"read-screen --surface " + string(implementationSurface),
+		"--workspace " + runWorkspaceID,
+		"--scrollback",
+		"--lines 200",
+	} {
+		if !strings.Contains(joined, wanted) {
+			t.Fatalf("adapter calls = %q, want %q", joined, wanted)
+		}
+	}
+}
+
+// TestCmuxRuntimeRejectsAnUnboundedSurfaceRead verifies the adapter refuses a
+// read without a line bound, so a diagnostic capture can never pull an
+// arbitrarily large transcript.
+func TestCmuxRuntimeRejectsAnUnboundedSurfaceRead(t *testing.T) {
+	runtime := terminal.NewCmuxRuntime(&fakeRunner{})
+	if _, err := runtime.ReadSurface(context.Background(), implementationSurface, 0); err == nil {
+		t.Fatal("ReadSurface() error = nil, want a rejected unbounded read")
+	}
+}
+
 // TestCmuxRuntimeKeepsTerminalHandlesBehindThePortableSeam verifies that the
 // adapter creates the control/run surfaces and routes input and notifications
 // without exposing adapter-specific command details to callers.
@@ -212,3 +250,4 @@ func (r *fakeRunner) Run(_ context.Context, args []string, _ []byte) ([]byte, er
 
 var _ terminal.CommandRunner = (*fakeRunner)(nil)
 var _ terminal.TerminalRuntime = (*terminal.CmuxRuntime)(nil)
+var _ terminal.SurfaceReader = (*terminal.CmuxRuntime)(nil)


### PR DESCRIPTION
## Problem

Three harness failures in a row have been undiagnosable after the fact. The harness reports why it could not start **on its surface**, and the coordinator tears that surface down before anyone reads the run. All that survives is a one-line reason.

The two harnesses lose it differently:

| | How a failed start is detected | What survived |
|---|---|---|
| **Codex** | Session discovery times out at launch (`codex.go:143`), surface closed immediately | `discover Codex native session: ... deadline exceeded` |
| **Claude** | Not detected at launch at all — the adapter assigns its own session id, so `launch` returns a `Session` for a process that may already be gone. The polling liveness monitor notices later (`interruption.go:503`) | `harness.lifecycle expected="...running" observed="exited"` |

Neither says *why*. For `run-de1e2e3f` the cause is still unknown: auth was present and valid, `config.toml` matched working volumes, the same model had succeeded two minutes earlier in the test role, and `.codex/tmp/arg0/` showed the binary was invoked and exited before creating a session. The one place that would have said why was the surface.

## Change

Capture the surface at the moment of detection, before teardown, on both paths.

- **`terminal`** — `SurfaceReader`, an optional adapter capability, implemented by `CmuxRuntime.ReadSurface` over `cmux read-screen --scrollback --lines N`. Follows the existing optional-capability pattern (`WorkspaceInspector`) and `CloseSurface`'s workspace resolution.
- **`harness`** — `LaunchFailure{Cause, Transcript}` and `captureLaunchFailure`, wired into both Codex discovery failure paths *before* `CloseSurface`.
- **`factory`** — `captureSurfaceTranscript` for the coordinator-observed case, called from the liveness monitor before reconciliation stops the worker. `writeHarnessFailureDiagnostic` writes `harness-failure.log` into the invocation directory; on the launch path it returns the path, which is wrapped into the classified error so every waiting projection names it.

The file records the occasion, so a launch that never started reads differently from a session that exited. The liveness path also closes the equivalent blind spot for a **Codex** session that dies after a successful launch.

Also extracts `invocationRoot`, now that a third caller needs the private per-invocation directory.

### Content boundary

The transcript is deliberately **absent from `Error()`**. That string is copied into the run lifecycle reason and the GitHub status comment, which this codebase keeps free of work content. The message names the path; the file holds the content, mode `0600`, on the coordinator host only. A test pins this.

### Failure modes

Capture never masks the failure it is diagnosing:

| Condition | Behavior |
|---|---|
| Adapter has no read capability | Empty transcript, no file, no path |
| Invocation has no surface | Same |
| Caller context past its deadline | Capture runs on `context.WithoutCancel` + 10s bound |
| Read or write fails | Original failure reported unchanged |
| Nothing captured | No file, no path — nothing points at a diagnostic that does not exist |

Classification still works: `LaunchFailure` unwraps to its cause, and `IsRateLimited` and friends use `errors.Is`.

## Verification

- 3 harness tests: transcript captured; capture happens **before** the surface is closed; transcript excluded from `Error()`; unreadable adapter degrades cleanly.
- 6 factory tests: file content and `0600` mode; occasion recorded for both launch and session exit; no-transcript case writes nothing; bounded read; three degradation paths.
- 2 terminal tests: exact command construction including `--scrollback` and `--lines`; unbounded read rejected.
- `gofmt`, `go vet`, full `go test ./...` pass.
- **Live check against the running cmux**: the adapter resolved the workspace from a bare surface ID and captured 1176 bytes of real Codex output from this repository's own stuck run. Run with a temporary test file, since the suite must stay hermetic.

## Not in this PR

The 60s Codex discovery window is unchanged. The evidence says the failing launch wrote no session at all rather than writing one slowly — the succeeding test role wrote its rollout in ~14s against that same 60s budget — so widening the window would delay reporting rather than prevent the failure. Worth revisiting once a captured transcript shows what the harness actually printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACfrat7V4yqp8sbZCRCvxa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Failed launches now include bounded terminal output to aid troubleshooting.
  - Diagnostics identify the failure occasion, including post-launch session exits.
  - Terminal output can be safely captured with time and size limits.
  - Original errors remain available alongside captured transcripts.

- **Bug Fixes**
  - Failure transcripts are preserved before terminal cleanup.
  - Native session discovery failures now retain relevant terminal output.
  - Unavailable, unreadable, or empty transcripts are handled quietly without unnecessary diagnostic files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->