### PR TITLE
feat: let repository policy own the retry limits

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,7 +48,8 @@ A bounded implementation-to-test dispute in which implementation submits the
 protected test's claim and observable evidence, the original test session may
 accept or reject that objection, and an accepted revision must pass independent
 red verification before implementation resumes. Automation is gated by the
-measured pilot and permits at most two revision attempts before human review.
+measured pilot and permits the repository's `retry_limits.test_revision`
+revision attempts before human review.
 _Avoid_: Test rewrite, implementation-owned test edit, unbounded repair
 
 **Workflow route**:

--- a/README.md
+++ b/README.md
@@ -868,7 +868,8 @@ protocol; implementation never edits protected tests directly. An accepted
 repair creates a new checkpoint, reruns every configured gate, and starts both
 review roles in fresh sessions against that new SHA. The repository's
 <code>retry_limits.review_repair</code> value bounds the budget, and a
-materially repeated blocker escalates immediately to a human. Taste and scope findings remain advisory.
+materially repeated blocker escalates immediately to a human. Taste and scope
+findings remain advisory.
 
 The run moves to <code>ready</code> only after both configured reviews succeed,
 the configured target branch has been merged into the factory branch when

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ operational store, GitHub comments, and the documentation.
 | **Gate**                 | A deterministic repository command, such as formatting, vetting, testing, or building, run in the policy-defined environment.                                  |
 | **Operational store**    | A private SQLite database that records run state, identities, effects, reports, gate results, and content-free evaluation summaries.                           |
 | **Baseline**             | The pre-edit setup and gate result for the frozen packet. It proves what the repository looked like before agent edits.                                        |
-| **Test objection cycle** | A bounded implementation-to-test dispute: implementation supplies a test claim and evidence, the original test session accepts or rejects it, and an accepted revision must pass independent red verification. Automation is pilot-gated and capped at two attempts. |
+| **Test objection cycle** | A bounded implementation-to-test dispute: implementation supplies a test claim and evidence, the original test session accepts or rejects it, and an accepted revision must pass independent red verification. Automation is pilot-gated and bounded by the repository's `retry_limits.test_revision` value. |
 | **Recovery diagnosis**   | A read-only comparison of durable state against Git, GitHub, the worktree, worker, terminal, harness, and operational store.                                   |
 | **Reconciliation**       | A deliberate restart pass that replays an exact pending effect or pauses for human inspection when external state is ambiguous.                                |
 
@@ -150,8 +150,9 @@ paths are carried into implementation, and an implementation report that changes
 a protected test path is rejected. Instead, implementation can submit a
 structured objection naming the test, disputed claim, and observable evidence.
 Before pilot authorization the objection is preserved for human disposition; an
-authorized run can resume the original test session for at most two independently
-verified revision attempts.
+authorized run can resume the original test session for as many independently
+verified revision attempts as the repository's <code>retry_limits.test_revision</code>
+value allows.
 
 ### Workflow routes
 
@@ -865,9 +866,9 @@ combined from both reviewers into one implementation repair packet. A finding
 that suggests test ownership must use the existing structured test-objection
 protocol; implementation never edits protected tests directly. An accepted
 repair creates a new checkpoint, reruns every configured gate, and starts both
-review roles in fresh sessions against that new SHA. The review-repair budget
-is capped at two attempts, and a materially repeated blocker escalates
-immediately to a human. Taste and scope findings remain advisory.
+review roles in fresh sessions against that new SHA. The repository's
+<code>retry_limits.review_repair</code> value bounds the budget, and a
+materially repeated blocker escalates immediately to a human. Taste and scope findings remain advisory.
 
 The run moves to <code>ready</code> only after both configured reviews succeed,
 the configured target branch has been merged into the factory branch when

--- a/README.md
+++ b/README.md
@@ -817,8 +817,8 @@ If a gate fails, the checkpoint remains pushed on the run branch and
 or updating the draft pull request. The next implementation invocation reuses
 the worker role volume and implementation surface, subject to the frozen repair
 budget. After an accepted repair report, run <code>factory draft-pr</code> again.
