### PR TITLE
A refresh after an accepted implementation checkpoint restarts implementation into an unsatisfiable report contract

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -495,8 +495,15 @@ authorized answer in a new specification-packet version and resumes a fresh
 implementation invocation with that packet. Clarification pauses do not
 consume retry budget. `/factory refresh` re-reads the issue into another packet
 version, preserves resolved answers, invalidates superseded downstream
-invocations and checkpoint results, and resumes implementation against the new
-snapshot. `/factory revision` is the authorized ready-PR amendment command: it
+invocations and checkpoint results, and resumes the role selected by the new
+packet. If an accepted implementation checkpoint already exists and the run
+worktree is clean, refresh instead treats that checkpoint as the new packet
+baseline, reruns the baseline gates there, and restarts the workflow from that
+checkpoint, reusing the prior implementation session when native resume is
+available. This checkpoint behavior also applies when the refreshed issue text
+is unchanged; it does not require fabricating an uncommitted worktree change.
+The lifecycle reason names `/factory refresh` while that restart is being
+established. `/factory revision` is the authorized ready-PR amendment command: it
 creates a new packet version from the current open issue, drafts the tracked PR,
 invalidates all prior gate and review results, treats the current clean
 checkpoint as the new amendment baseline, preserves the existing

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -901,7 +901,7 @@ func TestRefreshCommandReReadsTheIssueAndInvalidatesCheckpointResults(t *testing
 // accepted implementation checkpoint is treated as the new baseline before
 // the implementation session is resumed, and its next report remains active.
 func TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint(t *testing.T) {
-	service, runStore, workspace, workerRuntime, harnessRuntime := newCheckpointRefreshService(t)
+	service, runStore, workspace, workerRuntime, harnessRuntime, pullRequests := newCheckpointRefreshService(t)
 
 	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
 	if err != nil {
@@ -924,6 +924,7 @@ func TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint
 	if len(workspace.state.ChangedPaths) != 0 {
 		t.Fatalf("checkpoint worktree changes = %#v, want clean worktree", workspace.state.ChangedPaths)
 	}
+	pullRequests.existing = checkpointed.PullRequest
 
 	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
 		IssueNumber: runStore.current.IssueNumber,
@@ -1021,6 +1022,62 @@ func TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint
 	}
 	if runStore.current.Status != store.StatusActive {
 		t.Fatalf("run after second refreshed report = %#v, want active rather than waiting", runStore.current)
+	}
+}
+
+// TestRefreshDoesNotPromoteACleanFailedCheckpoint verifies a checkpoint gate
+// failure remains repairable through ordinary implementation refresh rather
+// than being mistaken for an accepted checkpoint baseline.
+func TestRefreshDoesNotPromoteACleanFailedCheckpoint(t *testing.T) {
+	service, runStore, workspace, _, harnessRuntime, _ := newCheckpointRefreshService(t)
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	if _, err := writeAgentTestReport(t, launch, "internal/factory/agent.go"); err != nil {
+		t.Fatalf("write initial implementation report: %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: launch.Invocation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() error = %v", err)
+	}
+
+	run := *runStore.current
+	run.Stage = store.StageCheck
+	run.Status = store.StatusActive
+	run.CheckpointSHA = implementationCheckpoint
+	run.BaseCheckpointSHA = factoryGateCheckpoint
+	run.LifecycleReason = "checkpoint gate failure"
+	workspace.state.HeadSHA = implementationCheckpoint
+	workspace.state.ChangedPaths = nil
+	runStore.gateResults[run.ID] = append(runStore.gateResults[run.ID], store.GateResult{
+		RunID: run.ID, CheckpointSHA: implementationCheckpoint, Phase: store.GatePhaseCheckpoint,
+		Ordinal: 0, GateName: "test", Outcome: store.GateOutcomeFailed,
+		Status: string(github.CommitStatusFailure), Blocking: true,
+	})
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun() failed-checkpoint fixture error = %v", err)
+	}
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: run.IssueNumber,
+		Comment:     github.Comment{ID: "refresh-failed-checkpoint", Author: "alice", Body: "/factory refresh"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() refresh error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive || result.Run.Stage != store.StageImplementation {
+		t.Fatalf("refresh result = %#v, want ordinary active implementation restart", result)
+	}
+	if result.Run.BaseCheckpointSHA != factoryGateCheckpoint {
+		t.Fatalf("refresh base checkpoint = %q, want the original baseline %q", result.Run.BaseCheckpointSHA, factoryGateCheckpoint)
+	}
+	if len(harnessRuntime.starts) != 2 || len(harnessRuntime.resumes) != 0 {
+		t.Fatalf("harness launches after failed checkpoint refresh = starts=%d resumes=%d, want a fresh repair session", len(harnessRuntime.starts), len(harnessRuntime.resumes))
+	}
+	for _, gateResult := range runStore.gateResults[run.ID] {
+		if gateResult.Phase == store.GatePhaseBaseline && gateResult.CheckpointSHA == implementationCheckpoint {
+			t.Fatalf("gate results = %#v, want no baseline promotion of failed checkpoint", runStore.gateResults[run.ID])
+		}
 	}
 }
 
@@ -1253,7 +1310,7 @@ func newAgentService(t *testing.T) (*factory.Service, *agentRunStore, *agentWork
 // newCheckpointRefreshService creates an advisory implementation run with a
 // real checkpoint/draft-PR boundary so refresh can be exercised from the same
 // clean committed state that caused the production failure.
-func newCheckpointRefreshService(t *testing.T) (*factory.Service, *agentRunStore, *draftGitWorkspace, *agentWorker, *agentHarness) {
+func newCheckpointRefreshService(t *testing.T) (*factory.Service, *agentRunStore, *draftGitWorkspace, *agentWorker, *agentHarness, *fakePullRequests) {
 	t.Helper()
 	root := t.TempDir()
 	repositoryPath := filepath.Join(root, "repository")
@@ -1355,7 +1412,7 @@ func newCheckpointRefreshService(t *testing.T) (*factory.Service, *agentRunStore
 	if err := runStore.SaveRun(context.Background(), run); err != nil {
 		t.Fatal(err)
 	}
-	return service, runStore, workspace, workerRuntime, harnessRuntime
+	return service, runStore, workspace, workerRuntime, harnessRuntime, pullRequests
 }
 
 // newFreshAgentService recreates a coordinator around the persisted claim so

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -896,6 +896,96 @@ func TestRefreshCommandReReadsTheIssueAndInvalidatesCheckpointResults(t *testing
 	}
 }
 
+// TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint
+// verifies the exact recovery sequence for an unchanged specification: an
+// accepted implementation checkpoint is treated as the new baseline before
+// the implementation session is resumed, and its next report remains active.
+func TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint(t *testing.T) {
+	service, runStore, workspace, workerRuntime, harnessRuntime := newCheckpointRefreshService(t)
+
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	if _, err := writeAgentTestReport(t, launch, "internal/factory/agent.go"); err != nil {
+		t.Fatalf("write initial implementation report: %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: launch.Invocation.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() error = %v", err)
+	}
+
+	checkpointed, err := service.CreateDraftPullRequest(context.Background(), factory.DraftPullRequestRequest{RunID: launch.Invocation.RunID})
+	if err != nil {
+		t.Fatalf("CreateDraftPullRequest() error = %v", err)
+	}
+	if checkpointed.Run.Stage != store.StageDraftPR || checkpointed.Run.CheckpointSHA != implementationCheckpoint {
+		t.Fatalf("checkpointed run = %#v, want draft_pr at the implementation checkpoint", checkpointed.Run)
+	}
+	if len(workspace.state.ChangedPaths) != 0 {
+		t.Fatalf("checkpoint worktree changes = %#v, want clean worktree", workspace.state.ChangedPaths)
+	}
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: runStore.current.IssueNumber,
+		Comment:     github.Comment{ID: "refresh-checkpoint", Author: "alice", Body: "/factory refresh"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() refresh error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive || result.Run.Stage != store.StageImplementation || result.Run.BaseCheckpointSHA != implementationCheckpoint {
+		t.Fatalf("refresh result = %#v, want accepted active implementation restart", result)
+	}
+	if !strings.Contains(result.Run.LifecycleReason, "/factory refresh") || !strings.Contains(factory.StatusCommentBody(result.Run), "/factory refresh") {
+		t.Fatalf("refresh lifecycle projection = %q, want the applying command in the status comment", result.Run.LifecycleReason)
+	}
+	if len(harnessRuntime.resumes) != 1 {
+		t.Fatalf("native resumes = %d, want one revision-style implementation resume", len(harnessRuntime.resumes))
+	}
+	if len(harnessRuntime.starts) != 1 {
+		t.Fatalf("fresh harness starts after refresh = %d, want only the initial session", len(harnessRuntime.starts))
+	}
+	var baselineAtCheckpoint bool
+	for _, gateResult := range runStore.gateResults[launch.Invocation.RunID] {
+		if gateResult.Phase == store.GatePhaseBaseline && gateResult.CheckpointSHA == implementationCheckpoint {
+			baselineAtCheckpoint = true
+		}
+	}
+	if !baselineAtCheckpoint {
+		t.Fatalf("gate results = %#v, want a baseline result for the accepted implementation checkpoint", runStore.gateResults[launch.Invocation.RunID])
+	}
+	if len(workerRuntime.commands) < 4 {
+		t.Fatalf("worker commands = %#v, want checkpoint gates and refreshed baseline gates", workerRuntime.commands)
+	}
+
+	refreshed := runStore.invocations[result.Run.ActiveInvocationIDs[0]]
+	value := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  refreshed.ID,
+		RunID:         refreshed.RunID,
+		Harness:       refreshed.Harness,
+		Role:          refreshed.Role,
+		Stage:         string(refreshed.Stage),
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "verified the unchanged issue against the accepted checkpoint",
+		Handoff: &report.Handoff{
+			ChangeSummary:     "verified the accepted implementation checkpoint",
+			AcceptanceMapping: []report.AcceptanceMapping{{Criterion: "unchanged issue", Evidence: "checkpoint baseline and focused verification"}},
+			FocusedCommands:   []string{"go test ./internal/factory"},
+		},
+		NativeSessionID: refreshed.NativeSessionID,
+		ReportedAt:      time.Now().UTC(),
+	}
+	if _, err := report.WriteAtomicForInvocation(refreshed.ResultDirectory, refreshed.ID, value); err != nil {
+		t.Fatalf("write refreshed implementation report: %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: refreshed.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() refreshed error = %v", err)
+	}
+	if runStore.current.Status != store.StatusActive {
+		t.Fatalf("run after refreshed report = %#v, want active rather than waiting", runStore.current)
+	}
+}
+
 // TestAcceptAgentReportTrustsThePersistedNativeSession verifies a report
 // cannot replace the native session identity already bound to the invocation.
 func TestAcceptAgentReportTrustsThePersistedNativeSession(t *testing.T) {
@@ -1120,6 +1210,114 @@ func newAgentService(t *testing.T) (*factory.Service, *agentRunStore, *agentWork
 		Status: string(github.CommitStatusSuccess), Blocking: policy.Gates[0].Blocking,
 	}}
 	return service, runStore, runtime, terminalRuntime, harnessRuntime
+}
+
+// newCheckpointRefreshService creates an advisory implementation run with a
+// real checkpoint/draft-PR boundary so refresh can be exercised from the same
+// clean committed state that caused the production failure.
+func newCheckpointRefreshService(t *testing.T) (*factory.Service, *agentRunStore, *draftGitWorkspace, *agentWorker, *agentHarness) {
+	t.Helper()
+	root := t.TempDir()
+	repositoryPath := filepath.Join(root, "repository")
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(filepath.Join(repositoryPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repositoryPath, ".git", "HEAD"), []byte("ref: refs/heads/factory/run-refresh-checkpoint\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := validRepositoryConfig()
+	policy.TestPolicy.Mode = config.TestModeAdvisory
+	delete(policy.RoleHarnessDefaults, workflow.RoleTest)
+	delete(policy.ModelOptions, workflow.RoleTest)
+	runStore := &agentRunStore{runs: map[string]store.Run{}, invocations: map[string]store.Invocation{}, gateResults: map[string][]store.GateResult{}}
+	workerRuntime := &agentWorker{}
+	terminalRuntime := &agentTerminal{}
+	harnessRuntime := &agentHarness{}
+	issue := github.Issue{Number: 6, Title: "Unchanged implementation", Body: "The accepted implementation already satisfies this issue.", State: "open", Labels: []string{github.LabelAgentReady}}
+	githubRuntime := &fakeGitHubWithPullRequests{fakeGitHub: &fakeGitHub{issueValue: issue}}
+	workspace := &draftGitWorkspace{
+		workspace: gitadapter.Workspace{BaseSHA: factoryGateCheckpoint, Branch: "factory/run-refresh-checkpoint", Worktree: worktreePath},
+		state: gitadapter.WorktreeState{
+			RepositoryPath: repositoryPath,
+			Branch:         "factory/run-refresh-checkpoint",
+			HeadSHA:        factoryGateCheckpoint,
+			ChangedPaths:   []string{"internal/factory/agent.go"},
+		},
+	}
+	pullRequests := &fakePullRequests{created: github.PullRequest{
+		Number: 17, URL: "https://github.com/example/project/pull/17", State: "open", Draft: true,
+		HeadBranch: "factory/run-refresh-checkpoint", BaseBranch: "main",
+	}}
+	operationalPath := filepath.Join(root, "state", "factory.db")
+	host := config.HostConfig{SchemaVersion: 1, Repositories: []config.RepositoryRegistration{{
+		Path:                 repositoryPath,
+		GitHub:               config.GitHubConfig{Owner: "example", Repository: "project"},
+		AuthorizedUsers:      []string{"alice"},
+		OperationalDataPath:  operationalPath,
+		RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
+		Cmux:                 config.CmuxConfig{ControlWorkspace: "factory-control"},
+	}}}
+	ids := []string{"run-refresh-checkpoint", "initial-implementation", "refreshed-implementation"}
+	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
+		Config: &fakeConfig{value: host},
+		OpenStore: func(context.Context, string) (factory.OperationalStore, error) {
+			return runStore, nil
+		},
+		LoadRepository: func(string) (config.RepositoryConfig, error) { return policy, nil },
+		GitHub:         githubRuntime,
+		PullRequests:   pullRequests,
+		Worktree:       workspace,
+		GitWorkspace:   workspace,
+		Worker:         workerRuntime,
+		Terminal:       terminalRuntime,
+		Harness:        harnessRuntime,
+		CommitStatuses: &gateStatuses{},
+		Now:            func() time.Time { return time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC) },
+		NewRunID: func() (string, error) {
+			if len(ids) == 0 {
+				return "", errors.New("refresh checkpoint test identifiers exhausted")
+			}
+			id := ids[0]
+			ids = ids[1:]
+			return id, nil
+		},
+	})
+	claimed, err := service.ClaimIssue(context.Background(), issue.Number)
+	if err != nil {
+		t.Fatalf("ClaimIssue() fixture setup error = %v", err)
+	}
+	run := claimed.Run
+	var packet factory.SpecificationPacket
+	if err := json.Unmarshal([]byte(run.SpecificationPacket), &packet); err != nil {
+		t.Fatal(err)
+	}
+	packet.RepositoryConfig.TestPolicy.Mode = config.TestModeAdvisory
+	delete(packet.RepositoryConfig.RoleHarnessDefaults, workflow.RoleTest)
+	delete(packet.RepositoryConfig.ModelOptions, workflow.RoleTest)
+	packetData, err := json.Marshal(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.SpecificationPacket = string(packetData)
+	run.Stage = store.StageImplementation
+	run.Status = store.StatusActive
+	run.TestStageSkipped = false
+	run.TestExemption = nil
+	run.TestHandoff = nil
+	runStore.gateResults[run.ID] = []store.GateResult{{
+		RunID: run.ID, CheckpointSHA: factoryGateCheckpoint, Phase: store.GatePhaseBaseline,
+		Ordinal: 0, GateName: policy.Gates[0].Name, Outcome: store.GateOutcomePassed,
+		Status: string(github.CommitStatusSuccess), Blocking: policy.Gates[0].Blocking,
+	}}
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	return service, runStore, workspace, workerRuntime, harnessRuntime
 }
 
 // newFreshAgentService recreates a coordinator around the persisted claim so

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -984,6 +984,44 @@ func TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint
 	if runStore.current.Status != store.StatusActive {
 		t.Fatalf("run after refreshed report = %#v, want active rather than waiting", runStore.current)
 	}
+
+	secondResult, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: runStore.current.IssueNumber,
+		Comment:     github.Comment{ID: "refresh-checkpoint-again", Author: "alice", Body: "/factory refresh"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() second refresh error = %v", err)
+	}
+	if secondResult.Outcome != factory.CommandAccepted || secondResult.Run.Status != store.StatusActive || secondResult.Run.Stage != store.StageImplementation || secondResult.Run.BaseCheckpointSHA != implementationCheckpoint {
+		t.Fatalf("second refresh result = %#v, want accepted active implementation restart", secondResult)
+	}
+	if len(harnessRuntime.resumes) != 2 {
+		t.Fatalf("native resumes after second refresh = %d, want two revision-style implementation resumes", len(harnessRuntime.resumes))
+	}
+	if len(harnessRuntime.starts) != 1 {
+		t.Fatalf("fresh harness starts after second refresh = %d, want only the initial session", len(harnessRuntime.starts))
+	}
+	secondRefreshed := runStore.invocations[secondResult.Run.ActiveInvocationIDs[0]]
+	if secondRefreshed.ID == refreshed.ID {
+		t.Fatalf("second refresh reused invocation %q, want a new resumed invocation", secondRefreshed.ID)
+	}
+	secondValue := value
+	secondValue.InvocationID = secondRefreshed.ID
+	secondValue.RunID = secondRefreshed.RunID
+	secondValue.Harness = secondRefreshed.Harness
+	secondValue.Role = secondRefreshed.Role
+	secondValue.Stage = string(secondRefreshed.Stage)
+	secondValue.NativeSessionID = secondRefreshed.NativeSessionID
+	secondValue.ReportedAt = time.Now().UTC()
+	if _, err := report.WriteAtomicForInvocation(secondRefreshed.ResultDirectory, secondRefreshed.ID, secondValue); err != nil {
+		t.Fatalf("write second refreshed implementation report: %v", err)
+	}
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: secondRefreshed.ID}); err != nil {
+		t.Fatalf("AcceptAgentReport() second refreshed error = %v", err)
+	}
+	if runStore.current.Status != store.StatusActive {
+		t.Fatalf("run after second refreshed report = %#v, want active rather than waiting", runStore.current)
+	}
 }
 
 // TestAcceptAgentReportTrustsThePersistedNativeSession verifies a report
