### PR TITLE
Replace progression action closures with typed commands

### DIFF
--- a/internal/factory/concurrent_review_internal_test.go
+++ b/internal/factory/concurrent_review_internal_test.go
@@ -190,7 +190,7 @@ func TestMissingConcurrentReviewRoleResumesTheUnlaunchedReviewer(t *testing.T) {
 				SpecificationReview: test.specification,
 				StandardsReview:     test.standards,
 			}}
-			if got, ok := missingConcurrentReviewRole(state); !ok || got != test.wantMissingRole {
+			if got, ok := missingConcurrentReviewRole(state, workflow.DefaultRegistry()); !ok || got != test.wantMissingRole {
 				t.Fatalf("missingConcurrentReviewRole() = %q/%t, want %q/true", got, ok, test.wantMissingRole)
 			}
 		})

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -138,6 +138,15 @@ func (e *progressionActionError) Error() string {
 	return fmt.Sprintf("invalid progression action %q: %s", e.Action.kind, e.Reason)
 }
 
+// validateNoAgentOperands rejects operands that belong only to agent-launch
+// or report-acceptance commands.
+func (a progressionAction) validateNoAgentOperands() error {
+	if a.role != "" || a.stage != "" || a.invocationID != "" {
+		return &progressionActionError{Action: a, Reason: "unexpected role, stage, or invocation operands"}
+	}
+	return nil
+}
+
 // validate checks that a typed command has exactly the operands its dispatch
 // arm accepts. A malformed command therefore cannot reach an adapter seam.
 func (a progressionAction) validate() error {
@@ -146,13 +155,6 @@ func (a progressionAction) validate() error {
 	}
 	if strings.TrimSpace(a.runID) == "" {
 		return &progressionActionError{Action: a, Reason: "run id is required"}
-	}
-
-	noAgentOperands := func() error {
-		if a.role != "" || a.stage != "" || a.invocationID != "" {
-			return &progressionActionError{Action: a, Reason: "unexpected role, stage, or invocation operands"}
-		}
-		return nil
 	}
 
 	switch a.kind {
@@ -177,7 +179,7 @@ func (a progressionAction) validate() error {
 		}
 	case progressionActionRunBaseline, progressionActionCreateDraftPullRequest,
 		progressionActionStartReviewRound, progressionActionRetryReviewReadiness:
-		if err := noAgentOperands(); err != nil {
+		if err := a.validateNoAgentOperands(); err != nil {
 			return err
 		}
 	default:

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -73,6 +73,117 @@ type progressionState struct {
 	// Supported reports whether the operational store exposes the durable
 	// invocation history that exactly-once progression requires.
 	Supported bool
+	// ReadyInvocationIDs records the report-readiness observation made while
+	// reading each active invocation. The planner must not repeat that I/O.
+	ReadyInvocationIDs map[string]bool
+}
+
+// progressionActionKind identifies one coordinator seam that can advance a
+// run. The set is intentionally closed so dispatch cannot silently ignore a
+// newly invented transition.
+type progressionActionKind string
+
+const (
+	// progressionActionStartAgent launches the role selected for a run stage.
+	progressionActionStartAgent progressionActionKind = "start_agent"
+	// progressionActionRunBaseline evaluates the frozen pre-edit gate suite.
+	progressionActionRunBaseline progressionActionKind = "run_baseline"
+	// progressionActionAcceptAgentReport accepts one invocation's report.
+	progressionActionAcceptAgentReport progressionActionKind = "accept_agent_report"
+	// progressionActionCreateDraftPullRequest creates the run's draft pull request.
+	progressionActionCreateDraftPullRequest progressionActionKind = "create_draft_pull_request"
+	// progressionActionStartReviewRound launches the concurrent review roles.
+	progressionActionStartReviewRound progressionActionKind = "start_review_round"
+	// progressionActionRetryReviewReadiness retries final pull-request readiness.
+	progressionActionRetryReviewReadiness progressionActionKind = "retry_review_readiness"
+)
+
+// progressionAction is a typed coordinator command selected from durable run
+// state. It contains only the operands needed to dispatch an existing seam;
+// it never captures a service, adapter, or context.
+type progressionAction struct {
+	// kind identifies the coordinator seam to dispatch.
+	kind progressionActionKind
+	// name is the operator-facing transition identity used in status text.
+	name string
+	// runID identifies the run that owns the transition.
+	runID string
+	// role optionally selects a specific role for an agent launch.
+	role string
+	// stage optionally selects a specific invocation stage for an agent launch.
+	stage store.Stage
+	// invocationID identifies the report to accept.
+	invocationID string
+}
+
+// progressionActionError reports an invalid or unhandled typed command.
+type progressionActionError struct {
+	// Action is the command that could not be dispatched.
+	Action progressionAction
+	// Reason explains the invalid operand or unsupported kind.
+	Reason string
+}
+
+// Error returns an actionable description of the invalid progression command.
+func (e *progressionActionError) Error() string {
+	if e == nil {
+		return "invalid progression action"
+	}
+	if e.Action.kind == "" {
+		return "invalid progression action: kind is required"
+	}
+	if e.Reason == "" {
+		return fmt.Sprintf("invalid progression action %q", e.Action.kind)
+	}
+	return fmt.Sprintf("invalid progression action %q: %s", e.Action.kind, e.Reason)
+}
+
+// validate checks that a typed command has exactly the operands its dispatch
+// arm accepts. A malformed command therefore cannot reach an adapter seam.
+func (a progressionAction) validate() error {
+	if strings.TrimSpace(a.name) == "" {
+		return &progressionActionError{Action: a, Reason: "operator-facing name is required"}
+	}
+	if strings.TrimSpace(a.runID) == "" {
+		return &progressionActionError{Action: a, Reason: "run id is required"}
+	}
+
+	noAgentOperands := func() error {
+		if a.role != "" || a.stage != "" || a.invocationID != "" {
+			return &progressionActionError{Action: a, Reason: "unexpected role, stage, or invocation operands"}
+		}
+		return nil
+	}
+
+	switch a.kind {
+	case progressionActionStartAgent:
+		hasRole := strings.TrimSpace(a.role) != ""
+		hasStage := strings.TrimSpace(string(a.stage)) != ""
+		if (a.role != "" && !hasRole) || (a.stage != "" && !hasStage) {
+			return &progressionActionError{Action: a, Reason: "agent role and stage cannot be blank"}
+		}
+		if hasRole != hasStage {
+			return &progressionActionError{Action: a, Reason: "agent role and stage must be provided together"}
+		}
+		if a.invocationID != "" {
+			return &progressionActionError{Action: a, Reason: "agent launch cannot include an invocation id"}
+		}
+	case progressionActionAcceptAgentReport:
+		if strings.TrimSpace(a.invocationID) == "" {
+			return &progressionActionError{Action: a, Reason: "invocation id is required"}
+		}
+		if a.role != "" || a.stage != "" {
+			return &progressionActionError{Action: a, Reason: "report acceptance cannot include role or stage operands"}
+		}
+	case progressionActionRunBaseline, progressionActionCreateDraftPullRequest,
+		progressionActionStartReviewRound, progressionActionRetryReviewReadiness:
+		if err := noAgentOperands(); err != nil {
+			return err
+		}
+	default:
+		return &progressionActionError{Action: a, Reason: "kind is not declared"}
+	}
+	return nil
 }
 
 // driveRun performs one bounded unattended progression pass for the registered
@@ -98,6 +209,7 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 	if lifecycle.Outcome == LifecycleCompleted || lifecycle.Outcome == LifecycleCancelled {
 		return progressionResult{Outcome: progressionTerminal, Run: lifecycle.Run, Reason: lifecycle.Reason}, nil
 	}
+	registry := workflow.DefaultRegistry()
 	for result.Steps < maxProgressionSteps {
 		if err := ctx.Err(); err != nil {
 			return result, err
@@ -113,13 +225,33 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 			return progressionResult{Outcome: progressionIdle, Steps: result.Steps, Reason: "no run to drive"}, nil
 		}
 		result.Run = *state.Run
-		step, stop := s.progressionStep(state)
+		step, stop := progressionStep(state, registry)
 		if stop != nil {
 			stop.Steps = result.Steps
 			return s.publishProgressionStop(ctx, registration, *state.Run, *stop)
 		}
-		if err := step.action(ctx); err != nil {
-			return s.stopProgressionAfterFailure(ctx, registration, *state.Run, step.name, err, result.Steps)
+		if err := step.validate(); err != nil {
+			return result, err
+		}
+		var stepErr error
+		switch step.kind {
+		case progressionActionStartAgent:
+			_, stepErr = s.StartAgent(ctx, AgentRequest{RunID: step.runID, Role: step.role, Stage: step.stage})
+		case progressionActionRunBaseline:
+			_, stepErr = s.RunBaseline(ctx, BaselineRequest{RunID: step.runID})
+		case progressionActionAcceptAgentReport:
+			_, stepErr = s.AcceptAgentReport(ctx, AgentReportRequest{RunID: step.runID, InvocationID: step.invocationID})
+		case progressionActionCreateDraftPullRequest:
+			_, stepErr = s.CreateDraftPullRequest(ctx, DraftPullRequestRequest{RunID: step.runID})
+		case progressionActionStartReviewRound:
+			stepErr = s.startReviewRound(ctx, step.runID)
+		case progressionActionRetryReviewReadiness:
+			stepErr = s.retryReviewReadiness(ctx, step.runID)
+		default:
+			stepErr = &progressionActionError{Action: step, Reason: "kind is not declared for dispatch"}
+		}
+		if stepErr != nil {
+			return s.stopProgressionAfterFailure(ctx, registration, *state.Run, step.name, stepErr, result.Steps)
 		}
 		result.Steps++
 		advanced, err := s.readProgressionState(ctx, registration)
@@ -189,15 +321,6 @@ func (s *Service) observePullRequestEvents(ctx context.Context, registration con
 	return lifecycle, s.consumeHumanReview(ctx, registration, runStore, lifecycle.Run)
 }
 
-// progressionAction is one coordinator-owned transition selected from durable
-// run state. The coordinator, never an agent, chooses it.
-type progressionAction struct {
-	// name is the operator-facing transition identity used in status text.
-	name string
-	// action performs the transition through an existing coordinator seam.
-	action func(context.Context) error
-}
-
 // startReviewRound launches the specification and standards reviewers for the
 // same frozen checkpoint. Launching is coordinator-serialized, while the two
 // resulting harness sessions remain live concurrently in their own workers,
@@ -225,15 +348,25 @@ func (s *Service) startReviewRound(ctx context.Context, runID string) error {
 
 // progressionStep selects the single legal next transition for a run, or the
 // waiting state that stops unattended progression. Exactly one of the two
-// return values is set.
-func (s *Service) progressionStep(state progressionState) (progressionAction, *progressionResult) {
+// return values is set. All observations needed by the decision are supplied
+// in state and registry.
+func progressionStep(state progressionState, registry workflow.Registry) (progressionAction, *progressionResult) {
 	run := *state.Run
-	if role, ok := missingConcurrentReviewRole(state); ok {
-		definition, _ := workflow.DefaultRegistry().Role(role)
-		return progressionAction{name: "start missing " + role + " review", action: func(ctx context.Context) error {
-			_, err := s.StartAgent(ctx, AgentRequest{RunID: run.ID, Role: definition.Name, Stage: definition.Stage})
-			return err
-		}}, nil
+	if role, ok := missingConcurrentReviewRole(state, registry); ok {
+		definition, declared := registry.Role(role)
+		if !declared {
+			return progressionAction{}, &progressionResult{
+				Outcome: progressionWaiting,
+				Reason:  fmt.Sprintf("workflow role %q is not declared by the workflow registry", role),
+			}
+		}
+		return progressionAction{
+			kind:  progressionActionStartAgent,
+			name:  "start missing " + role + " review",
+			runID: run.ID,
+			role:  definition.Name,
+			stage: definition.Stage,
+		}, nil
 	}
 	if reviewReadinessSettled(run) {
 		return progressionAction{}, &progressionResult{
@@ -243,15 +376,17 @@ func (s *Service) progressionStep(state progressionState) (progressionAction, *p
 		}
 	}
 	if reviewReadinessEligible(run) {
-		return progressionAction{name: "finalize pull-request readiness", action: func(ctx context.Context) error {
-			return s.retryReviewReadiness(ctx, run.ID)
-		}}, nil
+		return progressionAction{
+			kind:  progressionActionRetryReviewReadiness,
+			name:  "finalize pull-request readiness",
+			runID: run.ID,
+		}, nil
 	}
 	switch RunActivityFor(run) {
 	case ActivityTerminal:
 		return progressionAction{}, &progressionResult{Outcome: progressionTerminal, Reason: "run is " + string(run.Status)}
 	case ActivityWaitingForHuman:
-		if !hasActiveReviewInvocations(state) {
+		if !hasActiveReviewInvocations(state, registry) {
 			return progressionAction{}, &progressionResult{Outcome: progressionWaiting, Reason: waitingReason(run, "waiting for human disposition")}
 		}
 	case ActivityWaitingForHarness:
@@ -271,14 +406,15 @@ func (s *Service) progressionStep(state progressionState) (progressionAction, *p
 			}
 		}
 		for _, active := range activeInvocations {
-			if !agentResultReady(*active) {
+			if !state.ReadyInvocationIDs[active.ID] {
 				continue
 			}
-			invocationID := active.ID
-			return progressionAction{name: "accept agent report", action: func(ctx context.Context) error {
-				_, err := s.AcceptAgentReport(ctx, AgentReportRequest{RunID: run.ID, InvocationID: invocationID})
-				return err
-			}}, nil
+			return progressionAction{
+				kind:         progressionActionAcceptAgentReport,
+				name:         "accept agent report",
+				runID:        run.ID,
+				invocationID: active.ID,
+			}, nil
 		}
 		ids := make([]string, 0, len(activeInvocations))
 		for _, active := range activeInvocations {
@@ -286,15 +422,15 @@ func (s *Service) progressionStep(state progressionState) (progressionAction, *p
 		}
 		return progressionAction{}, &progressionResult{Outcome: progressionInvocationActive, Reason: fmt.Sprintf("invocations %s are executing", strings.Join(ids, ", "))}
 	}
-	return s.progressionStageStep(state)
+	return progressionStageStep(state, registry)
 }
 
 // missingConcurrentReviewRole returns the one reviewer that can be resumed
 // after a partial concurrent-review launch. It waits for any active reviewer
 // and requires one exact-checkpoint result so a human clarification is never
 // mistaken for a failed launch.
-func missingConcurrentReviewRole(state progressionState) (string, bool) {
-	if state.Run == nil || state.Run.Stage != store.StageReview || !concurrentReviewsConfigured(*state.Run) || hasActiveReviewInvocations(state) {
+func missingConcurrentReviewRole(state progressionState, registry workflow.Registry) (string, bool) {
+	if state.Run == nil || state.Run.Stage != store.StageReview || !concurrentReviewsConfigured(*state.Run) || hasActiveReviewInvocations(state, registry) {
 		return "", false
 	}
 	run := *state.Run
@@ -319,13 +455,17 @@ func missingConcurrentReviewRole(state progressionState) (string, bool) {
 
 // hasActiveReviewInvocations reports whether an otherwise human-waiting review
 // round still has an independent result that can be serialized and applied.
-func hasActiveReviewInvocations(state progressionState) bool {
+func hasActiveReviewInvocations(state progressionState, registry workflow.Registry) bool {
 	active := state.ActiveInvocations
 	if len(active) == 0 && state.Active != nil {
 		active = []*store.Invocation{state.Active}
 	}
 	for _, invocation := range active {
-		if roleIsKind(*invocation, workflow.RoleKindReview) {
+		if invocation == nil {
+			continue
+		}
+		definition, declared := registry.Role(invocation.Role)
+		if declared && definition.Stage == invocation.Stage && definition.Kind == workflow.RoleKindReview {
 			return true
 		}
 	}
@@ -337,22 +477,24 @@ func hasActiveReviewInvocations(state progressionState) bool {
 // stage authority: a stage that declares a coordinator event is driven by the
 // draft-pull-request seam that owns those events, and a stage that declares a
 // role is driven by launching that role.
-func (s *Service) progressionStageStep(state progressionState) (progressionAction, *progressionResult) {
+func progressionStageStep(state progressionState, registry workflow.Registry) (progressionAction, *progressionResult) {
 	run := *state.Run
-	registry := workflow.DefaultRegistry()
 	switch run.Stage {
 	case store.StageClaim:
 		// Leaving claim is the frozen baseline, whose healthy result selects
 		// the entry stage from the route and the repository test policy.
-		return progressionAction{name: "run baseline", action: func(ctx context.Context) error {
-			_, err := s.RunBaseline(ctx, BaselineRequest{RunID: run.ID})
-			return err
-		}}, nil
+		return progressionAction{
+			kind:  progressionActionRunBaseline,
+			name:  "run baseline",
+			runID: run.ID,
+		}, nil
 	case store.StageDraftPR:
 		if concurrentReviewsConfigured(run) {
-			return progressionAction{name: "start concurrent reviews", action: func(ctx context.Context) error {
-				return s.startReviewRound(ctx, run.ID)
-			}}, nil
+			return progressionAction{
+				kind:  progressionActionStartReviewRound,
+				name:  "start concurrent reviews",
+				runID: run.ID,
+			}, nil
 		}
 		// Older packets without the standards role retain the historical
 		// draft-pull-request stop until they are explicitly reviewed.
@@ -367,18 +509,20 @@ func (s *Service) progressionStageStep(state progressionState) (progressionActio
 	_, roleDeclared := registry.RoleForRunStage(run.Stage)
 	stageComplete := state.Latest != nil && state.Latest.Stage == run.Stage && state.Latest.Status == store.InvocationStatusCompleted
 	if len(definition.Events) > 0 && (!roleDeclared || stageComplete) {
-		return progressionAction{name: "create draft pull request", action: func(ctx context.Context) error {
-			_, err := s.CreateDraftPullRequest(ctx, DraftPullRequestRequest{RunID: run.ID})
-			return err
-		}}, nil
+		return progressionAction{
+			kind:  progressionActionCreateDraftPullRequest,
+			name:  "create draft pull request",
+			runID: run.ID,
+		}, nil
 	}
 	if !roleDeclared {
 		return progressionAction{}, &progressionResult{Outcome: progressionWaiting, Reason: fmt.Sprintf("no coordinator transition is declared for run stage %q", run.Stage)}
 	}
-	return progressionAction{name: "start agent", action: func(ctx context.Context) error {
-		_, err := s.StartAgent(ctx, AgentRequest{RunID: run.ID})
-		return err
-	}}, nil
+	return progressionAction{
+		kind:  progressionActionStartAgent,
+		name:  "start agent",
+		runID: run.ID,
+	}, nil
 }
 
 // readProgressionState reads the run and its invocation projection once. A
@@ -422,6 +566,13 @@ func (s *Service) readProgressionState(ctx context.Context, registration config.
 		return progressionState{}, fmt.Errorf("read active invocation for progression: %w", err)
 	} else if state.Active != nil {
 		state.ActiveInvocations = []*store.Invocation{state.Active}
+	}
+	state.ReadyInvocationIDs = make(map[string]bool, len(state.ActiveInvocations))
+	for _, invocation := range state.ActiveInvocations {
+		if invocation == nil {
+			continue
+		}
+		state.ReadyInvocationIDs[invocation.ID] = agentResultReady(*invocation)
 	}
 	if state.Latest, err = latestStore.LatestInvocation(ctx, run.ID); err != nil {
 		return progressionState{}, fmt.Errorf("read latest invocation for progression: %w", err)

--- a/internal/factory/progression_internal_test.go
+++ b/internal/factory/progression_internal_test.go
@@ -1,10 +1,17 @@
 package factory
 
 import (
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
+	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/workflow"
 )
@@ -150,6 +157,413 @@ func TestProgressionActionValidationRejectsInvalidKindAndOperands(t *testing.T) 
 		}
 	}
 }
+
+// TestDriveRunDispatchesEveryProgressionCommand verifies the real coordinator
+// dispatch reaches the existing seam for every declared progression command.
+// Each seam returns context.Canceled after recording its call, which makes the
+// test stop before any unrelated effect can obscure the dispatch assertion.
+func TestDriveRunDispatchesEveryProgressionCommand(t *testing.T) {
+	const checkpoint = "0123456789abcdef0123456789abcdef01234567"
+	reportDirectory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(reportDirectory, report.ReportFileName), nil, 0o600); err != nil {
+		t.Fatalf("write ready report marker: %v", err)
+	}
+
+	tests := []struct {
+		name               string
+		run                store.Run
+		active             []store.Invocation
+		pullRequestErrors  []error
+		wantInspectCalls   int
+		wantGateCalls      int
+		wantInvocationCall int
+		wantFindCalls      int
+	}{
+		{
+			name: "run baseline",
+			run: store.Run{
+				ID:                  "run-baseline-dispatch",
+				Stage:               store.StageClaim,
+				Status:              store.StatusActive,
+				SpecificationPacket: progressionDispatchPacket(t, false),
+				Worktree:            "/worktree",
+			},
+			wantInspectCalls: 1,
+		},
+		{
+			name: "start agent",
+			run: store.Run{
+				ID:                  "run-agent-dispatch",
+				Stage:               store.StageImplementation,
+				Status:              store.StatusActive,
+				CheckpointSHA:       checkpoint,
+				SpecificationPacket: progressionDispatchPacket(t, false),
+				Worktree:            "/worktree",
+			},
+			wantGateCalls: 1,
+		},
+		{
+			name: "accept agent report",
+			run: store.Run{
+				ID:                  "run-report-dispatch",
+				Stage:               store.StageImplementation,
+				Status:              store.StatusActive,
+				ActiveInvocationID:  "inv-report-dispatch",
+				ActiveInvocationIDs: []string{"inv-report-dispatch"},
+				SpecificationPacket: progressionDispatchPacket(t, false),
+				Worktree:            "/worktree",
+			},
+			active: []store.Invocation{{
+				ID:              "inv-report-dispatch",
+				RunID:           "run-report-dispatch",
+				Role:            workflow.RoleImplementation,
+				Stage:           store.StageImplementation,
+				Status:          store.InvocationStatusActive,
+				ResultDirectory: reportDirectory,
+			}},
+			wantInvocationCall: 1,
+		},
+		{
+			name: "create draft pull request",
+			run: store.Run{
+				ID:                  "run-draft-dispatch",
+				Stage:               store.StageCheck,
+				Status:              store.StatusActive,
+				CheckpointSHA:       checkpoint,
+				SpecificationPacket: progressionDispatchPacket(t, false),
+				Worktree:            "/worktree",
+			},
+			wantInspectCalls: 1,
+		},
+		{
+			name: "start review round",
+			run: store.Run{
+				ID:                  "run-review-dispatch",
+				Stage:               store.StageDraftPR,
+				Status:              store.StatusActive,
+				PullRequestNumber:   17,
+				CheckpointSHA:       checkpoint,
+				BaseCheckpointSHA:   checkpoint,
+				SpecificationPacket: progressionDispatchPacket(t, true),
+				Worktree:            "/worktree",
+			},
+			pullRequestErrors: []error{nil, context.Canceled},
+			wantInspectCalls:  1,
+			wantFindCalls:     1,
+		},
+		{
+			name: "retry review readiness",
+			run: store.Run{
+				ID:                  "run-readiness-dispatch",
+				Stage:               store.StageReview,
+				Status:              store.StatusActive,
+				CheckpointSHA:       checkpoint,
+				BaseCheckpointSHA:   checkpoint,
+				SpecificationPacket: progressionDispatchPacket(t, true),
+				SpecificationReview: &store.SpecificationReview{CheckpointSHA: checkpoint},
+				StandardsReview:     &store.StandardsReview{CheckpointSHA: checkpoint},
+			},
+			pullRequestErrors: []error{context.Canceled},
+			wantFindCalls:     1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runStore := &progressionDispatchStore{
+				run:            test.run,
+				active:         append([]store.Invocation(nil), test.active...),
+				gateResultsErr: context.Canceled,
+				invocationErr:  context.Canceled,
+			}
+			workspace := &progressionDispatchWorkspace{inspectErr: context.Canceled}
+			pullRequests := &progressionDispatchPullRequests{
+				findErrors: append([]error(nil), test.pullRequestErrors...),
+			}
+			registration := config.RepositoryRegistration{
+				Path:                 "/repository",
+				OperationalDataPath:  "/state/factory.db",
+				RepositoryConfigPath: "/repository/factory.yaml",
+				GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+			}
+			service := &Service{
+				configPath: "/host/config.yaml",
+				deps: Dependencies{
+					Config: progressionDispatchConfig{registration: registration},
+					OpenStore: func(context.Context, string) (OperationalStore, error) {
+						return runStore, nil
+					},
+					GitHub:       progressionDispatchGitHub{},
+					GitWorkspace: workspace,
+					PullRequests: pullRequests,
+					Now: func() time.Time {
+						return time.Unix(1, 0).UTC()
+					},
+					NewRunID: func() (string, error) {
+						return "dispatch-generated", nil
+					},
+				},
+				startupChecked: true,
+			}
+
+			result, err := service.driveRun(context.Background(), registration)
+			if err != nil {
+				t.Fatalf("driveRun() error = %v", err)
+			}
+			if result.Outcome != progressionWaiting || result.Reason != "coordinator stopped" {
+				t.Fatalf("driveRun() result = %#v, want context-canceled dispatch stop", result)
+			}
+			if result.Steps != 0 {
+				t.Fatalf("dispatch steps = %d, want zero after the controlled seam stop", result.Steps)
+			}
+			if workspace.inspectCalls != test.wantInspectCalls {
+				t.Fatalf("worktree inspection calls = %d, want %d", workspace.inspectCalls, test.wantInspectCalls)
+			}
+			if runStore.gateResultsCalls != test.wantGateCalls {
+				t.Fatalf("gate-result calls = %d, want %d", runStore.gateResultsCalls, test.wantGateCalls)
+			}
+			if runStore.invocationCalls != test.wantInvocationCall {
+				t.Fatalf("invocation lookup calls = %d, want %d", runStore.invocationCalls, test.wantInvocationCall)
+			}
+			if pullRequests.findCalls != test.wantFindCalls {
+				t.Fatalf("pull-request lookup calls = %d, want %d", pullRequests.findCalls, test.wantFindCalls)
+			}
+		})
+	}
+}
+
+// progressionDispatchConfig supplies the registration that coordinator seams
+// reload while the dispatch test is driving a run.
+type progressionDispatchConfig struct {
+	registration config.RepositoryRegistration
+}
+
+// Load returns the controlled repository registration.
+func (c progressionDispatchConfig) Load(string) (config.HostConfig, error) {
+	return config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{c.registration}}, nil
+}
+
+// Save satisfies the configuration repository seam.
+func (progressionDispatchConfig) Save(string, config.HostConfig) error { return nil }
+
+// Create satisfies the configuration repository seam.
+func (progressionDispatchConfig) Create(string) (config.HostConfig, error) {
+	return config.HostConfig{}, nil
+}
+
+// progressionDispatchPacket builds the smallest frozen packet accepted by the
+// coordinator seams exercised by TestDriveRunDispatchesEveryProgressionCommand.
+func progressionDispatchPacket(t *testing.T, reviews bool) string {
+	t.Helper()
+	packet := SpecificationPacket{
+		Version: specificationPacketVersion,
+		RepositoryConfig: config.RepositoryConfig{
+			TargetBranch: "main",
+			TestPolicy:   config.TestPolicy{Mode: config.TestModeAdvisory},
+			RoleHarnessDefaults: map[string]config.Harness{
+				workflow.RoleImplementation: config.HarnessCodex,
+			},
+			ModelOptions: map[string][]string{
+				workflow.RoleImplementation: {"gpt-5"},
+			},
+		},
+	}
+	if reviews {
+		packet.RepositoryConfig.RoleHarnessDefaults[workflow.RoleSpecificationReview] = config.HarnessCodex
+		packet.RepositoryConfig.RoleHarnessDefaults[workflow.RoleStandardsReview] = config.HarnessCodex
+		packet.RepositoryConfig.ModelOptions[workflow.RoleSpecificationReview] = []string{"gpt-5"}
+		packet.RepositoryConfig.ModelOptions[workflow.RoleStandardsReview] = []string{"gpt-5"}
+	}
+	data, err := json.Marshal(packet)
+	if err != nil {
+		t.Fatalf("marshal dispatch packet: %v", err)
+	}
+	return string(data)
+}
+
+// progressionDispatchStore is an in-memory operational store that exposes the
+// read projections driveRun needs and records seam-specific observations.
+type progressionDispatchStore struct {
+	run              store.Run
+	active           []store.Invocation
+	latest           *store.Invocation
+	gateResultsErr   error
+	invocationErr    error
+	gateResultsCalls int
+	invocationCalls  int
+}
+
+// CurrentRun returns the controlled active run projection.
+func (s *progressionDispatchStore) CurrentRun(context.Context) (*store.Run, error) {
+	run := s.run
+	return &run, nil
+}
+
+// SaveRun records a run save if a future dispatch path reaches one.
+func (s *progressionDispatchStore) SaveRun(_ context.Context, run store.Run) error {
+	s.run = run
+	return nil
+}
+
+// ClaimLifecycleNotification satisfies the run-store notification seam.
+func (*progressionDispatchStore) ClaimLifecycleNotification(context.Context, string, store.Status) (bool, error) {
+	return true, nil
+}
+
+// ReleaseLifecycleNotification satisfies the run-store notification seam.
+func (*progressionDispatchStore) ReleaseLifecycleNotification(context.Context, string, store.Status) error {
+	return nil
+}
+
+// Close satisfies the operational-store seam.
+func (*progressionDispatchStore) Close() error { return nil }
+
+// ActiveInvocations returns the controlled active-invocation projection.
+func (s *progressionDispatchStore) ActiveInvocations(context.Context, string) ([]store.Invocation, error) {
+	return append([]store.Invocation(nil), s.active...), nil
+}
+
+// LatestInvocation returns the controlled latest invocation projection.
+func (s *progressionDispatchStore) LatestInvocation(context.Context, string) (*store.Invocation, error) {
+	if s.latest == nil {
+		return nil, nil
+	}
+	latest := *s.latest
+	return &latest, nil
+}
+
+// SaveGateResults satisfies the gate-result persistence seam.
+func (*progressionDispatchStore) SaveGateResults(context.Context, []store.GateResult) error {
+	return nil
+}
+
+// GateResults records the gate-readiness observation used by agent launch.
+func (s *progressionDispatchStore) GateResults(context.Context, string, store.GatePhase, string) ([]store.GateResult, error) {
+	s.gateResultsCalls++
+	return nil, s.gateResultsErr
+}
+
+// SaveInvocation satisfies the visible-invocation persistence seam.
+func (*progressionDispatchStore) SaveInvocation(context.Context, store.Invocation) error {
+	return nil
+}
+
+// Invocation records the report-acceptance invocation lookup.
+func (s *progressionDispatchStore) Invocation(context.Context, string, string) (*store.Invocation, error) {
+	s.invocationCalls++
+	return nil, s.invocationErr
+}
+
+// progressionDispatchWorkspace is a controlled Git workspace whose inspection
+// error identifies the baseline, draft, or review launch seam being exercised.
+type progressionDispatchWorkspace struct {
+	inspectErr   error
+	inspectCalls int
+}
+
+// Create creates no workspace because dispatch tests stop at inspection.
+func (*progressionDispatchWorkspace) Create(context.Context, string, string, string) (gitadapter.Workspace, error) {
+	return gitadapter.Workspace{}, context.Canceled
+}
+
+// Remove satisfies the worktree-management seam.
+func (*progressionDispatchWorkspace) Remove(context.Context, string, gitadapter.Workspace) error {
+	return context.Canceled
+}
+
+// Inspect records the read-only seam reached by the dispatched command.
+func (w *progressionDispatchWorkspace) Inspect(context.Context, string) (gitadapter.WorktreeState, error) {
+	w.inspectCalls++
+	return gitadapter.WorktreeState{}, w.inspectErr
+}
+
+// CreateCheckpoint satisfies the checkpoint seam.
+func (*progressionDispatchWorkspace) CreateCheckpoint(context.Context, gitadapter.CheckpointRequest) (gitadapter.CheckpointResult, error) {
+	return gitadapter.CheckpointResult{}, context.Canceled
+}
+
+// Push satisfies the branch-push seam.
+func (*progressionDispatchWorkspace) Push(context.Context, gitadapter.PushRequest) error {
+	return context.Canceled
+}
+
+// SynchronizeBase satisfies the target-branch synchronization seam.
+func (*progressionDispatchWorkspace) SynchronizeBase(context.Context, gitadapter.BaseSyncRequest) error {
+	return context.Canceled
+}
+
+// progressionDispatchPullRequests is a controlled pull-request client whose
+// ordered errors distinguish lifecycle observation from readiness retry.
+type progressionDispatchPullRequests struct {
+	findErrors []error
+	findCalls  int
+}
+
+// FindPullRequest records a pull-request lookup and returns its configured error.
+func (p *progressionDispatchPullRequests) FindPullRequest(context.Context, github.Repository, string, string) (github.PullRequest, error) {
+	p.findCalls++
+	if len(p.findErrors) == 0 {
+		return github.PullRequest{}, nil
+	}
+	err := p.findErrors[0]
+	p.findErrors = p.findErrors[1:]
+	return github.PullRequest{}, err
+}
+
+// CreatePullRequest satisfies the pull-request creation seam.
+func (*progressionDispatchPullRequests) CreatePullRequest(context.Context, github.Repository, github.PullRequestRequest) (github.PullRequest, error) {
+	return github.PullRequest{}, context.Canceled
+}
+
+// UpdatePullRequest satisfies the pull-request update seam.
+func (*progressionDispatchPullRequests) UpdatePullRequest(context.Context, github.Repository, int, github.PullRequestRequest) (github.PullRequest, error) {
+	return github.PullRequest{}, context.Canceled
+}
+
+// progressionDispatchGitHub is the minimal issue client needed to let a
+// tracked draft pull request reach the review-round dispatch in driveRun.
+type progressionDispatchGitHub struct{}
+
+// Issue reports an open issue during lifecycle observation.
+func (progressionDispatchGitHub) Issue(context.Context, github.Repository, int) (github.Issue, error) {
+	return github.Issue{State: "open"}, nil
+}
+
+// CreateLabel satisfies the issue client seam.
+func (progressionDispatchGitHub) CreateLabel(context.Context, github.Repository, github.Label) error {
+	return context.Canceled
+}
+
+// ReplaceIssueLabels satisfies the issue client seam.
+func (progressionDispatchGitHub) ReplaceIssueLabels(context.Context, github.Repository, int, []string) error {
+	return context.Canceled
+}
+
+// CreateIssueComment satisfies the issue client seam.
+func (progressionDispatchGitHub) CreateIssueComment(context.Context, github.Repository, int, string) (github.Comment, error) {
+	return github.Comment{}, context.Canceled
+}
+
+// FindStatusComment satisfies the issue client seam.
+func (progressionDispatchGitHub) FindStatusComment(context.Context, github.Repository, int, string) (github.Comment, error) {
+	return github.Comment{}, context.Canceled
+}
+
+// EditIssueComment satisfies the issue client seam.
+func (progressionDispatchGitHub) EditIssueComment(context.Context, github.Repository, string, string) error {
+	return context.Canceled
+}
+
+var (
+	_ RunStore                 = (*progressionDispatchStore)(nil)
+	_ ActiveInvocationsStore   = (*progressionDispatchStore)(nil)
+	_ LatestInvocationStore    = (*progressionDispatchStore)(nil)
+	_ GateResultStore          = (*progressionDispatchStore)(nil)
+	_ InvocationStore          = (*progressionDispatchStore)(nil)
+	_ gitadapter.GitWorkspace  = (*progressionDispatchWorkspace)(nil)
+	_ github.Client            = progressionDispatchGitHub{}
+	_ github.PullRequestClient = (*progressionDispatchPullRequests)(nil)
+)
 
 // progressionRunWithConcurrentReviews builds a frozen packet that enables
 // both factory-owned review roles for planner branch coverage.

--- a/internal/factory/progression_internal_test.go
+++ b/internal/factory/progression_internal_test.go
@@ -1,0 +1,180 @@
+package factory
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/config"
+	"github.com/Stevie1704/sw-factory/internal/store"
+	"github.com/Stevie1704/sw-factory/internal/workflow"
+)
+
+// TestProgressionStepPlansReportAcceptanceFromObservedReadiness verifies the
+// planner consumes readiness observed by the coordinator without inspecting
+// the invocation result directory itself.
+func TestProgressionStepPlansReportAcceptanceFromObservedReadiness(t *testing.T) {
+	run := store.Run{ID: "run-1", Stage: store.StageImplementation, Status: store.StatusActive}
+	invocation := &store.Invocation{ID: "inv-1"}
+
+	action, stop := progressionStep(progressionState{
+		Run:                &run,
+		ActiveInvocations:  []*store.Invocation{invocation},
+		ReadyInvocationIDs: map[string]bool{"inv-1": true},
+	}, workflow.DefaultRegistry())
+	if stop != nil {
+		t.Fatalf("progressionStep() stopped with %#v, want report acceptance", stop)
+	}
+	if action.kind != progressionActionAcceptAgentReport {
+		t.Fatalf("planned action kind = %q, want %q", action.kind, progressionActionAcceptAgentReport)
+	}
+	if action.name != "accept agent report" {
+		t.Fatalf("planned action name = %q, want unchanged operator-facing name", action.name)
+	}
+	if action.runID != run.ID || action.invocationID != invocation.ID {
+		t.Fatalf("planned action operands = %#v, want run %q and invocation %q", action, run.ID, invocation.ID)
+	}
+}
+
+// TestProgressionStepPlansEveryCoordinatorCommand verifies each legal planner
+// branch returns a validated typed command while preserving its transition
+// name and required operands.
+func TestProgressionStepPlansEveryCoordinatorCommand(t *testing.T) {
+	registry := workflow.DefaultRegistry()
+	runWithReviews := progressionRunWithConcurrentReviews(t)
+	runWithMissingReview := runWithReviews
+	runWithMissingReview.ID = "run-missing-review"
+	runWithMissingReview.Stage = store.StageReview
+	runWithMissingReview.CheckpointSHA = "checkpoint"
+	runWithMissingReview.SpecificationReview = &store.SpecificationReview{CheckpointSHA: "checkpoint"}
+	tests := []struct {
+		name           string
+		state          progressionState
+		wantKind       progressionActionKind
+		wantName       string
+		wantInvocation string
+		wantRole       string
+		wantStage      store.Stage
+	}{
+		{
+			name:     "baseline",
+			state:    progressionState{Run: &store.Run{ID: "run-baseline", Stage: store.StageClaim, Status: store.StatusActive}},
+			wantKind: progressionActionRunBaseline,
+			wantName: "run baseline",
+		},
+		{
+			name:     "start agent",
+			state:    progressionState{Run: &store.Run{ID: "run-agent", Stage: store.StageImplementation, Status: store.StatusActive}},
+			wantKind: progressionActionStartAgent,
+			wantName: "start agent",
+		},
+		{
+			name:      "start missing review",
+			state:     progressionState{Run: &runWithMissingReview},
+			wantKind:  progressionActionStartAgent,
+			wantName:  "start missing standards_review review",
+			wantRole:  workflow.RoleStandardsReview,
+			wantStage: workflow.StageStandardsReview,
+		},
+		{
+			name: "accept report",
+			state: progressionState{
+				Run:                &store.Run{ID: "run-report", Stage: store.StageImplementation, Status: store.StatusActive},
+				ActiveInvocations:  []*store.Invocation{{ID: "inv-report"}},
+				ReadyInvocationIDs: map[string]bool{"inv-report": true},
+			},
+			wantKind:       progressionActionAcceptAgentReport,
+			wantName:       "accept agent report",
+			wantInvocation: "inv-report",
+		},
+		{
+			name: "create draft pull request",
+			state: progressionState{
+				Run: &store.Run{ID: "run-draft", Stage: store.StageCheck, Status: store.StatusActive},
+			},
+			wantKind: progressionActionCreateDraftPullRequest,
+			wantName: "create draft pull request",
+		},
+		{
+			name:     "start review round",
+			state:    progressionState{Run: &runWithReviews},
+			wantKind: progressionActionStartReviewRound,
+			wantName: "start concurrent reviews",
+		},
+		{
+			name:     "retry review readiness",
+			state:    progressionState{Run: &store.Run{ID: "run-readiness", Stage: store.StageReview, Status: store.StatusActive}},
+			wantKind: progressionActionRetryReviewReadiness,
+			wantName: "finalize pull-request readiness",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			action, stop := progressionStep(test.state, registry)
+			if stop != nil {
+				t.Fatalf("progressionStep() stopped with %#v, want %s", stop, test.wantKind)
+			}
+			if action.kind != test.wantKind || action.name != test.wantName {
+				t.Fatalf("planned action = %#v, want kind=%q name=%q", action, test.wantKind, test.wantName)
+			}
+			if action.runID == "" {
+				t.Fatal("planned action has no run id")
+			}
+			if action.invocationID != test.wantInvocation {
+				t.Fatalf("planned invocation id = %q, want %q", action.invocationID, test.wantInvocation)
+			}
+			if action.role != test.wantRole || action.stage != test.wantStage {
+				t.Fatalf("planned role/stage = %q/%q, want %q/%q", action.role, action.stage, test.wantRole, test.wantStage)
+			}
+			if err := action.validate(); err != nil {
+				t.Fatalf("planned action validation error = %v", err)
+			}
+		})
+	}
+}
+
+// TestProgressionActionValidationRejectsInvalidKindAndOperands verifies the
+// closed command set rejects malformed commands before coordinator dispatch.
+func TestProgressionActionValidationRejectsInvalidKindAndOperands(t *testing.T) {
+	tests := []progressionAction{
+		{kind: progressionActionKind("invented"), name: "invented", runID: "run-1"},
+		{kind: progressionActionAcceptAgentReport, name: "accept agent report", runID: "run-1", role: workflow.RoleTest, invocationID: "inv-1"},
+		{kind: progressionActionStartAgent, name: "start agent", runID: "run-1", role: workflow.RoleTest},
+	}
+
+	for index, action := range tests {
+		if err := action.validate(); err == nil {
+			t.Fatalf("action %d validation error = nil, want typed invalid-action error", index)
+		} else if _, ok := err.(*progressionActionError); !ok {
+			t.Fatalf("action %d validation error type = %T, want *progressionActionError", index, err)
+		}
+	}
+}
+
+// progressionRunWithConcurrentReviews builds a frozen packet that enables
+// both factory-owned review roles for planner branch coverage.
+func progressionRunWithConcurrentReviews(t *testing.T) store.Run {
+	t.Helper()
+	packetData, err := json.Marshal(SpecificationPacket{
+		Version: specificationPacketVersion,
+		RepositoryConfig: config.RepositoryConfig{
+			RoleHarnessDefaults: map[string]config.Harness{
+				workflow.RoleSpecificationReview: config.HarnessCodex,
+				workflow.RoleStandardsReview:     config.HarnessCodex,
+			},
+			ModelOptions: map[string][]string{
+				workflow.RoleSpecificationReview: {"gpt-5"},
+				workflow.RoleStandardsReview:     {"gpt-5"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal concurrent review packet: %v", err)
+	}
+	return store.Run{
+		ID:                  "run-reviews",
+		Stage:               store.StageDraftPR,
+		Status:              store.StatusActive,
+		SpecificationPacket: string(packetData),
+	}
+}


### PR DESCRIPTION
<!-- factory-generated:start -->
## Factory run

- run: `run-f66a7fc4-b775-423f-a07d-6552a8b86046`
- issue: #115 — Replace progression action closures with typed commands
- specification packet: version 1, target branch `main`
- checkpoint: `b7e132e13339869e059e29315a7a726fc94d96a8`
- stage: `draft_pr`
- intervention: `none`
- test policy: `advisory (implementation-owned TDD)`
- route: `default (repository test policy)`

Closes #115

<!-- factory-generated:review:start -->

### Specification review

- reviewed checkpoint: `b7e132e13339869e059e29315a7a726fc94d96a8`
- outcome: 0 blocking findings, 0 advisory findings
- findings: none

### Standards review

- reviewed checkpoint: `b7e132e13339869e059e29315a7a726fc94d96a8`
- outcome: 0 blocking findings, 0 advisory findings
- findings: none
<!-- factory-generated:review:end -->

### Issue summary

## Parent

#114 — Constrain dependency reach in the factory coordinator

## What to build

Make run-transition planning a pure function by turning `progressionAction` from a closure over `*Service` into a data value the coordinator interprets.

`progressionStep` (`internal/factory/progression.go:229`) and `progressionStageStep` (`internal/factory/progression.go:340`) already do the right thing structurally: they take a `progressionState` and return the next action without performing it. The separation is then undone by the action's shape (`internal/factory/progression.go:194`):

```go
type progressionAction struct {
	name   string
	action func(context.Context) error
}
```

Every branch builds a closure capturing `s`, so the planner still needs a fully wired `*Service` with all 21 adapters to name a transition it will not execute. That closure is the reason the decision layer cannot be tested, reasoned about, or reused without the effect layer, and it is where the `claim`↔`recovery` and `agent_launch`↔`interruption` cycles enter the decision path.

There are seven action-building sites, at `progression.go` lines 233, 246, 278, 347, 353, 370, and 378.

## Blocking discrepancy: the planner is not pure yet

Removing the receiver and the `context.Context` is necessary but not sufficient. `progressionStep` calls `agentResultReady` (`internal/factory/progression.go:483`) inside its active-invocation loop, and that helper does filesystem I/O:

```go
func agentResultReady(invocation store.Invocation) bool {
	if invocation.ResultDirectory == "" {
		return false
	}
	info, err := os.Stat(reportPath(invocation))
	return err == nil && info.Mode().IsRegular()
}
```

So `progressionState` does **not** yet carry everything the planner reads. A package-level `progressionStep` with no receiver and no `context.Context` would still stat the filesystem, and a test could still not construct a `progressionState` literal and get a deterministic answer.

The observation must move out of the planner: `readProgressionState` (`internal/factory/progression.go:389`) computes report readiness for each active invocation and records it on `progressionState` — for example as a readiness flag beside each invocation, or a `ReadyInvocationIDs` set. `agentResultReady` becomes the observation `readProgressionState` performs, not a call the planner makes.

`progressionStageStep` likewise reads `workflow.DefaultRegistry()` (`internal/workflow/registry.go:191`), a package-level constructor. The registry becomes a parameter, so the planner reads nothing ambient.

**1. Typed action.**

Replace the `action` field with a discriminated description of the transition — the action's identity plus the operands the coordinator needs to dispatch it (run identifier, role, invocation identifier, stage, and so on). Keep `name` as the operator-facing string already rendered in status text; it must not change wording.

**2. Complete the observation model.**

Extend `progressionState` beyond its current five fields (`Run`, `Active`, `ActiveInvocations`, `Latest`, `Supported`) with observed report readiness, computed in `readProgressionState`. This is the change that actually makes the planner pure; the typed action alone does not.

**3. Pure planner.**

`progressionStep` and `progressionStageStep` become package-level functions taking `progressionState` and the workflow registry, and returning the typed action. Neither takes a `context.Context` and neither takes a receiver.

Purity here means the planner uses no filesystem, no environment, no clock, no mutable global state, no adapter, and no `context.Context`. Every input is a parameter.

**4. Coordinator dispatch.**

`driveRun` (`internal/factory/progression.go:85`) gains one dispatch site mapping each typed action to the existing coordinator seam it already calls today — `s.retryReviewReadiness`, `s.startReviewRound`, report acceptance, and the rest. The seams themselves do not move in this issue.

## Non-goals

- Moving the coordinator seams the dispatch calls. That is the invocation-lifecycle child.
- Changing which transition is chosen for any state. This is a representation change; the decision table is identical before and after.
- Changing the operator-facing transition names in status text or the status comment.
- Introducing an interface for the planner. It is a pure function; a package-level function is the whole seam.
- Any new persisted field or store column.

## Acceptance criteria

- [ ] `progressionAction` carries no function value and no reference to `*Service`.
- [ ] `progressionStep` and `progressionStageStep` are package-level functions with no receiver, no `context.Context` parameter, and no access to `Dependencies`.
- [ ] The planner uses no filesystem, environment, clock, mutable global state, adapter, or `context.Context`. `agentResultReady` is no longer reachable from it, and the workflow registry arrives as a parameter.
- [ ] `progressionState` carries observed report readiness, and `readProgressionState` computes it.
- [ ] A test constructs a `progressionState` literal — including a readiness value — and asserts the planned action without building a `*Service`, touching the filesystem, or using any adapter fake.
- [ ] The command-kind set is defined explicitly, so an invalid kind-and-operand combination cannot reach dispatch.
- [ ] Every typed action has exactly one dispatch arm in `driveRun`, every kind is exercised through dispatch by a test, and an unhandled action is a typed error rather than a silent no-op.
- [ ] The operator-facing transition names rendered in status text are byte-identical to those produced before the change.
- [ ] `go test ./...` passes with no existing progression test rewritten to accommodate the new shape beyond constructing the typed action. No test currently executes `step.action(ctx)`, so no existing test observes the closure.

### Gates

- `format`: passed
- `vet`: passed
- `test`: passed
- `build`: passed

### Control commands

- `factory status`
- `factory draft-pr --run-id run-f66a7fc4-b775-423f-a07d-6552a8b86046`

<!-- factory-generated:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unattended workflow progression across baseline, agent, report, draft pull request, review, and readiness-retry steps.
  - Reports can now be accepted based on readiness already observed during progression, avoiding unnecessary repeated checks.
  - Added stronger validation for review roles and coordinator actions, helping prevent invalid workflow transitions.

- **Tests**
  - Expanded coverage for progression planning, command dispatch, readiness handling, and invalid-action rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->