### PR TITLE
A failed harness launch leaves invocation history that blocks a clean retry

### DIFF
--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -361,7 +361,10 @@ worker and surface, before unattended progression publishes its waiting state,
 and persists the void decision on the invocation. Restart reconciliation treats
 only that marked superseded launch as history with no live projection.
 A native session identity or report file protects the invocation history from
-being discarded. If the run is `waiting_for_human` with no active invocation,
+being discarded, and so does any indeterminate observation: when the durable
+effect journal or the report path cannot be read, the coordinator keeps the
+invocation `cannot_proceed`, names the discrepancy in its error, and does not
+void the launch. If the run is `waiting_for_human` with no active invocation,
 the lifecycle reason names this void rule and `/factory retry`; that command
 supersedes only the latest invocation satisfying the same rule and reopens the
 existing role boundary with the existing specification packet. It does not

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -354,6 +354,17 @@ invocation receives that packet. A `/factory refresh` command similarly
 re-reads the issue, versions the packet, and invalidates downstream results
 before resuming the role.
 
+A persisted invocation is void when its launch fails before it produces a native
+session identity and its result directory contains no regular `report.json`.
+The coordinator marks that invocation `superseded` while rolling back the
+worker and surface, before unattended progression publishes its waiting state.
+A native session identity or report file protects the invocation history from
+being discarded. If the run is `waiting_for_human` with no active invocation,
+the lifecycle reason names this void rule and `/factory retry`; that command
+supersedes only the latest invocation satisfying the same rule and reopens the
+existing role boundary with the existing specification packet. It does not
+create a new packet version or retry automatically.
+
 ## Authentication and session state
 
 Registration may name one explicit host credential file per harness:

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -357,7 +357,9 @@ before resuming the role.
 A persisted invocation is void when its launch fails before it produces a native
 session identity and its result directory contains no regular `report.json`.
 The coordinator marks that invocation `superseded` while rolling back the
-worker and surface, before unattended progression publishes its waiting state.
+worker and surface, before unattended progression publishes its waiting state,
+and persists the void decision on the invocation. Restart reconciliation treats
+only that marked superseded launch as history with no live projection.
 A native session identity or report file protects the invocation history from
 being discarded. If the run is `waiting_for_human` with no active invocation,
 the lifecycle reason names this void rule and `/factory retry`; that command

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -366,22 +366,32 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		if returnErr == nil || !invocationPersisted || preserveInvocation {
 			return
 		}
+		pendingIndeterminate := false
 		if journal, journaled := runStore.(PendingEffectStore); journaled {
 			pending, pendingErr := journal.PendingEffect(context.WithoutCancel(ctx), run.ID)
-			if pendingErr == nil && pending != nil {
+			switch {
+			case pendingErr != nil:
+				// The durable effect state is unknown, so the void rule must not
+				// discard an invocation whose reserved effect a later
+				// reconciliation may still own.
+				pendingIndeterminate = true
+				returnErr = fmt.Errorf("%w; durable pending-effect lookup was indeterminate; invocation kept protected: %v", returnErr, pendingErr)
+			case pending != nil:
 				// Leave the active invocation and its reserved effect intact. A
 				// restart must replay the exact worker boundary before deciding
 				// whether the native session can be resumed or needs human review.
 				return
 			}
 		}
-		var evidenceErr error
-		voidedLaunch, evidenceErr = failedLaunchHasNoEvidence(invocation)
-		if evidenceErr != nil {
-			returnErr = fmt.Errorf("%w; failed launch report presence was indeterminate; invocation kept protected: %v", returnErr, evidenceErr)
-		}
-		if voidedLaunch && !strings.Contains(returnErr.Error(), failedLaunchVoidMarker) {
-			returnErr = fmt.Errorf("%w; %s", returnErr, failedLaunchRetryGuidance(invocation))
+		if !pendingIndeterminate {
+			var evidenceErr error
+			voidedLaunch, evidenceErr = failedLaunchHasNoEvidence(invocation)
+			if evidenceErr != nil {
+				returnErr = fmt.Errorf("%w; failed launch report presence was indeterminate; invocation kept protected: %v", returnErr, evidenceErr)
+			}
+			if voidedLaunch && !strings.Contains(returnErr.Error(), failedLaunchVoidMarker) {
+				returnErr = fmt.Errorf("%w; %s", returnErr, failedLaunchRetryGuidance(invocation))
+			}
 		}
 		rollbackContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -617,6 +617,10 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	return AgentLaunchResult{Invocation: invocation, Prompt: promptText, TestPolicyMode: packet.RepositoryConfig.TestPolicy.Mode, Route: packet.Route}, nil
 }
 
+// failedLaunchVoidMarker names the launch failure the coordinator may void:
+// one that left neither a native session nor a structured report. It is the
+// single wording every seam matches, so a wrapped error is never annotated
+// with the same rule twice.
 const failedLaunchVoidMarker = "harness launch produced no native session or structured report"
 
 // failedLaunchHasNoEvidence reports whether a persisted launch has no native

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -360,6 +360,7 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	invocationPersisted := false
 	workerStarted := false
 	preserveInvocation := false
+	voidedLaunch := false
 	cleanupSurface := terminal.Surface{}
 	defer func() {
 		if returnErr == nil || !invocationPersisted || preserveInvocation {
@@ -374,9 +375,17 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 				return
 			}
 		}
+		voidedLaunch = failedLaunchHasNoEvidence(invocation)
+		if voidedLaunch && !strings.Contains(returnErr.Error(), failedLaunchVoidMarker) {
+			returnErr = fmt.Errorf("%w; %s", returnErr, failedLaunchRetryGuidance(invocation))
+		}
 		rollbackContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
-		invocation.Status = store.InvocationStatusCannotProceed
+		if voidedLaunch {
+			invocation.Status = store.InvocationStatusSuperseded
+		} else {
+			invocation.Status = store.InvocationStatusCannotProceed
+		}
 		invocation.UpdatedAt = s.deps.Now().UTC()
 		_ = invocationStore.SaveInvocation(rollbackContext, invocation)
 		if workerStarted {
@@ -500,6 +509,9 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 		session, err = harnessRuntime.Start(ctx, startRequest)
 	}
 	if err != nil {
+		if strings.TrimSpace(session.NativeSessionID) != "" {
+			invocation.NativeSessionID = session.NativeSessionID
+		}
 		classified := harness.ClassifyError(err, string(policy.Harness))
 		// A launch failure is otherwise unrecoverable after the fact: the
 		// surface is closed and the worker stopped, so whatever the harness
@@ -588,6 +600,20 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 	}
 	s.markInvocationStarted(invocation.ID)
 	return AgentLaunchResult{Invocation: invocation, Prompt: promptText, TestPolicyMode: packet.RepositoryConfig.TestPolicy.Mode, Route: packet.Route}, nil
+}
+
+const failedLaunchVoidMarker = "harness launch produced no native session or structured report"
+
+// failedLaunchHasNoEvidence reports whether a persisted launch has no native
+// session or structured report that a later recovery must protect.
+func failedLaunchHasNoEvidence(invocation store.Invocation) bool {
+	return strings.TrimSpace(invocation.NativeSessionID) == "" && !agentResultReady(invocation)
+}
+
+// failedLaunchRetryGuidance identifies a launch that left no evidence to
+// protect and tells the operator which command reopens its role boundary.
+func failedLaunchRetryGuidance(invocation store.Invocation) string {
+	return fmt.Sprintf("%s for %s/%s; use `/factory retry` to start a fresh invocation", failedLaunchVoidMarker, invocation.Role, invocation.Stage)
 }
 
 // resumePersistedInvocation restores one active invocation after a coordinator

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -375,13 +375,18 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 				return
 			}
 		}
