### PR TITLE
fix: keep the review prompt bounded by pointing at the mounted diff

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -290,6 +290,16 @@ technical test exemption is provisional evidence for the standards reviewer,
 not an automatic waiver. Both reviewers inspect the same immutable
 base-to-checkpoint diff and must report that checkpoint SHA.
 
+The diff is captured with a bounded context width, because a review role has
+the checkpoint worktree mounted read-only and can open any file it needs. It is
+mounted with the invocation packet and named in the prompt rather than repeated
+in it: a launch prompt travels as one command argument, and Linux refuses an
+argument longer than 32 pages, so a prompt that grew with the reviewed change
+could not be executed at all. Every adapter now refuses an oversized prompt
+before launch with a typed error naming the size, and a diff beyond the
+reviewer's reading budget stops the run at capture with a named reason instead
+of producing a packet no reviewer can work through.
+
 The reviewer publishes a completed report with repeated finding flags:
 
 ```sh

--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -23,9 +23,9 @@ const (
 	// by every documented-standards review invocation.
 	StandardsReviewStatusContext = "factory/review/standards"
 	// maxReviewDiffBytes bounds the immutable diff copied into a review packet.
-	// The bound is the reviewer's reading budget: a diff past it describes a
-	// checkpoint too large to review in one round, and the run stops with a
-	// named reason rather than sending a reviewer into an unreadable packet.
+	// A diff past it describes a checkpoint too large for one review round, so
+	// the run stops at capture with a named reason rather than sending a
+	// reviewer into a packet it cannot work through.
 	maxReviewDiffBytes = 128 << 10
 	// reviewDiffContextLines is the context width of the captured diff. A review
 	// role has the checkpoint worktree mounted read-only, so it can open any

--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -23,7 +23,16 @@ const (
 	// by every documented-standards review invocation.
 	StandardsReviewStatusContext = "factory/review/standards"
 	// maxReviewDiffBytes bounds the immutable diff copied into a review packet.
-	maxReviewDiffBytes = 512 << 10
+	// The bound is the reviewer's reading budget: a diff past it describes a
+	// checkpoint too large to review in one round, and the run stops with a
+	// named reason rather than sending a reviewer into an unreadable packet.
+	maxReviewDiffBytes = 128 << 10
+	// reviewDiffContextLines is the context width of the captured diff. A review
+	// role has the checkpoint worktree mounted read-only, so it can open any
+	// file it needs; the diff only has to make each hunk judgeable in place.
+	// Wide context multiplies the packet size without adding anything the
+	// reviewer could not already read.
+	reviewDiffContextLines = 10
 )
 
 // roleHandoffFromReport converts the report protocol's completed handoff into
@@ -198,7 +207,7 @@ func (s *Service) captureReviewDiff(ctx context.Context, run store.Run, invocati
 	result, err := s.deps.Worker.RunCommand(ctx, worker.CommandRequest{
 		RunID:             run.ID,
 		WorkerID:          workerIDForInvocation(invocation),
-		Command:           fmt.Sprintf("git diff --no-ext-diff --binary --unified=80 %s %s -- .", base, run.CheckpointSHA),
+		Command:           fmt.Sprintf("git diff --no-ext-diff --binary --unified=%d %s %s -- .", reviewDiffContextLines, base, run.CheckpointSHA),
 		EnvironmentPolicy: worker.EnvironmentPolicyClean,
 		Role:              invocation.Role,
 	})

--- a/internal/factory/review_test.go
+++ b/internal/factory/review_test.go
@@ -39,6 +39,22 @@ func TestSpecificationReviewUsesAnImmutablePacketAndRoutesAdvisories(t *testing.
 	if len(fixture.worker.starts) != 1 || len(fixture.worker.commands) != 1 || !strings.Contains(fixture.worker.commands[0].Command, reviewCheckpoint) {
 		t.Fatalf("review worker effects = starts %#v commands %#v, want one exact-diff command", fixture.worker.starts, fixture.worker.commands)
 	}
+	// A review role reads the checkpoint worktree for wider context, so the
+	// captured diff carries only enough to judge each hunk in place. Wide
+	// context multiplied the packet size without adding anything readable.
+	if !strings.Contains(fixture.worker.commands[0].Command, "--unified=10") {
+		t.Fatalf("review diff command = %q, want the bounded context width", fixture.worker.commands[0].Command)
+	}
+	// The prompt names the diff's location instead of carrying a second copy.
+	// The launch prompt travels as one command argument, so a prompt that grows
+	// with the reviewed change cannot be executed at all.
+	reviewPrompt := fixture.harness.starts[len(fixture.harness.starts)-1].Prompt
+	if strings.Contains(reviewPrompt, "diff --git") {
+		t.Fatalf("review prompt repeats the mounted diff:\n%s", reviewPrompt)
+	}
+	if !strings.Contains(reviewPrompt, "review_context.current_diff") {
+		t.Fatalf("review prompt does not name the mounted diff:\n%s", reviewPrompt)
+	}
 	if !fixture.worker.starts[0].WorktreeReadOnly {
 		t.Fatal("review worker worktree is writable, want a read-only checkpoint mount")
 	}
@@ -96,6 +112,22 @@ func TestSpecificationReviewUsesAnImmutablePacketAndRoutesAdvisories(t *testing.
 // TestSpecificationReviewRefusesReadinessWithoutFinalCheckpointGates
 // verifies a blocker-free review cannot mark a pull request ready when the
 // final checkpoint gate projection is missing success.
+// TestSpecificationReviewRefusesAnUnreadableDiff verifies a checkpoint whose
+// diff exceeds the reviewer's reading budget stops the run with a named reason
+// instead of sending a reviewer into a packet it cannot work through.
+func TestSpecificationReviewRefusesAnUnreadableDiff(t *testing.T) {
+	fixture := newReviewFixture(t)
+	fixture.worker.results = []worker.CommandResult{{ExitCode: 0, Stdout: strings.Repeat("-\tremoved line\n", 20000)}}
+
+	_, err := fixture.service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err == nil || !strings.Contains(err.Error(), "packet limit") {
+		t.Fatalf("StartAgent() error = %v, want the diff bound named", err)
+	}
+	if len(fixture.harness.starts) != 0 {
+		t.Fatalf("harness starts = %#v, want no reviewer launched for an unreadable diff", fixture.harness.starts)
+	}
+}
+
 func TestSpecificationReviewRefusesReadinessWithoutFinalCheckpointGates(t *testing.T) {
 	fixture := newReviewFixture(t)
 	run := fixture.runStore.current

--- a/internal/factory/review_test.go
+++ b/internal/factory/review_test.go
@@ -39,15 +39,13 @@ func TestSpecificationReviewUsesAnImmutablePacketAndRoutesAdvisories(t *testing.
 	if len(fixture.worker.starts) != 1 || len(fixture.worker.commands) != 1 || !strings.Contains(fixture.worker.commands[0].Command, reviewCheckpoint) {
 		t.Fatalf("review worker effects = starts %#v commands %#v, want one exact-diff command", fixture.worker.starts, fixture.worker.commands)
 	}
-	// A review role reads the checkpoint worktree for wider context, so the
-	// captured diff carries only enough to judge each hunk in place. Wide
-	// context multiplied the packet size without adding anything readable.
+	// The captured diff carries only enough to judge each hunk in place, for
+	// the reason recorded on reviewDiffContextLines.
 	if !strings.Contains(fixture.worker.commands[0].Command, "--unified=10") {
 		t.Fatalf("review diff command = %q, want the bounded context width", fixture.worker.commands[0].Command)
 	}
-	// The prompt names the diff's location instead of carrying a second copy.
-	// The launch prompt travels as one command argument, so a prompt that grows
-	// with the reviewed change cannot be executed at all.
+	// The prompt names the diff's location instead of carrying a second copy,
+	// so its size does not follow the reviewed change.
 	reviewPrompt := fixture.harness.starts[len(fixture.harness.starts)-1].Prompt
 	if strings.Contains(reviewPrompt, "diff --git") {
 		t.Fatalf("review prompt repeats the mounted diff:\n%s", reviewPrompt)

--- a/internal/harness/failure.go
+++ b/internal/harness/failure.go
@@ -146,6 +146,28 @@ func IsAuthenticationExpired(err error) bool {
 	return errors.Is(err, ErrAuthenticationExpired)
 }
 
+// PromptTooLargeError reports a prompt the harness cannot receive. It is a
+// bounded configuration or packet problem, never a transient one: the same
+// prompt fails the same way on every retry, so it reaches an operator rather
+// than a retry budget.
+type PromptTooLargeError struct {
+	// Harness identifies the adapter that refused the launch.
+	Harness string
+	// Bytes is the assembled prompt length.
+	Bytes int
+	// Limit is the largest prompt an adapter passes to its harness.
+	Limit int
+}
+
+// Error names the observed and permitted sizes so an operator can see which
+// packet content has to shrink.
+func (e *PromptTooLargeError) Error() string {
+	if e == nil {
+		return "harness prompt is too large"
+	}
+	return fmt.Sprintf("%s prompt is %d bytes and exceeds the %d-byte launch limit", safeHarnessName(e.Harness), e.Bytes, e.Limit)
+}
+
 // safeHarnessName keeps adapter labels bounded and free of control characters.
 func safeHarnessName(name string) string {
 	name = strings.TrimSpace(name)

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -20,6 +20,14 @@ const (
 	NameCodex = "codex"
 	// NameClaude identifies the Claude Code adapter.
 	NameClaude = "claude"
+	// maxPromptBytes bounds one launch prompt. Every adapter passes the prompt
+	// as a single command argument, and Linux refuses an argument longer than
+	// 32 pages (MAX_ARG_STRLEN, 128 KiB) with E2BIG. That refusal reaches the
+	// coordinator as an opaque "argument list too long" exec failure and an
+	// expired native-session deadline, so the launch is refused here instead,
+	// where the cause can be named. The headroom below the kernel limit covers
+	// the argument list a wrapper adds around the prompt.
+	maxPromptBytes = 96 << 10
 )
 
 // StartRequest contains the coordinator-owned identity and prompt for one
@@ -279,31 +287,6 @@ func discoverNativeSession(ctx context.Context, provider worker.NativeSessionSna
 // validateStartRequest rejects incomplete identities before any terminal or
 // worker side effect occurs. The harness name only labels the refusal; every
 // adapter enforces the same neutral contract.
-// maxPromptBytes bounds one launch prompt. Every adapter passes the prompt as a
-// single command argument, and Linux refuses an argument longer than 32 pages
-// (MAX_ARG_STRLEN, 128 KiB) with E2BIG. That refusal reaches the coordinator as
-// an opaque "argument list too long" exec failure and an expired native-session
-// deadline, so the launch is refused here instead, where the cause can be named.
-const maxPromptBytes = 96 << 10
-
-// PromptTooLargeError reports a prompt the harness cannot receive. It is a
-// bounded configuration or packet problem, never a transient one: the same
-// prompt fails the same way on every retry.
-type PromptTooLargeError struct {
-	// Harness identifies the adapter that refused the launch.
-	Harness string
-	// Bytes is the assembled prompt length.
-	Bytes int
-	// Limit is the largest prompt an adapter passes to its harness.
-	Limit int
-}
-
-// Error names the observed and permitted sizes so an operator can see which
-// packet content has to shrink.
-func (e *PromptTooLargeError) Error() string {
-	return fmt.Sprintf("%s prompt is %d bytes and exceeds the %d-byte launch limit", e.Harness, e.Bytes, e.Limit)
-}
-
 func validateStartRequest(harnessName string, request StartRequest) error {
 	for field, value := range map[string]string{
 		"invocation id": request.InvocationID,

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -279,6 +279,31 @@ func discoverNativeSession(ctx context.Context, provider worker.NativeSessionSna
 // validateStartRequest rejects incomplete identities before any terminal or
 // worker side effect occurs. The harness name only labels the refusal; every
 // adapter enforces the same neutral contract.
+// maxPromptBytes bounds one launch prompt. Every adapter passes the prompt as a
+// single command argument, and Linux refuses an argument longer than 32 pages
+// (MAX_ARG_STRLEN, 128 KiB) with E2BIG. That refusal reaches the coordinator as
+// an opaque "argument list too long" exec failure and an expired native-session
+// deadline, so the launch is refused here instead, where the cause can be named.
+const maxPromptBytes = 96 << 10
+
+// PromptTooLargeError reports a prompt the harness cannot receive. It is a
+// bounded configuration or packet problem, never a transient one: the same
+// prompt fails the same way on every retry.
+type PromptTooLargeError struct {
+	// Harness identifies the adapter that refused the launch.
+	Harness string
+	// Bytes is the assembled prompt length.
+	Bytes int
+	// Limit is the largest prompt an adapter passes to its harness.
+	Limit int
+}
+
+// Error names the observed and permitted sizes so an operator can see which
+// packet content has to shrink.
+func (e *PromptTooLargeError) Error() string {
+	return fmt.Sprintf("%s prompt is %d bytes and exceeds the %d-byte launch limit", e.Harness, e.Bytes, e.Limit)
+}
+
 func validateStartRequest(harnessName string, request StartRequest) error {
 	for field, value := range map[string]string{
 		"invocation id": request.InvocationID,
@@ -293,6 +318,9 @@ func validateStartRequest(harnessName string, request StartRequest) error {
 		if strings.ContainsAny(value, "\x00\r\n") && field != "prompt" {
 			return fmt.Errorf("%s %s must be a single line", harnessName, field)
 		}
+	}
+	if size := len(request.Prompt); size > maxPromptBytes {
+		return &PromptTooLargeError{Harness: harnessName, Bytes: size, Limit: maxPromptBytes}
 	}
 	if request.WorkspaceID == "" {
 		return fmt.Errorf("%s workspace id is required", harnessName)

--- a/internal/harness/prompt_limit_test.go
+++ b/internal/harness/prompt_limit_test.go
@@ -1,0 +1,86 @@
+package harness_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/harness"
+	"github.com/Stevie1704/sw-factory/internal/terminal"
+)
+
+// TestLaunchRefusesAPromptLargerThanOneCommandArgument verifies both adapters
+// refuse a prompt the kernel would reject at exec. Linux caps one argument at
+// 32 pages, and the resulting E2BIG reaches the coordinator only as an opaque
+// exec failure followed by an expired native-session deadline.
+func TestLaunchRefusesAPromptLargerThanOneCommandArgument(t *testing.T) {
+	oversized := strings.Repeat("x", 200<<10)
+	for _, name := range []string{"codex", "claude"} {
+		for _, resume := range []bool{false, true} {
+			mode := "start"
+			if resume {
+				mode = "resume"
+			}
+			t.Run(name+"/"+mode, func(t *testing.T) {
+				workerRuntime := &fakeWorker{}
+				terminalRuntime := &fakeTerminal{surface: terminal.Surface{ID: "surface-review", WorkspaceID: "workspace-run", Name: name}}
+				request := harness.StartRequest{
+					InvocationID: "inv-review",
+					RunID:        "run-review",
+					Role:         "spec_review",
+					Stage:        "review",
+					WorkspaceID:  "workspace-run",
+					Surface:      terminalRuntime.surface,
+					Prompt:       oversized,
+				}
+				var err error
+				switch {
+				case name == "codex" && resume:
+					request.ResumeSessionID = "session-1"
+					_, err = harness.NewCodex(workerRuntime, terminalRuntime).Resume(context.Background(), request)
+				case name == "codex":
+					_, err = harness.NewCodex(workerRuntime, terminalRuntime).Start(context.Background(), request)
+				case resume:
+					request.ResumeSessionID = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+					_, err = harness.NewClaude(workerRuntime, terminalRuntime).Resume(context.Background(), request)
+				default:
+					_, err = harness.NewClaude(workerRuntime, terminalRuntime).Start(context.Background(), request)
+				}
+				var tooLarge *harness.PromptTooLargeError
+				if !errors.As(err, &tooLarge) {
+					t.Fatalf("launch error = %v, want a typed prompt-size refusal", err)
+				}
+				if tooLarge.Bytes != len(oversized) || tooLarge.Limit >= tooLarge.Bytes {
+					t.Fatalf("refusal = %#v, want the observed size above the named limit", tooLarge)
+				}
+				if !strings.Contains(tooLarge.Error(), "launch limit") {
+					t.Fatalf("refusal message = %q, want the limit named", tooLarge.Error())
+				}
+				// The refusal happens before any worker command, so no surface
+				// or session is left behind for a human to clean up.
+				if len(workerRuntime.requests) != 0 {
+					t.Fatalf("worker requests = %#v, want the launch refused before execution", workerRuntime.requests)
+				}
+			})
+		}
+	}
+}
+
+// TestLaunchAcceptsAPromptWithinTheArgumentLimit verifies the guard bounds only
+// the prompts a harness genuinely cannot receive.
+func TestLaunchAcceptsAPromptWithinTheArgumentLimit(t *testing.T) {
+	workerRuntime := &fakeWorker{}
+	terminalRuntime := &fakeTerminal{surface: terminal.Surface{ID: "surface-implementation", WorkspaceID: "workspace-run", Name: "implementation"}}
+	if _, err := harness.NewCodex(workerRuntime, terminalRuntime).Start(context.Background(), harness.StartRequest{
+		InvocationID: "inv-1",
+		RunID:        "run-1",
+		Role:         "implementation",
+		Stage:        "implementation",
+		WorkspaceID:  "workspace-run",
+		Surface:      terminalRuntime.surface,
+		Prompt:       strings.Repeat("y", 64<<10),
+	}); err != nil {
+		t.Fatalf("Start() error = %v, want a prompt of ordinary size accepted", err)
+	}
+}

--- a/internal/harness/prompt_limit_test.go
+++ b/internal/harness/prompt_limit_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 // TestLaunchRefusesAPromptLargerThanOneCommandArgument verifies both adapters
-// refuse a prompt the kernel would reject at exec. Linux caps one argument at
-// 32 pages, and the resulting E2BIG reaches the coordinator only as an opaque
-// exec failure followed by an expired native-session deadline.
+// refuse a prompt the kernel would reject at exec, for the reason recorded on
+// maxPromptBytes.
 func TestLaunchRefusesAPromptLargerThanOneCommandArgument(t *testing.T) {
 	oversized := strings.Repeat("x", 200<<10)
 	for _, name := range []string{"codex", "claude"} {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -229,7 +229,9 @@ type ReviewContext struct {
 	// CheckpointSHA identifies the exact commit under review.
 	CheckpointSHA string `json:"checkpoint_sha"`
 	// CurrentDiff is the coordinator-captured diff from the base to checkpoint.
-	CurrentDiff string `json:"current_diff"`
+	// It is omitted when empty so a prompt can carry the rest of the context
+	// while pointing at the mounted packet for the diff itself.
+	CurrentDiff string `json:"current_diff,omitempty"`
 	// TestHandoff is retained for compatibility with older packet readers and is
 	// omitted from new isolated review packets.
 	TestHandoff *store.TestHandoff `json:"test_handoff,omitempty"`
@@ -364,11 +366,21 @@ Review-repair packet (coordinator-owned):
 		dynamicContext = fmt.Sprintf("\nProtected test-stage handoff (coordinator-owned):\n%s\n", data)
 	}
 	if definition.Kind == workflow.RoleKindReview && request.ReviewContext != nil {
-		data, err := marshalHandoff(request.ReviewContext)
+		// The diff grows with the reviewed change and is the one unbounded part
+		// of the context. It is already mounted with the packet, so the prompt
+		// carries the bounded observations and names where the diff is.
+		withoutDiff := *request.ReviewContext
+		withoutDiff.CurrentDiff = ""
+		data, err := marshalHandoff(withoutDiff)
 		if err != nil {
 			return "", fmt.Errorf("encode review context: %w", err)
 		}
-		dynamicContext = fmt.Sprintf("\nRead-only review context (coordinator-owned):\n%s\n", data)
+		dynamicContext = fmt.Sprintf(`
+Read-only review context (coordinator-owned):
+%s
+The exact diff for this checkpoint is %d bytes. Read it in the mounted packet at
+%s under review_context.current_diff; it is not repeated here.
+`, data, len(request.ReviewContext.CurrentDiff), WorkerSpecificationPath)
 	}
 	if request.Continuation {
 		return joinPromptSections(

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -375,12 +375,15 @@ Review-repair packet (coordinator-owned):
 		if err != nil {
 			return "", fmt.Errorf("encode review context: %w", err)
 		}
+		location := "This checkpoint changed nothing against its base, so the context carries no diff."
+		if size := len(request.ReviewContext.CurrentDiff); size > 0 {
+			location = fmt.Sprintf("The exact diff for this checkpoint is %d bytes. Read it in the mounted packet at\n%s under review_context.current_diff; it is not repeated here.", size, WorkerSpecificationPath)
+		}
 		dynamicContext = fmt.Sprintf(`
 Read-only review context (coordinator-owned):
 %s