-Infrastructure waits do not spend the check-repair budget; the hard ceiling is
-three attempts.
+Infrastructure waits do not spend the check-repair budget; the repository's
+<code>retry_limits.check_repair</code> value is the only bound.
 
 ### 6. Run the concurrent isolated reviews
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ a protected test path is rejected. Instead, implementation can submit a
 structured objection naming the test, disputed claim, and observable evidence.
 Before pilot authorization the objection is preserved for human disposition; an
 authorized run can resume the original test session for as many independently
-verified revision attempts as the repository's <code>retry_limits.test_revision</code>
-value allows.
+verified revision attempts as the repository's
+<code>retry_limits.test_revision</code> value allows.
 
 ### Workflow routes
 

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -415,7 +415,7 @@ counter advances only after resume and the final run-state write succeed; an
 interrupted reservation is marked for reconciliation and blocks blind
 relaunch. Setup, worker, GitHub status, harness, and other transport failures
 roll back before resume and move the run to `waiting_for_harness` without
-consuming the budget. Once the ceiling is reached, the run moves to
+consuming the budget. Once the budget is exhausted, the run moves to
 `check/waiting_for_human` and receives the `agent-needs-input` label. The
 single status comment always shows consumed, pending, and remaining attempts.
 After a repair report is accepted, the next checkpoint must have a new SHA and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,10 +289,11 @@ permitted scope. Deterministic gates and exact-checkpoint specification review
 remain unchanged in both modes.
 
 `retry_limits.review_repair` bounds automatic implementation repairs caused by
-blocking review findings and may not exceed four. Findings from the configured
-specification and standards reviewers are delivered together. If a materially
-same blocker survives an attempted repair, or the ceiling is exhausted, the
-run waits for a human. A successful repair creates a new checkpoint and the
+blocking review findings. The repository owns the value and the factory applies
+no upper limit of its own. Findings from the configured specification and
+standards reviewers are delivered together. If a materially same blocker
+survives an attempted repair, or the budget is exhausted, the run waits for a
+human. A successful repair creates a new checkpoint and the
 coordinator reruns the complete configured gate suite and both reviewers in
 fresh sessions.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,7 +289,7 @@ permitted scope. Deterministic gates and exact-checkpoint specification review
 remain unchanged in both modes.
 
 `retry_limits.review_repair` bounds automatic implementation repairs caused by
-blocking review findings and may not exceed two. Findings from the configured
+blocking review findings and may not exceed four. Findings from the configured
 specification and standards reviewers are delivered together. If a materially
 same blocker survives an attempted repair, or the ceiling is exhausted, the
 run waits for a human. A successful repair creates a new checkpoint and the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,9 +294,8 @@ blocking review findings. The repository owns the value and the factory applies
 no upper limit of its own. Findings from the configured specification and
 standards reviewers are delivered together. If a materially same blocker
 survives an attempted repair, or the budget is exhausted, the run waits for a
-human. A successful repair creates a new checkpoint and the
-coordinator reruns the complete configured gate suite and both reviewers in
-fresh sessions.
+human. A successful repair creates a new checkpoint and the coordinator reruns
+the complete configured gate suite and both reviewers in fresh sessions.
 
 When `base_synchronization.mode` is `before_ready`, the coordinator fetches the
 configured target branch and merges it into the factory branch immediately

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,8 +198,9 @@ The validator checks the schema version, target branch, setup, optional reposito
 implementation-to-test objection cycle. Keep it `false` until the measured
 pilot in issue #26 records `proceed`; while disabled, a structured objection is
 persisted and the run waits for a human. When enabled, the coordinator resumes
-the original test session, permits at most two revision attempts, and reruns the
-revised focused command independently before implementation can continue.
+the original test session, permits the repository's `retry_limits.test_revision`
+revision attempts, and reruns the revised focused command independently before
+implementation can continue.
 The coordinator also verifies the latest decision comment on #26 from an
 authorized maintainer. Use either `Decision: proceed` or
 `<!-- factory-pilot-decision: proceed -->` to open the gate. Use either

--- a/factory.yaml
+++ b/factory.yaml
@@ -45,9 +45,9 @@ timeouts:
   gate: 10m
   review: 30m
 retry_limits:
-  check_repair:6 
-  review_repair: 5
-  test_revision: 5
+  check_repair: 3
+  review_repair: 4
+  test_revision: 2
 test_policy:
   mode: advisory
   allow_human_exemption: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,7 +138,7 @@ const MaxCheckRepairAttempts = 3
 // MaxReviewRepairAttempts is the hard safety ceiling for automated review
 // repair rounds. Repository policy may choose a lower value, but never a
 // higher one.
