### PR TITLE
Remove the store.Run compatibility projections and consolidate its serializers

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -661,9 +661,6 @@ func runStatus(ctx context.Context, args []string, defaultConfigPath string, out
 		}
 		if result.Activity == factory.ActivityInvocationActive {
 			activeInvocationIDs := append([]string(nil), result.LatestRun.ActiveInvocationIDs...)
-			if len(activeInvocationIDs) == 0 && result.LatestRun.ActiveInvocationID != "" {
-				activeInvocationIDs = []string{result.LatestRun.ActiveInvocationID}
-			}
 			if len(activeInvocationIDs) == 1 {
 				if !writeOutput(output, errorsOutput, "active invocation: %s\n", activeInvocationIDs[0]) {
 					return 1

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -469,7 +469,7 @@ func TestRunStatusDistinguishesAnActiveInvocationFromAnActiveRun(t *testing.T) {
 		t.Fatalf("status output = %q, want run-active without an invocation identity", output.String())
 	}
 
-	run.ActiveInvocationID = "inv-cli-activity"
+	run.ActiveInvocationIDs = []string{"inv-cli-activity"}
 	run.UpdatedAt = started.Add(time.Minute)
 	saveRun(run)
 	output.Reset()

--- a/internal/factory/activity.go
+++ b/internal/factory/activity.go
@@ -43,7 +43,7 @@ func RunActivityFor(run store.Run) RunActivity {
 	case store.StatusWaitingForHarness:
 		return ActivityWaitingForHarness
 	}
-	if run.ActiveInvocationID != "" || len(run.ActiveInvocationIDs) > 0 {
+	if len(run.ActiveInvocationIDs) > 0 {
 		return ActivityInvocationActive
 	}
 	return ActivityRunActive
@@ -58,9 +58,6 @@ func activityStatusComment(run store.Run) string {
 		return fmt.Sprintf("- activity: `%s`\n", activity)
 	}
 	ids := append([]string(nil), run.ActiveInvocationIDs...)
-	if len(ids) == 0 && run.ActiveInvocationID != "" {
-		ids = []string{run.ActiveInvocationID}
-	}
 	if len(ids) == 1 {
 		return fmt.Sprintf("- activity: `%s`\n- active invocation: `%s`\n", activity, safeStatusCommentValue(ids[0]))
 	}

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -663,27 +663,16 @@ func (s *Service) resumeAcceptedStageProjection(ctx context.Context, registratio
 }
 
 // addActiveInvocation adds one invocation to the durable activity projection.
-// The singular marker remains the first active invocation for compatibility
-// with older status and recovery adapters.
 func addActiveInvocation(run *store.Run, invocationID string) {
 	if run == nil || strings.TrimSpace(invocationID) == "" {
 		return
 	}
-	if len(run.ActiveInvocationIDs) == 0 && run.ActiveInvocationID != "" {
-		run.ActiveInvocationIDs = []string{run.ActiveInvocationID}
-	}
 	for _, activeID := range run.ActiveInvocationIDs {
 		if activeID == invocationID {
-			if run.ActiveInvocationID == "" {
-				run.ActiveInvocationID = invocationID
-			}
 			return
 		}
 	}
 	run.ActiveInvocationIDs = append(run.ActiveInvocationIDs, invocationID)
-	if run.ActiveInvocationID == "" {
-		run.ActiveInvocationID = invocationID
-	}
 }
 
 // releaseActiveInvocation removes one invocation from the run's delegation
@@ -692,9 +681,6 @@ func releaseActiveInvocation(run *store.Run, invocationID string) {
 	if run == nil || strings.TrimSpace(invocationID) == "" {
 		return
 	}
-	if len(run.ActiveInvocationIDs) == 0 && run.ActiveInvocationID != "" {
-		run.ActiveInvocationIDs = []string{run.ActiveInvocationID}
-	}
 	remaining := make([]string, 0, len(run.ActiveInvocationIDs))
 	for _, activeID := range run.ActiveInvocationIDs {
 		if activeID != invocationID {
@@ -702,22 +688,14 @@ func releaseActiveInvocation(run *store.Run, invocationID string) {
 		}
 	}
 	run.ActiveInvocationIDs = remaining
-	if run.ActiveInvocationID == invocationID || !containsString(run.ActiveInvocationIDs, run.ActiveInvocationID) {
-		if len(run.ActiveInvocationIDs) == 0 {
-			run.ActiveInvocationID = ""
-		} else {
-			run.ActiveInvocationID = run.ActiveInvocationIDs[0]
-		}
-	}
 }
 
-// clearActiveInvocations clears both current activity projections when a
+// clearActiveInvocations clears the current activity projection when a
 // transition ends every visible invocation for the run.
 func clearActiveInvocations(run *store.Run) {
 	if run == nil {
 		return
 	}
-	run.ActiveInvocationID = ""
 	run.ActiveInvocationIDs = nil
 }
 
@@ -731,7 +709,7 @@ func reviewCanBeAcceptedWhileWaiting(run store.Run, invocation store.Invocation)
 	if containsString(run.ActiveInvocationIDs, invocation.ID) {
 		return true
 	}
-	return run.ActiveInvocationID == invocation.ID
+	return false
 }
 
 // reviewHasBlockingResult reports whether either isolated reviewer has a
@@ -801,7 +779,6 @@ func agentReportRunProjection(previous store.Run, invocationStage store.Stage, v
 	default:
 		if value.Handoff != nil {
 			next.RoleHandoff = roleHandoffFromReport(*value.Handoff)
-			next.ImplementationHandoff = next.RoleHandoff
 		}
 		next.PendingQuestions = nil
 	}

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -380,7 +380,7 @@ func (s *Service) handleRevisionCommand(ctx context.Context, registration config
 		rejection := &PolicyRejection{Code: PolicyRejectionRevisionState, Problem: "revision requires a tracked pull request"}
 		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
 	}
-	if run.ActiveInvocationID != "" || len(run.ActiveInvocationIDs) != 0 {
+	if len(run.ActiveInvocationIDs) != 0 {
 		rejection := &PolicyRejection{Code: PolicyRejectionRevisionState, Problem: "revision requires a ready run with no active invocation"}
 		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
 	}
@@ -496,7 +496,6 @@ func resetRevisionProjection(run *store.Run, packet SpecificationPacket) {
 	run.CheckRepairBudget = packet.RepositoryConfig.RetryLimits.CheckRepair
 	run.CheckRepairPendingAttempt = 0
 	run.RoleHandoff = nil
-	run.ImplementationHandoff = nil
 	run.SpecificationReview = nil
 	run.StandardsReview = nil
 	run.TestExemption = nil
@@ -653,7 +652,6 @@ func resetTestProjectionForPacketChange(run *store.Run, packet SpecificationPack
 	run.TestObjection = nil
 	run.TestRevisionBaseChangedPaths = nil
 	run.RoleHandoff = nil
-	run.ImplementationHandoff = nil
 	run.SpecificationReview = nil
 	run.StandardsReview = nil
 	run.ProtectedTestPaths = nil

--- a/internal/factory/concurrent_review_internal_test.go
+++ b/internal/factory/concurrent_review_internal_test.go
@@ -15,7 +15,6 @@ import (
 // run projection cannot alter the shared slice backing an earlier projection.
 func TestReleaseActiveInvocationDoesNotMutateCopiedRun(t *testing.T) {
 	previous := store.Run{
-		ActiveInvocationID:  "inv-specification",
 		ActiveInvocationIDs: []string{"inv-specification", "inv-standards"},
 	}
 	next := previous

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -241,8 +241,6 @@ type RegisterResult struct {
 }
 
 // StatusResult reports the registered repository and the latest known run.
-// ActiveRun is retained as the foundation field name for compatibility; it is
-// an alias of LatestRun and may contain a terminal run when no run is active.
 type StatusResult struct {
 	ConfigPath     string
 	RepositoryPath string
@@ -257,8 +255,6 @@ type StatusResult struct {
 	Activity RunActivity
 	// Recovery contains the read-only diagnosis for an interrupted run.
 	Recovery *RecoveryDiagnosis
-	// Deprecated: use LatestRun.
-	ActiveRun *store.Run
 }
 
 type fileConfigRepository struct{}
@@ -518,7 +514,6 @@ func (s *Service) Status(ctx context.Context) (StatusResult, error) {
 	} else {
 		result.LatestRun, err = opened.CurrentRun(ctx)
 	}
-	result.ActiveRun = result.LatestRun
 	if err != nil {
 		return StatusResult{}, err
 	}

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -64,9 +64,6 @@ func TestFactoryInitializesRegistersAndReportsAnEmptyRunStore(t *testing.T) {
 	if status.RepositoryPath != repositoryPath {
 		t.Fatalf("RepositoryPath = %q, want %q", status.RepositoryPath, repositoryPath)
 	}
-	if status.ActiveRun != nil {
-		t.Fatalf("ActiveRun = %#v, want empty store", status.ActiveRun)
-	}
 }
 
 func TestFactoryRefusesAnInvalidRegistrationBeforePersistingIt(t *testing.T) {
@@ -261,9 +258,6 @@ func TestFactoryStatusUsesTheHighLevelSeamWithARealSQLiteStoreAndFakeConfigAdapt
 	if err != nil {
 		t.Fatalf("Status() error = %v", err)
 	}
-	if status.ActiveRun != nil {
-		t.Fatalf("ActiveRun = %#v, want empty SQLite store", status.ActiveRun)
-	}
 	if status.RepositoryPath != "/work/repository" {
 		t.Fatalf("RepositoryPath = %q", status.RepositoryPath)
 	}
@@ -313,8 +307,8 @@ func TestFactoryStatusReportsTheLatestTerminalRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.ActiveRun == nil || status.ActiveRun.Status != store.StatusComplete || status.ActiveRun.Branch != "factory/run-complete" || status.ActiveRun.Worktree != "/worktrees/run-complete" {
-		t.Fatalf("status.ActiveRun = %#v, want latest terminal run details", status.ActiveRun)
+	if status.LatestRun == nil || status.LatestRun.Status != store.StatusComplete || status.LatestRun.Branch != "factory/run-complete" || status.LatestRun.Worktree != "/worktrees/run-complete" {
+		t.Fatalf("status.LatestRun = %#v, want latest terminal run details", status.LatestRun)
 	}
 }
 
@@ -645,9 +639,6 @@ func TestServiceStatusReturnsAnEmptyResultWhenNoRepositoryIsRegistered(t *testin
 	}
 	if status.RepositoryPath != "" {
 		t.Fatalf("RepositoryPath = %q, want empty", status.RepositoryPath)
-	}
-	if status.ActiveRun != nil {
-		t.Fatalf("ActiveRun = %#v, want nil", status.ActiveRun)
 	}
 }
 

--- a/internal/factory/interruption.go
+++ b/internal/factory/interruption.go
@@ -799,7 +799,7 @@ func (s *Service) supersedeInvocation(ctx context.Context, registration config.R
 	if err != nil {
 		return fmt.Errorf("read run to release superseded invocation: %w", err)
 	}
-	if current == nil || (current.ActiveInvocationID != invocation.ID && !containsString(current.ActiveInvocationIDs, invocation.ID)) {
+	if current == nil || !containsString(current.ActiveInvocationIDs, invocation.ID) {
 		return nil
 	}
 	previous := *current
@@ -867,7 +867,7 @@ func (s *Service) stopActiveRunWorkers(ctx context.Context, runStore RunStore, r
 			seen[workerID] = struct{}{}
 			workerIDs = append(workerIDs, workerID)
 		}
-	} else if run.ActiveInvocationID != "" || len(run.ActiveInvocationIDs) != 0 {
+	} else if len(run.ActiveInvocationIDs) != 0 {
 		workerIDs = append(workerIDs, run.ID)
 	}
 	if len(workerIDs) == 0 {

--- a/internal/factory/progression_internal_test.go
+++ b/internal/factory/progression_internal_test.go
@@ -208,7 +208,6 @@ func TestDriveRunDispatchesEveryProgressionCommand(t *testing.T) {
 				ID:                  "run-report-dispatch",
 				Stage:               store.StageImplementation,
 				Status:              store.StatusActive,
-				ActiveInvocationID:  "inv-report-dispatch",
 				ActiveInvocationIDs: []string{"inv-report-dispatch"},
 				SpecificationPacket: progressionDispatchPacket(t, false),
 				Worktree:            "/worktree",

--- a/internal/factory/review_test.go
+++ b/internal/factory/review_test.go
@@ -514,7 +514,7 @@ func newReviewFixture(t *testing.T) reviewFixture {
 	run := claimed.Run
 	run.TestStageSkipped = true
 	run.TestExemption = &store.TestExemption{Kind: "human", Justification: "review fixture"}
-	run.ImplementationHandoff = &store.ImplementationHandoff{
+	run.RoleHandoff = &store.RoleHandoff{
 		ChangeSummary:          "implemented review behavior",
 		AcceptanceMapping:      []store.HandoffAcceptance{{Criterion: "review behavior", Evidence: "focused test"}},
 		ProductionFilesChanged: []string{"internal/factory/review.go"},

--- a/internal/factory/test_stage.go
+++ b/internal/factory/test_stage.go
@@ -506,7 +506,6 @@ func projectImplementationTestObjection(previous store.Run, value report.Report,
 	}
 	next.TestRevisionBaseChangedPaths = basePaths
 	next.RoleHandoff = roleHandoffFromReport(*value.Handoff)
-	next.ImplementationHandoff = next.RoleHandoff
 	next.PendingQuestions = nil
 	next.ClarificationCommentID = ""
 	next.ClarificationNotificationSent = false

--- a/internal/factory/unattended_test.go
+++ b/internal/factory/unattended_test.go
@@ -58,8 +58,8 @@ func TestStartDrivesAnAdvisoryIssueFromQueueToDraftPullRequest(t *testing.T) {
 	if final.CheckpointSHA != implementationCheckpoint {
 		t.Fatalf("final checkpoint = %q, want the implementation checkpoint", final.CheckpointSHA)
 	}
-	if final.ActiveInvocationID != "" {
-		t.Fatalf("final active invocation = %q, want none once no harness executes", final.ActiveInvocationID)
+	if len(final.ActiveInvocationIDs) != 0 {
+		t.Fatalf("final active invocations = %#v, want none once no harness executes", final.ActiveInvocationIDs)
 	}
 	if final.TestHandoff != nil || final.TestCheckpointSHA != "" || len(final.ProtectedTestPaths) != 0 || final.TestStageSkipped {
 		t.Fatalf("advisory run = %#v, want no independent test-stage artifacts", final)
@@ -138,8 +138,8 @@ func TestStartLaunchesOnlyTheStageTheFrozenRouteSelects(t *testing.T) {
 		t.Fatalf("route effects = checkpoints %d pull requests %d, want none while the test role runs", len(fixture.workspace.checkpoints), len(fixture.pullRequests.createdRequests))
 	}
 	run := fixture.currentRun(t)
-	if run.Stage != store.StageTest || run.ActiveInvocationID == "" {
-		t.Fatalf("run = stage %q active invocation %q, want the test stage with a live invocation", run.Stage, run.ActiveInvocationID)
+	if run.Stage != store.StageTest || len(run.ActiveInvocationIDs) == 0 {
+		t.Fatalf("run = stage %q active invocations %#v, want the test stage with a live invocation", run.Stage, run.ActiveInvocationIDs)
 	}
 	if activity := factory.RunActivityFor(run); activity != factory.ActivityInvocationActive {
 		t.Fatalf("activity = %q, want invocation-active", activity)
@@ -271,7 +271,7 @@ func TestStatusCommentSeparatesAnActiveInvocationFromAnActiveRun(t *testing.T) {
 	if body := factory.StatusCommentBody(run); !strings.Contains(body, "- activity: `run-active`") || strings.Contains(body, "active invocation") {
 		t.Fatalf("status comment = %q, want run-active without an invocation identity", body)
 	}
-	run.ActiveInvocationID = "inv-1"
+	run.ActiveInvocationIDs = []string{"inv-1"}
 	if got := factory.RunActivityFor(run); got != factory.ActivityInvocationActive {
 		t.Fatalf("RunActivityFor(active invocation) = %q, want invocation-active", got)
 	}

--- a/internal/factory/workflow_helpers.go
+++ b/internal/factory/workflow_helpers.go
@@ -8,15 +8,6 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/workflow"
 )
 
-// roleHandoffForRun returns the role-neutral handoff while accepting rows and
-// fixtures that still populate the legacy implementation field.
-func roleHandoffForRun(run store.Run) *store.RoleHandoff {
-	if run.RoleHandoff != nil {
-		return run.RoleHandoff
-	}
-	return run.ImplementationHandoff
-}
-
 // roleDefinitionForInvocation resolves the factory declaration attached to a
 // persisted invocation and verifies that its role owns its stage.
 func roleDefinitionForInvocation(invocation store.Invocation) (workflow.RoleDefinition, error) {

--- a/internal/store/cleanup.go
+++ b/internal/store/cleanup.go
@@ -260,7 +260,7 @@ func (s *Store) cleanupRun(ctx context.Context, runID string) (*Run, error) {
 		       review_repair_attempts, review_repair_budget,
 		       review_repair_pending_attempt, review_repair_history, review_repair_packet,
 		       test_exemption, protected_test_paths, test_stage_skipped,
-		       active_invocation_id, active_invocation_ids,
+		       active_invocation_ids,
 		       image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent, ready_notification_sent,

--- a/internal/store/serializer_internal_test.go
+++ b/internal/store/serializer_internal_test.go
@@ -1,0 +1,15 @@
+package store
+
+import "testing"
+
+// TestJSONProjectionHelpersReturnMarshalErrors verifies unsupported values are
+// reported by both generic projection forms.
+func TestJSONProjectionHelpersReturnMarshalErrors(t *testing.T) {
+	if _, err := sliceJSON([]func(){func() {}}); err == nil {
+		t.Fatal("sliceJSON() error = nil, want marshal failure")
+	}
+	value := func() {}
+	if _, err := nullableJSON(&value); err == nil {
+		t.Fatal("nullableJSON() error = nil, want marshal failure")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CurrentSchemaVersion is the supported operational-store schema version.
-const CurrentSchemaVersion = 32
+const CurrentSchemaVersion = 33
 
 // MaxTestRevisionAttempts is the hard safety ceiling for automated
 // implementation-versus-test objection cycles.
@@ -484,9 +484,6 @@ type Run struct {
 	TestRevisionBaseChangedPaths []ProtectedTestPath
 	// RoleHandoff is the accepted role transfer packet.
 	RoleHandoff *RoleHandoff
-	// ImplementationHandoff is the legacy compatibility projection of
-	// RoleHandoff. New code should use RoleHandoff.
-	ImplementationHandoff *RoleHandoff
 	// SpecificationReview is the latest exact-checkpoint review result.
 	SpecificationReview *SpecificationReview
 	// StandardsReview is the latest exact-checkpoint standards result.
@@ -510,14 +507,8 @@ type Run struct {
 	ProtectedTestPaths []ProtectedTestPath
 	// TestStageSkipped records an authorized skip before implementation.
 	TestStageSkipped bool
-	// ActiveInvocationID identifies the harness invocation the run currently
-	// delegates to. It is empty whenever no harness is executing for the run,
-	// which lets a status projection separate an active run from an active
-	// invocation without reading the invocation table.
-	ActiveInvocationID string
 	// ActiveInvocationIDs identifies every concurrently executing harness
-	// invocation. ActiveInvocationID remains the compatibility projection of
-	// the first entry for older status consumers.
+	// invocation.
 	ActiveInvocationIDs []string
 	ImageDigest         string
 	Coordinator         string
@@ -847,7 +838,7 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 		       review_repair_attempts, review_repair_budget,
 		       review_repair_pending_attempt, review_repair_history, review_repair_packet,
 		       test_exemption, protected_test_paths, test_stage_skipped,
-		       active_invocation_id, active_invocation_ids,
+			active_invocation_ids,
 		       image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent, ready_notification_sent,
@@ -878,7 +869,7 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 		       review_repair_attempts, review_repair_budget,
 		       review_repair_pending_attempt, review_repair_history, review_repair_packet,
 		       test_exemption, protected_test_paths, test_stage_skipped,
-		       active_invocation_id, active_invocation_ids,
+		       active_invocation_ids,
 		       image_digest, coordinator, status_comment_id,
 		       pull_request_number, pull_request_url, merge_commit_sha,
 		       lifecycle_reason, lifecycle_notification_sent, ready_notification_sent,
@@ -936,7 +927,6 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&testExemptionJSON,
 		&protectedTestPathsJSON,
 		&run.TestStageSkipped,
-		&run.ActiveInvocationID,
 		&activeInvocationIDsJSON,
 		&run.ImageDigest,
 		&run.Coordinator,
@@ -1009,7 +999,6 @@ func scanRun(row *sql.Row) (*Run, error) {
 		if err := json.Unmarshal([]byte(roleHandoffJSON), run.RoleHandoff); err != nil {
 			return nil, fmt.Errorf("decode role handoff: %w", err)
 		}
-		run.ImplementationHandoff = run.RoleHandoff
 	}
 	if specificationReviewJSON != "" {
 		run.SpecificationReview = &SpecificationReview{}
@@ -1038,12 +1027,6 @@ func scanRun(row *sql.Row) (*Run, error) {
 		if err := json.Unmarshal([]byte(activeInvocationIDsJSON), &run.ActiveInvocationIDs); err != nil {
 			return nil, fmt.Errorf("decode active invocation ids: %w", err)
 		}
-	}
-	if len(run.ActiveInvocationIDs) == 0 && run.ActiveInvocationID != "" {
-		run.ActiveInvocationIDs = []string{run.ActiveInvocationID}
-	}
-	if run.ActiveInvocationID == "" && len(run.ActiveInvocationIDs) > 0 {
-		run.ActiveInvocationID = run.ActiveInvocationIDs[0]
 	}
 	if testExemptionJSON != "" {
 		run.TestExemption = &TestExemption{}
@@ -1081,7 +1064,11 @@ func (s *Store) SaveRun(ctx context.Context, run Run) error {
 	if err != nil {
 		return err
 	}
-	if _, err := s.db.ExecContext(ctx, saveRunStatement, runValues(run)...); err != nil {
+	values, err := runValues(run)
+	if err != nil {
+		return fmt.Errorf("encode run projections: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, saveRunStatement, values...); err != nil {
 		return fmt.Errorf("save run: %w", err)
 	}
 	return nil
@@ -1238,7 +1225,11 @@ func (s *Store) SaveRunIfRevision(ctx context.Context, expectedRevision int64, r
 	if run.Revision <= expectedRevision {
 		return fmt.Errorf("%w: got %d, expected greater than %d", ErrRevisionNotAdvanced, run.Revision, expectedRevision)
 	}
-	result, err := s.db.ExecContext(ctx, saveRunIfRevisionStatement, append(runValues(run)[1:], run.ID, expectedRevision)...)
+	values, err := runValues(run)
+	if err != nil {
+		return fmt.Errorf("encode run projections: %w", err)
+	}
+	result, err := s.db.ExecContext(ctx, saveRunIfRevisionStatement, append(values[1:], run.ID, expectedRevision)...)
 	if err != nil {
 		return fmt.Errorf("save run at revision %d: %w", expectedRevision, err)
 	}
@@ -1268,9 +1259,6 @@ func normalizeRun(run Run) (Run, error) {
 	}
 	if run.CheckpointSHA == "" && run.BaseCheckpointSHA != "" {
 		run.CheckpointSHA = run.BaseCheckpointSHA
-	}
-	if err := normalizeActiveInvocationProjection(&run); err != nil {
-		return Run{}, err
 	}
 	if err := validateTestProjection(run); err != nil {
 		return Run{}, err
@@ -1349,42 +1337,6 @@ func normalizeRun(run Run) (Run, error) {
 		run.TerminalAt = time.Time{}
 	}
 	return run, nil
-}
-
-// normalizeActiveInvocationProjection keeps the historical singular marker
-// and the concurrent invocation projection mutually compatible.
-func normalizeActiveInvocationProjection(run *Run) error {
-	if run == nil {
-		return errors.New("run is required for active invocation normalization")
-	}
-	ids := append([]string(nil), run.ActiveInvocationIDs...)
-	if run.ActiveInvocationID != "" {
-		found := false
-		for _, id := range ids {
-			if id == run.ActiveInvocationID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			ids = append([]string{run.ActiveInvocationID}, ids...)
-		}
-	}
-	seen := make(map[string]struct{}, len(ids))
-	for index, id := range ids {
-		if !safeQuestionIdentifier(id) {
-			return fmt.Errorf("run active invocation %d has an unsafe identifier", index)
-		}
-		if _, exists := seen[id]; exists {
-			return fmt.Errorf("run active invocation %q is duplicated", id)
-		}
-		seen[id] = struct{}{}
-	}
-	run.ActiveInvocationIDs = ids
-	if run.ActiveInvocationID == "" && len(ids) > 0 {
-		run.ActiveInvocationID = ids[0]
-	}
-	return nil
 }
 
 // validateTestProjection checks the bounded durable test-stage state before it
@@ -1492,7 +1444,7 @@ func validateTestProjection(run Run) error {
 			return errors.New("test objection invocation id is unsafe")
 		}
 	}
-	roleHandoff := roleHandoffForRun(run)
+	roleHandoff := run.RoleHandoff
 	if roleHandoff != nil {
 		if strings.TrimSpace(roleHandoff.ChangeSummary) == "" || strings.ContainsAny(roleHandoff.ChangeSummary, "\x00\r\n") {
 			return errors.New("role handoff change summary is required and must be single-line")
@@ -1731,177 +1683,87 @@ func safeQuestionIdentifier(value string) bool {
 	return true
 }
 
-// pendingQuestionsJSON serializes an empty projection as an empty JSON array
-// so migrated and newly created stores have one stable representation.
-func pendingQuestionsJSON(values []PendingQuestion) string {
+// sliceJSON serializes a slice projection as a stable JSON array. A nil slice
+// intentionally remains the empty array used by the operational store.
+func sliceJSON[T any](values []T) (string, error) {
 	if values == nil {
-		return "[]"
+		return "[]", nil
 	}
 	data, err := json.Marshal(values)
 	if err != nil {
-		return "[]"
+		return "", err
 	}
-	return string(data)
+	return string(data), nil
 }
 
-// testHandoffJSON serializes a nullable test handoff projection.
-func testHandoffJSON(value *TestHandoff) string {
+// nullableJSON serializes an optional projection while preserving the empty
+// string representation used for an absent value in the operational store.
+func nullableJSON[T any](value *T) (string, error) {
 	if value == nil {
-		return ""
+		return "", nil
 	}
 	data, err := json.Marshal(value)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return string(data)
-}
-
-// testRevisionHistoryJSON serializes the bounded objection-cycle history.
-func testRevisionHistoryJSON(values []TestRevision) string {
-	if values == nil {
-		return "[]"
-	}
-	data, err := json.Marshal(values)
-	if err != nil {
-		return "[]"
-	}
-	return string(data)
-}
-
-// testObjectionJSON serializes a nullable current objection.
-func testObjectionJSON(value *TestObjection) string {
-	if value == nil {
-		return ""
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return ""
-	}
-	return string(data)
-}
-
-// testRevisionBaseChangedPathsJSON serializes paths and content identities
-// already dirty when an implementation objection was submitted.
-func testRevisionBaseChangedPathsJSON(values []ProtectedTestPath) string {
-	if values == nil {
-		return "[]"
-	}
-	data, err := json.Marshal(values)
-	if err != nil {
-		return "[]"
-	}
-	return string(data)
-}
-
-// roleHandoffJSON serializes a nullable role handoff.
-func roleHandoffJSON(value *RoleHandoff) string {
-	if value == nil {
-		return ""
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return ""
-	}
-	return string(data)
-}
-
-// roleHandoffForRun returns the role-neutral handoff while accepting a legacy
-// run value that only populated the implementation compatibility field.
-func roleHandoffForRun(run Run) *RoleHandoff {
-	if run.RoleHandoff != nil {
-		return run.RoleHandoff
-	}
-	return run.ImplementationHandoff
-}
-
-// specificationReviewJSON serializes a nullable exact-checkpoint review.
-func specificationReviewJSON(value *SpecificationReview) string {
-	if value == nil {
-		return ""
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return ""
-	}
-	return string(data)
-}
-
-// standardsReviewJSON serializes a nullable exact-checkpoint standards review.
-func standardsReviewJSON(value *StandardsReview) string {
-	if value == nil {
-		return ""
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return ""
-	}
-	return string(data)
-}
-
-// reviewRepairHistoryJSON serializes the bounded review-repair history.
-func reviewRepairHistoryJSON(values []ReviewRepairAttempt) string {
-	if values == nil {
-		return "[]"
-	}
-	data, err := json.Marshal(values)
-	if err != nil {
-		return "[]"
-	}
-	return string(data)
-}
-
-// reviewRepairPacketJSON serializes a nullable review-repair packet.
-func reviewRepairPacketJSON(value *ReviewRepairPacket) string {
-	if value == nil {
-		return ""
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return ""
-	}
-	return string(data)
-}
-
-// activeInvocationIDsJSON serializes the concurrent invocation projection as
-// a stable JSON array for restart-safe status rendering.
-func activeInvocationIDsJSON(values []string) string {
-	if values == nil {
-		return "[]"
-	}
-	data, err := json.Marshal(values)
-	if err != nil {
-		return "[]"
-	}
-	return string(data)
-}
-
-// testExemptionJSON serializes a nullable test exemption projection.
-func testExemptionJSON(value *TestExemption) string {
-	if value == nil {
-		return ""
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return ""
-	}
-	return string(data)
-}
-
-// protectedTestPathsJSON serializes protected paths as a stable JSON array.
-func protectedTestPathsJSON(values []ProtectedTestPath) string {
-	if values == nil {
-		return "[]"
-	}
-	data, err := json.Marshal(values)
-	if err != nil {
-		return "[]"
-	}
-	return string(data)
+	return string(data), nil
 }
 
 // runValues returns the ordered SQL values shared by normal and revision-safe
-// run persistence.
-func runValues(run Run) []any {
+// run persistence, including errors from every JSON projection.
+func runValues(run Run) ([]any, error) {
+	testHandoff, err := nullableJSON(run.TestHandoff)
+	if err != nil {
+		return nil, fmt.Errorf("encode test handoff: %w", err)
+	}
+	testRevisionHistory, err := sliceJSON(run.TestRevisionHistory)
+	if err != nil {
+		return nil, fmt.Errorf("encode test revision history: %w", err)
+	}
+	testObjection, err := nullableJSON(run.TestObjection)
+	if err != nil {
+		return nil, fmt.Errorf("encode test objection: %w", err)
+	}
+	testRevisionBaseChangedPaths, err := sliceJSON(run.TestRevisionBaseChangedPaths)
+	if err != nil {
+		return nil, fmt.Errorf("encode test revision base changed paths: %w", err)
+	}
+	roleHandoff, err := nullableJSON(run.RoleHandoff)
+	if err != nil {
+		return nil, fmt.Errorf("encode role handoff: %w", err)
+	}
+	specificationReview, err := nullableJSON(run.SpecificationReview)
+	if err != nil {
+		return nil, fmt.Errorf("encode specification review: %w", err)
+	}
+	standardsReview, err := nullableJSON(run.StandardsReview)
+	if err != nil {
+		return nil, fmt.Errorf("encode standards review: %w", err)
+	}
+	reviewRepairHistory, err := sliceJSON(run.ReviewRepairHistory)
+	if err != nil {
+		return nil, fmt.Errorf("encode review repair history: %w", err)
+	}
+	reviewRepairPacket, err := nullableJSON(run.ReviewRepairPacket)
+	if err != nil {
+		return nil, fmt.Errorf("encode review repair packet: %w", err)
+	}
+	activeInvocationIDs, err := sliceJSON(run.ActiveInvocationIDs)
+	if err != nil {
+		return nil, fmt.Errorf("encode active invocation ids: %w", err)
+	}
+	testExemption, err := nullableJSON(run.TestExemption)
+	if err != nil {
+		return nil, fmt.Errorf("encode test exemption: %w", err)
+	}
+	protectedTestPaths, err := sliceJSON(run.ProtectedTestPaths)
+	if err != nil {
+		return nil, fmt.Errorf("encode protected test paths: %w", err)
+	}
+	pendingQuestions, err := sliceJSON(run.PendingQuestions)
+	if err != nil {
+		return nil, fmt.Errorf("encode pending questions: %w", err)
+	}
 	return []any{
 		run.ID,
 		run.RepositoryPath,
@@ -1913,26 +1775,25 @@ func runValues(run Run) []any {
 		run.CheckpointSHA,
 		run.BaseCheckpointSHA,
 		run.TestCheckpointSHA,
-		testHandoffJSON(run.TestHandoff),
+		testHandoff,
 		run.TestInvocationID,
 		run.TestRevisionAttempts,
 		run.TestRevisionBudget,
-		testRevisionHistoryJSON(run.TestRevisionHistory),
-		testObjectionJSON(run.TestObjection),
-		testRevisionBaseChangedPathsJSON(run.TestRevisionBaseChangedPaths),
-		roleHandoffJSON(roleHandoffForRun(run)),
-		specificationReviewJSON(run.SpecificationReview),
-		standardsReviewJSON(run.StandardsReview),
+		testRevisionHistory,
+		testObjection,
+		testRevisionBaseChangedPaths,
+		roleHandoff,
+		specificationReview,
+		standardsReview,
 		run.ReviewRepairAttempts,
 		run.ReviewRepairBudget,
 		run.ReviewRepairPendingAttempt,
-		reviewRepairHistoryJSON(run.ReviewRepairHistory),
-		reviewRepairPacketJSON(run.ReviewRepairPacket),
-		testExemptionJSON(run.TestExemption),
-		protectedTestPathsJSON(run.ProtectedTestPaths),
+		reviewRepairHistory,
+		reviewRepairPacket,
+		testExemption,
+		protectedTestPaths,
 		run.TestStageSkipped,
-		run.ActiveInvocationID,
-		activeInvocationIDsJSON(run.ActiveInvocationIDs),
+		activeInvocationIDs,
 		run.ImageDigest,
 		run.Coordinator,
 		run.StatusCommentID,
@@ -1955,13 +1816,13 @@ func runValues(run Run) []any {
 		run.CheckRepairBudget,
 		run.CheckRepairPendingAttempt,
 		run.SpecificationPacket,
-		pendingQuestionsJSON(run.PendingQuestions),
+		pendingQuestions,
 		run.ClarificationCommentID,
 		run.ClarificationNotificationSent,
 		terminalAtValue(run.TerminalAt),
 		run.CreatedAt.UTC().Format(runTimestampLayout),
 		run.UpdatedAt.UTC().Format(runTimestampLayout),
-	}
+	}, nil
 }
 
 // terminalAtValue serializes an absent terminal timestamp as the empty
@@ -1984,7 +1845,7 @@ const saveRunStatement = `
 			review_repair_attempts, review_repair_budget,
 			review_repair_pending_attempt, review_repair_history, review_repair_packet,
 			test_exemption, protected_test_paths, test_stage_skipped,
-			active_invocation_id, active_invocation_ids,
+			active_invocation_ids,
 			image_digest, coordinator, status_comment_id,
 			pull_request_number, pull_request_url, merge_commit_sha, lifecycle_reason,
 			lifecycle_notification_sent, ready_notification_sent,
@@ -2001,7 +1862,7 @@ const saveRunStatement = `
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?
 		)
 		ON CONFLICT(id) DO UPDATE SET
 			repository_path = excluded.repository_path,
@@ -2031,7 +1892,6 @@ const saveRunStatement = `
 			test_exemption = excluded.test_exemption,
 			protected_test_paths = excluded.protected_test_paths,
 			test_stage_skipped = excluded.test_stage_skipped,
-			active_invocation_id = excluded.active_invocation_id,
 			active_invocation_ids = excluded.active_invocation_ids,
 			image_digest = excluded.image_digest,
 			coordinator = excluded.coordinator,
@@ -2072,7 +1932,7 @@ const saveRunIfRevisionStatement = `
 			review_repair_attempts = ?, review_repair_budget = ?,
 			review_repair_pending_attempt = ?, review_repair_history = ?, review_repair_packet = ?,
 			test_exemption = ?, protected_test_paths = ?, test_stage_skipped = ?,
-			active_invocation_id = ?, active_invocation_ids = ?,
+			active_invocation_ids = ?,
 			image_digest = ?, coordinator = ?, status_comment_id = ?,
 			pull_request_number = ?, pull_request_url = ?, merge_commit_sha = ?, lifecycle_reason = ?,
 			lifecycle_notification_sent = ?, ready_notification_sent = ?,
@@ -2318,7 +2178,11 @@ func (s *Store) saveRunAndInvalidateResults(ctx context.Context, expectedRevisio
 	defer func() { _ = tx.Rollback() }()
 
 	// Update the run state with revision check
-	result, err := tx.ExecContext(ctx, saveRunIfRevisionStatement, append(runValues(run)[1:], run.ID, expectedRevision)...)
+	values, err := runValues(run)
+	if err != nil {
+		return fmt.Errorf("encode run projections: %w", err)
+	}
+	result, err := tx.ExecContext(ctx, saveRunIfRevisionStatement, append(values[1:], run.ID, expectedRevision)...)
 	if err != nil {
 		return fmt.Errorf("save run at revision %d: %w", expectedRevision, err)
 	}
@@ -3264,6 +3128,25 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 				if _, err := tx.ExecContext(ctx, statement); err != nil {
 					return fmt.Errorf("apply store migration 32: %w", err)
 				}
+			}
+		case 33:
+			if _, err := tx.ExecContext(ctx, `UPDATE operational_runs
+				SET active_invocation_ids = (
+					SELECT json_group_array(value)
+					FROM (
+						SELECT operational_runs.active_invocation_id AS value, -1 AS position
+						UNION ALL
+						SELECT json_each.value, json_each.key
+						FROM json_each(operational_runs.active_invocation_ids)
+						WHERE json_each.value <> operational_runs.active_invocation_id
+						ORDER BY position
+					)
+				)
+				WHERE active_invocation_id <> ''`); err != nil {
+				return fmt.Errorf("apply store migration 33 active invocation fold: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs DROP COLUMN active_invocation_id"); err != nil {
+				return fmt.Errorf("apply store migration 33 active invocation removal: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -50,6 +50,164 @@ func TestOpenCreatesVersionedStoreWithNoActiveRun(t *testing.T) {
 	}
 }
 
+// TestSchema33MigrationFoldsTheSingularActiveInvocationIntoTheSlice verifies
+// schema 32 rows retain every active invocation when the singular projection is
+// removed.
+func TestSchema33MigrationFoldsTheSingularActiveInvocationIntoTheSlice(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("initial Open() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("close initial store: %v", err)
+	}
+
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !testOperationalRunsColumnExists(t, database, "active_invocation_id") {
+		if _, err := database.ExecContext(t.Context(), "ALTER TABLE operational_runs ADD COLUMN active_invocation_id TEXT NOT NULL DEFAULT ''"); err != nil {
+			_ = database.Close()
+			t.Fatalf("add schema 32 active invocation column: %v", err)
+		}
+	}
+	_, err = database.ExecContext(t.Context(), `
+		INSERT INTO operational_runs (
+			id, repository_path, issue_number, stage, status,
+			active_invocation_id, active_invocation_ids, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+		UPDATE schema_metadata SET version = 32 WHERE singleton = 1`,
+		"run-schema-32", "/work/repository", 118, store.StageImplementation, store.StatusActive,
+		"inv-singular", `["inv-existing"]`, "2026-08-01T00:00:00.000000000Z", "2026-08-01T00:00:01.000000000Z")
+	if err != nil {
+		_ = database.Close()
+		t.Fatalf("write schema 32 fixture: %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("schema 33 migration error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if got := reopened.SchemaVersion(); got != 33 {
+		t.Fatalf("SchemaVersion() = %d, want 33", got)
+	}
+	got, err := reopened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentRun() error = %v", err)
+	}
+	if got == nil || len(got.ActiveInvocationIDs) != 2 || got.ActiveInvocationIDs[0] != "inv-singular" || got.ActiveInvocationIDs[1] != "inv-existing" {
+		t.Fatalf("CurrentRun() active invocations = %#v, want singular value first", got)
+	}
+
+	if err := reopened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	database, err = sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = database.Close() }()
+	if testOperationalRunsColumnExists(t, database, "active_invocation_id") {
+		t.Fatal("schema 33 still has the active_invocation_id column")
+	}
+}
+
+// testOperationalRunsColumnExists reports whether a column exists in the
+// migration fixture's operational_runs table.
+func testOperationalRunsColumnExists(t *testing.T, database *sql.DB, wanted string) bool {
+	t.Helper()
+	rows, err := database.QueryContext(t.Context(), "PRAGMA table_info(operational_runs)")
+	if err != nil {
+		t.Fatalf("inspect operational_runs columns: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var (
+		cid          int
+		name         string
+		columnType   string
+		notNull      int
+		defaultValue sql.NullString
+		primaryKey   int
+	)
+	for rows.Next() {
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatalf("scan operational_runs column: %v", err)
+		}
+		if name == wanted {
+			return true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate operational_runs columns: %v", err)
+	}
+	return false
+}
+
+// TestPreviousBuildImplementationHandoffRowsDecodeIntoRoleHandoff verifies
+// the existing implementation_handoff column remains the durable role-handoff
+// source when the Run compatibility field is removed.
+func TestPreviousBuildImplementationHandoffRowsDecodeIntoRoleHandoff(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("initial Open() error = %v", err)
+	}
+	if err := opened.SaveRun(context.Background(), store.Run{
+		ID:             "run-legacy-handoff",
+		RepositoryPath: "/work/repository",
+		Stage:          store.StageImplementation,
+		Status:         store.StatusActive,
+		CreatedAt:      time.Unix(100, 0).UTC(),
+		UpdatedAt:      time.Unix(200, 0).UTC(),
+	}); err != nil {
+		_ = opened.Close()
+		t.Fatalf("seed run: %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = database.ExecContext(t.Context(), `UPDATE operational_runs
+		SET implementation_handoff = ?
+		WHERE id = ?`,
+		`{"change_summary":"written by schema 32","acceptance_mapping":[{"criterion":"legacy row","evidence":"stored JSON"}],"production_files_changed":["internal/store/store.go"],"focused_commands":["go test ./internal/store"]}`,
+		"run-legacy-handoff")
+	if err != nil {
+		_ = database.Close()
+		t.Fatalf("write previous-build handoff row: %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("reopen error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentRun() error = %v", err)
+	}
+	if got == nil || got.RoleHandoff == nil || got.RoleHandoff.ChangeSummary != "written by schema 32" {
+		t.Fatalf("CurrentRun() role handoff = %#v, want previous-build handoff", got)
+	}
+}
+
 func TestOpenRejectsANewerSchemaVersion(t *testing.T) {
 	t.Parallel()
 
@@ -560,9 +718,9 @@ func TestRunPersistsTheTestObjectionProjection(t *testing.T) {
 	}
 }
 
-// TestRunPersistsImplementationAndSpecificationReviewProjections verifies the
+// TestRunPersistsRoleAndSpecificationReviewProjections verifies the
 // reviewer packet's durable handoffs survive the schema-20 restart boundary.
-func TestRunPersistsImplementationAndSpecificationReviewProjections(t *testing.T) {
+func TestRunPersistsRoleAndSpecificationReviewProjections(t *testing.T) {
 	t.Parallel()
 
 	opened, err := store.Open(context.Background(), filepath.Join(t.TempDir(), "data", "factory.db"))
@@ -577,7 +735,7 @@ func TestRunPersistsImplementationAndSpecificationReviewProjections(t *testing.T
 		Stage:          store.StageReview,
 		Status:         store.StatusWaitingForHuman,
 		CheckpointSHA:  checkpoint,
-		ImplementationHandoff: &store.ImplementationHandoff{
+		RoleHandoff: &store.RoleHandoff{
 			ChangeSummary:          "implemented the requested review behavior",
 			AcceptanceMapping:      []store.HandoffAcceptance{{Criterion: "criterion", Evidence: "focused test"}},
 			ProductionFilesChanged: []string{"internal/factory/review.go"},
@@ -599,8 +757,8 @@ func TestRunPersistsImplementationAndSpecificationReviewProjections(t *testing.T
 	if err != nil {
 		t.Fatalf("CurrentRun() error = %v", err)
 	}
-	if got == nil || got.ImplementationHandoff == nil || got.SpecificationReview == nil || got.SpecificationReview.CheckpointSHA != checkpoint || got.SpecificationReview.Findings[0].SuggestedOwner != "implementation" {
-		t.Fatalf("CurrentRun() = %#v, want implementation and review projections", got)
+	if got == nil || got.RoleHandoff == nil || got.SpecificationReview == nil || got.SpecificationReview.CheckpointSHA != checkpoint || got.SpecificationReview.Findings[0].SuggestedOwner != "implementation" {
+		t.Fatalf("CurrentRun() = %#v, want role handoff and review projections", got)
 	}
 }
 
@@ -766,13 +924,13 @@ func TestStorePersistsTheActiveInvocationDelegation(t *testing.T) {
 		t.Fatalf("Open() error = %v", err)
 	}
 	run := store.Run{
-		ID:                 "run-delegation",
-		RepositoryPath:     "/work/repository",
-		Stage:              store.StageImplementation,
-		Status:             store.StatusActive,
-		ActiveInvocationID: "inv-delegation",
-		CreatedAt:          time.Unix(100, 0).UTC(),
-		UpdatedAt:          time.Unix(200, 0).UTC(),
+		ID:                  "run-delegation",
+		RepositoryPath:      "/work/repository",
+		Stage:               store.StageImplementation,
+		Status:              store.StatusActive,
+		ActiveInvocationIDs: []string{"inv-delegation"},
+		CreatedAt:           time.Unix(100, 0).UTC(),
+		UpdatedAt:           time.Unix(200, 0).UTC(),
 	}
 	if err := opened.SaveRun(context.Background(), run); err != nil {
 		t.Fatalf("SaveRun() error = %v", err)
@@ -789,10 +947,10 @@ func TestStorePersistsTheActiveInvocationDelegation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CurrentRun() error = %v", err)
 	}
-	if got == nil || got.ActiveInvocationID != "inv-delegation" {
+	if got == nil || len(got.ActiveInvocationIDs) != 1 || got.ActiveInvocationIDs[0] != "inv-delegation" {
 		t.Fatalf("CurrentRun() = %#v, want the persisted active invocation identity", got)
 	}
-	run.ActiveInvocationID = ""
+	run.ActiveInvocationIDs = nil
 	run.UpdatedAt = time.Unix(300, 0).UTC()
 	if err := reopened.SaveRun(context.Background(), run); err != nil {
 		t.Fatalf("SaveRun() clearing error = %v", err)
@@ -801,7 +959,7 @@ func TestStorePersistsTheActiveInvocationDelegation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CurrentRun() after clearing error = %v", err)
 	}
-	if cleared == nil || cleared.ActiveInvocationID != "" {
+	if cleared == nil || len(cleared.ActiveInvocationIDs) != 0 {
 		t.Fatalf("CurrentRun() = %#v, want the delegation cleared", cleared)
 	}
 }


### PR DESCRIPTION
<!-- factory-generated:start -->
## Factory run

- run: `run-5b6c3a85-bacd-476e-8b5b-8e5adb0b9a95`
- issue: #118 — Remove the store.Run compatibility projections and consolidate its serializers
- specification packet: version 1, target branch `main`
- checkpoint: `e7934d8d93b45db0e2cb89b5781fadb368ee8b58`
- stage: `draft_pr`
- intervention: `none`
- test policy: `advisory (implementation-owned TDD)`
- route: `default (repository test policy)`

Closes #118

<!-- factory-generated:review:start -->

### Specification review

- status: not run

### Standards review

- status: not run
<!-- factory-generated:review:end -->

### Issue summary

## Related

Surfaced by #114 — Constrain dependency reach in the factory coordinator.

This issue is **not** a child of that epic. It touches `internal/store` only, shares no code with #115, #116, and #117, and the epic's no-behaviour-change and no-test-rewritten guarantees do not apply here. It can land in any order relative to those three.

Scope was reduced. The original issue combined three changes — domain grouping, compatibility removal, and serialization error handling. Grouping was separated out and deferred; see the last section for why and what would have to be decided first.

## 1. Delete the compatibility projections

Three fields duplicate a neighbour. Only one of the three needs a migration, and the difference matters.

| Projection | Backing | Removal |
| --- | --- | --- |
| `Run.ImplementationHandoff` (`internal/store/store.go:489`) | **The same column as `RoleHandoff`.** `type ImplementationHandoff = RoleHandoff` (`:326`) is a type alias, there is no `role_handoff` column, and `scanRun` decodes `implementation_handoff` once then assigns the same pointer to both fields (`:1008`–`:1012`) | **No migration.** Delete the field, delete `roleHandoffForRun` (`:1810`), and call `roleHandoffJSON(run.RoleHandoff)` directly |
| `Run.ActiveInvocationID` | Its own column `active_invocation_id`, separate from `active_invocation_ids` | **Migration required.** Fold the singular value into the first entry of `ActiveInvocationIDs`, then drop it along with `normalizeActiveInvocationProjection` (`:1350`) |
| `StatusResult.ActiveRun` (`internal/factory/factory.go:261`) | Not persisted. A Go field on a result type, already marked `// Deprecated: use LatestRun`, assigned from `LatestRun` at `factory.go:521` | **No migration.** Delete the field and its eight references in `factory_test.go` |

`CurrentSchemaVersion` is **32** (`internal/store/store.go:22`) and bumps to 33 for the `active_invocation_id` fold only. The migration follows the existing pattern in `migrate` (`internal/store/store.go:2903`).

Removing exported fields is a **source-compatibility break** for any embedder, even though persisted behaviour is unchanged. Say so in the commit message; do not describe this as behaviour-neutral without that qualifier.

`stopActiveRunWorkers` (`internal/factory/interruption.go:851`) reads `run.ActiveInvocationID`. #117 also edits that function; whichever lands second rewrites the read.

## 2. Collapse the thirteen serializers and propagate marshal errors

`pendingQuestionsJSON`, `testHandoffJSON`, `testRevisionHistoryJSON`, `testObjectionJSON`, `testRevisionBaseChangedPathsJSON`, `roleHandoffJSON`, `specificationReviewJSON`, `standardsReviewJSON`, `reviewRepairHistoryJSON`, `reviewRepairPacketJSON`, `activeInvocationIDsJSON`, `testExemptionJSON`, and `protectedTestPathsJSON` (`internal/store/store.go:1736`–`1893`) are the same two bodies repeated: a slice form falling back to `"[]"` and a nullable-pointer form falling back to `""`. Two generic functions replace all thirteen. This clears the project's three-occurrence threshold for extraction several times over.

While collapsing them, stop discarding the marshal error. All thirteen currently swallow it and return the empty value, so a marshal failure would persist as indistinguishable from an absent field. The generic form returns the error to `runValues` and its callers, which already have an error on every path.

**How to test this.** Every type currently serialized from `Run` is plain — no `any`, no `map`, no channel or function field — and `internal/store` defines no custom `MarshalJSON`. A `json.Marshal` failure on a real `Run` write is therefore **not naturally constructible**, and an acceptance criterion demanding one would push the implementer toward a test-only production hook. Test the generic helper directly with a value that cannot marshal, and test the propagation path from the helper through `runValues` to the caller's returned error. Do not add a seam to production code solely to fail a marshal.

## Non-goals

- Renaming any persisted column or changing the JSON shape of any serialized value.
- Changing the run revision, the compare-and-set protocol, or `ErrRevisionConflict` / `ErrRevisionNotAdvanced` semantics.
- Splitting `store.go` into more files. The file's 3,491 lines are a symptom of duplication; removing the duplication is the fix, and moving the remainder between files is not.
- Reducing the field set on any other grounds. Every field except the three named projections stays.
- Grouping `store.Run` fields. Deferred; see below.
- Touching `store/evaluation.go`.

## Acceptance criteria

- [ ] `Run.ImplementationHandoff`, `Run.ActiveInvocationID`, and `StatusResult.ActiveRun` are gone, along with `roleHandoffForRun` and `normalizeActiveInvocationProjection`.
- [ ] `CurrentSchemaVersion` is 33, and a migration test opens a database written at version 32 with `active_invocation_id` populated and asserts the value lands as the first entry of `ActiveInvocationIDs`.
- [ ] No migration is written for `implementation_handoff`; a test asserts a row written by the previous build still decodes into `RoleHandoff`.
- [ ] The thirteen `xxxJSON` helpers are replaced by two generic functions, and neither discards a marshal error.
- [ ] A test drives a marshal failure through the generic helper and asserts the error reaches the caller of `runValues`. No production seam exists solely to make this testable.
- [ ] The source-compatibility break from the removed exported fields is stated in the commit message.
- [ ] `store_test.go` passes without an assertion being weakened, and `go test ./...` passes.

## Deferred: grouping the `store.Run` field clusters

`store.Run` has 59 fields, and they do fall into seven named clusters — test stage, review, check repair, clarification, command watermark, last command, and pull request. The three budget-and-attempt triples (`TestRevision*`, `ReviewRepair*`, `CheckRepair*`) are the same bounded-attempt invariant written three times.

Grouping was removed from this issue because the two available shapes have opposite cost profiles and the choice has not been made:

| Shape | Cost | What it buys |
| --- | --- | --- |
| **Embedded** structs | ~126 composite-literal assignments across 9 files — `review_repair_internal_test.go` (63), `store_test.go` (34), `repair_test.go` (11), `concurrent_review_internal_test.go` (5), `command_test.go` (5), `claim.go` (4), and three more with 1–2 each. Reads are untouched: promotion keeps `run.TestHandoff` working, and `store.Run` carries no struct tags so no serialized shape changes | The declaration reads better. **Callers keep the same 59-field surface**, so it constrains no dependency reach and creates no deeper module |
| **Named, non-embedded** groups (`run.Test`, `run.Review`, `run.PullRequest`) | Every read site in the repository, far beyond the 126 literals | A real interface, with invariant ownership visible at each use |
| **Neither** | None | The duplication that motivated the issue is already removed by sections 1 and 2 |

The embedded form is the cheap option and buys close to nothing. The non-embedded form is the one worth having and is a much larger change. File it as its own issue with that trade-off decided, rather than landing the cosmetic version by default.

### Gates

- `format`: passed
- `vet`: passed
- `test`: passed
- `build`: passed

### Control commands

- `factory status`
- `factory draft-pr --run-id run-5b6c3a85-bacd-476e-8b5b-8e5adb0b9a95`

<!-- factory-generated:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved status, review, interruption, and delegation tracking by consistently using active invocation lists.
  - Serialization failures during data persistence are now surfaced instead of silently producing empty values.

- **Refactor**
  - Removed legacy single-invocation and compatibility handoff fields.
  - Status results now expose the latest run without the deprecated active-run field.
  - Role handoff data is used consistently across workflows.

- **Data Migration**
  - Existing single active invocation values are migrated into the active invocation list while preserving handoff information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->