@@ -1262,7 +1300,7 @@ func newCheckpointRefreshService(t *testing.T) (*factory.Service, *agentRunStore
 		RepositoryConfigPath: filepath.Join(repositoryPath, "factory.yaml"),
 		Cmux:                 config.CmuxConfig{ControlWorkspace: "factory-control"},
 	}}}
-	ids := []string{"run-refresh-checkpoint", "initial-implementation", "refreshed-implementation"}
+	ids := []string{"run-refresh-checkpoint", "initial-implementation", "refreshed-implementation", "second-refreshed-implementation"}
 	service := factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config: &fakeConfig{value: host},
 		OpenStore: func(context.Context, string) (factory.OperationalStore, error) {

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -933,7 +933,7 @@ func TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint
 	if err != nil {
 		t.Fatalf("HandleCommand() refresh error = %v", err)
 	}
-	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive || result.Run.Stage != store.StageImplementation || result.Run.BaseCheckpointSHA != implementationCheckpoint {
+	if result.Outcome != factory.CommandAccepted || result.Run.Status != store.StatusActive || result.Run.Stage != store.StageImplementation || result.Run.BaseCheckpointSHA != implementationCheckpoint || result.Run.AcceptedImplementationCheckpointSHA != implementationCheckpoint {
 		t.Fatalf("refresh result = %#v, want accepted active implementation restart", result)
 	}
 	if !strings.Contains(result.Run.LifecycleReason, "/factory refresh") || !strings.Contains(factory.StatusCommentBody(result.Run), "/factory refresh") {
@@ -976,14 +976,24 @@ func TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint
 		NativeSessionID: refreshed.NativeSessionID,
 		ReportedAt:      time.Now().UTC(),
 	}
-	if _, err := report.WriteAtomicForInvocation(refreshed.ResultDirectory, refreshed.ID, value); err != nil {
-		t.Fatalf("write refreshed implementation report: %v", err)
+	invalid := value
+	invalid.Handoff = &report.Handoff{
+		ChangeSummary:          value.Handoff.ChangeSummary,
+		AcceptanceMapping:      append([]report.AcceptanceMapping(nil), value.Handoff.AcceptanceMapping...),
+		ProductionFilesChanged: []string{"internal/factory/agent.go"},
+		FocusedCommands:        append([]string(nil), value.Handoff.FocusedCommands...),
 	}
-	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: refreshed.ID}); err != nil {
-		t.Fatalf("AcceptAgentReport() refreshed error = %v", err)
+	if _, err := report.WriteAtomicForInvocation(refreshed.ResultDirectory, refreshed.ID, invalid); err != nil {
+		t.Fatalf("write invalid refreshed implementation report: %v", err)
 	}
-	if runStore.current.Status != store.StatusActive {
-		t.Fatalf("run after refreshed report = %#v, want active rather than waiting", runStore.current)
+	if _, err := service.AcceptAgentReport(context.Background(), factory.AgentReportRequest{InvocationID: refreshed.ID}); err == nil || !strings.Contains(err.Error(), "was not observed in the worktree") {
+		t.Fatalf("AcceptAgentReport() invalid refreshed error = %v, want unobserved production path rejection", err)
+	}
+	paused := *runStore.current
+	paused.Status = store.StatusWaitingForHuman
+	paused.LifecycleReason = "unattended progression stopped at accept agent report: production_files_changed[0] was not observed in the worktree"
+	if err := runStore.SaveRun(context.Background(), paused); err != nil {
+		t.Fatalf("save invalid-report waiting state: %v", err)
 	}
 
 	secondResult, err := service.HandleCommand(context.Background(), factory.CommandRequest{
@@ -993,18 +1003,18 @@ func TestRefreshAfterAnAcceptedImplementationCheckpointRestartsFromTheCheckpoint
 	if err != nil {
 		t.Fatalf("HandleCommand() second refresh error = %v", err)
 	}
-	if secondResult.Outcome != factory.CommandAccepted || secondResult.Run.Status != store.StatusActive || secondResult.Run.Stage != store.StageImplementation || secondResult.Run.BaseCheckpointSHA != implementationCheckpoint {
+	if secondResult.Outcome != factory.CommandAccepted || secondResult.Run.Status != store.StatusActive || secondResult.Run.Stage != store.StageImplementation || secondResult.Run.BaseCheckpointSHA != implementationCheckpoint || secondResult.Run.AcceptedImplementationCheckpointSHA != implementationCheckpoint {
 		t.Fatalf("second refresh result = %#v, want accepted active implementation restart", secondResult)
 	}
 	if len(harnessRuntime.resumes) != 2 {
-		t.Fatalf("native resumes after second refresh = %d, want two revision-style implementation resumes", len(harnessRuntime.resumes))
+		t.Fatalf("native resumes after rejected-report refresh = %d, want two revision-style implementation resumes", len(harnessRuntime.resumes))
 	}
 	if len(harnessRuntime.starts) != 1 {
-		t.Fatalf("fresh harness starts after second refresh = %d, want only the initial session", len(harnessRuntime.starts))
+		t.Fatalf("fresh harness starts after rejected-report refresh = %d, want only the initial session", len(harnessRuntime.starts))
 	}
 	secondRefreshed := runStore.invocations[secondResult.Run.ActiveInvocationIDs[0]]
 	if secondRefreshed.ID == refreshed.ID {
-		t.Fatalf("second refresh reused invocation %q, want a new resumed invocation", secondRefreshed.ID)
+		t.Fatalf("rejected-report refresh reused invocation %q, want a new resumed invocation", secondRefreshed.ID)
 	}
 	secondValue := value
 	secondValue.InvocationID = secondRefreshed.ID

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -327,6 +327,10 @@ func (s *Service) handleRefreshCommand(ctx context.Context, registration config.
 		rejection := &PolicyRejection{Code: PolicyRejectionRefreshState, Problem: fmt.Sprintf("cannot refresh a %s issue", defaultString(issue.State, "non-open"))}
 		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
 	}
+	restartFromCheckpoint, err := s.shouldRestartFromAcceptedImplementationCheckpoint(ctx, run)
+	if err != nil {
+		return CommandResult{}, err
+	}
 	refreshedPacket := oldPacket
 	refreshedPacket.Version++
 	refreshedPacket.Issue = cloneIssue(issue)
@@ -345,6 +349,7 @@ func (s *Service) handleRefreshCommand(ctx context.Context, registration config.
 	next.PendingQuestions = nil
 	next.ClarificationCommentID = ""
 	next.ClarificationNotificationSent = false
+	markAcceptedCheckpointPacketRestart(&next, run, restartFromCheckpoint)
 	next.UpdatedAt = s.deps.Now().UTC()
 	// Clear ProcessedCommentID temporarily to defer watermark until after resumption
 	processedCommentID := next.ProcessedCommentID
@@ -588,6 +593,9 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 	if _, ok := runStore.(InvocationStore); !ok {
 		return run, nil
 	}
+	if strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecycleReason) {
+		return s.resumeAfterRevision(ctx, registration, runStore, run)
+	}
 	// The coordinator's progression pass owns the baseline, so a run that has
 	// not passed it yet must not launch a role here.
 	if awaitingBaseline(run) {
@@ -607,6 +615,59 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 		return *current, nil
 	}
 	return run, nil
+}
+
+// acceptedCheckpointRefreshLifecycleReason identifies the durable refresh
+// transition that must run baseline before launching implementation.
+const acceptedCheckpointRefreshLifecycleReason = "accepted /factory refresh; restarting from accepted implementation checkpoint"
+
+// markAcceptedCheckpointPacketRestart makes a checkpoint restart durable in
+// the packet-change projection before baseline work or native resume begins.
+func markAcceptedCheckpointPacketRestart(next *store.Run, previous store.Run, restart bool) {
+	if next == nil || !restart {
+		return
+	}
+	next.BaseCheckpointSHA = previous.CheckpointSHA
+	next.Stage = store.StageClaim
+	next.Status = store.StatusActive
+	next.LifecycleReason = acceptedCheckpointRefreshLifecycleReason
+}
+
+// baselineLifecycleReason keeps the command that selected a checkpoint
+// restart visible after the baseline transition replaces the packet-change
+// reason with its normal stage-ready explanation.
+func baselineLifecycleReason(run store.Run, reason string) string {
+	if strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecycleReason) {
+		return "accepted /factory refresh; " + reason
+	}
+	return reason
+}
+
+// shouldRestartFromAcceptedImplementationCheckpoint identifies the clean
+// committed implementation boundary that a packet refresh can safely reuse.
+// The protected test checkpoint is excluded: it is an implementation input,
+// not an accepted implementation checkpoint.
+func (s *Service) shouldRestartFromAcceptedImplementationCheckpoint(ctx context.Context, run store.Run) (bool, error) {
+	if run.CheckpointSHA == "" || run.BaseCheckpointSHA == "" || run.CheckpointSHA == run.BaseCheckpointSHA {
+		return false, nil
+	}
+	// A test-stage run's current checkpoint is protected test work, even if an
+	// older store did not retain the separate test-checkpoint marker.
+	if run.Stage == store.StageTest {
+		return false, nil
+	}
+	if run.TestCheckpointSHA != "" && run.TestCheckpointSHA == run.CheckpointSHA {
+		return false, nil
+	}
+	inspector := s.worktreeInspector()
+	if inspector == nil {
+		return false, nil
+	}
+	state, err := inspector.Inspect(ctx, run.Worktree)
+	if err != nil {
+		return false, fmt.Errorf("inspect implementation checkpoint before refresh resumption: %w", err)
+	}
+	return state.HeadSHA == run.CheckpointSHA && len(state.ChangedPaths) == 0, nil
 }
 
 // awaitingBaseline reports whether a run has not yet passed its frozen

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -640,6 +640,7 @@ func markAcceptedCheckpointPacketRestart(next *store.Run, previous store.Run, re
 		return
 	}
 	next.BaseCheckpointSHA = previous.CheckpointSHA
+	next.AcceptedImplementationCheckpointSHA = previous.CheckpointSHA
 	next.Stage = store.StageClaim
 	next.Status = store.StatusActive
 	next.LifecycleReason = acceptedCheckpointRefreshLifecycleReason
@@ -728,7 +729,11 @@ func (s *Service) shouldRestartFromAcceptedImplementationCheckpoint(ctx context.
 			return false, nil
 		}
 	case store.StageImplementation:
-		if strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecyclePrefix) {
+		// The packet transition invalidates downstream gate rows, and a rejected
+		// implementation report can replace the lifecycle marker with its
+		// waiting reason. The dedicated provenance remains the acceptance proof
+		// for the unchanged clean checkpoint across both transitions.
+		if run.AcceptedImplementationCheckpointSHA == run.CheckpointSHA || strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecyclePrefix) {
 			break
 		}
 		// A failed check can route back to implementation while an older PR is
@@ -803,6 +808,9 @@ func resetTestProjectionForPacketChange(run *store.Run, packet SpecificationPack
 	run.TestCheckpointSHA = ""
 	run.TestExemption = nil
 	run.TestStageSkipped = false
+	// Every invocation for the superseded packet is no longer current, even if
+	// its report later causes the coordinator to park the run while accepting it.
+	clearActiveInvocations(run)
 	// The healthy baseline result selects the entry stage, not the packet
 	// change itself. A packet the baseline could never leave still parks
 	// visibly, because advanceAfterBaseline rejects it after every pass.

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -327,7 +327,7 @@ func (s *Service) handleRefreshCommand(ctx context.Context, registration config.
 		rejection := &PolicyRejection{Code: PolicyRejectionRefreshState, Problem: fmt.Sprintf("cannot refresh a %s issue", defaultString(issue.State, "non-open"))}
 		return s.persistCommandRejection(ctx, registration, runStore, run, comment, parsed, rejection)
 	}
-	restartFromCheckpoint, err := s.shouldRestartFromAcceptedImplementationCheckpoint(ctx, run)
+	restartFromCheckpoint, err := s.shouldRestartFromAcceptedImplementationCheckpoint(ctx, runStore, run, oldPacket)
 	if err != nil {
 		return CommandResult{}, err
 	}
@@ -337,6 +337,11 @@ func (s *Service) handleRefreshCommand(ctx context.Context, registration config.
 	encodedPacket, err := json.Marshal(refreshedPacket)
 	if err != nil {
 		return CommandResult{}, fmt.Errorf("encode refreshed specification packet: %w", err)
+	}
+	if restartFromCheckpoint || (run.Stage == store.StageReady && run.PullRequestNumber > 0) {
+		if err := s.demotePullRequestForCheckpointRefresh(ctx, registration, run, oldPacket); err != nil {
+			return CommandResult{}, err
+		}
 	}
 	if err := s.stopRunWorkerIfActive(ctx, runStore, run); err != nil {
 		return CommandResult{}, err
@@ -650,11 +655,54 @@ func baselineLifecycleReason(run store.Run, reason string) string {
 	return reason
 }
 
+// demotePullRequestForCheckpointRefresh verifies the tracked pull request is
+// open and draft before a refreshed packet can restart implementation. A
+// failed or ambiguous external mutation leaves the packet transition
+// unapplied, so replaying the command safely re-reads the current PR state.
+func (s *Service) demotePullRequestForCheckpointRefresh(ctx context.Context, registration config.RepositoryRegistration, run store.Run, packet SpecificationPacket) error {
+	if run.PullRequestNumber <= 0 {
+		return nil
+	}
+	client := s.pullRequestClient()
+	if client == nil {
+		return errors.New("checkpoint refresh with a tracked pull request requires pull-request operations")
+	}
+	repository := commandRepository(registration)
+	existing, err := client.FindPullRequest(ctx, repository, run.Branch, packet.RepositoryConfig.TargetBranch)
+	if err != nil {
+		return fmt.Errorf("find pull request for checkpoint refresh: %w", err)
+	}
+	if existing.Number == 0 || existing.Number != run.PullRequestNumber {
+		return fmt.Errorf("tracked pull request #%d was not found for checkpoint refresh", run.PullRequestNumber)
+	}
+	if existing.Merged || !strings.EqualFold(strings.TrimSpace(existing.State), "open") {
+		return fmt.Errorf("pull request #%d is not open for checkpoint refresh", run.PullRequestNumber)
+	}
+	updated, err := s.setPullRequestDraft(ctx, repository, existing, true)
+	if err != nil {
+		return err
+	}
+	if updated.Number != run.PullRequestNumber {
+		return fmt.Errorf("checkpoint refresh returned pull request #%d, want tracked pull request #%d", updated.Number, run.PullRequestNumber)
+	}
+	if updated.Merged || !strings.EqualFold(strings.TrimSpace(updated.State), "open") {
+		return fmt.Errorf("pull request #%d is no longer open after checkpoint refresh", run.PullRequestNumber)
+	}
+	if !updated.Draft {
+		return fmt.Errorf("pull request #%d was not confirmed as draft before checkpoint refresh", run.PullRequestNumber)
+	}
+	return nil
+}
+
 // shouldRestartFromAcceptedImplementationCheckpoint identifies the clean
 // committed implementation boundary that a packet refresh can safely reuse.
-// The protected test checkpoint is excluded: it is an implementation input,
-// not an accepted implementation checkpoint.
-func (s *Service) shouldRestartFromAcceptedImplementationCheckpoint(ctx context.Context, run store.Run) (bool, error) {
+// A check-stage boundary must have exact passed checkpoint gates; a draft-PR
+// or later boundary must retain its tracked PR. An implementation-stage
+// boundary must have either the durable refresh marker or exact passed gates,
+// so a failed checkpoint cannot be promoted merely because an older PR exists.
+// The protected test checkpoint is excluded because it is implementation
+// input, not an accepted implementation checkpoint.
+func (s *Service) shouldRestartFromAcceptedImplementationCheckpoint(ctx context.Context, runStore RunStore, run store.Run, packet SpecificationPacket) (bool, error) {
 	if run.CheckpointSHA == "" || run.BaseCheckpointSHA == "" {
 		return false, nil
 	}
@@ -666,12 +714,33 @@ func (s *Service) shouldRestartFromAcceptedImplementationCheckpoint(ctx context.
 	if run.TestCheckpointSHA != "" && run.TestCheckpointSHA == run.CheckpointSHA {
 		return false, nil
 	}
-	// A checkpoint promoted as the packet baseline is still an accepted
-	// implementation checkpoint when the run already owns a draft or later
-	// pull-request projection. The lifecycle marker covers the same durable
-	// restart state before a pull request exists, so BaseCheckpointSHA equality
-	// cannot make a later clean refresh fall back to a fresh session.
-	if run.CheckpointSHA == run.BaseCheckpointSHA && run.PullRequestNumber == 0 && !strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecyclePrefix) {
+	switch run.Stage {
+	case store.StageCheck:
+		// CreateDraftPullRequest records the checkpoint before its gates run, so
+		// StageCheck alone does not prove the checkpoint was accepted.
+		if err := ensureFinalCheckpointGatesPassed(ctx, runStore, run, packet); err != nil {
+			return false, nil
+		}
+	case store.StageDraftPR, store.StageReview, store.StageReady:
+		// These stages are reached only after the checkpoint boundary and retain
+		// the PR identity that proves the boundary was published.
+		if run.PullRequestNumber == 0 {
+			return false, nil
+		}
+	case store.StageImplementation:
+		if strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecyclePrefix) {
+			break
+		}
+		// A failed check can route back to implementation while an older PR is
+		// still tracked. Require the current checkpoint's exact gate results in
+		// that state rather than treating the old PR as acceptance evidence.
+		if run.PullRequestNumber == 0 {
+			return false, nil
+		}
+		if err := ensureFinalCheckpointGatesPassed(ctx, runStore, run, packet); err != nil {
+			return false, nil
+		}
+	default:
 		return false, nil
 	}
 	inspector := s.worktreeInspector()

--- a/internal/factory/command.go
+++ b/internal/factory/command.go
@@ -593,7 +593,7 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 	if _, ok := runStore.(InvocationStore); !ok {
 		return run, nil
 	}
-	if strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecycleReason) {
+	if strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecyclePrefix) {
 		return s.resumeAfterRevision(ctx, registration, runStore, run)
 	}
 	// The coordinator's progression pass owns the baseline, so a run that has
@@ -617,9 +617,16 @@ func (s *Service) resumeAfterPacketChange(ctx context.Context, registration conf
 	return run, nil
 }
 
-// acceptedCheckpointRefreshLifecycleReason identifies the durable refresh
-// transition that must run baseline before launching implementation.
-const acceptedCheckpointRefreshLifecycleReason = "accepted /factory refresh; restarting from accepted implementation checkpoint"
+const (
+	// acceptedCheckpointRefreshLifecyclePrefix identifies the durable refresh
+	// transition that must run baseline before launching implementation. The
+	// prefix survives the baseline's more specific lifecycle explanation so a
+	// later clean refresh can recognize the same checkpoint again.
+	acceptedCheckpointRefreshLifecyclePrefix = "accepted /factory refresh; "
+	// acceptedCheckpointRefreshLifecycleReason identifies the durable refresh
+	// transition before the baseline has supplied its result.
+	acceptedCheckpointRefreshLifecycleReason = acceptedCheckpointRefreshLifecyclePrefix + "restarting from accepted implementation checkpoint"
+)
 
 // markAcceptedCheckpointPacketRestart makes a checkpoint restart durable in
 // the packet-change projection before baseline work or native resume begins.
@@ -637,8 +644,8 @@ func markAcceptedCheckpointPacketRestart(next *store.Run, previous store.Run, re
 // restart visible after the baseline transition replaces the packet-change
 // reason with its normal stage-ready explanation.
 func baselineLifecycleReason(run store.Run, reason string) string {
-	if strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecycleReason) {
-		return "accepted /factory refresh; " + reason
+	if strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecyclePrefix) {
+		return acceptedCheckpointRefreshLifecyclePrefix + reason
 	}
 	return reason
 }
@@ -648,7 +655,7 @@ func baselineLifecycleReason(run store.Run, reason string) string {
 // The protected test checkpoint is excluded: it is an implementation input,
 // not an accepted implementation checkpoint.
 func (s *Service) shouldRestartFromAcceptedImplementationCheckpoint(ctx context.Context, run store.Run) (bool, error) {
-	if run.CheckpointSHA == "" || run.BaseCheckpointSHA == "" || run.CheckpointSHA == run.BaseCheckpointSHA {
+	if run.CheckpointSHA == "" || run.BaseCheckpointSHA == "" {
 		return false, nil
 	}
 	// A test-stage run's current checkpoint is protected test work, even if an
@@ -657,6 +664,14 @@ func (s *Service) shouldRestartFromAcceptedImplementationCheckpoint(ctx context.
 		return false, nil
 	}
 	if run.TestCheckpointSHA != "" && run.TestCheckpointSHA == run.CheckpointSHA {
+		return false, nil
+	}
+	// A checkpoint promoted as the packet baseline is still an accepted
+	// implementation checkpoint when the run already owns a draft or later
+	// pull-request projection. The lifecycle marker covers the same durable
+	// restart state before a pull request exists, so BaseCheckpointSHA equality
+	// cannot make a later clean refresh fall back to a fresh session.
+	if run.CheckpointSHA == run.BaseCheckpointSHA && run.PullRequestNumber == 0 && !strings.HasPrefix(run.LifecycleReason, acceptedCheckpointRefreshLifecyclePrefix) {
 		return false, nil
 	}
 	inspector := s.worktreeInspector()

--- a/internal/factory/command_test.go
+++ b/internal/factory/command_test.go
@@ -204,6 +204,53 @@ func TestHandleCommandAmendsAReadyPullRequest(t *testing.T) {
 	}
 }
 
+// TestHandleCommandRefreshDemotesAReadyPullRequest verifies a checkpoint
+// refresh cannot leave a tracked pull request mergeable while its new packet
+// is being re-established and implemented.
+func TestHandleCommandRefreshDemotesAReadyPullRequest(t *testing.T) {
+	t.Parallel()
+
+	run := commandRun(t, store.StatusActive)
+	run.Stage = store.StageReady
+	run.Branch = "factory/run-command"
+	run.Worktree = "/worktree/run-command"
+	run.BaseCheckpointSHA = strings.Repeat("b", 64)
+	run.CheckpointSHA = strings.Repeat("a", 64)
+	run.PullRequestNumber = 17
+	run.PullRequestURL = "https://github.com/example/project/pull/17"
+	githubAdapter := &commandGitHub{
+		issue:         github.Issue{Number: 42, Title: "Refreshed issue", Body: "unchanged requirements", State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: "status-1"},
+		pullRequest: github.PullRequest{
+			Number: 17, URL: run.PullRequestURL, State: "open", Draft: false,
+			HeadBranch: run.Branch, BaseBranch: "main",
+		},
+	}
+	worktree := &inspectingWorktree{
+		fakeWorktree: fakeWorktree{workspace: gitadapter.Workspace{BaseSHA: run.CheckpointSHA, Branch: run.Branch, Worktree: run.Worktree}},
+		state:        gitadapter.WorktreeState{Branch: run.Branch, HeadSHA: run.CheckpointSHA},
+	}
+	runStore := &commandRunStore{current: &run, latest: &run}
+	service := newCommandServiceWithStoreAndWorktree(runStore, githubAdapter, nil, worktree)
+
+	result, err := service.HandleCommand(context.Background(), factory.CommandRequest{
+		IssueNumber: 42,
+		Comment:     github.Comment{ID: "refresh-ready", Author: "alice", Body: "/factory refresh"},
+	})
+	if err != nil {
+		t.Fatalf("HandleCommand() refresh error = %v", err)
+	}
+	if result.Outcome != factory.CommandAccepted || result.Run.Stage != store.StageClaim || result.Run.Status != store.StatusActive {
+		t.Fatalf("refresh result = %#v, want accepted active checkpoint restart", result)
+	}
+	if !githubAdapter.pullRequest.Draft || len(githubAdapter.draftChanges) != 1 || !githubAdapter.draftChanges[0] {
+		t.Fatalf("pull request draft transition = %#v/%#v, want one demotion before restart", githubAdapter.draftChanges, githubAdapter.pullRequest)
+	}
+	if result.Run.PullRequestNumber != run.PullRequestNumber || result.Run.PullRequestURL != run.PullRequestURL {
+		t.Fatalf("refresh lost tracked pull request = %#v, want #%d", result.Run, run.PullRequestNumber)
+	}
+}
+
 // TestHandleCommandPersistsAClaudeHarnessConfiguration verifies an authorized
 // issue comment can select Claude Code now that the adapter exists, and that
 // the run records the choice for the next invocation.

--- a/internal/factory/draft_pr.go
+++ b/internal/factory/draft_pr.go
@@ -173,6 +173,7 @@ func (s *Service) CreateDraftPullRequest(ctx context.Context, request DraftPullR
 		if !github.ValidCommitSHA(checkpoint.SHA) {
 			return DraftPullRequestResult{}, errors.New("GitWorkspace returned an invalid implementation checkpoint SHA")
 		}
+		next.AcceptedImplementationCheckpointSHA = ""
 		if run.CheckRepairAttempts > 0 && checkpoint.SHA == run.CheckpointSHA {
 			return DraftPullRequestResult{}, fmt.Errorf("check-repair attempt %d did not produce a new checkpoint SHA", run.CheckRepairAttempts)
 		}

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -1418,6 +1418,7 @@ func (s *Service) checkpointAndPersistWithEffect(ctx context.Context, runStore R
 		if !github.ValidCommitSHA(checkpoint.SHA) {
 			return errors.New("GitWorkspace returned an invalid checkpoint SHA")
 		}
+		next.AcceptedImplementationCheckpointSHA = ""
 		next.CheckpointSHA = checkpoint.SHA
 		if request.Kind == gitadapter.CheckpointKindTest {
 			next.TestCheckpointSHA = checkpoint.SHA
@@ -1482,6 +1483,7 @@ func (s *Service) replayPendingCheckpoint(ctx context.Context, runStore RunStore
 		return store.Run{}, errors.New("replayed checkpoint returned an invalid SHA")
 	}
 	next := payload.Next
+	next.AcceptedImplementationCheckpointSHA = ""
 	next.CheckpointSHA = checkpoint.SHA
 	if request.Kind == gitadapter.CheckpointKindTest {
 		next.TestCheckpointSHA = checkpoint.SHA

--- a/internal/factory/gate.go
+++ b/internal/factory/gate.go
@@ -194,9 +194,9 @@ func (s *Service) runBaselineProjection(ctx context.Context, registration config
 	next.Stage = store.StagePreflight
 	next.Status = store.StatusFailed
 	if suiteErr == nil && persistErr != nil {
-		next.LifecycleReason = "baseline gate result persistence failure"
+		next.LifecycleReason = baselineLifecycleReason(run, "baseline gate result persistence failure")
 	} else {
-		next.LifecycleReason = "baseline gate failure"
+		next.LifecycleReason = baselineLifecycleReason(run, "baseline gate failure")
 	}
 	next.UpdatedAt = s.deps.Now().UTC()
 	issue := packet.Issue

--- a/internal/factory/test_stage.go
+++ b/internal/factory/test_stage.go
@@ -962,6 +962,7 @@ func (s *Service) acceptTestStageReport(ctx context.Context, registration config
 	if _, journaled := runStore.(PendingEffectStore); journaled {
 		*run = next
 	} else {
+		next.AcceptedImplementationCheckpointSHA = ""
 		next.TestCheckpointSHA = checkpoint.SHA
 		next.CheckpointSHA = checkpoint.SHA
 		if err := s.persistAgentRunState(ctx, registration, runStore, previous, next); err != nil {
@@ -1150,6 +1151,7 @@ func (s *Service) acceptTestRevisionReport(ctx context.Context, registration con
 		return s.pauseTestRevisionForHuman(ctx, registration, runStore, run, invocation, value, store.TestRevisionVerificationFailed, "revised test checkpoint returned an invalid commit identity")
 	}
 	if _, journaled := runStore.(PendingEffectStore); !journaled {
+		next.AcceptedImplementationCheckpointSHA = ""
 		next.TestCheckpointSHA = checkpoint.SHA
 		next.CheckpointSHA = checkpoint.SHA
 		if err := s.persistAgentRunState(ctx, registration, runStore, previous, next); err != nil {

--- a/internal/factory/test_stage.go
+++ b/internal/factory/test_stage.go
@@ -198,7 +198,7 @@ func (s *Service) advanceAfterBaseline(ctx context.Context, registration config.
 		next.ProtectedTestPaths = nil
 		next.TestExemption = nil
 		next.TestStageSkipped = false
-		next.LifecycleReason = "baseline passed; " + postBaselineReason(entry)
+		next.LifecycleReason = baselineLifecycleReason(run, "baseline passed; "+postBaselineReason(entry))
 		next.UpdatedAt = s.deps.Now().UTC()
 		if err := s.persistAgentRunState(ctx, registration, runStore, run, next); err != nil {
 			return run, fmt.Errorf("persist post-baseline %q transition: %w", entry, err)
@@ -216,14 +216,14 @@ func (s *Service) advanceAfterBaseline(ctx context.Context, registration config.
 		next.Stage = store.StageImplementation
 		if justification == "" {
 			next.TestExemption = nil
-			next.LifecycleReason = "test stage skip requires an authorized human exemption"
+			next.LifecycleReason = baselineLifecycleReason(run, "test stage skip requires an authorized human exemption")
 		} else {
-			next.LifecycleReason = "test stage skipped by human exemption"
+			next.LifecycleReason = baselineLifecycleReason(run, "test stage skipped by human exemption")
 		}
 	} else {
 		next.Stage = store.StageTest
 		next.TestStageSkipped = false
-		next.LifecycleReason = "baseline passed; test stage ready"
+		next.LifecycleReason = baselineLifecycleReason(run, "baseline passed; test stage ready")
 	}
 	next.Status = store.StatusActive
 	next.UpdatedAt = s.deps.Now().UTC()

--- a/internal/store/cleanup.go
+++ b/internal/store/cleanup.go
@@ -252,7 +252,7 @@ func (t *cleanupTransaction) Rollback() error { return t.tx.Rollback() }
 func (s *Store) cleanupRun(ctx context.Context, runID string) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
-		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
+		       checkpoint_sha, base_checkpoint_sha, accepted_implementation_checkpoint_sha, test_checkpoint_sha,
 		       test_handoff, test_invocation_id, test_revision_attempts,
 		       test_revision_budget, test_revision_history, test_objection,
 		       test_revision_base_changed_paths,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CurrentSchemaVersion is the supported operational-store schema version.
-const CurrentSchemaVersion = 34
+const CurrentSchemaVersion = 35
 
 // ErrRevisionConflict reports that another coordinator revision was persisted
 // after a command read the run and before it attempted its compare-and-set.
@@ -454,6 +454,10 @@ type Run struct {
 	// specification version. An authorized revision promotes its clean current
 	// checkpoint to establish a new amendment baseline.
 	BaseCheckpointSHA string
+	// AcceptedImplementationCheckpointSHA records the implementation checkpoint
+	// accepted before a refresh restart. It remains valid while packet changes
+	// invalidate the checkpoint's gate-result rows and lifecycle reason.
+	AcceptedImplementationCheckpointSHA string
 	// TestCheckpointSHA identifies the separate protected test checkpoint.
 	TestCheckpointSHA string
 	// TestHandoff is the accepted structured test-stage transfer packet.
@@ -827,7 +831,7 @@ func (s *Store) SchemaVersion() int { return s.schemaVersion }
 func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
-		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
+		       checkpoint_sha, base_checkpoint_sha, accepted_implementation_checkpoint_sha, test_checkpoint_sha,
 		       test_handoff, test_invocation_id, test_revision_attempts,
 		       test_revision_budget, test_revision_history, test_objection,
 		       test_revision_base_changed_paths,
@@ -858,7 +862,7 @@ func (s *Store) CurrentRun(ctx context.Context) (*Run, error) {
 func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, repository_path, issue_number, stage, status, branch, worktree,
-		       checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
+		       checkpoint_sha, base_checkpoint_sha, accepted_implementation_checkpoint_sha, test_checkpoint_sha,
 		       test_handoff, test_invocation_id, test_revision_attempts,
 		       test_revision_budget, test_revision_history, test_objection,
 		       test_revision_base_changed_paths,
@@ -886,7 +890,7 @@ func (s *Store) LatestRun(ctx context.Context) (*Run, error) {
 // scanRun decodes one operational run row and its RFC3339 timestamps.
 func scanRun(row *sql.Row) (*Run, error) {
 	var run Run
-	var baseCheckpointSHA, testCheckpointSHA string
+	var baseCheckpointSHA, acceptedImplementationCheckpointSHA, testCheckpointSHA string
 	var testHandoffJSON, roleHandoffJSON, specificationReviewJSON, standardsReviewJSON string
 	var reviewRepairHistoryJSON, reviewRepairPacketJSON string
 	var testRevisionHistoryJSON, testObjectionJSON, testRevisionBaseChangedPathsJSON string
@@ -905,6 +909,7 @@ func scanRun(row *sql.Row) (*Run, error) {
 		&run.Worktree,
 		&run.CheckpointSHA,
 		&baseCheckpointSHA,
+		&acceptedImplementationCheckpointSHA,
 		&testCheckpointSHA,
 		&testHandoffJSON,
 		&run.TestInvocationID,
@@ -968,6 +973,7 @@ func scanRun(row *sql.Row) (*Run, error) {
 	if run.BaseCheckpointSHA == "" {
 		run.BaseCheckpointSHA = run.CheckpointSHA
 	}
+	run.AcceptedImplementationCheckpointSHA = acceptedImplementationCheckpointSHA
 	run.TestCheckpointSHA = testCheckpointSHA
 	if testHandoffJSON != "" {
 		run.TestHandoff = &TestHandoff{}
@@ -1759,6 +1765,7 @@ func runValues(run Run) ([]any, error) {
 		run.Worktree,
 		run.CheckpointSHA,
 		run.BaseCheckpointSHA,
+		run.AcceptedImplementationCheckpointSHA,
 		run.TestCheckpointSHA,
 		testHandoff,
 		run.TestInvocationID,
@@ -1822,7 +1829,7 @@ func terminalAtValue(value time.Time) string {
 const saveRunStatement = `
 		INSERT INTO operational_runs (
 			id, repository_path, issue_number, stage, status, branch, worktree,
-			checkpoint_sha, base_checkpoint_sha, test_checkpoint_sha,
+			checkpoint_sha, base_checkpoint_sha, accepted_implementation_checkpoint_sha, test_checkpoint_sha,
 			test_handoff, test_invocation_id, test_revision_attempts,
 			test_revision_budget, test_revision_history, test_objection,
 			test_revision_base_changed_paths, implementation_handoff,
@@ -1842,7 +1849,7 @@ const saveRunStatement = `
 			pending_questions, clarification_comment_id,
 			clarification_notification_sent, terminal_at, created_at, updated_at
 		) VALUES (
-			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
@@ -1858,6 +1865,7 @@ const saveRunStatement = `
 			worktree = excluded.worktree,
 			checkpoint_sha = excluded.checkpoint_sha,
 			base_checkpoint_sha = excluded.base_checkpoint_sha,
+			accepted_implementation_checkpoint_sha = excluded.accepted_implementation_checkpoint_sha,
 			test_checkpoint_sha = excluded.test_checkpoint_sha,
 			test_handoff = excluded.test_handoff,
 			test_invocation_id = excluded.test_invocation_id,
@@ -1909,7 +1917,7 @@ const saveRunStatement = `
 const saveRunIfRevisionStatement = `
 		UPDATE operational_runs SET
 			repository_path = ?, issue_number = ?, stage = ?, status = ?, branch = ?, worktree = ?,
-			checkpoint_sha = ?, base_checkpoint_sha = ?, test_checkpoint_sha = ?,
+			checkpoint_sha = ?, base_checkpoint_sha = ?, accepted_implementation_checkpoint_sha = ?, test_checkpoint_sha = ?,
 			test_handoff = ?, test_invocation_id = ?, test_revision_attempts = ?,
 			test_revision_budget = ?, test_revision_history = ?, test_objection = ?,
 			test_revision_base_changed_paths = ?, implementation_handoff = ?,
@@ -3139,6 +3147,10 @@ func migrate(ctx context.Context, database *sql.DB, from int) error {
 		case 34:
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE invocations ADD COLUMN launch_voided INTEGER NOT NULL DEFAULT 0"); err != nil {
 				return fmt.Errorf("apply store migration 34: %w", err)
+			}
+		case 35:
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE operational_runs ADD COLUMN accepted_implementation_checkpoint_sha TEXT NOT NULL DEFAULT ''"); err != nil {
+				return fmt.Errorf("apply store migration 35: %w", err)
 			}
 		default:
 			return fmt.Errorf("no migration registered for schema version %d", version+1)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -81,6 +81,12 @@ func TestSchema33MigrationFoldsTheSingularActiveInvocationIntoTheSlice(t *testin
 			t.Fatalf("remove schema 34 launch-voided column from schema 32 fixture: %v", err)
 		}
 	}
+	if testOperationalRunsColumnExists(t, database, "accepted_implementation_checkpoint_sha") {
+		if _, err := database.ExecContext(t.Context(), "ALTER TABLE operational_runs DROP COLUMN accepted_implementation_checkpoint_sha"); err != nil {
+			_ = database.Close()
+			t.Fatalf("remove schema 35 accepted-checkpoint column from schema 32 fixture: %v", err)
+		}
+	}
 	_, err = database.ExecContext(t.Context(), `
 		INSERT INTO operational_runs (
 			id, repository_path, issue_number, stage, status,
@@ -685,18 +691,19 @@ func TestRunPersistsTheProtectedTestHandoffProjection(t *testing.T) {
 	}
 	defer func() { _ = opened.Close() }()
 	want := store.Run{
-		ID:                 "run-test-projection",
-		RepositoryPath:     "/work/repository",
-		Stage:              store.StageImplementation,
-		Status:             store.StatusActive,
-		CheckpointSHA:      strings.Repeat("b", 64),
-		BaseCheckpointSHA:  strings.Repeat("a", 64),
-		TestCheckpointSHA:  strings.Repeat("b", 64),
-		TestHandoff:        &store.TestHandoff{AcceptanceCoverage: []store.TestAcceptanceCoverage{{Criterion: "criterion", Evidence: "red test"}}, ChangedFiles: []string{"internal/factory/agent_test.go"}, FocusedTestCommand: "go test ./internal/factory -run TestBehavior", ExpectedFailureReason: "expected behavior assertion", ObservedFailureEvidence: []store.TestFailureEvidence{{Kind: "exit_code", Detail: "1"}}},
-		TestExemption:      &store.TestExemption{Kind: "technical", Justification: "test runtime unavailable during pilot"},
-		ProtectedTestPaths: []store.ProtectedTestPath{{Path: "internal/factory/agent_test.go", SHA256: strings.Repeat("c", 64)}},
-		TestStageSkipped:   true,
-		CheckRepairBudget:  1,
+		ID:                                  "run-test-projection",
+		RepositoryPath:                      "/work/repository",
+		Stage:                               store.StageImplementation,
+		Status:                              store.StatusActive,
+		CheckpointSHA:                       strings.Repeat("b", 64),
+		BaseCheckpointSHA:                   strings.Repeat("a", 64),
+		AcceptedImplementationCheckpointSHA: strings.Repeat("d", 64),
+		TestCheckpointSHA:                   strings.Repeat("b", 64),
+		TestHandoff:                         &store.TestHandoff{AcceptanceCoverage: []store.TestAcceptanceCoverage{{Criterion: "criterion", Evidence: "red test"}}, ChangedFiles: []string{"internal/factory/agent_test.go"}, FocusedTestCommand: "go test ./internal/factory -run TestBehavior", ExpectedFailureReason: "expected behavior assertion", ObservedFailureEvidence: []store.TestFailureEvidence{{Kind: "exit_code", Detail: "1"}}},
+		TestExemption:                       &store.TestExemption{Kind: "technical", Justification: "test runtime unavailable during pilot"},
+		ProtectedTestPaths:                  []store.ProtectedTestPath{{Path: "internal/factory/agent_test.go", SHA256: strings.Repeat("c", 64)}},
+		TestStageSkipped:                    true,
+		CheckRepairBudget:                   1,
 	}
 	if err := opened.SaveRun(context.Background(), want); err != nil {
 		t.Fatalf("SaveRun() error = %v", err)
@@ -705,7 +712,7 @@ func TestRunPersistsTheProtectedTestHandoffProjection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LatestRun() error = %v", err)
 	}
-	if got == nil || got.BaseCheckpointSHA != want.BaseCheckpointSHA || got.TestCheckpointSHA != want.TestCheckpointSHA || got.TestHandoff == nil || got.TestExemption == nil || len(got.ProtectedTestPaths) != 1 || !got.TestStageSkipped {
+	if got == nil || got.BaseCheckpointSHA != want.BaseCheckpointSHA || got.AcceptedImplementationCheckpointSHA != want.AcceptedImplementationCheckpointSHA || got.TestCheckpointSHA != want.TestCheckpointSHA || got.TestHandoff == nil || got.TestExemption == nil || len(got.ProtectedTestPaths) != 1 || !got.TestStageSkipped {
 		t.Fatalf("LatestRun() = %#v, want persisted test projection", got)
 	}
 }


### PR DESCRIPTION
<!-- factory-generated:start -->
## Factory run

- run: `run-fd7758a5-4445-40c0-80ca-520d6fe40c80`
- issue: #129 — A refresh after an accepted implementation checkpoint restarts implementation into an unsatisfiable report contract
- specification packet: version 1, target branch `main`
- checkpoint: `0a6bda2acf0656c164c94fcc45c79e69d56221f0`
- stage: `draft_pr`
- intervention: `none`
- test policy: `advisory (implementation-owned TDD)`
- route: `default (repository test policy)`

Closes #129

<!-- factory-generated:review:start -->

### Specification review

- reviewed checkpoint: `0a6bda2acf0656c164c94fcc45c79e69d56221f0`
- outcome: 0 blocking findings, 0 advisory findings
- findings: none

### Standards review

- reviewed checkpoint: `0a6bda2acf0656c164c94fcc45c79e69d56221f0`
- outcome: 0 blocking findings, 2 advisory findings

#### Finding 1 — advisory/taste
- location: `internal/factory/command.go:601-603`
- claim: LifecycleReason is used as a machine-readable checkpoint-refresh state flag
- evidence: source=heuristic:Primitive Obsession;hunk=internal/factory/command.go:601-603;resumeAfterPacketChange selects the restart path by testing the free-form LifecycleReason string prefix "accepted /factory refresh; " rather than a typed transition or provenance field.
- suggested resolution: Use a dedicated typed or persisted restart marker, or a helper over AcceptedImplementationCheckpointSHA, for control flow and leave LifecycleReason display-only.
- suggested owner: `implementation`

#### Finding 2 — advisory/taste
- location: `internal/factory/command.go:672-680`
- claim: The checkpoint-refresh helper duplicates the tracked pull-request validation already used by handleRevisionCommand
- evidence: source=heuristic:Duplicated Code;hunk=internal/factory/command.go:672-680;the new helper repeats tracked pull-request lookup, identity, and open/not-merged checks already present in handleRevisionCommand at internal/factory/command.go:421-430.
- suggested resolution: Extract a shared tracked-open pull-request validation and demotion helper so refresh and revision cannot drift in their safety checks.
- suggested owner: `implementation`
<!-- factory-generated:review:end -->

### Issue summary

## What happened

Run `run-5b6c3a85-bacd-476e-8b5b-8e5adb0b9a95` (issue #118) reached `draft_pr` with an accepted implementation checkpoint `e7934d8` and an open pull request. Its specification-review launch then failed for an infrastructure reason, leaving the run parked with invocation history that blocked a clean retry (#128).

`/factory refresh` is the only command admitted in that state, so it was used. It behaved as documented: it created a new specification packet version, superseded both prior invocations, and resumed implementation. The run is now parked again, one stage earlier, in a state the implementation role cannot leave.

```
stage: implementation
status: waiting_for_human
lifecycle reason: unattended progression stopped at accept agent report:
  production_files_changed[0] "internal/store/store.go" was not observed in the worktree
```

## Why the stage cannot complete

The implementation work is already committed at the checkpoint, so the run worktree is clean: `git status --porcelain` is empty and `HEAD` is `e7934d8`.

`internal/factory/agent.go:382` fills the report validation context from `WorktreeState.ChangedPaths`, which `internal/git/worktree.go` derives from `git status --porcelain` — uncommitted paths only. `internal/report/report.go:792` then requires every `production_files_changed` entry to appear there:

```go
if context.WorktreeObserved {
    if _, exists := observed[clean]; !exists {
        return fmt.Errorf("production_files_changed[%d] %q was not observed in the worktree", index, path)
    }
}
```

A clean worktree observes nothing, so any non-empty `production_files_changed` is refused.

The role behaved correctly and still cannot pass. Its report reads:

> "Verified the issue 118 implementation already present in the clean implementation checkpoint."

and its handoff names the nine files it changed when it first ran. There is no honest report it can write: naming the files it changed is refused, and the frozen specification gives it no reason to change them again. Refreshing a second time reaches the same state.

## The condition

The failure needs all three:

1. an accepted implementation checkpoint exists, so the work is committed and the worktree is clean;
2. the packet is refreshed without the issue text changing, so no new work follows;
3. the report contract validates claimed paths against uncommitted worktree changes only.

Refresh's normal use is a changed issue, where new work produces new uncommitted changes and the contract is satisfiable. After a checkpoint with an unchanged issue it is not.

## What to decide

| Shape | Change | Trade-off |
| --- | --- | --- |
| **Refresh restarts from the checkpoint.** When an accepted implementation checkpoint exists and the worktree is clean, resume where `/factory revision` does — treat the current checkpoint as the baseline and restart the workflow from it, rather than resuming implementation | `resumeAfterPacketChange` gains the checkpoint case | Closest to intent, and `/factory revision` already establishes the pattern. Has to decide what a genuinely changed issue means for an existing checkpoint |
| **The contract accepts committed paths.** Validate `production_files_changed` against paths changed in the run's committed checkpoints as well as the uncommitted worktree | `report.go` validation plus the observation it is given | Weakens the guarantee that a handoff describes work this invocation actually did |
| **Refresh refuses this state.** Reject the command when an accepted checkpoint exists and the worktree is clean, naming the command that does apply | `handleRefreshCommand` | Smallest, but leaves the run parked with no admitted command, which is #128's dead end again |

The first is the one worth having. The third is not a fix on its own, because it only holds if #128 gives the state some other exit.

## Non-goals

- Weakening the rule that a review role must not change the immutable checkpoint worktree.
- Changing what `/factory revision` does.
- Making the implementation role fabricate a change to satisfy the contract.

## Acceptance criteria

- [ ] A refresh on a run with an accepted implementation checkpoint and a clean worktree leaves the run in a state its roles can complete.
- [ ] A test drives the exact sequence — accepted implementation checkpoint, refresh with an unchanged issue, implementation report — and asserts the run reaches its next stage rather than a waiting state.
- [ ] The report contract still refuses a `production_files_changed` entry naming a path no invocation in the run changed.
- [ ] The status comment's lifecycle reason names the command that applies, so an operator is not left with a refusal and no next step.
- [ ] `docs/configuration.md` records what refresh does when a checkpoint already exists.
- [ ] `go test ./...` passes.

## Evidence

- Run state and lifecycle reason read from the operational store.
- Invocation rows: the two prior invocations `superseded`, `inv-run-0914e5fc` active at `implementation`.
- The refused report at `.factory-agents/run-5b6c3a85-…/inv-run-0914e5fc-…/results/report.json`, outcome `completed`, nine entries in `production_files_changed`.
- `git status --porcelain` empty in the run worktree, `HEAD` = `e7934d8`.

### Gates

- `format`: passed
- `vet`: passed
- `test`: passed
- `build`: passed

### Control commands

- `factory status`
- `factory draft-pr --run-id run-fd7758a5-4445-40c0-80ca-520d6fe40c80`

<!-- factory-generated:end -->