-		voidedLaunch = failedLaunchHasNoEvidence(invocation)
+		var evidenceErr error
+		voidedLaunch, evidenceErr = failedLaunchHasNoEvidence(invocation)
+		if evidenceErr != nil {
+			returnErr = fmt.Errorf("%w; failed launch report presence was indeterminate; invocation kept protected: %v", returnErr, evidenceErr)
+		}
 		if voidedLaunch && !strings.Contains(returnErr.Error(), failedLaunchVoidMarker) {
 			returnErr = fmt.Errorf("%w; %s", returnErr, failedLaunchRetryGuidance(invocation))
 		}
 		rollbackContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if voidedLaunch {
+			invocation.LaunchVoided = true
 			invocation.Status = store.InvocationStatusSuperseded
 		} else {
 			invocation.Status = store.InvocationStatusCannotProceed
@@ -605,9 +610,18 @@ func (s *Service) startAgentWithStore(ctx context.Context, registration config.R
 const failedLaunchVoidMarker = "harness launch produced no native session or structured report"
 
 // failedLaunchHasNoEvidence reports whether a persisted launch has no native
-// session or structured report that a later recovery must protect.
-func failedLaunchHasNoEvidence(invocation store.Invocation) bool {
-	return strings.TrimSpace(invocation.NativeSessionID) == "" && !agentResultReady(invocation)
+// session or structured report that a later recovery must protect. An
+// indeterminate report inspection fails closed so unreadable evidence remains
+// protected.
+func failedLaunchHasNoEvidence(invocation store.Invocation) (bool, error) {
+	if strings.TrimSpace(invocation.NativeSessionID) != "" {
+		return false, nil
+	}
+	presence, err := structuredReportPresenceForInvocation(invocation)
+	if err != nil {
+		return false, err
+	}
+	return presence == structuredReportAbsent, nil
 }
 
 // failedLaunchRetryGuidance identifies a launch that left no evidence to

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -437,20 +437,132 @@ func TestStartAgentAppliesTheExceptionOnlyToAClaimStage(t *testing.T) {
 	}
 }
 
-// TestStartAgentRollsBackASetupFailure verifies a partially launched session
-// cannot remain active after the harness fails to start.
-func TestStartAgentRollsBackASetupFailure(t *testing.T) {
+// TestStartAgentVoidsASetupFailure verifies a launch without a native session
+// or structured report is superseded while its worker and surface are rolled
+// back.
+func TestStartAgentVoidsASetupFailure(t *testing.T) {
 	service, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
 	harnessRuntime.startErr = errors.New("harness unavailable")
 	if _, err := service.StartAgent(context.Background(), factory.AgentRequest{}); err == nil {
 		t.Fatal("StartAgent() succeeded while the harness was unavailable")
+	} else if !strings.Contains(err.Error(), "use `/factory retry`") {
+		t.Fatalf("StartAgent() error = %v, want retry guidance", err)
 	}
 	invocation, ok := runStore.invocations["inv-generated"]
-	if !ok || invocation.Status != store.InvocationStatusCannotProceed {
-		t.Fatalf("rolled-back invocation = %#v, want cannot_proceed", invocation)
+	if !ok || invocation.Status != store.InvocationStatusSuperseded {
+		t.Fatalf("rolled-back invocation = %#v, want superseded", invocation)
 	}
 	if runtime.stops != 1 || len(terminalRuntime.closed) != 1 || terminalRuntime.closed[0] != "surface-implementation" {
 		t.Fatalf("rollback side effects: stops=%d closed=%v", runtime.stops, terminalRuntime.closed)
+	}
+}
+
+// TestHandleCommandRetriesAWaitingRunAfterFailedLaunch verifies a launch that
+// never produced a session can be retried without changing the specification
+// packet or repeating the upstream stage.
+func TestHandleCommandRetriesAWaitingRunAfterFailedLaunch(t *testing.T) {
+	service, runStore, _, _, harnessRuntime := newAgentService(t)
+	harnessRuntime.startErr = errors.New("prompt exceeds launch limit")
+	if _, err := service.StartAgent(context.Background(), factory.AgentRequest{}); err == nil {
+		t.Fatal("StartAgent() succeeded while the harness launch was unavailable")
+	}
+
+	failed := runStore.invocations["inv-generated"]
+	if failed.Status != store.InvocationStatusSuperseded {
+		t.Fatalf("failed invocation = %#v, want superseded before retry", failed)
+	}
+	run := *runStore.current
+	run.Status = store.StatusWaitingForHuman
+	run.ActiveInvocationIDs = nil
+	run.LifecycleReason = "unattended progression stopped at start agent: harness launch produced no native session or structured report; use /factory retry"
+	packetBeforeRetry := run.SpecificationPacket
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("persist waiting launch failure: %v", err)
+	}
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: run.IssueNumber,
+		Comment:     github.Comment{ID: "retry-failed-launch", Author: "alice", Body: "/factory retry"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive {
+		t.Fatalf("retry result = %#v, want accepted active run", result)
+	}
+	if result.Run.SpecificationPacket != packetBeforeRetry {
+		t.Fatalf("specification packet changed during retry, want %q", packetBeforeRetry)
+	}
+	if got := runStore.invocations[failed.ID].Status; got != store.InvocationStatusSuperseded {
+		t.Fatalf("failed invocation status = %q, want superseded", got)
+	}
+
+	harnessRuntime.startErr = nil
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() after retry error = %v", err)
+	}
+	if launch.Invocation.ID == failed.ID || launch.Invocation.Role != failed.Role || launch.Invocation.Stage != failed.Stage {
+		t.Fatalf("recovered invocation = %#v, want a fresh %s/%s invocation", launch.Invocation, failed.Role, failed.Stage)
+	}
+}
+
+// TestHandleCommandDoesNotVoidAReportedLaunch verifies a waiting run cannot
+// use retry to discard a structured report merely because its invocation has
+// no native session identity.
+func TestHandleCommandDoesNotVoidAReportedLaunch(t *testing.T) {
+	service, runStore, _, _, _ := newAgentService(t)
+	run := *runStore.current
+	resultDirectory := filepath.Join(t.TempDir(), "results")
+	invocation := store.Invocation{
+		ID:              "inv-reported-launch",
+		RunID:           run.ID,
+		Harness:         "codex",
+		Role:            "implementation",
+		Stage:           store.StageImplementation,
+		ResultDirectory: resultDirectory,
+		Status:          store.InvocationStatusCannotProceed,
+		CreatedAt:       run.UpdatedAt,
+		UpdatedAt:       run.UpdatedAt.Add(time.Minute),
+	}
+	if err := runStore.SaveInvocation(context.Background(), invocation); err != nil {
+		t.Fatalf("SaveInvocation() error = %v", err)
+	}
+	reported := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  invocation.ID,
+		RunID:         invocation.RunID,
+		Harness:       invocation.Harness,
+		Role:          invocation.Role,
+		Stage:         string(invocation.Stage),
+		Outcome:       report.OutcomeCannotProceed,
+		Summary:       "launch evidence is available",
+		Evidence:      []report.Evidence{{Kind: "harness", Detail: "launch diagnostic"}},
+		ReportedAt:    time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(invocation.ResultDirectory, invocation.ID, reported); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() error = %v", err)
+	}
+	run.Status = store.StatusWaitingForHuman
+	run.ActiveInvocationIDs = nil
+	run.LifecycleReason = "unattended progression stopped at start agent"
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("persist waiting reported launch: %v", err)
+	}
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: run.IssueNumber,
+		Comment:     github.Comment{ID: "retry-reported-launch", Author: "alice", Body: "/factory retry"},
+	})
+	var rejection *factory.PolicyRejection
+	if !errors.As(err, &rejection) || rejection.Code != factory.PolicyRejectionRetryState {
+		t.Fatalf("HandleCommand() error = %v, want retry_state rejection", err)
+	}
+	if result.Outcome != factory.CommandRejected || result.Run.Status != store.StatusWaitingForHuman {
+		t.Fatalf("retry result = %#v, want rejected waiting run", result)
+	}
+	if got := runStore.invocations[invocation.ID].Status; got != store.InvocationStatusCannotProceed {
+		t.Fatalf("reported invocation status = %q, want unchanged cannot_proceed", got)
 	}
 }
 

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -481,6 +481,35 @@ func TestStartAgentPreservesAnIndeterminateReportPath(t *testing.T) {
 	}
 }
 