-const MaxReviewRepairAttempts = 2
+const MaxReviewRepairAttempts = 4
 
 // MaxTestRevisionAttempts is the hard safety ceiling for automated disputes
 // between implementation-owned behavior and protected tests.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,19 +131,6 @@ type RetryLimits struct {
 	TestRevision int `yaml:"test_revision"`
 }
 
-// MaxCheckRepairAttempts is the hard safety ceiling for deterministic repairs.
-// Repository policy may choose a lower value, but never a higher one.
-const MaxCheckRepairAttempts = 3
-
-// MaxReviewRepairAttempts is the hard safety ceiling for automated review
-// repair rounds. Repository policy may choose a lower value, but never a
-// higher one.
-const MaxReviewRepairAttempts = 4
-
-// MaxTestRevisionAttempts is the hard safety ceiling for automated disputes
-// between implementation-owned behavior and protected tests.
-const MaxTestRevisionAttempts = 2
-
 type TestMode string
 
 const (
@@ -541,15 +528,6 @@ func ValidateRepository(config RepositoryConfig) error {
 	} {
 		if value < 1 {
 			return validation(field, "must be greater than zero")
-		}
-		if field == "retry_limits.check_repair" && value > MaxCheckRepairAttempts {
-			return validation(field, fmt.Sprintf("must not exceed %d", MaxCheckRepairAttempts))
-		}
-		if field == "retry_limits.review_repair" && value > MaxReviewRepairAttempts {
-			return validation(field, fmt.Sprintf("must not exceed %d", MaxReviewRepairAttempts))
-		}
-		if field == "retry_limits.test_revision" && value > MaxTestRevisionAttempts {
-			return validation(field, fmt.Sprintf("must not exceed %d", MaxTestRevisionAttempts))
 		}
 	}
 	if err := validateTestPolicyPaths("test_policy.test_paths", config.TestPolicy.TestPaths); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -584,6 +584,19 @@ func TestValidateRepositoryAcceptsAnEmptyAllowedOverridesList(t *testing.T) {
 	}
 }
 
