### PR TITLE
fix: close the tracked issue when the pull request merges

### DIFF
--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -458,14 +458,10 @@ func generatedPullRequestBody(run store.Run, packet SpecificationPacket, gates [
 		}
 	}
 	// GitHub links a pull request to its issue, and closes that issue on merge,
-	// only for an explicit closing keyword; the bare `#42` reference above is a
+	// only for an explicit closing keyword; the bare `#42` identity line is a
 	// mention. The keyword belongs to the regenerated factory section so that
 	// neither a repeated draft-PR pass nor human-authored PR text can drop it.
-	closingDeclaration := ""
-	if run.IssueNumber > 0 {
-		closingDeclaration = fmt.Sprintf("\n\nCloses #%d", run.IssueNumber)
-	}
-	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `draft_pr`\n- intervention: `%s`\n%s%s\n\n%s\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, intervention, testStageDisposition, closingDeclaration, generatedReviewSection(run), issueBody, strings.Join(gateLines, "\n"), run.ID, generatedPullRequestEnd)
+	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `draft_pr`\n- intervention: `%s`\n%s\n\nCloses #%d\n\n%s\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, intervention, testStageDisposition, run.IssueNumber, generatedReviewSection(run), issueBody, strings.Join(gateLines, "\n"), run.ID, generatedPullRequestEnd)
 }
 
 // generatedReviewSection renders every configured exact-checkpoint review,

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -457,7 +457,15 @@ func generatedPullRequestBody(run store.Run, packet SpecificationPacket, gates [
 			testStageDisposition += fmt.Sprintf("\n- test-stage disposition: `%s` (provisional): %s", safeStatusCommentValue(run.TestExemption.Kind), safeStatusCommentValue(run.TestExemption.Justification))
 		}
 	}
-	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `draft_pr`\n- intervention: `%s`\n%s\n\n%s\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, intervention, testStageDisposition, generatedReviewSection(run), issueBody, strings.Join(gateLines, "\n"), run.ID, generatedPullRequestEnd)
+	// GitHub links a pull request to its issue, and closes that issue on merge,
+	// only for an explicit closing keyword; the bare `#42` reference above is a
+	// mention. The keyword belongs to the regenerated factory section so that
+	// neither a repeated draft-PR pass nor human-authored PR text can drop it.
+	closingDeclaration := ""
+	if run.IssueNumber > 0 {
+		closingDeclaration = fmt.Sprintf("\n\nCloses #%d", run.IssueNumber)
+	}
+	return fmt.Sprintf("%s\n## Factory run\n\n- run: `%s`\n- issue: #%d — %s\n- specification packet: version %d, target branch `%s`\n- checkpoint: `%s`\n- stage: `draft_pr`\n- intervention: `%s`\n%s%s\n\n%s\n\n### Issue summary\n\n%s\n\n### Gates\n\n%s\n\n### Control commands\n\n- `factory status`\n- `factory draft-pr --run-id %s`\n\n%s", generatedPullRequestStart, run.ID, packet.Issue.Number, defaultString(packet.Issue.Title, "(untitled)"), packet.Version, packet.RepositoryConfig.TargetBranch, run.CheckpointSHA, intervention, testStageDisposition, closingDeclaration, generatedReviewSection(run), issueBody, strings.Join(gateLines, "\n"), run.ID, generatedPullRequestEnd)
 }
 
 // generatedReviewSection renders every configured exact-checkpoint review,

--- a/internal/factory/draft_pr_internal_test.go
+++ b/internal/factory/draft_pr_internal_test.go
@@ -24,28 +24,14 @@ func TestGeneratedPullRequestBodyDeclaresTheClosingKeyword(t *testing.T) {
 			TestPolicy:   config.TestPolicy{Mode: config.TestModeAdvisory},
 		},
 	}
+	run := store.Run{ID: "run-close", IssueNumber: 42, CheckpointSHA: "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"}
 