+// TestStartAgentPreservesAnIndeterminatePendingEffect verifies a launch is kept
+// protected when the durable journal cannot prove the run reserved no effect.
+func TestStartAgentPreservesAnIndeterminatePendingEffect(t *testing.T) {
+	_, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	run := *runStore.current
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{Worktree: run.Worktree}},
+		state:        gitadapter.WorktreeState{RepositoryPath: run.RepositoryPath, Branch: run.Branch, HeadSHA: run.CheckpointSHA},
+	}
+	journal := &journaledAgentRunStore{agentRunStore: runStore, armPendingErr: errors.New("effect journal unavailable")}
+	fresh := newFreshAgentServiceWithStore(t, runStore, journal, worktree, runtime, terminalRuntime, harnessRuntime)
+	harnessRuntime.startErr = errors.New("prompt exceeds launch limit")
+
+	_, err := fresh.StartAgent(context.Background(), factory.AgentRequest{})
+	if err == nil {
+		t.Fatal("StartAgent() succeeded while the harness launch was unavailable")
+	}
+	if !strings.Contains(err.Error(), "invocation kept protected") {
+		t.Fatalf("StartAgent() error = %v, want the recorded pending-effect discrepancy", err)
+	}
+	if strings.Contains(err.Error(), "use `/factory retry`") {
+		t.Fatalf("StartAgent() exposed retry guidance for an indeterminate effect journal: %v", err)
+	}
+	invocation, ok := runStore.invocations["inv-generated"]
+	if !ok || invocation.Status != store.InvocationStatusCannotProceed || invocation.LaunchVoided {
+		t.Fatalf("indeterminate launch = %#v, want protected cannot_proceed invocation", invocation)
+	}
+}
+
 // TestHandleCommandRetriesAWaitingRunAfterFailedLaunch verifies a launch that
 // never produced a session can be retried without changing the specification
 // packet or repeating the upstream stage.
