### PR TITLE
close terminal workspaces during run cleanup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -183,6 +183,14 @@ tables are separate from repository configuration, disposable run artifacts,
 and the isolated local evaluation-summary projection.
 _Avoid_: Event journal, telemetry, transcript archive
 
+**Terminal workspace**:
+The visible workspace one run owns in the terminal adapter, identified by an
+opaque handle the adapter alone interprets. It holds the run's surfaces and
+uses the run worktree as its working directory. A terminal outcome retains it;
+only cleanup closes it. Distinct from the Git worktree and branch the
+coordinator removes at the same moment.
+_Avoid_: cmux window, pane, tab, Git workspace
+
 **Cleanup**:
 The explicit, seven-day retention operation that previews and removes one or
 more terminal runs' local worktrees, local branches, workers, role sessions,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -188,8 +188,9 @@ The visible workspace one run owns in the terminal adapter, identified by an
 opaque handle the adapter alone interprets. It holds the run's surfaces and
 uses the run worktree as its working directory. A terminal outcome retains it;
 only cleanup closes it. Distinct from the Git worktree and branch the
-coordinator removes at the same moment.
-_Avoid_: cmux window, pane, tab, Git workspace
+coordinator removes at the same moment, and from the coordinator's own control
+workspace, which no run owns and cleanup never closes.
+_Avoid_: Terminal window, pane, tab, Git workspace
 
 **Cleanup**:
 The explicit, seven-day retention operation that previews and removes one or

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -186,6 +186,8 @@ _Avoid_: Event journal, telemetry, transcript archive
 **Cleanup**:
 The explicit, seven-day retention operation that previews and removes one or
 more terminal runs' local worktrees, local branches, workers, role sessions,
-generated outputs, and operational rows while retaining remote branches,
-credential stores, and local evaluation summaries.
+terminal workspaces, generated outputs, and operational rows while retaining
+remote branches, credential stores, and local evaluation summaries. It is the
+last operation that knows a run's workspace handles, so a workspace it cannot
+close is reported for manual closure instead of being lost silently.
 _Avoid_: Remote branch deletion, automatic summary deletion

--- a/README.md
+++ b/README.md
@@ -1364,8 +1364,8 @@ factory cleanup \
   --confirm
 ~~~
 
-A pending effect, malformed run identity, unproven path scope, or a still-open
-pull request blocks cleanup for that run. The confirmation pass refuses a
+A pending effect, malformed run identity, malformed terminal workspace handle,
+unproven path scope, or a still-open pull request blocks cleanup for that run. The confirmation pass refuses a
 changed plan, so the resources displayed in the preview are the resources being
 authorized for removal.
 

--- a/README.md
+++ b/README.md
@@ -1365,9 +1365,9 @@ factory cleanup \
 ~~~
 
 A pending effect, malformed run identity, malformed terminal workspace handle,
-unproven path scope, or a still-open pull request blocks cleanup for that run. The confirmation pass refuses a
-changed plan, so the resources displayed in the preview are the resources being
-authorized for removal.
+unproven path scope, or a still-open pull request blocks cleanup for that run.
+The confirmation pass refuses a changed plan, so the resources displayed in the
+preview are the resources being authorized for removal.
 
 Cleanup also closes the terminal workspaces the removed runs created, because
 the deleted invocation rows are the only durable record of those handles. A

--- a/README.md
+++ b/README.md
@@ -1241,7 +1241,8 @@ transition, so a terminal disposition always wins over further work.
 Either terminal outcome releases the one-active-run constraint. The same
 <code>factory start</code> process then claims the next oldest eligible issue
 without waiting for a full polling interval and without an operator restart.
-Retention is unchanged: cleanup stays an explicit, separate seven-day
+Retention is unchanged: the terminal workspace, branch, worktree, and worker
+survive the transition, and cleanup stays an explicit, separate seven-day
 operation.
 
 ### States that intentionally pause progression
@@ -1344,9 +1345,9 @@ factory cleanup --config /Users/me/.config/factory/config.yaml
 ~~~
 
 The preview lists each selected worktree, local branch, worker target, role
-volume, and stored output. The preview intentionally returns exit status
-<code>2</code> when no <code>--confirm</code> flag is supplied. Confirm the
-displayed plan:
+volume, stored output, and terminal workspace. The preview intentionally
+returns exit status <code>2</code> when no <code>--confirm</code> flag is
+supplied. Confirm the displayed plan:
 
 ~~~sh
 factory cleanup \
@@ -1367,6 +1368,13 @@ A pending effect, malformed run identity, unproven path scope, or a still-open
 pull request blocks cleanup for that run. The confirmation pass refuses a
 changed plan, so the resources displayed in the preview are the resources being
 authorized for removal.
+
+Cleanup also closes the terminal workspaces the removed runs created, because
+the deleted invocation rows are the only durable record of those handles. A
+workspace close never blocks local deletion: when the terminal is unavailable
+or refuses the close, cleanup removes the local resources anyway and prints
+<code>cleanup retained terminal workspace</code> for each workspace the
+operator has to close by hand.
 
 ## Security and data boundaries
 

--- a/internal/cli/cleanup_output_internal_test.go
+++ b/internal/cli/cleanup_output_internal_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/factory"
+)
+
+// TestWriteRetainedWorkspacesNamesEveryWorkspace verifies the operator-facing
+// line for a workspace cleanup could not close. Cleanup deletes the only
+// durable record of the handle, so this line is the operator's sole notice
+// that manual closure is required.
+func TestWriteRetainedWorkspacesNamesEveryWorkspace(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	if !writeRetainedWorkspaces(&output, &output, []factory.CleanupRetainedWorkspace{
+		{RunID: "run-a", WorkspaceID: "workspace-a", Reason: "terminal server is not running"},
+		{RunID: "run-b", WorkspaceID: "workspace-b", Reason: "connection refused"},
+	}) {
+		t.Fatal("writeRetainedWorkspaces() = false, want a successful write")
+	}
+	lines := strings.Split(strings.TrimSuffix(output.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("retained workspace output = %q, want one line per workspace", output.String())
+	}
+	for index, wanted := range []string{
+		"cleanup retained terminal workspace: workspace-a run=run-a reason=terminal server is not running (close it manually)",
+		"cleanup retained terminal workspace: workspace-b run=run-b reason=connection refused (close it manually)",
+	} {
+		if lines[index] != wanted {
+			t.Fatalf("retained workspace line %d = %q, want %q", index, lines[index], wanted)
+		}
+	}
+}
+
+// TestWriteRetainedWorkspacesReportsAWriteFailure verifies the helper reports a
+// failed write instead of losing the notice silently.
+func TestWriteRetainedWorkspacesReportsAWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	if writeRetainedWorkspaces(failingWriter{}, &bytes.Buffer{}, []factory.CleanupRetainedWorkspace{
+		{RunID: "run-a", WorkspaceID: "workspace-a", Reason: "connection refused"},
+	}) {
+		t.Fatal("writeRetainedWorkspaces() = true, want a failed write to be reported")
+	}
+}
+
+// failingWriter rejects every write so the helper's error path is observable.
+type failingWriter struct{}
+
+// Write always fails.
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("closed pipe") }

--- a/internal/cli/cleanup_test.go
+++ b/internal/cli/cleanup_test.go
@@ -63,6 +63,20 @@ func TestCleanupCommandPrintsTargetsBeforeConfirmation(t *testing.T) {
 		_ = opened.Close()
 		t.Fatal(err)
 	}
+	if err := opened.SaveInvocation(context.Background(), store.Invocation{
+		ID:          "invocation-cli-cleanup",
+		RunID:       "run-cli-cleanup",
+		Harness:     "codex",
+		Role:        "implementation",
+		Stage:       store.StageImplementation,
+		Status:      store.InvocationStatusCompleted,
+		WorkspaceID: "workspace-cli-cleanup",
+		CreatedAt:   now.Add(-8 * 24 * time.Hour),
+		UpdatedAt:   now.Add(-8 * 24 * time.Hour),
+	}); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
 	if err := opened.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -76,6 +90,7 @@ func TestCleanupCommandPrintsTargetsBeforeConfirmation(t *testing.T) {
 		"cleanup worktree: " + worktreePath,
 		"cleanup branch: factory/run-cli-cleanup (local only; remote retained)",
 		"cleanup container: run=run-cli-cleanup",
+		"cleanup terminal workspace: workspace-cli-cleanup",
 		"cleanup stored output:",
 		"cleanup requires --confirm; no resources removed",
 	} {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -952,6 +952,11 @@ func runCleanup(ctx context.Context, args []string, defaultConfigPath string, ou
 		Before:       preview.Plan.Before,
 		ExpectedPlan: &preview.Plan,
 	})