-	tests := []struct {
-		name        string
-		issueNumber int
-		want        string
-		unwanted    string
-	}{
-		{name: "tracked issue", issueNumber: 42, want: "\n\nCloses #42\n"},
-		{name: "unidentified issue", issueNumber: 0, unwanted: "Closes #"},
+	body := generatedPullRequestBody(run, packet, nil, "none")
+
+	if !strings.Contains(body, "\n\nCloses #42\n") {
+		t.Fatalf("generated body = %q, want a closing declaration for issue 42", body)
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			run := store.Run{ID: "run-close", IssueNumber: test.issueNumber, CheckpointSHA: "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"}
-			body := generatedPullRequestBody(run, packet, nil, "none")
-			if test.want != "" && !strings.Contains(body, test.want) {
-				t.Fatalf("generated body = %q, want closing declaration %q", body, test.want)
-			}
-			if test.unwanted != "" && strings.Contains(body, test.unwanted) {
-				t.Fatalf("generated body = %q, want no closing declaration for an unidentified issue", body)
-			}
-		})
+	if !strings.Contains(body, generatedPullRequestStart) || !strings.Contains(body, generatedPullRequestEnd) {
+		t.Fatalf("generated body = %q, want the factory-generated markers that carry the declaration", body)
 	}
 }

--- a/internal/factory/draft_pr_internal_test.go
+++ b/internal/factory/draft_pr_internal_test.go
@@ -1,0 +1,51 @@
+package factory
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestGeneratedPullRequestBodyDeclaresTheClosingKeyword pins the reference that
+// makes GitHub link the pull request to its issue and close that issue on
+// merge. A bare `#42` mention does not, so the keyword is asserted separately
+// from the issue identity line.
+func TestGeneratedPullRequestBodyDeclaresTheClosingKeyword(t *testing.T) {
+	t.Parallel()
+
+	packet := SpecificationPacket{
+		Version: 1,
+		Issue:   github.Issue{Number: 42, Title: "Close the issue on merge", Body: "Link the pull request to its issue."},
+		RepositoryConfig: config.RepositoryConfig{
+			TargetBranch: "main",
+			TestPolicy:   config.TestPolicy{Mode: config.TestModeAdvisory},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		issueNumber int
+		want        string
+		unwanted    string
+	}{
+		{name: "tracked issue", issueNumber: 42, want: "\n\nCloses #42\n"},
+		{name: "unidentified issue", issueNumber: 0, unwanted: "Closes #"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			run := store.Run{ID: "run-close", IssueNumber: test.issueNumber, CheckpointSHA: "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"}
+			body := generatedPullRequestBody(run, packet, nil, "none")
+			if test.want != "" && !strings.Contains(body, test.want) {
+				t.Fatalf("generated body = %q, want closing declaration %q", body, test.want)
+			}
+			if test.unwanted != "" && strings.Contains(body, test.unwanted) {
+				t.Fatalf("generated body = %q, want no closing declaration for an unidentified issue", body)
+			}
+		})
+	}
+}