@@ -1097,6 +1126,14 @@ func newAgentService(t *testing.T) (*factory.Service, *agentRunStore, *agentWork
 // tests exercise the cross-process startup seam rather than cached service state.
 func newFreshAgentService(t *testing.T, runStore *agentRunStore, worktree *inspectingWorktree, runtime *agentWorker, terminalRuntime *agentTerminal, harnessRuntime *agentHarness) *factory.Service {
 	t.Helper()
+	return newFreshAgentServiceWithStore(t, runStore, runStore, worktree, runtime, terminalRuntime, harnessRuntime)
+}
+
+// newFreshAgentServiceWithStore rebuilds the same coordinator around an
+// explicit operational store, so a journal-capable wrapper can take part in
+// the launch seam while the fixture keeps its in-memory run view.
+func newFreshAgentServiceWithStore(t *testing.T, runStore *agentRunStore, operational factory.OperationalStore, worktree *inspectingWorktree, runtime *agentWorker, terminalRuntime *agentTerminal, harnessRuntime *agentHarness) *factory.Service {
+	t.Helper()
 	if runStore.current == nil {
 		t.Fatal("fresh coordinator fixture requires a persisted run")
 	}
@@ -1115,7 +1152,7 @@ func newFreshAgentService(t *testing.T, runStore *agentRunStore, worktree *inspe
 	}
 	return factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config:         &fakeConfig{value: host},
-		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return runStore, nil },
+		OpenStore:      func(context.Context, string) (factory.OperationalStore, error) { return operational, nil },
 		LoadRepository: func(string) (config.RepositoryConfig, error) { return validRepositoryConfig(), nil },
 		Worker:         runtime,
 		Terminal:       terminalRuntime,
@@ -1152,6 +1189,52 @@ func (w *inspectingWorktree) Inspect(context.Context, string) (gitadapter.Worktr
 // githubIssueFixture returns the frozen issue used by agent tests.
 func githubIssueFixture() github.Issue {
 	return github.Issue{Number: 6, Title: "Visible implementation", Body: "Repository guidance", State: "open"}
+}
+
+// journaledAgentRunStore adds the durable pending-effect journal to the agent
+// store fake, so the launch seam can be exercised on the journaled path with
+// an injectable lookup failure.
+type journaledAgentRunStore struct {
+	*agentRunStore
+	pending *store.PendingEffect
+	// pendingErr fails every journal lookup while it is set.
+	pendingErr error
+	// armPendingErr becomes pendingErr once one invocation is persisted, so a
+	// pre-launch recovery diagnosis still reads a healthy journal.
+	armPendingErr error
+}
+
+// SaveInvocation persists the invocation and arms the pending journal failure
+// the launch rollback must meet.
+func (s *journaledAgentRunStore) SaveInvocation(ctx context.Context, invocation store.Invocation) error {
+	if err := s.agentRunStore.SaveInvocation(ctx, invocation); err != nil {
+		return err
+	}
+	if s.armPendingErr != nil {
+		s.pendingErr, s.armPendingErr = s.armPendingErr, nil
+	}
+	return nil
+}
+
+// PendingEffect returns the reserved effect, or the injected failure that
+// leaves the coordinator unable to prove the run reserved nothing.
+func (s *journaledAgentRunStore) PendingEffect(context.Context, string) (*store.PendingEffect, error) {
+	if s.pendingErr != nil {
+		return nil, s.pendingErr
+	}
+	return s.pending, nil
+}
+
+// SavePendingEffect reserves one effect before its external mutation.
+func (s *journaledAgentRunStore) SavePendingEffect(_ context.Context, effect store.PendingEffect) error {
+	s.pending = &effect
+	return nil
+}
+
+// ClearPendingEffect releases the reserved effect after it completed.
+func (s *journaledAgentRunStore) ClearPendingEffect(context.Context, string, string) error {
+	s.pending = nil
+	return nil
 }
 
 // agentRunStore is an in-memory invocation-capable operational-store fake.

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -457,6 +457,30 @@ func TestStartAgentVoidsASetupFailure(t *testing.T) {
 	}
 }
 
+// TestStartAgentPreservesAnIndeterminateReportPath verifies a launch is kept
+// protected when the coordinator cannot determine whether report.json exists.
+func TestStartAgentPreservesAnIndeterminateReportPath(t *testing.T) {
+	service, runStore, runtime, _, harnessRuntime := newAgentService(t)
+	runtime.startHook = func(request worker.StartRequest) {
+		if err := os.Remove(request.ResultPath); err != nil {
+			t.Fatalf("remove result directory: %v", err)
+		}
+		if err := os.WriteFile(request.ResultPath, []byte("result path is not a directory"), 0o600); err != nil {
+			t.Fatalf("replace result directory with a file: %v", err)
+		}
+	}
+	harnessRuntime.startErr = errors.New("harness unavailable")
+	if _, err := service.StartAgent(context.Background(), factory.AgentRequest{}); err == nil {
+		t.Fatal("StartAgent() succeeded while the harness was unavailable")
+	} else if strings.Contains(err.Error(), "use `/factory retry`") {
+		t.Fatalf("StartAgent() exposed retry guidance for an indeterminate report path: %v", err)
+	}
+	invocation, ok := runStore.invocations["inv-generated"]
+	if !ok || invocation.Status != store.InvocationStatusCannotProceed || invocation.LaunchVoided {
+		t.Fatalf("indeterminate launch = %#v, want protected cannot_proceed invocation", invocation)
+	}
+}
+
 // TestHandleCommandRetriesAWaitingRunAfterFailedLaunch verifies a launch that
 // never produced a session can be retried without changing the specification
 // packet or repeating the upstream stage.
@@ -1319,6 +1343,7 @@ func (*agentRunStore) Close() error { return nil }
 // agentWorker records the worker start request without running Docker.
 type agentWorker struct {
 	starts        []worker.StartRequest
+	startHook     func(worker.StartRequest)
 	stops         int
 	commands      []worker.CommandRequest
 	results       []worker.CommandResult
@@ -1337,6 +1362,9 @@ func (w *agentWorker) Start(_ context.Context, request worker.StartRequest) erro
 		*w.events = append(*w.events, "start worker")
 	}
 	w.starts = append(w.starts, request)
+	if w.startHook != nil {
+		w.startHook(request)
+	}
 	return nil
 }
 

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -982,9 +982,29 @@ type commandRevisionStore interface {
 // handleRetryCommand reopens a failed run at its existing stage and applies
 // the normal label/comment transition without creating a new status comment.
 func (s *Service) handleRetryCommand(ctx context.Context, registration config.RepositoryRegistration, runStore RunStore, run store.Run, comment github.Comment, parsed commandlanguage.Request) (CommandResult, error) {
-	if run.Status != store.StatusFailed && run.Status != store.StatusCancelled {
+	var launch *store.Invocation
+	launchRetry := false
+	if run.Status == store.StatusWaitingForHuman {
+		var launchErr error
+		launch, launchRetry, launchErr = failedLaunchForRetry(ctx, runStore, run)
+		if launchErr != nil {
+			return CommandResult{}, launchErr
+		}
+	}
+	if run.Status != store.StatusFailed && run.Status != store.StatusCancelled && !launchRetry {
 		rejection := &PolicyRejection{Code: PolicyRejectionRetryState, Problem: fmt.Sprintf("retry is only allowed for a failed or cancelled run, not status %q", run.Status)}
 		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
+	}
+	if launchRetry {
+		launch.Status = store.InvocationStatusSuperseded
+		launch.UpdatedAt = s.deps.Now().UTC()
+		invocationStore, ok := runStore.(InvocationStore)
+		if !ok {
+			return CommandResult{}, errors.New("operational store does not support failed-launch retry")
+		}
+		if err := invocationStore.SaveInvocation(ctx, *launch); err != nil {
+			return CommandResult{}, fmt.Errorf("supersede failed launch before retry: %w", err)
+		}
 	}
 	if run.StatusCommentID == "" {
 		updated, err := s.recoverCommandStatusComment(ctx, registration, run)
@@ -1008,7 +1028,16 @@ func (s *Service) handleRetryCommand(ctx context.Context, registration config.Re
 			return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
 		}
 	}
-	next := commandProjection(run, comment, parsed, string(parsed.Kind), "command accepted; retrying run")
+	retryMessage := "command accepted; retrying run"
+	if launchRetry {
+		retryMessage = fmt.Sprintf("command accepted; retrying void %s/%s launch", launch.Role, launch.Stage)
+	}
+	next := commandProjection(run, comment, parsed, string(parsed.Kind), retryMessage)
+	if launchRetry {
+		// The active projection is authoritative for the retry precondition; a
+		// stale denormalized ID must not follow the fresh invocation.
+		next.ActiveInvocationIDs = nil
+	}
 	next.Status = store.StatusActive
 	next.MergeCommitSHA = ""
 	next.LifecycleReason = ""
@@ -1022,6 +1051,67 @@ func (s *Service) handleRetryCommand(ctx context.Context, registration config.Re
 		PersistBeforeEffects: true,
 	})
 	return CommandResult{Outcome: CommandAccepted, Command: parsed, Run: updated}, err
+}
+
+// failedLaunchForRetry returns the one invocation a bounded waiting-state
+// retry may void. A retry is admitted only when the run has no active
+// invocation and the latest invocation has neither a native session nor a
+// structured report, so accepted work and recoverable sessions remain guarded.
+func failedLaunchForRetry(ctx context.Context, runStore RunStore, run store.Run) (*store.Invocation, bool, error) {
+	if run.Status != store.StatusWaitingForHuman {
+		return nil, false, nil
+	}
+	active, supported, err := activeInvocationsForRun(ctx, runStore, run.ID)
+	if err != nil {
+		return nil, false, fmt.Errorf("look up active invocations for failed-launch retry: %w", err)
+	}
+	if !supported || len(active) != 0 {
+		return nil, false, nil
+	}
+	latestStore, ok := runStore.(LatestInvocationStore)
+	if !ok {
+		return nil, false, nil
+	}
+	latest, err := latestStore.LatestInvocation(ctx, run.ID)
+	if err != nil {
+		return nil, false, fmt.Errorf("look up failed launch for retry: %w", err)
+	}
+	if latest == nil || !isRetryableFailedLaunch(run, *latest) {
+		return nil, false, nil
+	}
+	if _, ok := runStore.(InvocationStore); !ok {
+		return nil, false, nil
+	}
+	return latest, true, nil
+}
+
+// isRetryableFailedLaunch applies the void rule at the command seam. The
+// invocation must be a failed launch for the run's current role boundary; a
+// report or native session is evidence that the history must remain protected.
+func isRetryableFailedLaunch(run store.Run, invocation store.Invocation) bool {
+	if invocation.RunID != run.ID || !failedLaunchHasNoEvidence(invocation) {
+		return false
+	}
+	if invocation.Status != store.InvocationStatusCannotProceed && invocation.Status != store.InvocationStatusSuperseded {
+		return false
+	}
+	if invocation.Status == store.InvocationStatusSuperseded && !supersededFailedLaunchReason(run.LifecycleReason) {
+		return false
+	}
+	definition, declared := workflow.DefaultRegistry().Role(invocation.Role)
+	if !declared || definition.Stage != invocation.Stage {
+		return false
+	}
+	if run.Stage == store.StageDraftPR {
+		return invocation.Stage == store.StageReview && definition.Kind == workflow.RoleKindReview
+	}
+	return invocation.Stage == definition.Stage && workflow.DefaultRegistry().CanStartFrom(invocation.Role, run.Stage)
+}
+
+// supersededFailedLaunchReason identifies a coordinator-voided launch in the
+// lifecycle projection without adding another persisted run status.
+func supersededFailedLaunchReason(reason string) bool {
+	return strings.Contains(reason, failedLaunchVoidMarker)
 }
 
 // handleHarnessConfiguration validates an authorized harness override against

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -997,6 +997,7 @@ func (s *Service) handleRetryCommand(ctx context.Context, registration config.Re
 	}
 	if launchRetry {
 		launch.Status = store.InvocationStatusSuperseded
+		launch.LaunchVoided = true
 		launch.UpdatedAt = s.deps.Now().UTC()
 		invocationStore, ok := runStore.(InvocationStore)
 		if !ok {
@@ -1089,13 +1090,17 @@ func failedLaunchForRetry(ctx context.Context, runStore RunStore, run store.Run)
 // invocation must be a failed launch for the run's current role boundary; a
 // report or native session is evidence that the history must remain protected.
 func isRetryableFailedLaunch(run store.Run, invocation store.Invocation) bool {
-	if invocation.RunID != run.ID || !failedLaunchHasNoEvidence(invocation) {
+	if invocation.RunID != run.ID {
+		return false
+	}
+	noEvidence, err := failedLaunchHasNoEvidence(invocation)
+	if err != nil || !noEvidence {
 		return false
 	}
 	if invocation.Status != store.InvocationStatusCannotProceed && invocation.Status != store.InvocationStatusSuperseded {
 		return false
 	}
-	if invocation.Status == store.InvocationStatusSuperseded && !supersededFailedLaunchReason(run.LifecycleReason) {
+	if invocation.Status == store.InvocationStatusSuperseded && !invocation.LaunchVoided {
 		return false
 	}
 	definition, declared := workflow.DefaultRegistry().Role(invocation.Role)
@@ -1106,12 +1111,6 @@ func isRetryableFailedLaunch(run store.Run, invocation store.Invocation) bool {
 		return invocation.Stage == store.StageReview && definition.Kind == workflow.RoleKindReview
 	}
 	return invocation.Stage == definition.Stage && workflow.DefaultRegistry().CanStartFrom(invocation.Role, run.Stage)
-}
-
-// supersededFailedLaunchReason identifies a coordinator-voided launch in the
-// lifecycle projection without adding another persisted run status.
-func supersededFailedLaunchReason(reason string) bool {
-	return strings.Contains(reason, failedLaunchVoidMarker)
 }
 
 // handleHarnessConfiguration validates an authorized harness override against

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -1107,9 +1107,6 @@ func isRetryableFailedLaunch(run store.Run, invocation store.Invocation) bool {
 	if !declared || definition.Stage != invocation.Stage {
 		return false
 	}
-	if run.Stage == store.StageDraftPR {
-		return invocation.Stage == store.StageReview && definition.Kind == workflow.RoleKindReview
-	}
 	return invocation.Stage == definition.Stage && workflow.DefaultRegistry().CanStartFrom(invocation.Role, run.Stage)
 }
 

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -636,8 +636,14 @@ func invocationIdentity(invocation *store.Invocation) string {
 type structuredReportPresence uint8
 
 const (
+	// structuredReportAbsent means the accepted report path definitively holds
+	// no regular file.
 	structuredReportAbsent structuredReportPresence = iota
+	// structuredReportPresent means a regular report file exists at the only
+	// accepted path.
 	structuredReportPresent
+	// structuredReportIndeterminate means the filesystem could not answer, so
+	// the observation proves nothing about the report.
 	structuredReportIndeterminate
 )
 

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -630,15 +630,43 @@ func invocationIdentity(invocation *store.Invocation) string {
 	return invocation.ID + "/" + string(invocation.Status)
 }
 
-// agentResultReady reports whether the invocation has written its structured
-// report. `factory-report` renames the file into place, so its presence is the
-// durable signal that the coordinator may validate a completed result.
-func agentResultReady(invocation store.Invocation) bool {
+// structuredReportPresence identifies whether report.json is absent, present,
+// or impossible to inspect. A stat error other than a definitive not-found
+// result must not be treated as proof that an invocation has no report.
+type structuredReportPresence uint8
+
+const (
+	structuredReportAbsent structuredReportPresence = iota
+	structuredReportPresent
+	structuredReportIndeterminate
+)
+
+// structuredReportPresenceForInvocation inspects the only accepted report
+// path without interpreting an unreadable parent or filesystem as absence.
+func structuredReportPresenceForInvocation(invocation store.Invocation) (structuredReportPresence, error) {
 	if invocation.ResultDirectory == "" {
-		return false
+		return structuredReportAbsent, nil
 	}
 	info, err := os.Stat(reportPath(invocation))
-	return err == nil && info.Mode().IsRegular()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return structuredReportAbsent, nil
+		}
+		return structuredReportIndeterminate, err
+	}
+	if !info.Mode().IsRegular() {
+		return structuredReportAbsent, nil
+	}
+	return structuredReportPresent, nil
+}
+
+// agentResultReady reports whether the invocation has written its structured
+// report. `factory-report` renames the file into place, so its presence is the
+// durable signal that the coordinator may validate a completed result. An
+// indeterminate filesystem observation remains not-ready for progression.
+func agentResultReady(invocation store.Invocation) bool {
+	presence, err := structuredReportPresenceForInvocation(invocation)
+	return err == nil && presence == structuredReportPresent
 }
 
 // reportPath returns the only accepted structured-report location inside one

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -738,11 +738,21 @@ func workerProjectionExpectedStopped(run store.Run, invocation store.Invocation)
 // whether or not it had already reserved a workspace or a surface: the rollback
 // stops the worker and closes the surface it created. The coordinator must read
 // those identities as recorded history rather than as an infrastructure
-// discrepancy. Only the cannot-proceed status records that rollback; every other
-// status is compared so missing identities remain drift.
+// discrepancy. A legacy cannot-proceed rollback is accepted for compatibility;
+// a superseded rollback is accepted only with the durable LaunchVoided marker
+// and a definitively absent regular report.
 func invocationProjectionNeverEstablished(invocation store.Invocation) bool {
-	return invocation.Status == store.InvocationStatusCannotProceed &&
-		strings.TrimSpace(invocation.NativeSessionID) == ""
+	if strings.TrimSpace(invocation.NativeSessionID) != "" {
+		return false
+	}
+	presence, err := structuredReportPresenceForInvocation(invocation)
+	if err != nil || presence != structuredReportAbsent {
+		return false
+	}
+	if invocation.Status == store.InvocationStatusCannotProceed {
+		return true
+	}
+	return invocation.Status == store.InvocationStatusSuperseded && invocation.LaunchVoided
 }
 
 // terminalInvocationProjectionExpectedStopped reports the coordinator-owned

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -582,6 +582,21 @@ func TestInvocationProjectionNeverEstablishedRequiresCannotProceed(t *testing.T)
 			},
 			want: false,
 		},
+		{
+			name: "superseded without a void marker",
+			invocation: store.Invocation{
+				Status: store.InvocationStatusSuperseded,
+			},
+			want: false,
+		},
+		{
+			name: "voided superseded launch",
+			invocation: store.Invocation{
+				Status:       store.InvocationStatusSuperseded,
+				LaunchVoided: true,
+			},
+			want: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/factory/review_test.go
+++ b/internal/factory/review_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/report"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/worker"
+	"github.com/Stevie1704/sw-factory/internal/workflow"
 )
 
 const reviewCheckpoint = "fedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedc"
@@ -468,6 +469,73 @@ func TestStandardsReviewCanBlockAProvisionalTestExemption(t *testing.T) {
 	}
 }
 
+// TestStandardsReviewLaunchCanRetryFromDraftPullRequest verifies a voided
+// standards-review launch reopens its declared invocation boundary rather than
+// being rejected by the draft-pull-request retry path.
+func TestStandardsReviewLaunchCanRetryFromDraftPullRequest(t *testing.T) {
+	fixture := newReviewFixture(t)
+	run := *fixture.runStore.current
+	var packet factory.SpecificationPacket
+	if err := json.Unmarshal([]byte(run.SpecificationPacket), &packet); err != nil {
+		t.Fatalf("decode review packet: %v", err)
+	}
+	packet.RepositoryConfig.RoleHarnessDefaults[workflow.RoleStandardsReview] = config.HarnessCodex
+	packet.RepositoryConfig.ModelOptions[workflow.RoleStandardsReview] = []string{"gpt-5"}
+	packetData, err := json.Marshal(packet)
+	if err != nil {
+		t.Fatalf("encode review packet: %v", err)
+	}
+	run.SpecificationPacket = string(packetData)
+	if err := fixture.runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save standards review packet: %v", err)
+	}
+
+	fixture.harness.startErr = errors.New("standards reviewer unavailable")
+	_, err = fixture.service.StartAgent(context.Background(), factory.AgentRequest{
+		RunID: run.ID, Role: workflow.RoleStandardsReview, Stage: workflow.StageStandardsReview,
+	})
+	if err == nil || !strings.Contains(err.Error(), "use `/factory retry`") {
+		t.Fatalf("StartAgent(standards review) error = %v, want void-launch retry guidance", err)
+	}
+	failed, err := fixture.runStore.LatestInvocation(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("read failed standards invocation: %v", err)
+	}
+	if failed == nil || failed.Status != store.InvocationStatusSuperseded || !failed.LaunchVoided {
+		t.Fatalf("failed standards invocation = %#v, want a voided superseded launch", failed)
+	}
+
+	run = *fixture.runStore.current
+	run.Status = store.StatusWaitingForHuman
+	run.ActiveInvocationIDs = nil
+	run.LifecycleReason = "unattended progression stopped at standards review launch: harness launch produced no native session or structured report; use /factory retry"
+	if err := fixture.runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("persist waiting standards launch: %v", err)
+	}
+
+	retry, err := fixture.service.HandleCommand(context.Background(), factory.CommandRequest{
+		RunID: run.ID, IssueNumber: run.IssueNumber,
+		Comment: github.Comment{ID: "retry-standards-launch", Author: "alice", Body: "/factory retry"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand(standards review) error = %v", err)
+	}
+	if retry.Outcome != factory.CommandAccepted || retry.Run.Status != store.StatusActive || retry.Run.Stage != store.StageDraftPR {
+		t.Fatalf("standards retry result = %#v, want accepted active draft_pr run", retry)
+	}
+
+	fixture.harness.startErr = nil
+	launch, err := fixture.service.StartAgent(context.Background(), factory.AgentRequest{
+		RunID: run.ID, Role: workflow.RoleStandardsReview, Stage: workflow.StageStandardsReview,
+	})
+	if err != nil {
+		t.Fatalf("StartAgent(standards review) after retry error = %v", err)
+	}
+	if launch.Invocation.ID == failed.ID || launch.Invocation.Role != workflow.RoleStandardsReview || launch.Invocation.Stage != workflow.StageStandardsReview {
+		t.Fatalf("recovered standards invocation = %#v, want a fresh standards_review/standards_review invocation", launch.Invocation)
+	}
+}
+
 // reviewFixture bundles the Factory seam and all isolated review projections.
 type reviewFixture struct {
 	service      *factory.Service
@@ -515,7 +583,7 @@ func newReviewFixture(t *testing.T) reviewFixture {
 	terminalRuntime := &agentTerminal{}
 	harnessRuntime := &agentHarness{}
 	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
-		Path: repositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+		Path: repositoryPath, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"}, AuthorizedUsers: []string{"alice"},
 		Cmux: config.CmuxConfig{ControlWorkspace: "factory-control"}, OperationalDataPath: filepath.Join(root, "state", "factory.db"), RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
 	}}}
 	ids := []string{"run-review", "review-session", "standards-session", "repair-session"}

--- a/internal/factory/unattended_test.go
+++ b/internal/factory/unattended_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -109,6 +110,87 @@ func TestUnattendedProgressionStopsAtAWaitingStateAndPublishesIt(t *testing.T) {
 	}
 	if !strings.Contains(factory.StatusCommentBody(final), "- activity: `waiting-for-human`") {
 		t.Fatalf("status comment = %q, want the waiting activity", factory.StatusCommentBody(final))
+	}
+}
+
+// TestFailedLaunchCanRetryTheSameRoleAndPacket verifies the complete recovery
+// seam: unattended progression voids a launch with no native evidence, the
+// operator retry reopens the existing stage, and a fresh invocation reuses the
+// same specification packet.
+func TestFailedLaunchCanRetryTheSameRoleAndPacket(t *testing.T) {
+	fixture := newUnattendedFixture(t)
+	fixture.harness.startErr = errors.New("prompt exceeds launch limit")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopAfterLeaseRenewals(cancel, 3)
+
+	if err := fixture.service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	waiting := fixture.currentRun(t)
+	if waiting.Status != store.StatusWaitingForHuman || waiting.Stage != store.StageImplementation {
+		t.Fatalf("waiting run = stage %q status %q, want implementation/waiting_for_human", waiting.Stage, waiting.Status)
+	}
+	if !strings.Contains(waiting.LifecycleReason, "harness launch produced no native session or structured report") || !strings.Contains(waiting.LifecycleReason, "/factory retry") {
+		t.Fatalf("lifecycle reason = %q, want the void rule and retry command", waiting.LifecycleReason)
+	}
+
+	opened, err := store.Open(context.Background(), fixture.operationalPath)
+	if err != nil {
+		t.Fatalf("open operational store after failed launch: %v", err)
+	}
+	failed, err := opened.LatestInvocation(context.Background(), waiting.ID)
+	if err != nil {
+		_ = opened.Close()
+		t.Fatalf("read failed invocation: %v", err)
+	}
+	if failed == nil || failed.Status != store.InvocationStatusSuperseded || failed.Role != "implementation" || failed.Stage != store.StageImplementation {
+		_ = opened.Close()
+		t.Fatalf("failed invocation = %#v, want superseded implementation launch", failed)
+	}
+	failedPacket, err := os.ReadFile(filepath.Join(failed.InvocationDirectory, "specification.json"))
+	if err != nil {
+		_ = opened.Close()
+		t.Fatalf("read failed invocation packet: %v", err)
+	}
+	var failedPacketValue factory.InvocationPacket
+	if err := json.Unmarshal(failedPacket, &failedPacketValue); err != nil {
+		_ = opened.Close()
+		t.Fatalf("decode failed invocation packet: %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("close failed-launch store: %v", err)
+	}
+
+	retry, err := fixture.service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: waiting.IssueNumber,
+		Comment:     github.Comment{ID: "retry-failed-launch", Author: "alice", Body: "/factory retry"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() error = %v", err)
+	}
+	if retry.Outcome != factory.CommandAccepted || retry.Run.Status != store.StatusActive || retry.Run.SpecificationPacket != waiting.SpecificationPacket {
+		t.Fatalf("retry result = %#v, want accepted active run with the same packet", retry)
+	}
+
+	fixture.harness.startErr = nil
+	launch, err := fixture.service.StartAgent(context.Background(), factory.AgentRequest{RunID: waiting.ID})
+	if err != nil {
+		t.Fatalf("StartAgent() after retry error = %v", err)
+	}
+	if launch.Invocation.ID == failed.ID || launch.Invocation.Role != failed.Role || launch.Invocation.Stage != failed.Stage {
+		t.Fatalf("recovered invocation = %#v, want a fresh %s/%s invocation", launch.Invocation, failed.Role, failed.Stage)
+	}
+	recoveredPacket, err := os.ReadFile(filepath.Join(launch.Invocation.InvocationDirectory, "specification.json"))
+	if err != nil {
+		t.Fatalf("read recovered invocation packet: %v", err)
+	}
+	var recoveredPacketValue factory.InvocationPacket
+	if err := json.Unmarshal(recoveredPacket, &recoveredPacketValue); err != nil {
+		t.Fatalf("decode recovered invocation packet: %v", err)
+	}
+	if recoveredPacketValue.SpecificationPacket != failedPacketValue.SpecificationPacket {
+		t.Fatalf("recovered specification packet changed from %q to %q", failedPacketValue.SpecificationPacket, recoveredPacketValue.SpecificationPacket)
 	}
 }
 

--- a/internal/factory/unattended_test.go
+++ b/internal/factory/unattended_test.go
@@ -144,7 +144,7 @@ func TestFailedLaunchCanRetryTheSameRoleAndPacket(t *testing.T) {
 		_ = opened.Close()
 		t.Fatalf("read failed invocation: %v", err)
 	}
-	if failed == nil || failed.Status != store.InvocationStatusSuperseded || failed.Role != "implementation" || failed.Stage != store.StageImplementation {
+	if failed == nil || failed.Status != store.InvocationStatusSuperseded || !failed.LaunchVoided || failed.Role != "implementation" || failed.Stage != store.StageImplementation {
 		_ = opened.Close()
 		t.Fatalf("failed invocation = %#v, want superseded implementation launch", failed)
 	}
@@ -162,7 +162,7 @@ func TestFailedLaunchCanRetryTheSameRoleAndPacket(t *testing.T) {
 		t.Fatalf("close failed-launch store: %v", err)
 	}
 
-	retry, err := fixture.service.HandleCommand(context.Background(), factory.CommandRequest{
+	retry, err := fixture.restart().HandleCommand(context.Background(), factory.CommandRequest{
 		IssueNumber: waiting.IssueNumber,
 		Comment:     github.Comment{ID: "retry-failed-launch", Author: "alice", Body: "/factory retry"},
 	})

--- a/internal/store/invocation_test.go
+++ b/internal/store/invocation_test.go
@@ -41,6 +41,7 @@ func TestStorePersistsRecoverableInvocationState(t *testing.T) {
 		PromptCraftSourcePath:   "docs/factory/craft/implementation.md",
 		PromptCraftSHA256:       strings.Repeat("a", 64),
 		Status:                  store.InvocationStatusActive,
+		LaunchVoided:            true,
 		CreatedAt:               created,
 		UpdatedAt:               created,
 	}
@@ -59,7 +60,7 @@ func TestStorePersistsRecoverableInvocationState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Invocation() error = %v", err)
 	}
-	if got == nil || got.NativeSessionID != want.NativeSessionID || got.CredentialStoreID != want.CredentialStoreID || got.RoleSurfaceID != want.RoleSurfaceID || got.ImplementationSurfaceID != want.ImplementationSurfaceID || got.ResultDirectory != want.ResultDirectory || got.PromptCraftSourcePath != want.PromptCraftSourcePath || got.PromptCraftSHA256 != want.PromptCraftSHA256 || len(got.PermittedPaths) != 1 || got.PermittedPaths[0] != "internal/factory" {
+	if got == nil || got.NativeSessionID != want.NativeSessionID || got.CredentialStoreID != want.CredentialStoreID || got.RoleSurfaceID != want.RoleSurfaceID || got.ImplementationSurfaceID != want.ImplementationSurfaceID || got.ResultDirectory != want.ResultDirectory || got.PromptCraftSourcePath != want.PromptCraftSourcePath || got.PromptCraftSHA256 != want.PromptCraftSHA256 || !got.LaunchVoided || len(got.PermittedPaths) != 1 || got.PermittedPaths[0] != "internal/factory" {
 		t.Fatalf("Invocation() = %#v, want %#v", got, want)
 	}
 	if got.UpdatedAt.UTC() != created {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CurrentSchemaVersion is the supported operational-store schema version.
-const CurrentSchemaVersion = 33
+const CurrentSchemaVersion = 34
 
 // MaxTestRevisionAttempts is the hard safety ceiling for automated
 // implementation-versus-test objection cycles.
@@ -631,6 +631,10 @@ type Invocation struct {
 	PromptCraftSHA256 string
 	// Status is the invocation lifecycle state.
 	Status InvocationStatus
+	// LaunchVoided records that the coordinator or an explicit operator retry
+	// proved this launch produced no native session or structured report and
+	// rolled it back before retry.
+	LaunchVoided bool
 	// RecoveryResumeCount records the number of coordinator-owned native resume
 	// attempts completed for this invocation. Reconciliation permits one.
 	RecoveryResumeCount int
@@ -2001,8 +2005,8 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 				id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 				native_session_id, workspace_id, status_surface_id,
 				role_surface_id, implementation_surface_id, checks_surface_id, invocation_directory,
-				result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, recovery_resume_count, attach_required, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, launch_voided, recovery_resume_count, attach_required, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			run_id = excluded.run_id,
 			harness = excluded.harness,
@@ -2024,6 +2028,7 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 				prompt_craft_source_path = excluded.prompt_craft_source_path,
 				prompt_craft_sha256 = excluded.prompt_craft_sha256,
 				status = excluded.status,
+				launch_voided = excluded.launch_voided,
 				recovery_resume_count = excluded.recovery_resume_count,
 				attach_required = excluded.attach_required,
 				updated_at = excluded.updated_at`,
@@ -2048,6 +2053,7 @@ func (s *Store) SaveInvocation(ctx context.Context, invocation Invocation) error
 		invocation.PromptCraftSourcePath,
 		invocation.PromptCraftSHA256,
 		invocation.Status,
+		invocation.LaunchVoided,
 		invocation.RecoveryResumeCount,
 		invocation.AttachRequired,
 		invocation.CreatedAt.UTC().Format(runTimestampLayout),
@@ -2224,7 +2230,7 @@ func (s *Store) Invocation(ctx context.Context, runID, invocationID string) (*In
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       role_surface_id, implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, recovery_resume_count, attach_required, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, launch_voided, recovery_resume_count, attach_required, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ? AND id = ?`, runID, invocationID)
 	return scanInvocation(row)
@@ -2241,7 +2247,7 @@ func (s *Store) LatestInvocation(ctx context.Context, runID string) (*Invocation
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       role_surface_id, implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, recovery_resume_count, attach_required, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, launch_voided, recovery_resume_count, attach_required, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ?
 		ORDER BY updated_at DESC, id DESC
@@ -2263,7 +2269,7 @@ func (s *Store) LatestInvocationByRole(ctx context.Context, runID, role string) 
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       role_surface_id, implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, recovery_resume_count, attach_required, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, launch_voided, recovery_resume_count, attach_required, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ? AND role = ?
 		ORDER BY updated_at DESC, id DESC
@@ -2296,7 +2302,7 @@ func (s *Store) ActiveInvocation(ctx context.Context, runID string) (*Invocation
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       role_surface_id, implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, recovery_resume_count, attach_required, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, launch_voided, recovery_resume_count, attach_required, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ? AND status = ?
 		ORDER BY updated_at DESC
@@ -2315,7 +2321,7 @@ func (s *Store) ActiveInvocations(ctx context.Context, runID string) ([]Invocati
 		SELECT id, run_id, harness, role, stage, model, reasoning_effort, credential_store_id,
 		       native_session_id, workspace_id, status_surface_id,
 		       role_surface_id, implementation_surface_id, checks_surface_id, invocation_directory,
-		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, recovery_resume_count, attach_required, created_at, updated_at
+		       result_directory, permitted_paths, prompt_version, prompt_craft_source_path, prompt_craft_sha256, status, launch_voided, recovery_resume_count, attach_required, created_at, updated_at
 		FROM invocations
 		WHERE run_id = ? AND status = ?
 		ORDER BY updated_at, id`, runID, InvocationStatusActive)
@@ -2363,6 +2369,7 @@ func scanInvocation(row interface{ Scan(...any) error }) (*Invocation, error) {
 		&invocation.PromptCraftSourcePath,
 		&invocation.PromptCraftSHA256,
 		&invocation.Status,
+		&invocation.LaunchVoided,
 		&invocation.RecoveryResumeCount,
 		&invocation.AttachRequired,
 		&createdAt,
@@ -3148,6 +3155,10 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 			}
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs DROP COLUMN active_invocation_id"); err != nil {
 				return fmt.Errorf("apply store migration 33 active invocation removal: %w", err)
+			}
+		case 34:
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE invocations ADD COLUMN launch_voided INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return fmt.Errorf("apply store migration 34: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -145,7 +145,8 @@ const (
 	// InvocationStatusCannotProceed means the report contained blocking evidence.
 	InvocationStatusCannotProceed InvocationStatus = "cannot_proceed"
 	// InvocationStatusSuperseded means a later specification packet invalidated
-	// the invocation before its result could be used for progression.
+	// the invocation, or the coordinator voided a launch with no native session
+	// or structured report, before its result could be used for progression.
 	InvocationStatusSuperseded InvocationStatus = "superseded"
 )
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -75,6 +75,12 @@ func TestSchema33MigrationFoldsTheSingularActiveInvocationIntoTheSlice(t *testin
 			t.Fatalf("add schema 32 active invocation column: %v", err)
 		}
 	}
+	if testInvocationColumnExists(t, database, "launch_voided") {
+		if _, err := database.ExecContext(t.Context(), "ALTER TABLE invocations DROP COLUMN launch_voided"); err != nil {
+			_ = database.Close()
+			t.Fatalf("remove schema 34 launch-voided column from schema 32 fixture: %v", err)
+		}
+	}
 	_, err = database.ExecContext(t.Context(), `
 		INSERT INTO operational_runs (
 			id, repository_path, issue_number, stage, status,
@@ -96,8 +102,8 @@ func TestSchema33MigrationFoldsTheSingularActiveInvocationIntoTheSlice(t *testin
 		t.Fatalf("schema 33 migration error = %v", err)
 	}
 	defer func() { _ = reopened.Close() }()
-	if got := reopened.SchemaVersion(); got != 33 {
-		t.Fatalf("SchemaVersion() = %d, want 33", got)
+	if got := reopened.SchemaVersion(); got != store.CurrentSchemaVersion {
+		t.Fatalf("SchemaVersion() = %d, want %d", got, store.CurrentSchemaVersion)
 	}
 	got, err := reopened.CurrentRun(context.Background())
 	if err != nil {
@@ -147,6 +153,37 @@ func testOperationalRunsColumnExists(t *testing.T, database *sql.DB, wanted stri
 	}
 	if err := rows.Err(); err != nil {
 		t.Fatalf("iterate operational_runs columns: %v", err)
+	}
+	return false
+}
+
+// testInvocationColumnExists reports whether a column exists in the
+// migration fixture's invocations table.
+func testInvocationColumnExists(t *testing.T, database *sql.DB, wanted string) bool {
+	t.Helper()
+	rows, err := database.QueryContext(t.Context(), "PRAGMA table_info(invocations)")
+	if err != nil {
+		t.Fatalf("inspect invocations columns: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var (
+		cid          int
+		name         string
+		columnType   string
+		notNull      int
+		defaultValue sql.NullString
+		primaryKey   int
+	)
+	for rows.Next() {
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatalf("scan invocations column: %v", err)
+		}
+		if name == wanted {
+			return true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate invocations columns: %v", err)
 	}
 	return false
 }


### PR DESCRIPTION
<!-- factory-generated:start -->
## Factory run

- run: `run-f7d69ea1-199e-4a77-aaf9-fac09ba7072a`
- issue: #128 — A failed harness launch leaves invocation history that blocks a clean retry
- specification packet: version 1, target branch `main`
- checkpoint: `a8e335e794afae42c18ccc9482ffc877ad511b53`
- stage: `draft_pr`
- intervention: `none`
- test policy: `advisory (implementation-owned TDD)`
- route: `default (repository test policy)`

Closes #128

<!-- factory-generated:review:start -->

### Specification review

- reviewed checkpoint: `a8e335e794afae42c18ccc9482ffc877ad511b53`
- outcome: 0 blocking findings, 0 advisory findings
- findings: none

### Standards review

- reviewed checkpoint: `a8e335e794afae42c18ccc9482ffc877ad511b53`
- outcome: 1 blocking findings, 2 advisory findings

#### Finding 1 — blocker/documented_standards
- location: `internal/factory/agent_launch.go:378-395`
- claim: The launch-void decision is not fail-closed when the durable pending-effect lookup fails.
- evidence: source=guidance:CONTEXT.md;hunk=internal/factory/agent_launch.go:378-395;the PendingEffect error is ignored at line 370 and the subsequent no-evidence result can set LaunchVoided and Superseded, discarding an unresolved durable effect instead of preserving it for reconciliation.
- suggested resolution: Treat a non-nil PendingEffect error as indeterminate: keep the invocation and reserved effect protected, record the discrepancy, and only apply the void rule after a definitive no-pending result.
- suggested owner: `implementation`

#### Finding 2 — advisory/documented_standards
- location: `internal/factory/agent_launch.go:610`
- claim: The new package-level failedLaunchVoidMarker definition has no docstring.
- evidence: source=guidance:AGENTS.md;hunk=internal/factory/agent_launch.go:610;AGENTS.md requires docstrings for functions and definitions, but this newly added package-level constant is undocumented while nearby package constants describe their identifiers.
- suggested resolution: Add a Go doc comment explaining that the marker identifies a launch with no native session or structured report.
- suggested owner: `implementation`

#### Finding 3 — advisory/documented_standards
- location: `internal/factory/progression.go:639-641`
- claim: The new structuredReportPresence constants are undocumented definitions.
- evidence: source=guidance:AGENTS.md;hunk=internal/factory/progression.go:639-641;AGENTS.md requires docstrings for definitions, but structuredReportAbsent, structuredReportPresent, and structuredReportIndeterminate have no individual comments despite the surrounding progression enum constants being documented.
- suggested resolution: Add comments for each presence-state constant, or document the const block according to the repository convention.
- suggested owner: `implementation`
<!-- factory-generated:review:end -->

### Issue summary

## What happened

Run \`run-5b6c3a85-bacd-476e-8b5b-8e5adb0b9a95\` (issue #118) could not launch its specification reviewer. The prompt exceeded the per-argument exec limit, so `exec` failed, no native session was discovered before the deadline, and unattended progression stopped at `draft_pr` / `waiting_for_human`. That cause is fixed in #127.

The recovery state it left behind is the problem here, and it outlives that fix.

## The blocking state

The failed launch persisted an invocation:

| Invocation | Role / stage | Status |
| --- | --- | --- |
| `inv-run-bdcd214e…` | implementation / implementation | `completed` |
| `inv-run-ca9b50ba…` | spec_review / review | `cannot_proceed` |

The run itself is `draft_pr` / `waiting_for_human` with no active invocation.

`internal/factory/agent_launch.go:159` then refuses every later attempt:

```
run "run-5b6c3a85-…" already has invocation history for spec_review/review
```

The guard admits only an invocation already marked `superseded`. That guard is correct in itself — a review round must not silently run twice — but nothing in the failure path marks a launch that never started as superseded.

## Why no supported command recovers it

Checked against this run's exact state (`draft_pr` / `waiting_for_human`, no active invocation):

| Command | Admitted? | Guard |
| --- | --- | --- |
| `/factory retry` | no | `command.go:988` admits only `failed` or `cancelled` |
| `/factory revision` | no | `command.go:376` requires stage `ready` |
| `/factory refresh` | yes | not terminal, no pending check-repair attempt |

Only `refresh` clears the blockage, and it does so by creating a new specification packet version, invalidating downstream invocations and checkpoint results, and restarting at **implementation**. A recoverable infrastructure failure in the review stage therefore costs a repeat of an already accepted implementation stage, its gates, and both review axes.

The failed invocation produced nothing to protect: its result directory is empty, it wrote no structured report, and a review invocation creates no checkpoint.

## What to decide

Two shapes, and the choice has not been made. Both remove the dead end; they differ in where the authority sits.

| Shape | Change | Cost | Risk |
| --- | --- | --- | --- |
| **Coordinator-owned.** A launch that never produced a session marks its own invocation `superseded` before the run reaches its waiting state | Failure path in `agent_launch.go` | Small and local | The coordinator decides that an invocation is void; the rule has to be exactly \"no native session and no structured report\", or it could discard evidence |
| **Operator-owned.** `/factory retry` admits `waiting_for_human` when the run has no active invocation, and supersedes the blocked role's invocation as part of the retry | `handleRetryCommand` plus the supersede step | Slightly larger, and widens a command's admitted states | An operator can reopen a stage the coordinator paused deliberately, so the widened state needs its own bound |

The two are not exclusive. The coordinator-owned rule handles the common case without a human; the operator-owned command covers whatever the rule cannot classify.

## Non-goals

- Changing the launch guard at `agent_launch.go:159` to admit non-superseded history. The guard is what stops a duplicate review round.
- Changing what `/factory refresh` or `/factory revision` do.
- Any new terminal status or waiting state.
- Retrying the launch automatically. A launch that failed for a deterministic reason fails identically on retry; this is about making a human-initiated retry possible, not about looping.

## Acceptance criteria

- [ ] A run whose role launch failed before any harness session existed can start that role again without a new specification packet version and without repeating an accepted upstream stage.
- [ ] The launch guard at `agent_launch.go:159` still refuses a second invocation for a role and stage whose earlier invocation produced a structured report.
- [ ] A test drives a launch failure through to the recovered state and asserts the run reaches a fresh invocation for the same role and stage.
- [ ] The recovery path is named in the status comment's lifecycle reason, so an operator reads what to do from the run rather than from the source.
- [ ] `docs/agent-runtime.md` records the rule that decides when a failed launch's invocation is void.
- [ ] `go test ./...` passes.

## Evidence

- Status comment lifecycle reason on #118 and the launch diagnostic at `.factory-agents/run-5b6c3a85-…/inv-run-ca9b50ba-…/harness-failure.log`.
- Invocation rows above, read from the operational store.
- `factory resume` refusal quoted above.

### Gates

- `format`: passed
- `vet`: passed
- `test`: passed
- `build`: passed

### Control commands

- `factory status`
- `factory draft-pr --run-id run-f7d69ea1-199e-4a77-aaf9-fac09ba7072a`

<!-- factory-generated:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `/factory retry` for eligible failed launches from the existing workflow stage.
  - Retries reuse the existing specification packet without creating a new version.
  - Failed launches without a session or structured result are marked voided and can be retried.

- **Bug Fixes**
  - Improved recovery when agent startup fails before producing usable launch evidence.
  - Unreadable journals or reports now preserve the invocation and record the discrepancy.
  - Launches with sessions, reports, active work, or uncertain evidence remain protected from replacement.
  - Retry handling restores the appropriate workflow boundary for a fresh invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->