+// TestValidateRepositoryAcceptsRepositoryChosenRetryLimits verifies the
+// repository owns its retry limits outright. Values far above every previously
+// hard-coded ceiling must validate; only a value below one is rejected.
+func TestValidateRepositoryAcceptsRepositoryChosenRetryLimits(t *testing.T) {
+	t.Parallel()
+
+	policy := validRepositoryConfig()
+	policy.RetryLimits = config.RetryLimits{CheckRepair: 7, ReviewRepair: 12, TestRevision: 9}
+	if err := config.ValidateRepository(policy); err != nil {
+		t.Fatalf("ValidateRepository() error = %v, want no error for repository-chosen retry limits", err)
+	}
+}
+
 func TestValidateRepositoryRejectsInvalidFieldsOneAtATime(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -586,7 +586,7 @@ func TestValidateRepositoryAcceptsAnEmptyAllowedOverridesList(t *testing.T) {
 
 // TestValidateRepositoryAcceptsRepositoryChosenRetryLimits verifies the
 // repository owns its retry limits outright. Values far above every previously
-// hard-coded ceiling must validate; only a value below one is rejected.
+// hard-coded ceiling must still validate; only a value below one is rejected.
 func TestValidateRepositoryAcceptsRepositoryChosenRetryLimits(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -700,30 +700,6 @@ func TestValidateRepositoryRejectsInvalidFieldsOneAtATime(t *testing.T) {
 			field: "retry_limits.check_repair",
 		},
 		{
-			name: "check repair limit above hard ceiling",
-			mutate: func(c config.RepositoryConfig) config.RepositoryConfig {
-				c.RetryLimits.CheckRepair = config.MaxCheckRepairAttempts + 1
-				return c
-			},
-			field: "retry_limits.check_repair",
-		},
-		{
-			name: "test revision limit above hard ceiling",
-			mutate: func(c config.RepositoryConfig) config.RepositoryConfig {
-				c.RetryLimits.TestRevision = config.MaxTestRevisionAttempts + 1
-				return c
-			},
-			field: "retry_limits.test_revision",
-		},
-		{
-			name: "review repair limit above hard ceiling",
-			mutate: func(c config.RepositoryConfig) config.RepositoryConfig {
-				c.RetryLimits.ReviewRepair = config.MaxReviewRepairAttempts + 1
-				return c
-			},
-			field: "retry_limits.review_repair",
-		},
-		{
 			name: "invalid test policy mode",
 			mutate: func(c config.RepositoryConfig) config.RepositoryConfig {
 				c.TestPolicy.Mode = "sometimes"

--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -193,7 +193,7 @@ type InvocationPacket struct {
 	TestObjection *store.TestObjection `json:"test_objection,omitempty"`
 	// TestRevisionAttempt identifies the active objection cycle.
 	TestRevisionAttempt int `json:"test_revision_attempt,omitempty"`
-	// TestRevisionBudget is the frozen objection-cycle ceiling.
+	// TestRevisionBudget is the frozen objection-cycle budget.
 	TestRevisionBudget int `json:"test_revision_budget,omitempty"`
 	// ProtectedTestPaths records test files implementation must not edit.
 	ProtectedTestPaths []store.ProtectedTestPath `json:"protected_test_paths,omitempty"`

--- a/internal/factory/agent_launch.go
+++ b/internal/factory/agent_launch.go
@@ -927,7 +927,7 @@ func checkRepairAttempt(packet *CheckRepairPacket) int {
 	return packet.Attempt
 }
 
-// checkRepairBudget extracts the configured repair ceiling from a persisted
+// checkRepairBudget extracts the configured repair budget from a persisted
 // invocation packet.
 func checkRepairBudget(packet *CheckRepairPacket) int {
 	if packet == nil {

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -321,9 +321,9 @@ func testRevisionBudgetForPacket(packet SpecificationPacket) int {
 	return 0
 }
 
-// reviewRepairBudgetForPacket returns the frozen review-repair ceiling for a
-// packet. The repository policy owns the value; the coordinator enforces the
-// hard maximum before persisting or launching a repair.
+// reviewRepairBudgetForPacket returns the frozen review-repair budget for a
+// packet. The repository policy owns the value and the factory imposes no
+// bound of its own.
 func reviewRepairBudgetForPacket(packet SpecificationPacket) int {
 	return packet.RepositoryConfig.RetryLimits.ReviewRepair
 }

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -311,7 +311,7 @@ func (s *Service) claimCommentWatermark(ctx context.Context, repository github.R
 	return latestCommentID, nil
 }
 
-// testRevisionBudgetForPacket returns a revision ceiling only for runs that
+// testRevisionBudgetForPacket returns a revision budget only for runs that
 // actually have an independently owned test stage. Advisory implementation
 // runs do not expose the protected-test objection protocol.
 func testRevisionBudgetForPacket(packet SpecificationPacket) int {

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -96,7 +96,7 @@ const (
 	CheckRepairWaitingForHarness CheckRepairOutcome = "waiting_for_harness"
 	// CheckRepairWaitingForHuman means the coordinator cannot safely continue.
 	CheckRepairWaitingForHuman CheckRepairOutcome = "waiting_for_human"
-	// CheckRepairExhausted means the configured repair ceiling was reached.
+	// CheckRepairExhausted means the configured repair budget was reached.
 	CheckRepairExhausted CheckRepairOutcome = "exhausted"
 )
 
@@ -112,7 +112,7 @@ type CheckRepairResult struct {
 	Invocation store.Invocation
 	// Attempt is the current one-based consumed attempt count.
 	Attempt int
-	// Budget is the configured repair ceiling.
+	// Budget is the frozen repair budget the repository configured.
 	Budget int
 	// Remaining is the number of attempts still available after the decision.
 	Remaining int
@@ -139,7 +139,7 @@ const (
 	checkRepairStartDecision checkRepairDecisionKind = "start"
 	// checkRepairWaitDecision pauses until the harness can be retried.
 	checkRepairWaitDecision checkRepairDecisionKind = "wait"
-	// checkRepairExhaustDecision escalates after the frozen repair ceiling.
+	// checkRepairExhaustDecision escalates after the frozen repair budget.
 	checkRepairExhaustDecision checkRepairDecisionKind = "exhaust"
 )
 

--- a/internal/factory/repair.go
+++ b/internal/factory/repair.go
@@ -173,9 +173,6 @@ func decideCheckRepair(run store.Run, kind checkRepairFailureKind) (checkRepairD
 	if run.CheckRepairBudget <= 0 {
 		return checkRepairDecision{}, errors.New("check repair budget must be positive")
 	}
-	if run.CheckRepairBudget > config.MaxCheckRepairAttempts {
-		return checkRepairDecision{}, fmt.Errorf("check repair budget must not exceed %d", config.MaxCheckRepairAttempts)
-	}
 	if run.CheckRepairAttempts < 0 || run.CheckRepairAttempts > run.CheckRepairBudget {
 		return checkRepairDecision{}, fmt.Errorf("check repair attempts %d are outside budget %d", run.CheckRepairAttempts, run.CheckRepairBudget)
 	}

--- a/internal/factory/repair_test.go
+++ b/internal/factory/repair_test.go
@@ -123,14 +123,6 @@ func TestDecideCheckRepairTable(t *testing.T) {
 			kind:    checkRepairDeterministicFailure,
 			wantErr: true,
 		},
-		{
-			name: "budget above hard ceiling",
-			run: store.Run{
-				Stage: store.StageCheck, Status: store.StatusActive, CheckRepairBudget: config.MaxCheckRepairAttempts + 1,
-			},
-			kind:    checkRepairDeterministicFailure,
-			wantErr: true,
-		},
 	}
 	for _, test := range tests {
 		test := test

--- a/internal/factory/repair_test.go
+++ b/internal/factory/repair_test.go
@@ -69,6 +69,17 @@ func TestDecideCheckRepairTable(t *testing.T) {
 			wantRemain:  0,
 		},
 		{
+			name:         "repository-chosen budget above the removed ceiling",
+			run:          store.Run{Stage: store.StageCheck, Status: store.StatusActive, CheckRepairBudget: 7},
+			kind:         checkRepairDeterministicFailure,
+			wantKind:     checkRepairStartDecision,
+			wantStage:    store.StageImplementation,
+			wantStatus:   store.StatusActive,
+			wantAttempt:  1,
+			wantRemain:   6,
+			wantConsumed: true,
+		},
+		{
 			name:        "infrastructure does not consume budget",
 			run:         store.Run{Stage: store.StageCheck, Status: store.StatusActive, CheckRepairAttempts: 1, CheckRepairBudget: 3},
 			kind:        checkRepairInfrastructureFailure,

--- a/internal/factory/review_repair.go
+++ b/internal/factory/review_repair.go
@@ -30,7 +30,7 @@ type ReviewRepairResult struct {
 	Outcome store.ReviewRepairOutcome
 	// Attempt is the current or newly reserved repair round.
 	Attempt int
-	// Budget is the frozen repair ceiling.
+	// Budget is the frozen repair budget.
 	Budget int
 	// Remaining is the unused budget after a start decision.
 	Remaining int

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -176,7 +176,7 @@ type Request struct {
 	// prompt is repairing a failed deterministic checkpoint. Zero means a fresh
 	// implementation prompt.
 	CheckRepairAttempt int
-	// CheckRepairBudget is the run's configured repair ceiling when a repair is
+	// CheckRepairBudget is the run's configured repair budget when a repair is
 	// active.
 	CheckRepairBudget int
 	// ReviewRepair carries the complete blocking-review packet to an
@@ -190,7 +190,7 @@ type Request struct {
 	TestObjection *store.TestObjection
 	// TestRevisionAttempt is the one-based objection cycle being reviewed.
 	TestRevisionAttempt int
-	// TestRevisionBudget is the frozen objection-cycle ceiling.
+	// TestRevisionBudget is the frozen objection-cycle budget.
 	TestRevisionBudget int
 	// ProtectedTestPaths identifies test files implementation must preserve.
 	ProtectedTestPaths []store.ProtectedTestPath

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -356,7 +356,7 @@ const (
 	ReviewRepairStarted ReviewRepairOutcome = "started"
 	// ReviewRepairRepeated means a materially identical blocker returned.
 	ReviewRepairRepeated ReviewRepairOutcome = "repeated"
-	// ReviewRepairExhausted means the configured review-repair ceiling was used.
+	// ReviewRepairExhausted means the configured review-repair budget was used.
 	ReviewRepairExhausted ReviewRepairOutcome = "exhausted"
 	// ReviewRepairWaitingForHuman means the repair could not safely continue.
 	ReviewRepairWaitingForHuman ReviewRepairOutcome = "waiting_for_human"

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,14 +21,6 @@ import (
 // CurrentSchemaVersion is the supported operational-store schema version.
 const CurrentSchemaVersion = 34
 
-// MaxTestRevisionAttempts is the hard safety ceiling for automated
-// implementation-versus-test objection cycles.
-const MaxTestRevisionAttempts = 2
-
-// MaxReviewRepairAttempts is the hard safety ceiling for automated review
-// repair rounds.
-const MaxReviewRepairAttempts = 2
-
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
 var ErrRevisionConflict = errors.New("run revision conflict")
@@ -1292,9 +1284,6 @@ func normalizeRun(run Run) (Run, error) {
 	if run.ReviewRepairBudget < 0 {
 		return Run{}, errors.New("run review-repair budget must not be negative")
 	}
-	if run.ReviewRepairBudget > MaxReviewRepairAttempts {
-		return Run{}, fmt.Errorf("run review-repair budget must not exceed %d", MaxReviewRepairAttempts)
-	}
 	if run.ReviewRepairAttempts > run.ReviewRepairBudget {
 		return Run{}, errors.New("run review-repair attempts must not exceed budget")
 	}
@@ -1312,9 +1301,6 @@ func normalizeRun(run Run) (Run, error) {
 	}
 	if run.TestRevisionBudget < 0 {
 		return Run{}, errors.New("run test-revision budget must not be negative")
-	}
-	if run.TestRevisionBudget > MaxTestRevisionAttempts {
-		return Run{}, fmt.Errorf("run test-revision budget must not exceed %d", MaxTestRevisionAttempts)
 	}
 	if run.TestRevisionAttempts > run.TestRevisionBudget {
 		return Run{}, errors.New("run test-revision attempts must not exceed budget")
@@ -1388,9 +1374,6 @@ func validateTestProjection(run Run) error {
 	}
 	if run.TestInvocationID != "" && !safeQuestionIdentifier(run.TestInvocationID) {
 		return errors.New("run test invocation id is unsafe")
-	}
-	if len(run.TestRevisionHistory) > MaxTestRevisionAttempts {
-		return fmt.Errorf("run test revision history exceeds %d entries", MaxTestRevisionAttempts)
 	}
 	seenAttempts := make(map[int]struct{}, len(run.TestRevisionHistory))
 	disputeKey := ""
@@ -1502,9 +1485,6 @@ func validateTestProjection(run Run) error {
 // validateReviewRepairProjection checks the bounded review-repair state before
 // it is serialized into the operational store.
 func validateReviewRepairProjection(run Run) error {
-	if len(run.ReviewRepairHistory) > MaxReviewRepairAttempts {
-		return fmt.Errorf("run review repair history exceeds %d entries", MaxReviewRepairAttempts)
-	}
 	seenAttempts := make(map[int]struct{}, len(run.ReviewRepairHistory))
 	for index, revision := range run.ReviewRepairHistory {
 		if revision.Attempt < 1 || revision.Attempt > run.ReviewRepairBudget {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -824,7 +824,7 @@ func TestRunRejectsAReviewProjectionForAnOlderCheckpoint(t *testing.T) {
 	}
 }
 
-// TestStorePersistsCheckRepairBudget verifies the retry ceiling, consumed
+// TestStorePersistsCheckRepairBudget verifies the retry budget, consumed
 // attempt count, and in-flight reservation survive the restart boundary.
 func TestStorePersistsCheckRepairBudget(t *testing.T) {
 	t.Parallel()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -916,9 +916,9 @@ func TestStorePersistsReviewRepairState(t *testing.T) {
 }
 
 // TestStorePersistsRepositoryChosenRetryBudgets verifies the frozen per-run
-// budgets are the only bound the store applies. A review-repair budget and
-// history far above every previously hard-coded ceiling must survive a
-// restart unchanged.
+// budgets are the only bound the store applies. Review-repair and
+// test-revision budgets, and both attempt histories, far above every
+// previously hard-coded ceiling must survive a restart unchanged.
 func TestStorePersistsRepositoryChosenRetryBudgets(t *testing.T) {
 	t.Parallel()
 
@@ -931,6 +931,10 @@ func TestStorePersistsRepositoryChosenRetryBudgets(t *testing.T) {
 	for attempt := 1; attempt <= 6; attempt++ {
 		history = append(history, store.ReviewRepairAttempt{Attempt: attempt, Outcome: store.ReviewRepairStarted})
 	}
+	revisions := make([]store.TestRevision, 0, 4)
+	for attempt := 1; attempt <= 4; attempt++ {
+		revisions = append(revisions, store.TestRevision{Attempt: attempt, Outcome: store.TestRevisionRejected})
+	}
 	run := store.Run{
 		ID:                   "run-repository-budgets",
 		RepositoryPath:       "/work/repository",
@@ -940,7 +944,9 @@ func TestStorePersistsRepositoryChosenRetryBudgets(t *testing.T) {
 		ReviewRepairAttempts: 6,
 		ReviewRepairBudget:   12,
 		ReviewRepairHistory:  history,
+		TestRevisionAttempts: 4,
 		TestRevisionBudget:   9,
+		TestRevisionHistory:  revisions,
 		CheckpointSHA:        strings.Repeat("b", 64),
 		BaseCheckpointSHA:    strings.Repeat("c", 64),
 		CreatedAt:            time.Unix(100, 0).UTC(), UpdatedAt: time.Unix(200, 0).UTC(),
@@ -960,7 +966,7 @@ func TestStorePersistsRepositoryChosenRetryBudgets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CurrentRun() error = %v", err)
 	}
-	if got == nil || got.CheckRepairBudget != 7 || got.ReviewRepairBudget != 12 || got.TestRevisionBudget != 9 || len(got.ReviewRepairHistory) != 6 {
+	if got == nil || got.CheckRepairBudget != 7 || got.ReviewRepairBudget != 12 || got.TestRevisionBudget != 9 || len(got.ReviewRepairHistory) != 6 || len(got.TestRevisionHistory) != 4 {
 		t.Fatalf("CurrentRun() = %#v, want repository-chosen budgets preserved", got)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -915,6 +915,56 @@ func TestStorePersistsReviewRepairState(t *testing.T) {
 	}
 }
 
+// TestStorePersistsRepositoryChosenRetryBudgets verifies the frozen per-run
+// budgets are the only bound the store applies. A review-repair budget and
+// history far above every previously hard-coded ceiling must survive a
+// restart unchanged.
+func TestStorePersistsRepositoryChosenRetryBudgets(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "data", "factory.db")
+	opened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	history := make([]store.ReviewRepairAttempt, 0, 6)
+	for attempt := 1; attempt <= 6; attempt++ {
+		history = append(history, store.ReviewRepairAttempt{Attempt: attempt, Outcome: store.ReviewRepairStarted})
+	}
+	run := store.Run{
+		ID:                   "run-repository-budgets",
+		RepositoryPath:       "/work/repository",
+		Stage:                store.StageImplementation,
+		Status:               store.StatusActive,
+		CheckRepairBudget:    7,
+		ReviewRepairAttempts: 6,
+		ReviewRepairBudget:   12,
+		ReviewRepairHistory:  history,
+		TestRevisionBudget:   9,
+		CheckpointSHA:        strings.Repeat("b", 64),
+		BaseCheckpointSHA:    strings.Repeat("c", 64),
+		CreatedAt:            time.Unix(100, 0).UTC(), UpdatedAt: time.Unix(200, 0).UTC(),
+	}
+	if err := opened.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	reopened, err := store.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("reopen error = %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	got, err := reopened.CurrentRun(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentRun() error = %v", err)
+	}
+	if got == nil || got.CheckRepairBudget != 7 || got.ReviewRepairBudget != 12 || got.TestRevisionBudget != 9 || len(got.ReviewRepairHistory) != 6 {
+		t.Fatalf("CurrentRun() = %#v, want repository-chosen budgets preserved", got)
+	}
+}
+
 // TestStoreRejectsIncompleteReviewRepairFindings verifies repair packets use
 // the same complete nested finding contract as exact-checkpoint reviews.
 func TestStoreRejectsIncompleteReviewRepairFindings(t *testing.T) {


### PR DESCRIPTION
## Why

Starting the factory failed on every claim:

```
error: claim oldest eligible issue #129: persist frozen specification packet:
run review-repair budget must not exceed 2
```

The retry ceiling existed **twice**. `config.MaxReviewRepairAttempts` was raised to 4 in 35b26b5; `store.MaxReviewRepairAttempts` was missed and stayed at 2. So `factory.yaml: review_repair: 4` passed config validation, was frozen onto the run as `ReviewRepairBudget = 4`, and was then rejected by the store on write. The two copies of one constant could drift, and did.

Rather than bump the second copy, this removes the ceilings. The frozen per-run budget is the real bound: it is validated on every write, bounds each history entry, and is shown in the status comment. A second global bound on top of it only limits what a repository may choose.

**Scope:** all three limits — `check_repair`, `review_repair`, `test_revision`. They were one construct sharing one comment; capping any of them reproduces the same wall later.

## What changed

| Removed | Was |
|---|---|
| `config.MaxCheckRepairAttempts` + its validation branch | 3 |
| `config.MaxReviewRepairAttempts` + its validation branch | 4 |
| `config.MaxTestRevisionAttempts` + its validation branch | 2 |
| `store.MaxReviewRepairAttempts` + budget and history checks | 2 |
| `store.MaxTestRevisionAttempts` + budget and history checks | 2 |
| `decideCheckRepair` budget check (`repair.go`) | ≤ 3 |

`retry_limits` values must still be greater than zero. That is now the only constraint the factory applies.

The history length caps went with the constants. Each history loop already rejects an attempt outside `[1, budget]` and rejects duplicates, so a history cannot hold more entries than the budget allows. Those caps also never sat on the read path — `scanRun` unmarshals history JSON without validation — so deserialization exposure is unchanged.

## Contract impact

- **`factory.yaml`**: strictly widening. Every previously valid config stays valid; values above the old ceilings now validate instead of failing.
- **Operational store**: no schema change. `review_repair_budget` and friends were already plain `INTEGER NOT NULL` columns with no `CHECK` constraint, so existing databases need no migration.
- **Behaviour preserved**: the repeated-blocker immediate escalation and the budget-exhaustion path are untouched.
- **Safety posture**: `retry_limits.test_revision` carried a pilot-safety rationale tied to `allow_automated_objections` (#26). That gate is unchanged and still defaults closed; only the numeric cap moved to repository ownership.

Relates to #17, which specified the cap as "an initial configurable safety ceiling" that evaluation data "can tune". Its acceptance criterion "capped at two as a configurable safety ceiling" was already broken before this change — `store.MaxReviewRepairAttempts = 2` silently overrode the configurable value. Not closing #17; it is already closed.

## Test plan

`make check` (fmt-check, vet, test, build) green. Three tests added, each verified to **fail against `main`** with the exact clamp it pins:

| Test | Fails on `main` with |
|---|---|
| `TestValidateRepositoryAcceptsRepositoryChosenRetryLimits` | `retry_limits.<one of the three>: must not exceed …` (map iteration order picks which) |
| `TestStorePersistsRepositoryChosenRetryBudgets` | `run test revision history exceeds 2 entries` |
| `TestDecideCheckRepairTable/repository-chosen budget above the removed ceiling` | `check repair budget must not exceed 3` |

Reviewed with `/code-review main` over three rounds (Standards + Spec axes). Round 1 found five stale doc passages asserting the deleted caps and one stale docstring; round 2 found two unpinned clamps, an overclaiming test docstring and vocabulary drift; round 3 returned **no blocking findings on either axis** and confirmed all prior findings resolved, leaving only wrap-width and comment-vocabulary polish, fixed in `be5f5c4`.

Round 2 also withdrew a round-1 concern that removing the `len(history) > Max*` guards left the histories unbounded: those guards sat in `normalizeRun`, which only the write path reaches, and `scanRun` unmarshals history JSON with no validation at all — so read-path exposure is unchanged.

Docs updated: `README.md`, `CONTEXT.md`, `docs/configuration.md`, `docs/agent-runtime.md`. No ADR contradicts this; `docs/adr/` records no retry-policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hUhvPz31TKiZhe1E5JvJ2
