### PR TITLE
Stage the launch command instead of typing it into the surface

### DIFF
--- a/internal/terminal/runtime.go
+++ b/internal/terminal/runtime.go
@@ -284,8 +284,13 @@ func (r *CmuxRuntime) CreateSurface(ctx context.Context, request SurfaceRequest)
 }
 
 // LaunchSurface starts a command in a surface created as part of a workspace
-// layout. The command is sent as one shell-quoted line; terminal output is
-// never read to determine whether it started.
+// layout. The command is written to a private script and only that script's
+// path is typed, because a terminal is a lossy channel for anything longer
+// than a short single line. A role prompt is multi-kilobyte and multi-line, and
+// typing it races the interactive program redrawing its own screen: the
+// program receives the argument truncated and re-spliced, with no error
+// anywhere. Terminal output is still never read to decide whether the command
+// started.
 func (r *CmuxRuntime) LaunchSurface(ctx context.Context, surfaceID SurfaceID, command Command) error {
 	if strings.TrimSpace(string(surfaceID)) == "" {
 		return errors.New("surface id is required")
@@ -293,10 +298,39 @@ func (r *CmuxRuntime) LaunchSurface(ctx context.Context, surfaceID SurfaceID, co
 	if err := validateCommand(command); err != nil {
 		return err
 	}
-	if err := r.sendToSurface(ctx, surfaceID, commandLine(command)+"\n"); err != nil {
+	script, err := writeLaunchScript(commandLine(command))
+	if err != nil {
+		return fmt.Errorf("stage terminal launch: %w", err)
+	}
+	if err := r.sendToSurface(ctx, surfaceID, "sh "+shellQuote(script)+"\n"); err != nil {
+		_ = os.Remove(script)
 		return fmt.Errorf("launch terminal surface: %w", err)
 	}
 	return nil
+}
+
+// writeLaunchScript stores one launch command line in a private script and
+// returns its path. The script removes itself before exec, so a command line
+// carrying a role prompt does not outlive the launch; the shell keeps reading
+// the script through its own open descriptor after the file is unlinked. The
+// exec then leaves the surface owning the same process it owned before.
+func writeLaunchScript(launchCommand string) (string, error) {
+	file, err := os.CreateTemp("", "factory-launch-*.sh")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	body := "rm -f " + shellQuote(path) + "\nexec " + launchCommand + "\n"
+	if _, err := file.WriteString(body); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
 }
 
 // SendInput routes exact bytes to a visible surface; screen content is never

--- a/internal/terminal/runtime_test.go
+++ b/internal/terminal/runtime_test.go
@@ -3,6 +3,7 @@ package terminal_test
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -27,6 +28,102 @@ func treeResponse(workspaceID string, titledSurfaces map[string]string) string {
 		panes = append(panes, `{"surfaces":[{"id":"`+identifier+`","title":"`+title+`","type":"terminal"}]}`)
 	}
 	return `{"windows":[{"workspaces":[{"id":"` + workspaceID + `","panes":[` + strings.Join(panes, ",") + `]}]}]}`
+}
+
+// TestLaunchSurfaceNeverTypesTheCommandItself verifies the launch keeps a
+// large multi-line argument off the terminal. A role prompt is delivered this
+// way, and typing one races the interactive program's own screen redraw: the
+// program then receives it truncated and re-spliced with no error reported
+// anywhere, which is how an agent ends up working from an incomplete prompt.
+func TestLaunchSurfaceNeverTypesTheCommandItself(t *testing.T) {
+	runner := &fakeRunner{}
+	runtime := terminal.NewCmuxRuntime(runner)
+	prompt := "factory prompt version implementation-v1\n" + strings.Repeat("frozen specification line\n", 400)
+
+	if err := runtime.LaunchSurface(context.Background(), implementationSurface, terminal.Command{
+		Executable: "factory-worker-attach",
+		Args:       []string{"--run-id", "run-1", "--", "codex", prompt},
+	}); err != nil {
+		t.Fatalf("LaunchSurface() error = %v", err)
+	}
+
+	joined := strings.Join(runner.calls, "\n")
+	if strings.Contains(joined, "frozen specification line") {
+		t.Fatal("adapter typed the command argument into the terminal, want only a script path")
+	}
+	if strings.Contains(joined, "\n") != strings.Contains(joined, "send-key") {
+		t.Fatalf("adapter calls = %q, want no embedded newline beyond the call separator", joined)
+	}
+	script := launchScriptPath(t, runner.calls)
+	defer func() { _ = os.Remove(script) }()
+	// One short line plus the trailing Enter keystroke, whatever the size of
+	// the command being launched.
+	if sent := sentBody(t, runner.calls); sent != "sh "+quoteForTest(script) {
+		t.Fatalf("typed line = %q, want only the script path", sent)
+	}
+}
+
+// TestLaunchScriptRunsTheCommandAndRemovesItself verifies the staged script
+// carries the whole command, replaces the shell through exec so the surface
+// keeps owning one process, and unlinks itself so a prompt does not outlive
+// the launch.
+func TestLaunchScriptRunsTheCommandAndRemovesItself(t *testing.T) {
+	runner := &fakeRunner{}
+	runtime := terminal.NewCmuxRuntime(runner)
+	if err := runtime.LaunchSurface(context.Background(), implementationSurface, terminal.Command{
+		Executable: "factory-worker-attach",
+		Args:       []string{"--run-id", "run-1", "--", "codex", "a prompt with 'quotes' and\nnewlines"},
+	}); err != nil {
+		t.Fatalf("LaunchSurface() error = %v", err)
+	}
+	script := launchScriptPath(t, runner.calls)
+	defer func() { _ = os.Remove(script) }()
+
+	body, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v, want the staged launch script", err)
+	}
+	for _, want := range []string{"rm -f ", "exec 'factory-worker-attach'", "a prompt with '\\''quotes'\\'' and\nnewlines"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("launch script = %q, want it to contain %q", string(body), want)
+		}
+	}
+	info, err := os.Stat(script)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	// The script holds the role prompt, so it stays owner-readable only.
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("launch script mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+// sentBody returns the single text body the adapter typed into the surface.
+func sentBody(t *testing.T, calls []string) string {
+	t.Helper()
+	for _, call := range calls {
+		if after, found := strings.CutPrefix(call, "send --surface "+string(implementationSurface)+" "); found {
+			return after
+		}
+	}
+	t.Fatalf("adapter calls = %q, want one send call", calls)
+	return ""
+}
+
+// launchScriptPath returns the staged script path the adapter typed.
+func launchScriptPath(t *testing.T, calls []string) string {
+	t.Helper()
+	body := sentBody(t, calls)
+	path, found := strings.CutPrefix(body, "sh ")
+	if !found {
+		t.Fatalf("typed line = %q, want a staged script invocation", body)
+	}
+	return strings.ReplaceAll(strings.Trim(path, "'"), "'\\''", "'")
+}
+
+// quoteForTest mirrors the adapter's single-quote shell quoting.
+func quoteForTest(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 // TestCmuxRuntimeKeepsTerminalHandlesBehindThePortableSeam verifies that the


### PR DESCRIPTION
## Problem

`LaunchSurface` typed the entire shell-quoted command line into the surface, and the role prompt is one of its arguments:

```go
if err := r.sendToSurface(ctx, surfaceID, commandLine(command)+"\n"); err != nil {
```

A role prompt is multi-kilobyte and multi-line — `validateCommand` explicitly permits `\n` in arguments. Typing that into a PTY races the interactive program redrawing its own screen, so the program receives the argument truncated and re-spliced. Nothing reports an error.

### Evidence

Both roles of `run-c4059027`, read from Codex's own rollout files rather than from the screen:

| Role | Prompt received | Contains `factory-report` | Tail |
|---|---|---|---|
| test | 6223 bytes | yes | `…through /usr/local/bin/factory-report in the invocation result directory.` |
| implementation | **3113 bytes** | **no** | `…private chain-y g- Do not reveal or ownership.` |

The implementation prompt should be the *longer* of the two — it also carries the test handoff. Its tail had collapsed into `- Do not reveal or claim private chain-of-thought` repeated ten times, and the final line is a splice of two different rules. The three rules that follow, including *"Write the outcome through /usr/local/bin/factory-report"*, were never delivered.

The agent implemented the feature correctly, printed a summary, and returned to its prompt without reporting. It did exactly what it was told; it was never told to write the report. The run has been sitting `active` at the implementation stage ever since, with no draft PR.

**This is worse than one stuck run.** The frozen specification packet is in the same string and truncated the same way — the issue body cuts off mid-sentence at `"print one greeti`. An agent can silently receive incomplete requirements and implement against them. This run failed loudly by hanging. A prompt that drops an acceptance criterion instead of a reporting rule fails quietly.

It is also intermittent, not a fixed cutoff: 6223 bytes arrived intact while 3113 did not.

## Change

Write the command line to a private `0600` script and type only its path:

```
rm -f '<path>'
exec '<executable>' '<arg>' …
```

The script unlinks itself before `exec`, so a command line carrying a role prompt does not outlive the launch — the shell keeps reading through its own open descriptor after the unlink. The `exec` means the surface owns the same single process it owned before.

`cmux` offers no socket route for launching a command in an existing surface (`new-surface` has no `--command`), so typing stays the only mechanism; this makes what gets typed short and constant-size. Workspace-layout commands already travel over the socket as JSON and are untouched.

## Verification

- Regression test: a 400-line prompt argument never reaches the terminal; fails without the fix.
- Test on script contents: whole command staged, `exec` present, shell quoting correct for embedded quotes and newlines, mode `0600`.
- **End-to-end fidelity through a real shell** — a 16645-byte multi-line prompt containing quotes and `$dollars`, launched exactly as the adapter would type it:

```
prompt bytes:            16645
typed line bytes:        82
typed line has newline:  false
received bytes:          16645
byte-identical:          true
sentinel survived:       true
script self-removed:     true
```

- `gofmt`, `go vet`, full `go test ./...` pass.

## Note

If a launch never runs, its staged script remains in the OS temp directory until reaped. It is `0600` and self-removing on the normal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACfrat7V4yqp8sbZCRCvxa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to read a limited amount of terminal surface scrollback.
  * Prevented unbounded terminal history reads for improved reliability.

* **Bug Fixes**
  * Improved terminal command launching for long or multiline commands.
  * Commands are safely staged in temporary scripts with proper shell quoting.
  * Temporary scripts clean themselves up after execution or failed launches.
  * Terminal surfaces receive only the script path, improving launch reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->