--- a/internal/factory/draft_pr_test.go
+++ b/internal/factory/draft_pr_test.go
@@ -101,6 +101,7 @@ func TestCreateDraftPullRequestPushesTheCheckpointBeforeGatesAndCreatesOneDraft(
 	for _, expected := range []string{
 		"<!-- factory-generated:start -->", "Add the factory handoff", "Implement the supervised draft PR boundary.",
 		"stage: `draft_pr`", "format", "test", "intervention: `none`", "factory status", "factory draft-pr --run-id run-draft",
+		"Closes #42",
 	} {
 		if !strings.Contains(body, expected) {
 			t.Errorf("generated PR body %q does not contain %q", body, expected)
@@ -126,6 +127,11 @@ func TestCreateDraftPullRequestPushesTheCheckpointBeforeGatesAndCreatesOneDraft(
 	updatedBody := pullRequests.updatedRequests[0].Body
 	if !strings.Contains(updatedBody, "human-authored notes") || strings.Count(updatedBody, "<!-- factory-generated:start -->") != 1 || !strings.Contains(updatedBody, "intervention: `human reviewed`") {
 		t.Fatalf("updated PR body = %q, want preserved human text and one regenerated section", updatedBody)
+	}
+	// The closing keyword is what makes GitHub link the pull request to the
+	// issue and close it on merge, so regeneration must never drop it.
+	if strings.Count(updatedBody, "Closes #42") != 1 {
+		t.Fatalf("updated PR body = %q, want exactly one closing keyword for issue 42", updatedBody)
 	}
 }
 

--- a/internal/factory/draft_pr_test.go
+++ b/internal/factory/draft_pr_test.go
@@ -116,7 +116,11 @@ func TestCreateDraftPullRequestPushesTheCheckpointBeforeGatesAndCreatesOneDraft(
 
 	// A repeated command recovers the existing pull request and does not make
 	// another checkpoint, push, or pull request.
-	pullRequests.existing = github.PullRequest{Number: 17, URL: pullRequests.created.URL, Body: "human-authored notes", State: "open", Draft: true, HeadBranch: "factory/run-draft", BaseBranch: "main"}
+	// The existing body carries human text on both sides of a stale generated
+	// section, so regeneration must take the replace branch rather than append
+	// a second one. Human text alone would exercise only the append branch.
+	priorBody := "human-authored notes\n\n<!-- factory-generated:start -->\n## Factory run\n\n- stale generated section\n\nCloses #42\n<!-- factory-generated:end -->\n\ntrailing human notes"
+	pullRequests.existing = github.PullRequest{Number: 17, URL: pullRequests.created.URL, Body: priorBody, State: "open", Draft: true, HeadBranch: "factory/run-draft", BaseBranch: "main"}
 	repeated, err := service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: "run-draft", Intervention: "human reviewed"})
 	if err != nil {
 		t.Fatalf("repeated CreateDraftPullRequest() error = %v", err)
@@ -125,11 +129,18 @@ func TestCreateDraftPullRequestPushesTheCheckpointBeforeGatesAndCreatesOneDraft(
 		t.Fatalf("repeated effects/result = %#v, checkpoints=%d pushes=%d creates=%d updates=%d", repeated, len(workspace.checkpoints), len(workspace.pushes), len(pullRequests.createdRequests), len(pullRequests.updatedRequests))
 	}
 	updatedBody := pullRequests.updatedRequests[0].Body
-	if !strings.Contains(updatedBody, "human-authored notes") || strings.Count(updatedBody, "<!-- factory-generated:start -->") != 1 || !strings.Contains(updatedBody, "intervention: `human reviewed`") {
-		t.Fatalf("updated PR body = %q, want preserved human text and one regenerated section", updatedBody)
+	if !strings.Contains(updatedBody, "human-authored notes") || !strings.Contains(updatedBody, "trailing human notes") {
+		t.Fatalf("updated PR body = %q, want human text preserved on both sides of the generated section", updatedBody)
+	}
+	if strings.Count(updatedBody, "<!-- factory-generated:start -->") != 1 || strings.Contains(updatedBody, "stale generated section") {
+		t.Fatalf("updated PR body = %q, want the stale generated section replaced by exactly one regenerated section", updatedBody)
+	}
+	if !strings.Contains(updatedBody, "intervention: `human reviewed`") {
+		t.Fatalf("updated PR body = %q, want the regenerated intervention marker", updatedBody)
 	}
 	// The closing keyword is what makes GitHub link the pull request to the
-	// issue and close it on merge, so regeneration must never drop it.
+	// issue and close it on merge, so regeneration must carry it over exactly
+	// once: dropping it stops the auto-close, duplicating it is malformed.
 	if strings.Count(updatedBody, "Closes #42") != 1 {
 		t.Fatalf("updated PR body = %q, want exactly one closing keyword for issue 42", updatedBody)
 	}

--- a/internal/terminal/runtime_test.go
+++ b/internal/terminal/runtime_test.go
@@ -3,7 +3,6 @@ package terminal_test
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 	"testing"
 


### PR DESCRIPTION
## Summary

- The coordinator-generated PR body rendered the issue as a bare `#42` reference. GitHub treats that as a mention, not a link, so a merged factory PR left its issue open for a human to close by hand.
- Adds an explicit `Closes #N` declaration, rendered from the run's tracked issue number.
- The declaration sits inside the `<!-- factory-generated:start -->` section, so `mergeGeneratedPullRequestBody` rewrites it on every regeneration and human-authored PR text cannot displace it.
- Rejected the alternative — a new `CloseIssue` GitHub adapter method plus pending-effect journaling in `observeLifecycle` — because it adds an external mutation to make restart-safe and only fires while the coordinator is polling. The keyword also links the issue in the sidebar *before* merge and works when a human merges through the GitHub UI.

## Changes

**`internal/factory/draft_pr.go`** — `generatedPullRequestBody` emits the closing declaration as its own paragraph between the metadata list and the review section. Source is `run.IssueNumber`, the identity the coordinator tracks and every GitHub call uses.

**`internal/factory/draft_pr_test.go`** — asserts the keyword in the created body. The regeneration case starts from human text wrapped around a stale generated section, so the merge takes the replace branch, and asserts the section is replaced in place with the keyword carried over exactly once.

**`internal/factory/draft_pr_internal_test.go`** (new) — unit test on `generatedPullRequestBody` pinning the declaration and the markers that carry it.

**`internal/terminal/runtime_test.go`** — drops an unused `os` import that was breaking `go vet ./...` and `go test ./...` on `main`. Unrelated to the closing keyword, kept as its own commit.

## Contract Impact

Changes the coordinator-owned PR body, which is an operator-visible contract. Existing PRs are unaffected until their next regeneration, which adds the declaration in place. No store schema, config schema, or adapter interface changes.

**Known limitation:** GitHub auto-closes only when the PR's base branch is the repository default branch. `factory.yaml` sets `target_branch: main`, which satisfies this. A repository targeting a non-default branch gets the sidebar link but no auto-close.

## Test Plan

- [ ] `go test ./internal/factory/` passes
- [ ] `test -z "$(gofmt -l .)"` and `go vet ./internal/factory/` clean
- [ ] On merge, this PR's own body has no closing keyword (no originating issue), so verify against the next factory-generated PR: the issue shows under Development, and merging closes it
- [ ] Confirm the run reaches `complete`, not `cancelled`, after the auto-close — `observeLifecycle` evaluates `pullRequest.Merged` before the closed-issue branch

## Checklist

- [x] Tests pass — `gofmt`, `go vet ./...` and `go test ./...` all clean across every package
- [x] No breaking changes
- [ ] CLAUDE.md updated if architecture changed — not needed, no architecture change

## Review findings addressed

A two-axis review raised two items, both now fixed in `8d7d9ff`:

1. **The regeneration assertion passed trivially.** Its fixture body carried no factory markers, so `mergeGeneratedPullRequestBody` took the append branch and the replacement property was never exercised. The fixture now wraps human text around a stale generated section, and the assertions check that the stale section is gone, exactly one generated section remains, human text survives on both sides, and the keyword appears exactly once. Verified by mutation: removing the keyword, and appending instead of replacing, both fail the test.
2. **The `if run.IssueNumber > 0` guard was unreachable.** `ClaimIssue` rejects a non-positive issue number before a run exists (`claim.go:144`) and `run.IssueNumber` is set from that validated value (`claim.go:232`). The guard and the table row defending it are gone; the keyword now renders unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrDRfPTNz7htCGCEbaFmdr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated pull request descriptions now automatically include a closing reference for the associated issue.
  * Regenerating a description preserves user-authored content while updating generated sections.

* **Bug Fixes**
  * Regenerated descriptions now retain exactly one closing reference and remove outdated generated content, preventing duplicate or stale references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