+	// Retained workspaces are reported before any failure, because cleanup has
+	// already deleted the invocation rows holding their handles.
+	if !writeRetainedWorkspaces(output, errorsOutput, result.Retained) {
+		return 1
+	}
 	if err != nil {
 		writeError(errorsOutput, err)
 		return 1
@@ -959,12 +964,18 @@ func runCleanup(ctx context.Context, args []string, defaultConfigPath string, ou
 	if !writeOutput(output, errorsOutput, "cleanup complete: runs=%d\n", len(result.Deleted)) {
 		return 1
 	}
-	for _, retained := range result.Retained {
-		if !writeOutput(output, errorsOutput, "cleanup retained terminal workspace: %s run=%s reason=%s (close it manually)\n", retained.WorkspaceID, retained.RunID, retained.Reason) {
-			return 1
+	return 0
+}
+
+// writeRetainedWorkspaces names every terminal workspace the operator now has
+// to close by hand.
+func writeRetainedWorkspaces(output, errorsOutput io.Writer, retained []factory.CleanupRetainedWorkspace) bool {
+	for _, workspace := range retained {
+		if !writeOutput(output, errorsOutput, "cleanup retained terminal workspace: %s run=%s reason=%s (close it manually)\n", workspace.WorkspaceID, workspace.RunID, workspace.Reason) {
+			return false
 		}
 	}
-	return 0
+	return true
 }
 
 // writeCleanupPlan renders every exact target before any confirmed mutation.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -959,6 +959,11 @@ func runCleanup(ctx context.Context, args []string, defaultConfigPath string, ou
 	if !writeOutput(output, errorsOutput, "cleanup complete: runs=%d\n", len(result.Deleted)) {
 		return 1
 	}
+	for _, retained := range result.Retained {
+		if !writeOutput(output, errorsOutput, "cleanup retained terminal workspace: %s run=%s reason=%s (close it manually)\n", retained.WorkspaceID, retained.RunID, retained.Reason) {
+			return 1
+		}
+	}
 	return 0
 }
 
@@ -972,6 +977,14 @@ func writeCleanupPlan(output, errorsOutput io.Writer, plan factory.CleanupPlan) 
 			return false
 		}
 		if len(run.Roles) > 0 && !writeOutput(output, errorsOutput, "cleanup worker roles: %s\n", strings.Join(run.Roles, ", ")) {
+			return false
+		}
+		for _, workspaceID := range run.WorkspaceIDs {
+			if !writeOutput(output, errorsOutput, "cleanup terminal workspace: %s\n", workspaceID) {
+				return false
+			}
+		}
+		if len(run.WorkspaceIDs) == 0 && !writeOutput(output, errorsOutput, "cleanup terminal workspace: none\n") {
 			return false
 		}
 		for _, outputPath := range run.StoredOutputs {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -952,8 +952,9 @@ func runCleanup(ctx context.Context, args []string, defaultConfigPath string, ou
 		Before:       preview.Plan.Before,
 		ExpectedPlan: &preview.Plan,
 	})
-	// Retained workspaces are reported before any failure, because cleanup has
-	// already deleted the invocation rows holding their handles.
+	// Retained workspaces are reported before any failure, because a run
+	// cleaned earlier in the same pass may already have lost the invocation
+	// rows holding its handle.
 	if !writeRetainedWorkspaces(output, errorsOutput, result.Retained) {
 		return 1
 	}

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/github"
@@ -1191,7 +1192,7 @@ func renderReviewStatusComment(title string, review *store.ReviewResult, run sto
 // a value carrying one could forge a line on an operator's screen.
 func safeStatusCommentValue(value string) string {
 	value = strings.Map(func(character rune) rune {
-		if character < ' ' || character == 0x7f {
+		if unicode.IsControl(character) {
 			return ' '
 		}
 		return character

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -1185,10 +1185,18 @@ func renderReviewStatusComment(title string, review *store.ReviewResult, run sto
 }
 
 // safeStatusCommentValue keeps command feedback single-line and prevents
-// untrusted GitHub login or parser text from changing the status-comment
-// structure.
+// untrusted GitHub login, parser, or adapter text from changing the structure
+// of the surface it is rendered on. Every control character is replaced, not
+// only the newline: a terminal renders an escape sequence as line movement, so
+// a value carrying one could forge a line on an operator's screen.
 func safeStatusCommentValue(value string) string {
-	value = strings.NewReplacer("\r", " ", "\n", " ", "`", "'", "\x00", " ").Replace(value)
+	value = strings.Map(func(character rune) rune {
+		if character < ' ' || character == 0x7f {
+			return ' '
+		}
+		return character
+	}, value)
+	value = strings.ReplaceAll(value, "`", "'")
 	return strings.TrimSpace(value)
 }
 

--- a/internal/factory/claim_comment_internal_test.go
+++ b/internal/factory/claim_comment_internal_test.go
@@ -8,6 +8,26 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/github"
 )
 
+// TestSafeStatusCommentValueReplacesC1Controls verifies that every Unicode
+// control character is made safe before untrusted text reaches a status comment.
+func TestSafeStatusCommentValueReplacesC1Controls(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		value string
+	}{
+		{name: "next line", value: "before\u0085after"},
+		{name: "control sequence introducer", value: "before\u009bafter"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got, want := safeStatusCommentValue(test.value), "before after"; got != want {
+				t.Fatalf("safeStatusCommentValue(%q) = %q, want %q", test.value, got, want)
+			}
+		})
+	}
+}
+
 // TestClaimCommentWatermarkFailsClosedWithoutCommentReader verifies a claim
 // cannot proceed without the command cutoff reader required by every run.
 func TestClaimCommentWatermarkFailsClosedWithoutCommentReader(t *testing.T) {

--- a/internal/factory/cleanup.go
+++ b/internal/factory/cleanup.go
@@ -22,6 +22,9 @@ const (
 	// CleanupRetention is the minimum age of a terminal run before ordinary
 	// local run artifacts may be removed.
 	CleanupRetention = 7 * 24 * time.Hour
+	// cleanupWorkspaceCloseTimeout bounds one best-effort terminal workspace
+	// close so an unresponsive terminal cannot stall local deletion.
+	cleanupWorkspaceCloseTimeout = 10 * time.Second
 )
 
 // cleanupWorkerRoles covers every factory-declared role that can create a
@@ -229,7 +232,7 @@ func (s *Service) Cleanup(ctx context.Context, request CleanupRequest) (CleanupR
 		// The terminal workspace runs in the worktree that the next step
 		// removes, so it is closed first. A close failure never blocks local
 		// deletion; it is reported instead.
-		result.Retained = append(result.Retained, s.closeRunWorkspaces(ctx, registration, target)...)
+		result.Retained = append(result.Retained, s.closeRunWorkspaces(ctx, registration.Cmux.SocketPath, target)...)
 		if err := workspace.Remove(ctx, registration.Path, gitadapter.Workspace{RunID: target.RunID, Branch: target.Branch, Worktree: target.Worktree}); err != nil {
 			rollback()
 			return result, fmt.Errorf("remove Git workspace for run %q: %w", target.RunID, err)
@@ -254,14 +257,14 @@ func (s *Service) Cleanup(ctx context.Context, request CleanupRequest) (CleanupR
 // and returns the workspaces that survived. Cleanup must still remove local
 // resources when the terminal server is absent, so an unavailable runtime and
 // a rejected close are both reported rather than returned as errors.
-func (s *Service) closeRunWorkspaces(ctx context.Context, registration config.RepositoryRegistration, target CleanupRun) []CleanupRetainedWorkspace {
+func (s *Service) closeRunWorkspaces(ctx context.Context, socketPath string, target CleanupRun) []CleanupRetainedWorkspace {
 	if len(target.WorkspaceIDs) == 0 {
 		return nil
 	}
 	terminalRuntime := s.deps.Terminal
 	if terminalRuntime == nil {
 		var err error
-		terminalRuntime, err = s.ensureTerminalRuntime(registration.Cmux.SocketPath)
+		terminalRuntime, err = s.ensureTerminalRuntime(socketPath)
 		if err != nil {
 			retained := make([]CleanupRetainedWorkspace, 0, len(target.WorkspaceIDs))
 			for _, workspaceID := range target.WorkspaceIDs {
@@ -272,7 +275,13 @@ func (s *Service) closeRunWorkspaces(ctx context.Context, registration config.Re
 	}
 	var retained []CleanupRetainedWorkspace
 	for _, workspaceID := range target.WorkspaceIDs {
-		if err := terminalRuntime.CloseWorkspace(ctx, terminal.WorkspaceID(workspaceID)); err != nil {
+		// An unreachable terminal can accept the connection and never answer,
+		// so each close is bounded rather than allowed to stall the removal of
+		// local resources that follows it.
+		closeCtx, cancel := context.WithTimeout(ctx, cleanupWorkspaceCloseTimeout)
+		err := terminalRuntime.CloseWorkspace(closeCtx, terminal.WorkspaceID(workspaceID))
+		cancel()
+		if err != nil {
 			retained = append(retained, CleanupRetainedWorkspace{RunID: target.RunID, WorkspaceID: workspaceID, Reason: err.Error()})
 		}
 	}
@@ -392,23 +401,10 @@ func (s *Service) cleanupTarget(ctx context.Context, registration config.Reposit
 	for _, role := range roles {
 		roleSet[role] = struct{}{}
 	}
-	workspaceIDs := make([]string, 0, len(candidate.Invocations))
-	seenWorkspaceIDs := make(map[string]struct{}, len(candidate.Invocations))
-	for _, invocation := range candidate.Invocations {
-		workspaceID := strings.TrimSpace(invocation.WorkspaceID)
-		if workspaceID == "" {
-			continue
-		}
-		if _, exists := seenWorkspaceIDs[workspaceID]; exists {
-			continue
-		}
-		seenWorkspaceIDs[workspaceID] = struct{}{}
-		workspaceIDs = append(workspaceIDs, workspaceID)
-	}
-	sort.Strings(workspaceIDs)
-
 	workerIDs := []string{run.ID}
 	seenWorkerIDs := map[string]struct{}{run.ID: {}}
+	var workspaceIDs []string
+	seenWorkspaceIDs := make(map[string]struct{}, len(candidate.Invocations))
 	for _, invocation := range candidate.Invocations {
 		if !safeCleanupIdentifier(invocation.Role) {
 			return CleanupRun{}, fmt.Sprintf("invocation %q has an unsafe worker role", invocation.ID)
@@ -425,9 +421,20 @@ func (s *Service) cleanupTarget(ctx context.Context, registration config.Reposit
 			roleSet[invocation.Role] = struct{}{}
 			roles = append(roles, invocation.Role)
 		}
+		if invocation.WorkspaceID == "" {
+			continue
+		}
+		if !safeWorkspaceHandle(invocation.WorkspaceID) {
+			return CleanupRun{}, fmt.Sprintf("invocation %q has an unsafe terminal workspace handle", invocation.ID)
+		}
+		if _, exists := seenWorkspaceIDs[invocation.WorkspaceID]; !exists {
+			seenWorkspaceIDs[invocation.WorkspaceID] = struct{}{}
+			workspaceIDs = append(workspaceIDs, invocation.WorkspaceID)
+		}
 	}
 	sort.Strings(workerIDs)
 	sort.Strings(roles)
+	sort.Strings(workspaceIDs)
 	eligibleAt := run.TerminalAt
 	if eligibleAt.IsZero() {
 		eligibleAt = run.UpdatedAt
@@ -484,6 +491,23 @@ func safeCleanupIdentifier(value string) bool {
 			continue
 		}
 		return false
+	}
+	return true
+}
+
+// safeWorkspaceHandle accepts an opaque terminal workspace handle that is safe
+// to display in the plan and to pass as one command argument. Handles are
+// adapter-generated and never name a path, so this is deliberately wider than
+// safeCleanupIdentifier: it rejects only empty, padded, option-shaped, and
+// control-character values.
+func safeWorkspaceHandle(value string) bool {
+	if value == "" || strings.TrimSpace(value) != value || strings.HasPrefix(value, "-") {
+		return false
+	}
+	for _, character := range value {
+		if character < ' ' || character == 0x7f {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/factory/cleanup.go
+++ b/internal/factory/cleanup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/config"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 	"github.com/Stevie1704/sw-factory/internal/workflow"
 )
@@ -75,6 +76,10 @@ type CleanupRun struct {
 	Branch string
 	// Worktree is the exact local worktree path to remove.
 	Worktree string
+	// WorkspaceIDs contains the opaque terminal workspace handles this run
+	// created. Cleanup is the last operation that knows them, because the
+	// deleted invocation rows are their only durable record.
+	WorkspaceIDs []string
 	// WorkerRunID is the logical worker identity passed to the runtime adapter;
 	// Docker names remain private to that adapter.
 	WorkerRunID string
@@ -107,6 +112,18 @@ type CleanupPlan struct {
 	Skipped []CleanupSkippedRun
 }
 
+// CleanupRetainedWorkspace reports one terminal workspace that survived a
+// confirmed cleanup. Its run's local resources are already removed, so the
+// operator has to close the workspace by hand.
+type CleanupRetainedWorkspace struct {
+	// RunID identifies the run that created the workspace.
+	RunID string
+	// WorkspaceID is the opaque terminal workspace handle left in place.
+	WorkspaceID string
+	// Reason is the bounded operator-facing explanation.
+	Reason string
+}
+
 // CleanupResult contains the preview and any operational rows removed after
 // confirmation.
 type CleanupResult struct {
@@ -114,6 +131,9 @@ type CleanupResult struct {
 	Plan CleanupPlan
 	// Deleted contains one row-count projection for each removed run.
 	Deleted []store.CleanupDeletionResult
+	// Retained contains every workspace that could not be closed. Local
+	// deletion continues regardless, so this is a report, not a failure.
+	Retained []CleanupRetainedWorkspace
 }
 
 // CleanupConfirmationRequiredError tells a CLI or embedder to display the
@@ -147,7 +167,9 @@ func (*CleanupPlanChangedError) Error() string { return "cleanup plan changed; p
 // Cleanup previews eligible local artifacts and removes them only when the
 // caller explicitly confirms the complete plan. It reads the lifecycle of a
 // tracked pull request but never mutates GitHub, deletes remote branches, or
-// removes local evaluation summaries.
+// removes local evaluation summaries. A confirmed cleanup also closes the
+// terminal workspaces of every removed run, because their handles live only in
+// the invocation rows this operation deletes.
 func (s *Service) Cleanup(ctx context.Context, request CleanupRequest) (CleanupResult, error) {
 	s.commandMu.Lock()
 	defer s.commandMu.Unlock()
@@ -204,6 +226,10 @@ func (s *Service) Cleanup(ctx context.Context, request CleanupRequest) (CleanupR
 			rollback()
 			return result, fmt.Errorf("clean worker for run %q: %w", target.RunID, err)
 		}
+		// The terminal workspace runs in the worktree that the next step
+		// removes, so it is closed first. A close failure never blocks local
+		// deletion; it is reported instead.
+		result.Retained = append(result.Retained, s.closeRunWorkspaces(ctx, registration, target)...)
 		if err := workspace.Remove(ctx, registration.Path, gitadapter.Workspace{RunID: target.RunID, Branch: target.Branch, Worktree: target.Worktree}); err != nil {
 			rollback()
 			return result, fmt.Errorf("remove Git workspace for run %q: %w", target.RunID, err)
@@ -222,6 +248,35 @@ func (s *Service) Cleanup(ctx context.Context, request CleanupRequest) (CleanupR
 		}
 	}
 	return result, nil
+}
+
+// closeRunWorkspaces closes every terminal workspace one cleanup target owns
+// and returns the workspaces that survived. Cleanup must still remove local
+// resources when the terminal server is absent, so an unavailable runtime and
+// a rejected close are both reported rather than returned as errors.
+func (s *Service) closeRunWorkspaces(ctx context.Context, registration config.RepositoryRegistration, target CleanupRun) []CleanupRetainedWorkspace {
+	if len(target.WorkspaceIDs) == 0 {
+		return nil
+	}
+	terminalRuntime := s.deps.Terminal
+	if terminalRuntime == nil {
+		var err error
+		terminalRuntime, err = s.ensureTerminalRuntime(registration.Cmux.SocketPath)
+		if err != nil {
+			retained := make([]CleanupRetainedWorkspace, 0, len(target.WorkspaceIDs))
+			for _, workspaceID := range target.WorkspaceIDs {
+				retained = append(retained, CleanupRetainedWorkspace{RunID: target.RunID, WorkspaceID: workspaceID, Reason: fmt.Sprintf("ensure terminal runtime: %v", err)})
+			}
+			return retained
+		}
+	}
+	var retained []CleanupRetainedWorkspace
+	for _, workspaceID := range target.WorkspaceIDs {
+		if err := terminalRuntime.CloseWorkspace(ctx, terminal.WorkspaceID(workspaceID)); err != nil {
+			retained = append(retained, CleanupRetainedWorkspace{RunID: target.RunID, WorkspaceID: workspaceID, Reason: err.Error()})
+		}
+	}
+	return retained
 }
 
 // openCleanupStore loads the registered repository and opens its cleanup-capable
@@ -337,6 +392,21 @@ func (s *Service) cleanupTarget(ctx context.Context, registration config.Reposit
 	for _, role := range roles {
 		roleSet[role] = struct{}{}
 	}
+	workspaceIDs := make([]string, 0, len(candidate.Invocations))
+	seenWorkspaceIDs := make(map[string]struct{}, len(candidate.Invocations))
+	for _, invocation := range candidate.Invocations {
+		workspaceID := strings.TrimSpace(invocation.WorkspaceID)
+		if workspaceID == "" {
+			continue
+		}
+		if _, exists := seenWorkspaceIDs[workspaceID]; exists {
+			continue
+		}
+		seenWorkspaceIDs[workspaceID] = struct{}{}
+		workspaceIDs = append(workspaceIDs, workspaceID)
+	}
+	sort.Strings(workspaceIDs)
+
 	workerIDs := []string{run.ID}
 	seenWorkerIDs := map[string]struct{}{run.ID: {}}
 	for _, invocation := range candidate.Invocations {
@@ -372,6 +442,7 @@ func (s *Service) cleanupTarget(ctx context.Context, registration config.Reposit
 		RepositoryPath: registration.Path,
 		Branch:         run.Branch,
 		Worktree:       worktree,
+		WorkspaceIDs:   workspaceIDs,
 		WorkerRunID:    run.ID,
 		WorkerIDs:      workerIDs,
 		StoredOutputs:  storedOutputs,
@@ -425,7 +496,7 @@ func cleanupPlansEqual(left, right CleanupPlan) bool {
 	}
 	for index := range left.Runs {
 		leftRun, rightRun := left.Runs[index], right.Runs[index]
-		if leftRun.RunID != rightRun.RunID || leftRun.Status != rightRun.Status || !leftRun.EligibleAt.Equal(rightRun.EligibleAt) || leftRun.RepositoryPath != rightRun.RepositoryPath || leftRun.Branch != rightRun.Branch || leftRun.Worktree != rightRun.Worktree || leftRun.WorkerRunID != rightRun.WorkerRunID || !stringSlicesEqual(leftRun.WorkerIDs, rightRun.WorkerIDs) || !stringSlicesEqual(leftRun.StoredOutputs, rightRun.StoredOutputs) || !stringSlicesEqual(leftRun.Roles, rightRun.Roles) {
+		if leftRun.RunID != rightRun.RunID || leftRun.Status != rightRun.Status || !leftRun.EligibleAt.Equal(rightRun.EligibleAt) || leftRun.RepositoryPath != rightRun.RepositoryPath || leftRun.Branch != rightRun.Branch || leftRun.Worktree != rightRun.Worktree || leftRun.WorkerRunID != rightRun.WorkerRunID || !stringSlicesEqual(leftRun.WorkspaceIDs, rightRun.WorkspaceIDs) || !stringSlicesEqual(leftRun.WorkerIDs, rightRun.WorkerIDs) || !stringSlicesEqual(leftRun.StoredOutputs, rightRun.StoredOutputs) || !stringSlicesEqual(leftRun.Roles, rightRun.Roles) {
 			return false
 		}
 	}

--- a/internal/factory/cleanup.go
+++ b/internal/factory/cleanup.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
@@ -512,7 +513,7 @@ func safeWorkspaceHandle(value string) bool {
 		return false
 	}
 	for _, character := range value {
-		if character < ' ' || character == 0x7f {
+		if unicode.IsControl(character) {
 			return false
 		}
 	}

--- a/internal/factory/cleanup.go
+++ b/internal/factory/cleanup.go
@@ -23,7 +23,10 @@ const (
 	// local run artifacts may be removed.
 	CleanupRetention = 7 * 24 * time.Hour
 	// cleanupWorkspaceCloseTimeout bounds one best-effort terminal workspace
-	// close so an unresponsive terminal cannot stall local deletion.
+	// close so an unresponsive terminal cannot stall local deletion. The
+	// adapter adds its own wait delay after this deadline kills the command,
+	// so one close costs slightly more than this and a run costs one close per
+	// workspace it owns.
 	cleanupWorkspaceCloseTimeout = 10 * time.Second
 )
 
@@ -123,7 +126,8 @@ type CleanupRetainedWorkspace struct {
 	RunID string
 	// WorkspaceID is the opaque terminal workspace handle left in place.
 	WorkspaceID string
-	// Reason is the bounded operator-facing explanation.
+	// Reason is the single-line operator-facing explanation of why the close
+	// did not happen.
 	Reason string
 }
 
@@ -267,8 +271,9 @@ func (s *Service) closeRunWorkspaces(ctx context.Context, socketPath string, tar
 		terminalRuntime, err = s.ensureTerminalRuntime(socketPath)
 		if err != nil {
 			retained := make([]CleanupRetainedWorkspace, 0, len(target.WorkspaceIDs))
+			reason := safeStatusCommentValue(fmt.Sprintf("ensure terminal runtime: %v", err))
 			for _, workspaceID := range target.WorkspaceIDs {
-				retained = append(retained, CleanupRetainedWorkspace{RunID: target.RunID, WorkspaceID: workspaceID, Reason: fmt.Sprintf("ensure terminal runtime: %v", err)})
+				retained = append(retained, CleanupRetainedWorkspace{RunID: target.RunID, WorkspaceID: workspaceID, Reason: reason})
 			}
 			return retained
 		}
@@ -282,7 +287,9 @@ func (s *Service) closeRunWorkspaces(ctx context.Context, socketPath string, tar
 		err := terminalRuntime.CloseWorkspace(closeCtx, terminal.WorkspaceID(workspaceID))
 		cancel()
 		if err != nil {
-			retained = append(retained, CleanupRetainedWorkspace{RunID: target.RunID, WorkspaceID: workspaceID, Reason: err.Error()})
+			// Adapter stderr reaches the operator's plan output verbatim, so a
+			// multi-line failure must not be able to forge a cleanup line.
+			retained = append(retained, CleanupRetainedWorkspace{RunID: target.RunID, WorkspaceID: workspaceID, Reason: safeStatusCommentValue(err.Error())})
 		}
 	}
 	return retained

--- a/internal/factory/cleanup_test.go
+++ b/internal/factory/cleanup_test.go
@@ -13,6 +13,7 @@ import (
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
 	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
 )
 
@@ -77,6 +78,7 @@ func TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun(t *testing.T) 
 		Status:              store.InvocationStatusCompleted,
 		InvocationDirectory: invocationPath,
 		ResultDirectory:     resultPath,
+		WorkspaceID:         "workspace-eligible",
 		CreatedAt:           terminalAt,
 		UpdatedAt:           terminalAt,
 	}); err != nil {
@@ -87,8 +89,10 @@ func TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	workspace := &cleanupTestWorkspace{}
+	var events []string
+	workspace := &cleanupTestWorkspace{events: &events}
 	runtime := &cleanupTestWorker{}
+	terminalRuntime := &cleanupTestTerminal{events: &events}
 	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config: &fakeConfigRepository{value: config.HostConfig{
 			SchemaVersion: 1,
@@ -102,6 +106,7 @@ func TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun(t *testing.T) 
 		},
 		GitWorkspace: workspace,
 		Worker:       runtime,
+		Terminal:     terminalRuntime,
 		Now: func() time.Time {
 			return now
 		},
@@ -117,6 +122,12 @@ func TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun(t *testing.T) 
 	}
 	if result.Plan.Runs[0].RunID != "run-eligible" {
 		t.Fatalf("planned run = %q, want run-eligible", result.Plan.Runs[0].RunID)
+	}
+	if got := result.Plan.Runs[0].WorkspaceIDs; len(got) != 1 || got[0] != "workspace-eligible" {
+		t.Fatalf("planned workspaces = %#v, want [workspace-eligible]", got)
+	}
+	if len(terminalRuntime.closed) != 0 {
+		t.Fatalf("workspace closes = %#v, want preview to be side-effect free", terminalRuntime.closed)
 	}
 	if len(workspace.removed) != 0 {
 		t.Fatalf("workspace removals = %d, want preview to be side-effect free", len(workspace.removed))
@@ -143,6 +154,17 @@ func TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun(t *testing.T) 
 	}
 	if len(runtime.cleaned) != 1 || runtime.cleaned[0].RunID != "run-eligible" {
 		t.Fatalf("worker cleanups = %#v, want run-eligible", runtime.cleaned)
+	}
+	if len(confirmed.Retained) != 0 {
+		t.Fatalf("retained workspaces = %#v, want none", confirmed.Retained)
+	}
+	if got := terminalRuntime.closed; len(got) != 1 || got[0] != "workspace-eligible" {
+		t.Fatalf("workspace closes = %#v, want [workspace-eligible]", got)
+	}
+	// The workspace runs in the worktree, so it must be closed before the
+	// worktree is removed.
+	if len(events) != 2 || events[0] != "close-workspace" || events[1] != "remove-worktree" {
+		t.Fatalf("cleanup effect order = %#v, want close-workspace then remove-worktree", events)
 	}
 	for _, path := range []string{worktreePath, invocationPath, resultPath, filepath.Join(root, "worktrees", ".factory-git", "run-eligible")} {
 		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
@@ -308,9 +330,108 @@ func TestCleanupKeepsAnOpenPullRequestRun(t *testing.T) {
 	}
 }
 
+// TestCleanupReportsWorkspacesItCannotClose verifies that an unreachable
+// terminal never blocks local deletion and that the surviving workspace is
+// reported, because cleanup deletes the only durable record of its handle.
+func TestCleanupReportsWorkspacesItCannotClose(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktrees", "run-retained")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	for _, path := range []string{repositoryPath, worktreePath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+	terminalAt := now.Add(-8 * 24 * time.Hour)
+	opened, err := store.Open(ctx, operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SaveRun(ctx, store.Run{
+		ID:             "run-retained",
+		RepositoryPath: repositoryPath,
+		IssueNumber:    23,
+		Stage:          store.StageReady,
+		Status:         store.StatusComplete,
+		Branch:         "factory/run-retained",
+		Worktree:       worktreePath,
+		TerminalAt:     terminalAt,
+		CreatedAt:      terminalAt.Add(-time.Hour),
+		UpdatedAt:      terminalAt,
+	}); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.SaveInvocation(ctx, store.Invocation{
+		ID:          "invocation-1",
+		RunID:       "run-retained",
+		Harness:     "codex",
+		Role:        "implementation",
+		Stage:       store.StageImplementation,
+		Status:      store.InvocationStatusCompleted,
+		WorkspaceID: "workspace-unreachable",
+		CreatedAt:   terminalAt,
+		UpdatedAt:   terminalAt,
+	}); err != nil {
+		_ = opened.Close()
+		t.Fatal(err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	workspace := &cleanupTestWorkspace{}
+	runtime := &cleanupTestWorker{}
+	terminalRuntime := &cleanupTestTerminal{closeErr: errors.New("terminal server is not running")}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfigRepository{value: config.HostConfig{
+			SchemaVersion: 1,
+			Repositories: []config.RepositoryRegistration{{
+				Path:                repositoryPath,
+				OperationalDataPath: operationalPath,
+			}},
+		}},
+		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		GitWorkspace: workspace,
+		Worker:       runtime,
+		Terminal:     terminalRuntime,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	confirmed, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
+	if err != nil {
+		t.Fatalf("confirmed Cleanup() error = %v, want a failed close to be non-fatal", err)
+	}
+	if len(confirmed.Deleted) != 1 || confirmed.Deleted[0].RunID != "run-retained" {
+		t.Fatalf("confirmed deletions = %#v, want run-retained", confirmed.Deleted)
+	}
+	if len(workspace.removed) != 1 {
+		t.Fatalf("workspace removals = %#v, want the worktree removed anyway", workspace.removed)
+	}
+	if len(confirmed.Retained) != 1 {
+		t.Fatalf("retained workspaces = %#v, want one", confirmed.Retained)
+	}
+	retained := confirmed.Retained[0]
+	if retained.RunID != "run-retained" || retained.WorkspaceID != "workspace-unreachable" || retained.Reason == "" {
+		t.Fatalf("retained workspace = %#v, want the run-owned handle with a reason", retained)
+	}
+}
+
 // cleanupTestWorkspace records host cleanup effects for the Factory seam.
 type cleanupTestWorkspace struct {
 	removed []gitadapter.Workspace
+	// events is an optional shared log that orders cleanup effects.
+	events *[]string
 }
 
 // Create returns an unused workspace because preview cleanup never creates one.
@@ -321,6 +442,9 @@ func (*cleanupTestWorkspace) Create(context.Context, string, string, string) (gi
 // Remove records the exact workspace selected for deletion.
 func (w *cleanupTestWorkspace) Remove(_ context.Context, _ string, workspace gitadapter.Workspace) error {
 	w.removed = append(w.removed, workspace)
+	if w.events != nil {
+		*w.events = append(*w.events, "remove-worktree")
+	}
 	if err := os.RemoveAll(workspace.Worktree); err != nil {
 		return err
 	}
@@ -381,4 +505,51 @@ func (w *cleanupTestWorker) Cleanup(_ context.Context, request worker.CleanupReq
 		}
 	}
 	return nil
+}
+
+// cleanupTestTerminal records terminal workspace closes for the Factory seam.
+type cleanupTestTerminal struct {
+	closed []string
+	// closeErr fails every close so retention reporting can be observed.
+	closeErr error
+	// events is an optional shared log that orders cleanup effects.
+	events *[]string
+}
+
+// EnsureControlWorkspace satisfies terminal.TerminalRuntime for cleanup tests.
+func (*cleanupTestTerminal) EnsureControlWorkspace(context.Context, terminal.WorkspaceRequest) (terminal.Workspace, error) {
+	return terminal.Workspace{ID: "control"}, nil
+}
+
+// EnsureRunWorkspace satisfies terminal.TerminalRuntime for cleanup tests.
+func (*cleanupTestTerminal) EnsureRunWorkspace(context.Context, terminal.RunWorkspaceRequest) (terminal.RunWorkspace, error) {
+	return terminal.RunWorkspace{}, errors.New("unexpected run workspace creation")
+}
+
+// CreateSurface satisfies terminal.TerminalRuntime for cleanup tests.
+func (*cleanupTestTerminal) CreateSurface(context.Context, terminal.SurfaceRequest) (terminal.Surface, error) {
+	return terminal.Surface{}, errors.New("unexpected surface creation")
+}
+
+// LaunchSurface satisfies terminal.TerminalRuntime for cleanup tests.
+func (*cleanupTestTerminal) LaunchSurface(context.Context, terminal.SurfaceID, terminal.Command) error {
+	return nil
+}
+
+// SendInput satisfies terminal.TerminalRuntime for cleanup tests.
+func (*cleanupTestTerminal) SendInput(context.Context, terminal.SurfaceID, []byte) error { return nil }
+
+// Notify satisfies terminal.TerminalRuntime for cleanup tests.
+func (*cleanupTestTerminal) Notify(context.Context, terminal.Notification) error { return nil }
+
+// CloseSurface satisfies terminal.TerminalRuntime for cleanup tests.
+func (*cleanupTestTerminal) CloseSurface(context.Context, terminal.SurfaceID) error { return nil }
+
+// CloseWorkspace records the exact workspace handle cleanup closed.
+func (t *cleanupTestTerminal) CloseWorkspace(_ context.Context, workspaceID terminal.WorkspaceID) error {
+	t.closed = append(t.closed, string(workspaceID))
+	if t.events != nil {
+		*t.events = append(*t.events, "close-workspace")
+	}
+	return t.closeErr
 }

--- a/internal/factory/cleanup_test.go
+++ b/internal/factory/cleanup_test.go
@@ -414,38 +414,49 @@ func TestCleanupReportsRetainedWorkspacesWhenALaterStepFails(t *testing.T) {
 func TestCleanupSkipsARunWithAnUnsafeWorkspaceHandle(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	root := t.TempDir()
-	repositoryPath := filepath.Join(root, "repository")
-	worktreePath := filepath.Join(root, "worktrees", "run-unsafe")
-	operationalPath := filepath.Join(root, "state", "factory.db")
-	for _, path := range []string{repositoryPath, worktreePath} {
-		if err := os.MkdirAll(path, 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
+	for _, test := range []struct {
+		name        string
+		workspaceID string
+	}{
+		{name: "option shaped", workspaceID: "--workspace"},
+		{name: "next line", workspaceID: "workspace\u0085unsafe"},
+		{name: "control sequence introducer", workspaceID: "workspace\u009bunsafe"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			root := t.TempDir()
+			repositoryPath := filepath.Join(root, "repository")
+			worktreePath := filepath.Join(root, "worktrees", "run-unsafe")
+			operationalPath := filepath.Join(root, "state", "factory.db")
+			for _, path := range []string{repositoryPath, worktreePath} {
+				if err := os.MkdirAll(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
-	saveCleanupFixture(ctx, t, repositoryPath, operationalPath, "run-unsafe", worktreePath, "--workspace", now)
+			now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+			saveCleanupFixture(ctx, t, repositoryPath, operationalPath, "run-unsafe", worktreePath, test.workspaceID, now)
 
-	workspace := &cleanupTestWorkspace{}
-	runtime := &cleanupTestWorker{}
-	terminalRuntime := &cleanupTestTerminal{}
-	service := newCleanupService(repositoryPath, operationalPath, workspace, runtime, terminalRuntime, now)
+			workspace := &cleanupTestWorkspace{}
+			runtime := &cleanupTestWorker{}
+			terminalRuntime := &cleanupTestTerminal{}
+			service := newCleanupService(repositoryPath, operationalPath, workspace, runtime, terminalRuntime, now)
 
-	result, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
-	var blockedErr *factory.CleanupBlockedError
-	if !errors.As(err, &blockedErr) {
-		t.Fatalf("Cleanup() error = %v, want CleanupBlockedError", err)
-	}
-	if len(result.Plan.Runs) != 0 || len(result.Plan.Skipped) != 1 {
-		t.Fatalf("cleanup plan = %#v, want only the unsafe run skipped", result.Plan)
-	}
-	if !strings.Contains(result.Plan.Skipped[0].Reason, "unsafe terminal workspace handle") {
-		t.Fatalf("skip reason = %q, want the unsafe workspace handle", result.Plan.Skipped[0].Reason)
-	}
-	if len(terminalRuntime.closed) != 0 || len(workspace.removed) != 0 {
-		t.Fatalf("cleanup effects = closes=%#v removals=%#v, want none", terminalRuntime.closed, workspace.removed)
+			result, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
+			var blockedErr *factory.CleanupBlockedError
+			if !errors.As(err, &blockedErr) {
+				t.Fatalf("Cleanup() error = %v, want CleanupBlockedError", err)
+			}
+			if len(result.Plan.Runs) != 0 || len(result.Plan.Skipped) != 1 {
+				t.Fatalf("cleanup plan = %#v, want only the unsafe run skipped", result.Plan)
+			}
+			if !strings.Contains(result.Plan.Skipped[0].Reason, "unsafe terminal workspace handle") {
+				t.Fatalf("skip reason = %q, want the unsafe workspace handle", result.Plan.Skipped[0].Reason)
+			}
+			if len(terminalRuntime.closed) != 0 || len(workspace.removed) != 0 {
+				t.Fatalf("cleanup effects = closes=%#v removals=%#v, want none", terminalRuntime.closed, workspace.removed)
+			}
+		})
 	}
 }
 

--- a/internal/factory/cleanup_test.go
+++ b/internal/factory/cleanup_test.go
@@ -338,11 +338,13 @@ func TestCleanupReportsWorkspacesItCannotClose(t *testing.T) {
 	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
 	// A tmux-shaped handle also pins that the plan admits the handle forms of
 	// the adapter this seam is expected to migrate to.
-	saveCleanupFixture(ctx, t, operationalPath, repositoryPath, "run-retained", worktreePath, "$3", now)
+	saveCleanupFixture(ctx, t, repositoryPath, operationalPath, "run-retained", worktreePath, "$3", now)
 
 	workspace := &cleanupTestWorkspace{}
 	runtime := &cleanupTestWorker{}
-	terminalRuntime := &cleanupTestTerminal{closeErr: errors.New("terminal server is not running")}
+	// The adapter reports terminal stderr verbatim, so the failure carries the
+	// newline that would otherwise forge a second cleanup line.
+	terminalRuntime := &cleanupTestTerminal{closeErr: errors.New("terminal server is not running\ncleanup complete: runs=0")}
 	service := newCleanupService(repositoryPath, operationalPath, workspace, runtime, terminalRuntime, now)
 
 	confirmed, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
@@ -361,6 +363,9 @@ func TestCleanupReportsWorkspacesItCannotClose(t *testing.T) {
 	retained := confirmed.Retained[0]
 	if retained.RunID != "run-retained" || retained.WorkspaceID != "$3" || retained.Reason == "" {
 		t.Fatalf("retained workspace = %#v, want the run-owned handle with a reason", retained)
+	}
+	if strings.ContainsAny(retained.Reason, "\r\n") {
+		t.Fatalf("retained reason = %q, want one operator-facing line", retained.Reason)
 	}
 }
 
@@ -383,7 +388,7 @@ func TestCleanupReportsRetainedWorkspacesWhenALaterStepFails(t *testing.T) {
 	}
 
 	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
-	saveCleanupFixture(ctx, t, operationalPath, repositoryPath, "run-failing", worktreePath, "workspace-failing", now)
+	saveCleanupFixture(ctx, t, repositoryPath, operationalPath, "run-failing", worktreePath, "workspace-failing", now)
 
 	workspace := &cleanupTestWorkspace{removeErr: errors.New("worktree is locked")}
 	runtime := &cleanupTestWorker{}
@@ -417,7 +422,7 @@ func TestCleanupSkipsARunWithAnUnsafeWorkspaceHandle(t *testing.T) {
 	}
 
 	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
-	saveCleanupFixture(ctx, t, operationalPath, repositoryPath, "run-unsafe", worktreePath, "--workspace", now)
+	saveCleanupFixture(ctx, t, repositoryPath, operationalPath, "run-unsafe", worktreePath, "--workspace", now)
 
 	workspace := &cleanupTestWorkspace{}
 	runtime := &cleanupTestWorker{}
@@ -465,7 +470,7 @@ func newCleanupService(repositoryPath, operationalPath string, workspace *cleanu
 
 // saveCleanupFixture persists one seven-day-old terminal run and the single
 // invocation that owns its terminal workspace handle.
-func saveCleanupFixture(ctx context.Context, t *testing.T, operationalPath, repositoryPath, runID, worktreePath, workspaceID string, now time.Time) {
+func saveCleanupFixture(ctx context.Context, t *testing.T, repositoryPath, operationalPath, runID, worktreePath, workspaceID string, now time.Time) {
 	t.Helper()
 
 	terminalAt := now.Add(-8 * 24 * time.Hour)

--- a/internal/factory/cleanup_test.go
+++ b/internal/factory/cleanup_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -160,6 +161,10 @@ func TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun(t *testing.T) 
 	}
 	if got := terminalRuntime.closed; len(got) != 1 || got[0] != "workspace-eligible" {
 		t.Fatalf("workspace closes = %#v, want [workspace-eligible]", got)
+	}
+	// An unresponsive terminal must not stall the local deletion that follows.
+	if terminalRuntime.unboundedCloses != 0 {
+		t.Fatalf("unbounded workspace closes = %d, want every close bounded", terminalRuntime.unboundedCloses)
 	}
 	// The workspace runs in the worktree, so it must be closed before the
 	// worktree is removed.
@@ -427,9 +432,165 @@ func TestCleanupReportsWorkspacesItCannotClose(t *testing.T) {
 	}
 }
 
+// TestCleanupReportsRetainedWorkspacesWhenALaterStepFails verifies that a
+// failed cleanup still names the workspaces it left behind. The invocation
+// rows holding those handles may already be gone, so a report suppressed by an
+// error would lose them permanently.
+func TestCleanupReportsRetainedWorkspacesWhenALaterStepFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktrees", "run-failing")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	for _, path := range []string{repositoryPath, worktreePath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+	saveCleanupFixture(ctx, t, operationalPath, repositoryPath, "run-failing", worktreePath, "workspace-failing", now)
+
+	workspace := &cleanupTestWorkspace{removeErr: errors.New("worktree is locked")}
+	runtime := &cleanupTestWorker{}
+	terminalRuntime := &cleanupTestTerminal{closeErr: errors.New("terminal server is not running")}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfigRepository{value: config.HostConfig{
+			SchemaVersion: 1,
+			Repositories: []config.RepositoryRegistration{{
+				Path:                repositoryPath,
+				OperationalDataPath: operationalPath,
+			}},
+		}},
+		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		GitWorkspace: workspace,
+		Worker:       runtime,
+		Terminal:     terminalRuntime,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	result, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
+	if err == nil {
+		t.Fatal("Cleanup() error = nil, want the failed worktree removal")
+	}
+	if len(result.Retained) != 1 || result.Retained[0].WorkspaceID != "workspace-failing" {
+		t.Fatalf("retained workspaces = %#v, want workspace-failing reported alongside the error", result.Retained)
+	}
+}
+
+// TestCleanupSkipsARunWithAnUnsafeWorkspaceHandle verifies that a malformed
+// terminal handle cannot enter the plan, matching how cleanup treats every
+// other unvalidated run identity.
+func TestCleanupSkipsARunWithAnUnsafeWorkspaceHandle(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktrees", "run-unsafe")
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	for _, path := range []string{repositoryPath, worktreePath} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
+	saveCleanupFixture(ctx, t, operationalPath, repositoryPath, "run-unsafe", worktreePath, "--workspace", now)
+
+	workspace := &cleanupTestWorkspace{}
+	runtime := &cleanupTestWorker{}
+	terminalRuntime := &cleanupTestTerminal{}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfigRepository{value: config.HostConfig{
+			SchemaVersion: 1,
+			Repositories: []config.RepositoryRegistration{{
+				Path:                repositoryPath,
+				OperationalDataPath: operationalPath,
+			}},
+		}},
+		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
+			return store.Open(ctx, path)
+		},
+		GitWorkspace: workspace,
+		Worker:       runtime,
+		Terminal:     terminalRuntime,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	result, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
+	var blockedErr *factory.CleanupBlockedError
+	if !errors.As(err, &blockedErr) {
+		t.Fatalf("Cleanup() error = %v, want CleanupBlockedError", err)
+	}
+	if len(result.Plan.Runs) != 0 || len(result.Plan.Skipped) != 1 {
+		t.Fatalf("cleanup plan = %#v, want only the unsafe run skipped", result.Plan)
+	}
+	if !strings.Contains(result.Plan.Skipped[0].Reason, "unsafe terminal workspace handle") {
+		t.Fatalf("skip reason = %q, want the unsafe workspace handle", result.Plan.Skipped[0].Reason)
+	}
+	if len(terminalRuntime.closed) != 0 || len(workspace.removed) != 0 {
+		t.Fatalf("cleanup effects = closes=%#v removals=%#v, want none", terminalRuntime.closed, workspace.removed)
+	}
+}
+
+// saveCleanupFixture persists one seven-day-old terminal run and the single
+// invocation that owns its terminal workspace handle.
+func saveCleanupFixture(ctx context.Context, t *testing.T, operationalPath, repositoryPath, runID, worktreePath, workspaceID string, now time.Time) {
+	t.Helper()
+
+	terminalAt := now.Add(-8 * 24 * time.Hour)
+	opened, err := store.Open(ctx, operationalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := opened.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if err := opened.SaveRun(ctx, store.Run{
+		ID:             runID,
+		RepositoryPath: repositoryPath,
+		IssueNumber:    23,
+		Stage:          store.StageReady,
+		Status:         store.StatusComplete,
+		Branch:         "factory/" + runID,
+		Worktree:       worktreePath,
+		TerminalAt:     terminalAt,
+		CreatedAt:      terminalAt.Add(-time.Hour),
+		UpdatedAt:      terminalAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SaveInvocation(ctx, store.Invocation{
+		ID:          "invocation-1",
+		RunID:       runID,
+		Harness:     "codex",
+		Role:        "implementation",
+		Stage:       store.StageImplementation,
+		Status:      store.InvocationStatusCompleted,
+		WorkspaceID: workspaceID,
+		CreatedAt:   terminalAt,
+		UpdatedAt:   terminalAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // cleanupTestWorkspace records host cleanup effects for the Factory seam.
 type cleanupTestWorkspace struct {
 	removed []gitadapter.Workspace
+	// removeErr fails removal so later cleanup steps can be observed.
+	removeErr error
 	// events is an optional shared log that orders cleanup effects.
 	events *[]string
 }
@@ -444,6 +605,9 @@ func (w *cleanupTestWorkspace) Remove(_ context.Context, _ string, workspace git
 	w.removed = append(w.removed, workspace)
 	if w.events != nil {
 		*w.events = append(*w.events, "remove-worktree")
+	}
+	if w.removeErr != nil {
+		return w.removeErr
 	}
 	if err := os.RemoveAll(workspace.Worktree); err != nil {
 		return err
@@ -512,6 +676,8 @@ type cleanupTestTerminal struct {
 	closed []string
 	// closeErr fails every close so retention reporting can be observed.
 	closeErr error
+	// unboundedCloses counts closes that arrived without a deadline.
+	unboundedCloses int
 	// events is an optional shared log that orders cleanup effects.
 	events *[]string
 }
@@ -546,8 +712,11 @@ func (*cleanupTestTerminal) Notify(context.Context, terminal.Notification) error
 func (*cleanupTestTerminal) CloseSurface(context.Context, terminal.SurfaceID) error { return nil }
 
 // CloseWorkspace records the exact workspace handle cleanup closed.
-func (t *cleanupTestTerminal) CloseWorkspace(_ context.Context, workspaceID terminal.WorkspaceID) error {
+func (t *cleanupTestTerminal) CloseWorkspace(ctx context.Context, workspaceID terminal.WorkspaceID) error {
 	t.closed = append(t.closed, string(workspaceID))
+	if _, bounded := ctx.Deadline(); !bounded {
+		t.unboundedCloses++
+	}
 	if t.events != nil {
 		*t.events = append(*t.events, "close-workspace")
 	}

--- a/internal/factory/cleanup_test.go
+++ b/internal/factory/cleanup_test.go
@@ -344,7 +344,7 @@ func TestCleanupReportsWorkspacesItCannotClose(t *testing.T) {
 	runtime := &cleanupTestWorker{}
 	// The adapter reports terminal stderr verbatim, so the failure carries the
 	// newline that would otherwise forge a second cleanup line.
-	terminalRuntime := &cleanupTestTerminal{closeErr: errors.New("terminal server is not running\ncleanup complete: runs=0")}
+	terminalRuntime := &cleanupTestTerminal{closeErr: errors.New("terminal server is not running\n\x1b[1Ecleanup complete: runs=0")}
 	service := newCleanupService(repositoryPath, operationalPath, workspace, runtime, terminalRuntime, now)
 
 	confirmed, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
@@ -364,8 +364,12 @@ func TestCleanupReportsWorkspacesItCannotClose(t *testing.T) {
 	if retained.RunID != "run-retained" || retained.WorkspaceID != "$3" || retained.Reason == "" {
 		t.Fatalf("retained workspace = %#v, want the run-owned handle with a reason", retained)
 	}
-	if strings.ContainsAny(retained.Reason, "\r\n") {
-		t.Fatalf("retained reason = %q, want one operator-facing line", retained.Reason)
+	// A terminal renders an escape sequence as line movement, so the reason
+	// must carry no control character at all, not merely no newline.
+	for _, character := range retained.Reason {
+		if character < ' ' || character == 0x7f {
+			t.Fatalf("retained reason = %q, want one operator-facing line", retained.Reason)
+		}
 	}
 }
 

--- a/internal/factory/cleanup_test.go
+++ b/internal/factory/cleanup_test.go
@@ -94,24 +94,7 @@ func TestCleanupPreviewRequiresConfirmationAndProtectsEligibleRun(t *testing.T) 
 	workspace := &cleanupTestWorkspace{events: &events}
 	runtime := &cleanupTestWorker{}
 	terminalRuntime := &cleanupTestTerminal{events: &events}
-	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
-		Config: &fakeConfigRepository{value: config.HostConfig{
-			SchemaVersion: 1,
-			Repositories: []config.RepositoryRegistration{{
-				Path:                repositoryPath,
-				OperationalDataPath: operationalPath,
-			}},
-		}},
-		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
-			return store.Open(ctx, path)
-		},
-		GitWorkspace: workspace,
-		Worker:       runtime,
-		Terminal:     terminalRuntime,
-		Now: func() time.Time {
-			return now
-		},
-	})
+	service := newCleanupService(repositoryPath, operationalPath, workspace, runtime, terminalRuntime, now)
 
 	result, err := service.Cleanup(ctx, factory.CleanupRequest{})
 	var confirmationErr *factory.CleanupConfirmationRequiredError
@@ -353,65 +336,14 @@ func TestCleanupReportsWorkspacesItCannotClose(t *testing.T) {
 	}
 
 	now := time.Date(2026, time.January, 20, 12, 0, 0, 0, time.UTC)
-	terminalAt := now.Add(-8 * 24 * time.Hour)
-	opened, err := store.Open(ctx, operationalPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := opened.SaveRun(ctx, store.Run{
-		ID:             "run-retained",
-		RepositoryPath: repositoryPath,
-		IssueNumber:    23,
-		Stage:          store.StageReady,
-		Status:         store.StatusComplete,
-		Branch:         "factory/run-retained",
-		Worktree:       worktreePath,
-		TerminalAt:     terminalAt,
-		CreatedAt:      terminalAt.Add(-time.Hour),
-		UpdatedAt:      terminalAt,
-	}); err != nil {
-		_ = opened.Close()
-		t.Fatal(err)
-	}
-	if err := opened.SaveInvocation(ctx, store.Invocation{
-		ID:          "invocation-1",
-		RunID:       "run-retained",
-		Harness:     "codex",
-		Role:        "implementation",
-		Stage:       store.StageImplementation,
-		Status:      store.InvocationStatusCompleted,
-		WorkspaceID: "workspace-unreachable",
-		CreatedAt:   terminalAt,
-		UpdatedAt:   terminalAt,
-	}); err != nil {
-		_ = opened.Close()
-		t.Fatal(err)
-	}
-	if err := opened.Close(); err != nil {
-		t.Fatal(err)
-	}
+	// A tmux-shaped handle also pins that the plan admits the handle forms of
+	// the adapter this seam is expected to migrate to.
+	saveCleanupFixture(ctx, t, operationalPath, repositoryPath, "run-retained", worktreePath, "$3", now)
 
 	workspace := &cleanupTestWorkspace{}
 	runtime := &cleanupTestWorker{}
 	terminalRuntime := &cleanupTestTerminal{closeErr: errors.New("terminal server is not running")}
-	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
-		Config: &fakeConfigRepository{value: config.HostConfig{
-			SchemaVersion: 1,
-			Repositories: []config.RepositoryRegistration{{
-				Path:                repositoryPath,
-				OperationalDataPath: operationalPath,
-			}},
-		}},
-		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
-			return store.Open(ctx, path)
-		},
-		GitWorkspace: workspace,
-		Worker:       runtime,
-		Terminal:     terminalRuntime,
-		Now: func() time.Time {
-			return now
-		},
-	})
+	service := newCleanupService(repositoryPath, operationalPath, workspace, runtime, terminalRuntime, now)
 
 	confirmed, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
 	if err != nil {
@@ -427,7 +359,7 @@ func TestCleanupReportsWorkspacesItCannotClose(t *testing.T) {
 		t.Fatalf("retained workspaces = %#v, want one", confirmed.Retained)
 	}
 	retained := confirmed.Retained[0]
-	if retained.RunID != "run-retained" || retained.WorkspaceID != "workspace-unreachable" || retained.Reason == "" {
+	if retained.RunID != "run-retained" || retained.WorkspaceID != "$3" || retained.Reason == "" {
 		t.Fatalf("retained workspace = %#v, want the run-owned handle with a reason", retained)
 	}
 }
@@ -456,24 +388,7 @@ func TestCleanupReportsRetainedWorkspacesWhenALaterStepFails(t *testing.T) {
 	workspace := &cleanupTestWorkspace{removeErr: errors.New("worktree is locked")}
 	runtime := &cleanupTestWorker{}
 	terminalRuntime := &cleanupTestTerminal{closeErr: errors.New("terminal server is not running")}
-	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
-		Config: &fakeConfigRepository{value: config.HostConfig{
-			SchemaVersion: 1,
-			Repositories: []config.RepositoryRegistration{{
-				Path:                repositoryPath,
-				OperationalDataPath: operationalPath,
-			}},
-		}},
-		OpenStore: func(ctx context.Context, path string) (factory.OperationalStore, error) {
-			return store.Open(ctx, path)
-		},
-		GitWorkspace: workspace,
-		Worker:       runtime,
-		Terminal:     terminalRuntime,
-		Now: func() time.Time {
-			return now
-		},
-	})
+	service := newCleanupService(repositoryPath, operationalPath, workspace, runtime, terminalRuntime, now)
 
 	result, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
 	if err == nil {
@@ -507,7 +422,28 @@ func TestCleanupSkipsARunWithAnUnsafeWorkspaceHandle(t *testing.T) {
 	workspace := &cleanupTestWorkspace{}
 	runtime := &cleanupTestWorker{}
 	terminalRuntime := &cleanupTestTerminal{}
-	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+	service := newCleanupService(repositoryPath, operationalPath, workspace, runtime, terminalRuntime, now)
+
+	result, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
+	var blockedErr *factory.CleanupBlockedError
+	if !errors.As(err, &blockedErr) {
+		t.Fatalf("Cleanup() error = %v, want CleanupBlockedError", err)
+	}
+	if len(result.Plan.Runs) != 0 || len(result.Plan.Skipped) != 1 {
+		t.Fatalf("cleanup plan = %#v, want only the unsafe run skipped", result.Plan)
+	}
+	if !strings.Contains(result.Plan.Skipped[0].Reason, "unsafe terminal workspace handle") {
+		t.Fatalf("skip reason = %q, want the unsafe workspace handle", result.Plan.Skipped[0].Reason)
+	}
+	if len(terminalRuntime.closed) != 0 || len(workspace.removed) != 0 {
+		t.Fatalf("cleanup effects = closes=%#v removals=%#v, want none", terminalRuntime.closed, workspace.removed)
+	}
+}
+
+// newCleanupService builds a Factory service whose destructive seams are all
+// test doubles, so a cleanup test observes effects instead of performing them.
+func newCleanupService(repositoryPath, operationalPath string, workspace *cleanupTestWorkspace, runtime *cleanupTestWorker, terminalRuntime *cleanupTestTerminal, now time.Time) *factory.Service {
+	return factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config: &fakeConfigRepository{value: config.HostConfig{
 			SchemaVersion: 1,
 			Repositories: []config.RepositoryRegistration{{
@@ -525,21 +461,6 @@ func TestCleanupSkipsARunWithAnUnsafeWorkspaceHandle(t *testing.T) {
 			return now
 		},
 	})
-
-	result, err := service.Cleanup(ctx, factory.CleanupRequest{Confirm: true})
-	var blockedErr *factory.CleanupBlockedError
-	if !errors.As(err, &blockedErr) {
-		t.Fatalf("Cleanup() error = %v, want CleanupBlockedError", err)
-	}
-	if len(result.Plan.Runs) != 0 || len(result.Plan.Skipped) != 1 {
-		t.Fatalf("cleanup plan = %#v, want only the unsafe run skipped", result.Plan)
-	}
-	if !strings.Contains(result.Plan.Skipped[0].Reason, "unsafe terminal workspace handle") {
-		t.Fatalf("skip reason = %q, want the unsafe workspace handle", result.Plan.Skipped[0].Reason)
-	}
-	if len(terminalRuntime.closed) != 0 || len(workspace.removed) != 0 {
-		t.Fatalf("cleanup effects = closes=%#v removals=%#v, want none", terminalRuntime.closed, workspace.removed)
-	}
 }
 
 // saveCleanupFixture persists one seven-day-old terminal run and the single
@@ -673,6 +594,7 @@ func (w *cleanupTestWorker) Cleanup(_ context.Context, request worker.CleanupReq
 
 // cleanupTestTerminal records terminal workspace closes for the Factory seam.
 type cleanupTestTerminal struct {
+	// closed records every workspace handle cleanup asked to close.
 	closed []string
 	// closeErr fails every close so retention reporting can be observed.
 	closeErr error

--- a/internal/terminal/runtime.go
+++ b/internal/terminal/runtime.go
@@ -430,15 +430,26 @@ func (r *CmuxRuntime) ReadSurface(ctx context.Context, surfaceID SurfaceID, line
 	return string(output), nil
 }
 
-// CloseWorkspace closes a workspace through the adapter lifecycle command.
+// CloseWorkspace closes a workspace through the adapter lifecycle command. A
+// workspace the adapter already lost is reported as closed, because the
+// caller's intended end state is the one that already holds.
 func (r *CmuxRuntime) CloseWorkspace(ctx context.Context, workspaceID WorkspaceID) error {
 	if strings.TrimSpace(string(workspaceID)) == "" {
 		return errors.New("workspace id is required")
 	}
 	if _, err := r.run(ctx, []string{"close-workspace", "--workspace", string(workspaceID)}, nil); err != nil {
+		if isWorkspaceNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("close terminal workspace: %w", err)
 	}
 	return nil
+}
+
+// isWorkspaceNotFound reports the adapter's absent-workspace response, which
+// both inspection and close treat as a successful negative result.
+func isWorkspaceNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not_found: Workspace not found")
 }
 
 // InspectWorkspace reads one workspace and its surface identities without
@@ -451,7 +462,7 @@ func (r *CmuxRuntime) InspectWorkspace(ctx context.Context, workspaceID Workspac
 	}
 	topology, err := r.topology(ctx, []string{"tree", "--workspace", string(workspaceID), "--json", "--id-format", "uuids"})
 	if err != nil {
-		if strings.Contains(err.Error(), "not_found: Workspace not found") {
+		if isWorkspaceNotFound(err) {
 			return WorkspaceInspection{WorkspaceID: workspaceID}, nil
 		}
 		return WorkspaceInspection{}, err

--- a/internal/terminal/runtime.go
+++ b/internal/terminal/runtime.go
@@ -13,7 +13,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
+
+// commandWaitDelay bounds how long a terminal command may hold its output
+// pipes open after its context ended.
+const commandWaitDelay = 5 * time.Second
 
 // WorkspaceID is an opaque terminal workspace handle.
 type WorkspaceID string
@@ -447,7 +452,9 @@ func (r *CmuxRuntime) CloseWorkspace(ctx context.Context, workspaceID WorkspaceI
 }
 
 // isWorkspaceNotFound reports the adapter's absent-workspace response, which
-// both inspection and close treat as a successful negative result.
+// both inspection and close treat as a successful negative result. An adapter
+// that reports an absent workspace some other way costs only a redundant
+// close report, never a failed cleanup.
 func isWorkspaceNotFound(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "not_found: Workspace not found")
 }
@@ -494,6 +501,9 @@ func (r *CmuxRuntime) run(ctx context.Context, args []string, input []byte) ([]b
 		binary = "cmux"
 	}
 	command := exec.CommandContext(ctx, binary, args...)
+	// A killed terminal command can leave a descendant holding the inherited
+	// output pipes, which would block Wait after the deadline that killed it.
+	command.WaitDelay = commandWaitDelay
 	// Deprecation hints are written to the same stream this adapter reports as
 	// a failure reason, so silence them and keep stderr to actual errors.
 	command.Env = append(os.Environ(), "CMUX_QUIET=1")

--- a/internal/terminal/runtime_test.go
+++ b/internal/terminal/runtime_test.go
@@ -220,7 +220,9 @@ type fakeRunner struct {
 	workspaceIDs []string
 	tree         string
 	// treeErr is returned when the fixture handles a topology query.
-	treeErr    error
+	treeErr error
+	// closeErr is returned when the fixture handles a workspace close.
+	closeErr   error
 	newSurface string
 	calls      []string
 }
@@ -243,6 +245,11 @@ func (r *fakeRunner) Run(_ context.Context, args []string, _ []byte) ([]byte, er
 		return []byte(r.tree), nil
 	case args[0] == "new-surface":
 		return []byte(r.newSurface), nil
+	case args[0] == "close-workspace":
+		if r.closeErr != nil {
+			return nil, r.closeErr
+		}
+		return []byte("OK\n"), nil
 	default:
 		return []byte("OK\n"), nil
 	}
@@ -251,3 +258,31 @@ func (r *fakeRunner) Run(_ context.Context, args []string, _ []byte) ([]byte, er
 var _ terminal.CommandRunner = (*fakeRunner)(nil)
 var _ terminal.TerminalRuntime = (*terminal.CmuxRuntime)(nil)
 var _ terminal.SurfaceReader = (*terminal.CmuxRuntime)(nil)
+
+// TestCmuxRuntimeTreatsAnAbsentWorkspaceAsClosed verifies that closing a
+// workspace the terminal already lost succeeds. Cleanup reports every close it
+// cannot complete, so an absent workspace must not produce a false report of
+// work the operator still has to do.
+func TestCmuxRuntimeTreatsAnAbsentWorkspaceAsClosed(t *testing.T) {
+	runner := &fakeRunner{closeErr: errors.New("terminal command failed: not_found: Workspace not found")}
+	runtime := terminal.NewCmuxRuntime(runner)
+
+	if err := runtime.CloseWorkspace(context.Background(), runWorkspaceID); err != nil {
+		t.Fatalf("CloseWorkspace() error = %v, want an absent workspace to be closed", err)
+	}
+	if joined := strings.Join(runner.calls, "\n"); !strings.Contains(joined, "close-workspace --workspace "+runWorkspaceID) {
+		t.Fatalf("adapter calls = %q, want the close command", joined)
+	}
+}
+
+// TestCmuxRuntimeReportsAFailedWorkspaceClose verifies that an ordinary close
+// failure still reaches the caller.
+func TestCmuxRuntimeReportsAFailedWorkspaceClose(t *testing.T) {
+	runner := &fakeRunner{closeErr: errors.New("terminal command failed: connection refused")}
+	runtime := terminal.NewCmuxRuntime(runner)
+
+	err := runtime.CloseWorkspace(context.Background(), runWorkspaceID)
+	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("CloseWorkspace() error = %v, want the adapter failure", err)
+	}
+}

--- a/internal/terminal/runtime_test.go
+++ b/internal/terminal/runtime_test.go
@@ -217,14 +217,18 @@ func TestCmuxRuntimePreservesOtherInspectionErrors(t *testing.T) {
 // JSON for creation and topology queries, and a plain acknowledgement line for
 // every lifecycle command.
 type fakeRunner struct {
+	// workspaceIDs supplies the handles returned by successive creations.
 	workspaceIDs []string
-	tree         string
+	// tree is the topology fixture returned by a topology query.
+	tree string
 	// treeErr is returned when the fixture handles a topology query.
 	treeErr error
 	// closeErr is returned when the fixture handles a workspace close.
-	closeErr   error
+	closeErr error
+	// newSurface is the response returned by a surface creation.
 	newSurface string
-	calls      []string
+	// calls records every host terminal command the adapter issued.
+	calls []string
 }
 
 // Run records one host terminal command and returns its fixture.


### PR DESCRIPTION
## Summary

cmux workspaces accumulated one per run and were never closed. The `TerminalRuntime` seam already exposed `CloseWorkspace`, but no production code called it.

This closes them during `factory cleanup` rather than at the lifecycle transition. Cleanup is the last operation that knows a run's workspace handles: the invocation rows it deletes are their only durable record, so after cleanup nothing can ever close them.

Closing at merge or issue-close was the alternative and is worse:

| | Close on merge/cancel | Close during cleanup |
|---|---|---|
| Worktree still exists | Yes — kills the window into a directory that lives another seven days | No — window and directory die together |
| Cancelled run retry | Breaks it. `retryTargetIsOpen` reactivates a run when the issue reopens; the failure evidence would already be gone | Unaffected; the run is past retention |
| Restart safety | A new external side effect inside a journaled transition. Terminal notification already needed a claim table to be idempotent | Already a confirmed, transactional, preview-then-mutate command |
| Operator visibility | Silent | Appears in the plan before confirmation |

`transitionTerminal` is untouched, so its documented promise — terminal surfaces, sessions, branches, worktrees, and logs stay in place — still holds.

## What changed

- `CleanupRun` carries the run's workspace handles, collected from its invocations, validated, deduped, and deterministically ordered.
- The handles appear in the preview plan and in the plan-changed guard, so a preview/confirm mismatch still fails closed.
- On a confirmed cleanup each workspace is closed **before** its worktree is removed, since the worktree is its working directory.
- A close failure never blocks local deletion: cleanup still works when the terminal is gone, and every surviving workspace is reported for manual closure — including when a later step then fails.
- Each close is individually bounded, and the adapter now sets `WaitDelay` so a descendant holding the inherited pipes cannot block the wait after the deadline.
- The adapter treats an already-absent workspace as closed, matching how `InspectWorkspace` handles the same response.
- `safeStatusCommentValue` now replaces the whole control range. Adapter stderr reaches operator-facing output verbatim, and an escape sequence renders as line movement — enough to forge a `cleanup ...` line on a terminal.

## Test plan

- `make check` — gofmt, vet, full suite, build. All green.
- New coverage: plan contents and preview side-effect freedom; close-before-remove ordering; every close bounded; retained report on both the success and the failure path; unsafe handle skipped; tmux-shaped handle accepted (verified to fail if the validator is reverted); control characters stripped from the reason; absent-workspace tolerance and ordinary close failure in the adapter; the operator-facing retained line and its write-failure path.

Reviewed over four rounds on both the standards and spec axes; both closed with no blocking findings.

## Known gaps

- The CLI's end-to-end ordering (retained lines printed before the error return) is not covered — reaching it needs the real Docker worker and Git adapters to fail in a set order. The helper itself and the service half are both pinned.
- `isWorkspaceNotFound` matches a response string only ever observed from the adapter's `tree` command. A mismatch costs a redundant "close it manually" line, never a failed cleanup.

## Follow-up, not in this PR

`safeStatusCommentValue` is now used at three surfaces — GitHub comments, a terminal notification body, and CLI stdout — and its name and doc only describe the first. A rename to intent is earned, but it touches 32 call sites across five files this change does not otherwise touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrDRfPTNz7htCGCEbaFmdr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cleanup previews now show terminal workspaces associated with each run.
  * Cleanup closes terminal workspaces and reports any that require manual closure.
  * Retained workspace details now include the run, workspace, and reason.

* **Bug Fixes**
  * Cleanup continues removing local resources when workspace closure fails.
  * Improved handling of missing workspaces and stalled terminal processes.
  * Strengthened validation and sanitization of workspace handles and status text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->