-The exact diff for this checkpoint is %d bytes. Read it in the mounted packet at
-%s under review_context.current_diff; it is not repeated here.
-`, data, len(request.ReviewContext.CurrentDiff), WorkerSpecificationPath)
+%s
+`, data, location)
 	}
 	if request.Continuation {
 		return joinPromptSections(

--- a/internal/prompt/review_context_test.go
+++ b/internal/prompt/review_context_test.go
@@ -1,0 +1,74 @@
+package prompt_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/prompt"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// reviewRequestWithDiff builds a specification-review prompt request whose diff
+// is larger than every other part of the prompt combined.
+func reviewRequestWithDiff(diff string) prompt.Request {
+	return prompt.Request{
+		InvocationID:        "inv-review",
+		RunID:               "run-review",
+		Role:                "spec_review",
+		Stage:               "review",
+		SpecificationPacket: "## Issue 118: Remove the compatibility projections",
+		RepositoryGuidance:  "### AGENTS.md\nUse the repository guidance.",
+		ReviewContext: &prompt.ReviewContext{
+			CheckpointSHA: "e7934d8d93b45db0e2cb89b5781fadb368ee8b58",
+			CurrentDiff:   diff,
+			RelevantLogs:  []prompt.ReviewLog{{Source: "gate:test", Detail: "passed at the exact checkpoint"}},
+			PriorFindings: []store.ReviewFinding{{Location: "internal/store/store.go:1810", Claim: "the projection is still read"}},
+		},
+	}
+}
+
+// TestBuildReviewPromptPointsAtTheMountedDiff verifies the prompt keeps the
+// bounded review observations and names where the exact diff is, rather than
+// carrying a second copy of content already mounted with the packet.
+func TestBuildReviewPromptPointsAtTheMountedDiff(t *testing.T) {
+	diff := "diff --git a/internal/store/store.go b/internal/store/store.go\n" + strings.Repeat("-\tremoved line\n", 8000)
+	value, err := prompt.Build(reviewRequestWithDiff(diff))
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if strings.Contains(value, "removed line") {
+		t.Fatalf("review prompt repeats the mounted diff:\n%s", value[:2000])
+	}
+	for _, present := range []string{
+		"e7934d8d93b45db0e2cb89b5781fadb368ee8b58",
+		"passed at the exact checkpoint",
+		"the projection is still read",
+		fmt.Sprintf("is %d bytes", len(diff)),
+		prompt.WorkerSpecificationPath,
+		"review_context.current_diff",
+	} {
+		if !strings.Contains(value, present) {
+			t.Fatalf("review prompt missing %q:\n%s", present, value)
+		}
+	}
+}
+
+// TestBuildReviewPromptSizeDoesNotFollowTheDiff verifies a reviewed change can
+// grow without the prompt growing with it, which is what made a large
+// checkpoint impossible to launch.
+func TestBuildReviewPromptSizeDoesNotFollowTheDiff(t *testing.T) {
+	small, err := prompt.Build(reviewRequestWithDiff("diff --git a/a b/a\n-one line\n"))
+	if err != nil {
+		t.Fatalf("Build() small diff error = %v", err)
+	}
+	large, err := prompt.Build(reviewRequestWithDiff(strings.Repeat("-\tremoved line\n", 40000)))
+	if err != nil {
+		t.Fatalf("Build() large diff error = %v", err)
+	}
+	// Only the rendered byte count differs, so the growth is bounded by the
+	// width of a decimal number rather than by the diff.
+	if growth := len(large) - len(small); growth > 32 {
+		t.Fatalf("prompt grew %d bytes with the diff, want a bounded reference", growth)
+	}
+}


### PR DESCRIPTION
## Why

Run `run-5b6c3a85` stopped at `draft_pr / waiting_for_human` on issue #118. The launch diagnostic held the whole story:

```
exec /usr/local/bin/codex: argument list too long
cause: discover Codex native session: native harness session was not discovered
       before the deadline: context deadline exceeded
```

The specification reviewer could not be launched. The review prompt embeds the review context, whose `current_diff` was **258,084 bytes**, making the assembled prompt roughly 300 KB. Every adapter passes the prompt as a **single command argument**, and Linux caps one argument at `MAX_ARG_STRLEN` = 32 pages = **131,072 bytes** regardless of total `ARG_MAX`. `exec` failed with E2BIG, Codex never started, no native session appeared, and the discovery deadline expired.

Nothing caught it earlier: `maxReviewDiffBytes` was `512 << 10`, four times the size at which the launch becomes physically impossible.

The diff was that large because of context width, not change size. PR #126 is 303 additions / 304 deletions across 18 files, captured with `git diff --unified=80`:

| Context | Diff bytes |
|---|---|
| `--unified=80` (before) | 258,084 |
| `--unified=20` | 111,926 |
| `--unified=10` (now) | 79,235 |
| `--unified=3` | 47,322 |

## What changed

1. **The prompt names the diff instead of carrying it.** The diff is already mounted at `/invocation/specification.json`, and both review role bodies already instruct the reviewer to read `review_context` there. The prompt now carries the bounded observations — checkpoint SHA, relevant logs, prior findings — and a line giving the diff's size and location. Prompt size no longer follows the reviewed change.
2. **A typed pre-launch guard.** `harness.PromptTooLargeError` refuses a prompt above `maxPromptBytes` (96 KiB) in `validateStartRequest`, before any worker command runs, so the failure names the observed and permitted sizes instead of surfacing as an opaque exec error plus an expired deadline.
3. **A context width a reviewer actually needs.** `--unified=10`. A review role has the checkpoint worktree mounted read-only and can open any file, so 80 lines of context multiplied the packet without adding anything it could not already read.
4. **`maxReviewDiffBytes` is now the reading budget**, `128 << 10` rather than `512 << 10`. A diff beyond it stops the run at capture with a named reason rather than producing a packet no reviewer can work through.

## Effect on the run that failed

Rebuilding that exact invocation's prompt against this branch, with the same 258 KB diff still in the packet:

```
captured_diff=258084  prompt_now=33763  limit=98304
```

300 KB → **33,763 bytes**, comfortably under both the guard and the kernel limit. Re-captured at `--unified=10` the diff itself is 79 KB, inside the new packet bound.

## Test plan

- `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` — **1010 pass**, `go build ./cmd/factory` ok.
- New: the review prompt omits the mounted diff while keeping checkpoint SHA, logs and prior findings, and names size plus location; prompt size grows by at most a decimal number when the diff grows 40,000 lines; both adapters refuse an oversized prompt on start and on resume with the typed error and leave no worker command behind; a prompt of ordinary size is still accepted; the capture command carries the bounded context width; an oversized diff refuses the launch with the bound named and starts no reviewer.

## Note on the stuck run

No repair budget was consumed (`check-repair attempts: 0/3`), and PR #126 is open with the implementation complete. After `make build`, `factory resume --run-id run-5b6c3a85-bacd-476e-8b5b-8e5adb0b9a95` re-runs the review round with a clean budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hUhvPz31TKiZhe1E5JvJ2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review diffs now use bounded context to prevent oversized review packets.
  * Oversized diffs and prompts are rejected before reviewer execution with clear size-limit errors.
  * Review prompts reference mounted diff content instead of embedding large diffs, keeping prompt sizes bounded.
  * Review checkpoints clearly indicate when no diff is available.

* **Tests**
  * Added coverage for size limits, boundary conditions, launch prevention, and bounded prompt growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->