### PR TITLE
An accepted structured report can build a run state the operational store refuses, and reconciliation cannot leave it

### DIFF
--- a/internal/factory/agent.go
+++ b/internal/factory/agent.go
@@ -777,7 +777,7 @@ func agentReportRunProjection(previous store.Run, invocationStage store.Stage, v
 	case report.OutcomeCannotProceed:
 		next.PendingQuestions = nil
 	default:
-		if value.Handoff != nil {
+		if value.Handoff != nil && len(value.Handoff.ProductionFilesChanged) != 0 {
 			next.RoleHandoff = roleHandoffFromReport(*value.Handoff)
 		}
 		next.PendingQuestions = nil

--- a/internal/factory/agent_test.go
+++ b/internal/factory/agent_test.go
@@ -1204,6 +1204,102 @@ func TestAcceptAgentReportRejectsAPermittedPathRequestMismatch(t *testing.T) {
 	}
 }
 
+// TestAcceptAgentReportRejectsAnEmptyProductionFileListBeforeEffects verifies
+// the coordinator report-acceptance seam keeps an implementation run and its
+// invocation active when a dirty worktree exposes an unpersistable handoff.
+func TestAcceptAgentReportRejectsAnEmptyProductionFileListBeforeEffects(t *testing.T) {
+	service, runStore, runtime, terminalRuntime, harnessRuntime := newAgentService(t)
+	launch, err := service.StartAgent(context.Background(), factory.AgentRequest{})
+	if err != nil {
+		t.Fatalf("StartAgent() error = %v", err)
+	}
+	run := *runStore.current
+	invocationBefore := runStore.invocations[launch.Invocation.ID]
+	finishedBefore := len(harnessRuntime.finished)
+	stopsBefore := runtime.stops
+	invocationBefore.NativeSessionID = "session-empty-production-files"
+	// Model an invocation that already crossed the bounded recovery resume so
+	// the fresh coordinator can inspect it without launching a second session.
+	invocationBefore.RecoveryResumeCount = 1
+	if err := runStore.SaveInvocation(context.Background(), invocationBefore); err != nil {
+		t.Fatalf("persist native session identity: %v", err)
+	}
+	runStore.worktree.state.RepositoryPath = run.RepositoryPath
+	workerRequest := runtime.starts[len(runtime.starts)-1]
+	runtime.inspectResult = &worker.Inspection{
+		Exists:           true,
+		Running:          true,
+		Image:            workerRequest.Image + "@" + workerRequest.ImageDigest,
+		MountFingerprint: worker.MountContractFingerprint(workerRequest),
+	}
+	githubRuntime := &fakeGitHub{
+		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)},
+	}
+	journal := &journaledAgentRunStore{agentRunStore: runStore}
+	terminalForRecovery := &inspectingAgentTerminal{
+		agentTerminal: terminalRuntime,
+		inspection: terminal.WorkspaceInspection{
+			Exists:      true,
+			WorkspaceID: terminal.WorkspaceID(invocationBefore.WorkspaceID),
+			Surfaces: []terminal.Surface{
+				{ID: terminal.SurfaceID(invocationBefore.StatusSurfaceID), WorkspaceID: terminal.WorkspaceID(invocationBefore.WorkspaceID)},
+				{ID: terminal.SurfaceID(invocationBefore.ImplementationSurfaceID), WorkspaceID: terminal.WorkspaceID(invocationBefore.WorkspaceID)},
+				{ID: terminal.SurfaceID(invocationBefore.ChecksSurfaceID), WorkspaceID: terminal.WorkspaceID(invocationBefore.WorkspaceID)},
+			},
+		},
+	}
+	harnessForRecovery := &inspectingAgentHarness{
+		agentHarness:  harnessRuntime,
+		nativeSession: invocationBefore.NativeSessionID,
+	}
+	fresh := newFreshAgentServiceWithStoreAndGitHub(t, runStore, journal, runStore.worktree, runtime, terminalForRecovery, harnessForRecovery, githubRuntime)
+	value := report.Report{
+		SchemaVersion: report.SchemaVersion,
+		InvocationID:  launch.Invocation.ID,
+		RunID:         launch.Invocation.RunID,
+		Harness:       launch.Invocation.Harness,
+		Role:          launch.Invocation.Role,
+		Stage:         string(launch.Invocation.Stage),
+		Outcome:       report.OutcomeCompleted,
+		Summary:       "implementation completed without a newly changed path",
+		Handoff: &report.Handoff{
+			ChangeSummary:     "verified the implementation checkpoint",
+			AcceptanceMapping: []report.AcceptanceMapping{{Criterion: "criterion", Evidence: "focused test"}},
+			FocusedCommands:   []string{"go test ./internal/factory"},
+		},
+		NativeSessionID: invocationBefore.NativeSessionID,
+		ReportedAt:      time.Now().UTC(),
+	}
+	if value.NativeSessionID == "" {
+		value.NativeSessionID = "session-empty-production-files"
+	}
+	if _, err := report.WriteAtomicForInvocation(launch.Invocation.ResultDirectory, launch.Invocation.ID, value); err != nil {
+		t.Fatalf("WriteAtomicForInvocation() error = %v", err)
+	}
+	if _, err := fresh.AcceptAgentReport(context.Background(), factory.AgentReportRequest{RunID: run.ID, InvocationID: launch.Invocation.ID}); err == nil || !strings.Contains(err.Error(), "production_files_changed") {
+		t.Fatalf("AcceptAgentReport() error = %v, want empty production-file rejection", err)
+	}
+	if runStore.current.Status != store.StatusActive || runStore.current.Stage != store.StageImplementation {
+		t.Fatalf("run after rejected report = %#v, want active implementation run", runStore.current)
+	}
+	invocationAfter, ok := runStore.invocations[launch.Invocation.ID]
+	if !ok || invocationAfter.Status != store.InvocationStatusActive {
+		t.Fatalf("invocation after rejected report = %#v, want active invocation", invocationAfter)
+	}
+	if pending, err := journal.PendingEffect(context.Background(), run.ID); err != nil {
+		t.Fatalf("PendingEffect() error = %v", err)
+	} else if pending != nil {
+		t.Fatalf("pending effect after rejected report = %#v, want none", pending)
+	}
+	if len(githubRuntime.replacedLabels) != 0 || len(githubRuntime.createdComments) != 0 || len(githubRuntime.editedComments) != 0 {
+		t.Fatalf("GitHub mutations after rejected report = labels=%d creates=%d edits=%d, want all zero", len(githubRuntime.replacedLabels), len(githubRuntime.createdComments), len(githubRuntime.editedComments))
+	}
+	if len(harnessRuntime.finished) != finishedBefore || runtime.stops != stopsBefore {
+		t.Fatalf("runtime effects after rejected report = finishes=%d stops=%d, want %d/%d", len(harnessRuntime.finished), runtime.stops, finishedBefore, stopsBefore)
+	}
+}
+
 // TestAcceptAgentReportRejectsATerminalInvocation verifies a completed
 // invocation cannot be accepted again or finish its harness twice.
 func TestAcceptAgentReportRejectsATerminalInvocation(t *testing.T) {
@@ -1436,6 +1532,13 @@ func newFreshAgentService(t *testing.T, runStore *agentRunStore, worktree *inspe
 // explicit operational store, so a journal-capable wrapper can take part in
 // the launch seam while the fixture keeps its in-memory run view.
 func newFreshAgentServiceWithStore(t *testing.T, runStore *agentRunStore, operational factory.OperationalStore, worktree *inspectingWorktree, runtime *agentWorker, terminalRuntime *agentTerminal, harnessRuntime *agentHarness) *factory.Service {
+	return newFreshAgentServiceWithStoreAndGitHub(t, runStore, operational, worktree, runtime, terminalRuntime, harnessRuntime, nil)
+}
+
+// newFreshAgentServiceWithStoreAndGitHub rebuilds a coordinator with an
+// injectable GitHub fake so public report acceptance tests can assert that an
+// invalid projection crossed no external mutation boundary.
+func newFreshAgentServiceWithStoreAndGitHub(t *testing.T, runStore *agentRunStore, operational factory.OperationalStore, worktree *inspectingWorktree, runtime *agentWorker, terminalRuntime terminal.TerminalRuntime, harnessRuntime harness.Runtime, githubRuntime *fakeGitHub) *factory.Service {
 	t.Helper()
 	if runStore.current == nil {
 		t.Fatal("fresh coordinator fixture requires a persisted run")
@@ -1449,9 +1552,11 @@ func newFreshAgentServiceWithStore(t *testing.T, runStore *agentRunStore, operat
 		OperationalDataPath:  filepath.Join(filepath.Dir(run.RepositoryPath), "state", "factory.db"),
 		RepositoryConfigPath: filepath.Join(run.RepositoryPath, "factory.yaml"),
 	}}}
-	githubRuntime := &fakeGitHub{
-		issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
-		statusComment: github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)},
+	if githubRuntime == nil {
+		githubRuntime = &fakeGitHub{
+			issueValue:    github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+			statusComment: github.Comment{ID: run.StatusCommentID, Body: factory.StatusCommentBody(run)},
+		}
 	}
 	return factory.NewWithDependencies("/host/config.yaml", factory.Dependencies{
 		Config:         &fakeConfig{value: host},
@@ -1465,6 +1570,30 @@ func newFreshAgentServiceWithStore(t *testing.T, runStore *agentRunStore, operat
 		Now:            func() time.Time { return time.Date(2026, 8, 21, 8, 0, 0, 0, time.UTC) },
 		NewRunID:       func() (string, error) { return "generated", nil },
 	})
+}
+
+// inspectingAgentTerminal supplies the read-only topology required by a fresh
+// journal-capable coordinator before it reaches public report acceptance.
+type inspectingAgentTerminal struct {
+	*agentTerminal
+	inspection terminal.WorkspaceInspection
+}
+
+// InspectWorkspace returns the persisted run workspace and role surfaces.
+func (t *inspectingAgentTerminal) InspectWorkspace(context.Context, terminal.WorkspaceID) (terminal.WorkspaceInspection, error) {
+	return t.inspection, nil
+}
+
+// inspectingAgentHarness supplies the native session identity required by a
+// fresh coordinator before it reaches public report acceptance.
+type inspectingAgentHarness struct {
+	*agentHarness
+	nativeSession string
+}
+
+// NativeSessionID returns the persisted identity from the recovery fixture.
+func (h *inspectingAgentHarness) NativeSessionID(context.Context, harness.NativeSessionRequest) (string, error) {
+	return h.nativeSession, nil
 }
 
 // eventIndex returns the first position of one recorded test effect.

--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -417,6 +417,9 @@ func (s *Service) applyStateTransition(ctx context.Context, runStore RunStore, t
 	if !store.IsTerminalStatus(next.Status) {
 		next.TerminalAt = time.Time{}
 	}
+	if err := validateRunBeforeEffect(store.PendingEffectKindStateTransition, next); err != nil {
+		return next, err
+	}
 	if _, journaled := runStore.(PendingEffectStore); journaled {
 		return s.applyJournaledStateTransition(ctx, runStore, transition, next)
 	}

--- a/internal/factory/clarification.go
+++ b/internal/factory/clarification.go
@@ -117,6 +117,9 @@ func (s *Service) ensureClarificationPublication(ctx context.Context, registrati
 			target = run.PullRequestNumber
 		}
 		body := clarificationCommentBody(run, packet.Version, run.PendingQuestions)
+		if err := validateRunBeforeEffect(store.PendingEffectKindClarificationComment, run); err != nil {
+			return run, err
+		}
 		payload := clarificationCommentEffectPayload{
 			Repository: commandRepository(registration), Target: target, Body: body,
 			PacketVersion: packet.Version,

--- a/internal/factory/effects.go
+++ b/internal/factory/effects.go
@@ -191,6 +191,26 @@ func (s *Service) newPendingEffect(runID string, kind store.PendingEffectKind, i
 	return effectkernel.NewPendingEffect(s.deps.Now().UTC(), runID, kind, identity, payload)
 }
 
+// validateRunBeforeEffect rejects a run projection before its external effect
+// is reserved, keeping operational-store validation ahead of the journal and
+// every mutation that the journal protects.
+func validateRunBeforeEffect(kind store.PendingEffectKind, run store.Run) error {
+	if err := store.ValidateRun(run); err != nil {
+		return fmt.Errorf("validate run before reserving %s effect: %w", kind, err)
+	}
+	return nil
+}
+
+// validateRunBeforeReplay rejects an invalid durable run projection before a
+// replay can repeat any external mutation. Workflow classification preserves
+// the refusal as the cause of reconciliation rather than infrastructure drift.
+func validateRunBeforeReplay(kind store.PendingEffectKind, run store.Run) error {
+	if err := store.ValidateRun(run); err != nil {
+		return workflowProjectionFailuref("validate %s run projection before replay: %v", kind, err)
+	}
+	return nil
+}
+
 // decodePendingEffect decodes one bounded replay payload and reports malformed
 // journal data as an infrastructure discrepancy rather than a workflow result.
 func decodePendingEffect(effect store.PendingEffect, destination any) error {
@@ -365,6 +385,9 @@ func (s *Service) replayPendingClarificationComment(ctx context.Context, runStor
 	if current == nil {
 		return store.Run{}, fmt.Errorf("run %q disappeared during clarification replay", effect.RunID)
 	}
+	if err := validateRunBeforeReplay(store.PendingEffectKindClarificationComment, *current); err != nil {
+		return store.Run{}, err
+	}
 	comment, err := s.findOrCreateClarificationComment(ctx, payload.Repository, payload.Target, effect.RunID, payload.PacketVersion, payload.Body)
 	if err != nil {
 		return store.Run{}, fmt.Errorf("replay clarification comment: %w", err)
@@ -389,6 +412,9 @@ func (s *Service) replayPendingClarificationComment(ctx context.Context, runStor
 // the action so a process stop between the two writes leaves a replayable
 // intent instead of an apparently processed but stale command.
 func (s *Service) persistCommandProjectionWithEffect(ctx context.Context, runStore RunStore, repository github.Repository, previous, next store.Run) (store.Run, error) {
+	if err := validateRunBeforeEffect(store.PendingEffectKindStatusComment, next); err != nil {
+		return next, err
+	}
 	payload := statusCommentEffectPayload{Repository: repository, Previous: previous, Next: next}
 	effect, err := s.newPendingEffect(next.ID, store.PendingEffectKindStatusComment, fmt.Sprintf("revision=%d\x00comment=%s", next.Revision, next.ProcessedCommentID), payload)
 	if err != nil {
@@ -433,6 +459,9 @@ func (s *Service) persistCommandProjectionWithEffect(ctx context.Context, runSto
 func (s *Service) replayPendingStatusComment(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
 	var payload statusCommentEffectPayload
 	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	if err := validateRunBeforeReplay(store.PendingEffectKindStatusComment, payload.Next); err != nil {
 		return store.Run{}, err
 	}
 	current, err := readReconciliationRun(ctx, runStore)
@@ -1002,6 +1031,9 @@ func (s *Service) publishStatusCheckpoint(ctx context.Context, run store.Run, sh
 // acceptResultWithEffect journals harness finalization, invocation state, and
 // the resulting workflow projection as one replayable acceptance operation.
 func (s *Service) acceptResultWithEffect(ctx context.Context, runStore RunStore, invocationStore InvocationStore, registration config.RepositoryRegistration, harnessRuntime harness.Runtime, session harness.Session, invocation store.Invocation, previous, next store.Run, stopWorker bool, acceptedReport report.Report) (store.Invocation, store.Run, error) {
+	if err := validateRunBeforeEffect(store.PendingEffectKindResultAcceptance, next); err != nil {
+		return invocation, next, err
+	}
 	// Encode the accepted report once for durable replay
 	acceptedReportJSON, err := json.Marshal(acceptedReport)
 	if err != nil {
@@ -1099,6 +1131,9 @@ func (s *Service) acceptResultWithEffect(ctx context.Context, runStore RunStore,
 func (s *Service) replayPendingResultAcceptance(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
 	var payload resultAcceptanceEffectPayload
 	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	if err := validateRunBeforeReplay(store.PendingEffectKindResultAcceptance, payload.Next); err != nil {
 		return store.Run{}, err
 	}
 	currentRun, err := readReconciliationRun(ctx, runStore)
@@ -1237,6 +1272,9 @@ func samePullRequestRequest(existing github.PullRequest, request github.PullRequ
 // discover a created PR and finish the missing durable state without creating a
 // second PR.
 func (s *Service) upsertPullRequestAndPersistWithEffect(ctx context.Context, runStore RunStore, client github.PullRequestClient, repository github.Repository, issue github.Issue, previous, next store.Run, request github.PullRequestRequest, expectedNumber int) (github.PullRequest, store.Run, error) {
+	if err := validateRunBeforeEffect(store.PendingEffectKindPullRequest, next); err != nil {
+		return github.PullRequest{}, next, err
+	}
 	payload := pullRequestEffectPayload{Repository: repository, Number: expectedNumber, Request: request, PersistRun: true, Issue: issue, Previous: previous, Next: next}
 	effect, err := s.newPendingEffect(next.ID, store.PendingEffectKindPullRequest, request.HeadBranch+"\x00"+request.BaseBranch+"\x00"+request.Body, payload)
 	if err != nil {
@@ -1295,6 +1333,11 @@ func (s *Service) replayPendingPullRequest(ctx context.Context, runStore RunStor
 	var payload pullRequestEffectPayload
 	if err := decodePendingEffect(effect, &payload); err != nil {
 		return store.Run{}, err
+	}
+	if payload.PersistRun {
+		if err := validateRunBeforeReplay(store.PendingEffectKindPullRequest, payload.Next); err != nil {
+			return store.Run{}, err
+		}
 	}
 	client := s.pullRequestClient()
 	if client == nil {
@@ -1390,6 +1433,9 @@ func checkpointRequest(value checkpointRequestJSON) gitadapter.CheckpointRequest
 // run projection one restart-safe operation. The marker in the Git adapter
 // handles a commit that was created just before the process stopped.
 func (s *Service) checkpointAndPersistWithEffect(ctx context.Context, runStore RunStore, workspace gitadapter.GitWorkspace, request gitadapter.CheckpointRequest, repository github.Repository, issue github.Issue, previous, nextTemplate store.Run) (gitadapter.CheckpointResult, store.Run, error) {
+	if err := validateRunBeforeEffect(store.PendingEffectKindCheckpoint, nextTemplate); err != nil {
+		return gitadapter.CheckpointResult{}, nextTemplate, err
+	}
 	payload := checkpointEffectPayload{
 		Request: checkpointRequestJSON{
 			RunID:        request.RunID,
@@ -1423,6 +1469,9 @@ func (s *Service) checkpointAndPersistWithEffect(ctx context.Context, runStore R
 		if request.Kind == gitadapter.CheckpointKindTest {
 			next.TestCheckpointSHA = checkpoint.SHA
 		}
+		if err := validateRunBeforeEffect(store.PendingEffectKindCheckpoint, next); err != nil {
+			return err
+		}
 		if err := s.applyStateTransitionEffects(ctx, &next, stateTransition{
 			Repository: repository,
 			Issue:      issue,
@@ -1453,6 +1502,9 @@ func (s *Service) checkpointAndPersistWithEffect(ctx context.Context, runStore R
 func (s *Service) replayPendingCheckpoint(ctx context.Context, runStore RunStore, effect store.PendingEffect) (store.Run, error) {
 	var payload checkpointEffectPayload
 	if err := decodePendingEffect(effect, &payload); err != nil {
+		return store.Run{}, err
+	}
+	if err := validateRunBeforeReplay(store.PendingEffectKindCheckpoint, payload.Next); err != nil {
 		return store.Run{}, err
 	}
 	workspace := s.gitWorkspace()
@@ -1488,6 +1540,9 @@ func (s *Service) replayPendingCheckpoint(ctx context.Context, runStore RunStore
 	if request.Kind == gitadapter.CheckpointKindTest {
 		next.TestCheckpointSHA = checkpoint.SHA
 	}
+	if err := validateRunBeforeReplay(store.PendingEffectKindCheckpoint, next); err != nil {
+		return store.Run{}, err
+	}
 	if err := s.applyStateTransitionEffects(ctx, &next, stateTransition{
 		Repository: payload.Repository,
 		Issue:      payload.Issue,
@@ -1519,6 +1574,9 @@ func (s *Service) replayPendingStateTransition(ctx context.Context, runStore Run
 	}
 	if payload.Next.ID == "" || payload.Next.ID != effect.RunID {
 		return store.Run{}, errors.New("pending state transition run identity does not match its journal")
+	}
+	if err := validateRunBeforeReplay(store.PendingEffectKindStateTransition, payload.Next); err != nil {
+		return store.Run{}, err
 	}
 	current, err := readReconciliationRun(ctx, runStore)
 	if err != nil {

--- a/internal/factory/effects_test.go
+++ b/internal/factory/effects_test.go
@@ -607,6 +607,106 @@ func TestResultAcceptanceEffectReplaysTheActualFinish(t *testing.T) {
 	}
 }
 
+// TestResultAcceptanceRejectsAnUnpersistableHandoffBeforeTheEffect verifies a
+// completed implementation projection is validated before harness, worker, or
+// GitHub effects can cross their external boundaries.
+func TestResultAcceptanceRejectsAnUnpersistableHandoffBeforeTheEffect(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(run)},
+	}
+	harnessRuntime := &effectMatrixHarness{}
+	workerRuntime := &effectMatrixWorker{started: true}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	service.deps.Harness = harnessRuntime
+	service.deps.Worker = workerRuntime
+	invocation := store.Invocation{
+		ID: "inv-invalid-handoff", RunID: run.ID, Harness: harness.NameCodex,
+		Role: "implementation", Stage: store.StageImplementation,
+		NativeSessionID: "session-invalid-handoff", Status: store.InvocationStatusActive,
+		CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt,
+	}
+	if err := opened.SaveInvocation(ctx, invocation); err != nil {
+		t.Fatal(err)
+	}
+	accepted := invocation
+	accepted.Status = store.InvocationStatusCompleted
+	previous := run
+	next := run
+	next.Revision++
+	next.RoleHandoff = &store.RoleHandoff{
+		ChangeSummary:     "completed implementation",
+		AcceptanceMapping: []store.HandoffAcceptance{{Criterion: "criterion", Evidence: "focused test"}},
+		FocusedCommands:   []string{"go test ./internal/factory"},
+	}
+	acceptedReport := report.Report{
+		SchemaVersion: report.SchemaVersion, InvocationID: invocation.ID, RunID: run.ID,
+		Harness: invocation.Harness, Role: invocation.Role, Stage: string(invocation.Stage),
+		Outcome: report.OutcomeCompleted, Summary: "completed implementation",
+		Handoff: &report.Handoff{
+			ChangeSummary:     "completed implementation",
+			AcceptanceMapping: []report.AcceptanceMapping{{Criterion: "criterion", Evidence: "focused test"}},
+			FocusedCommands:   []string{"go test ./internal/factory"},
+		},
+	}
+	if _, _, err := service.acceptResultWithEffect(ctx, opened, opened, effectMatrixRegistration(), harnessRuntime, harness.Session{
+		InvocationID: invocation.ID, NativeSessionID: invocation.NativeSessionID,
+	}, accepted, previous, next, true, acceptedReport); err == nil {
+		t.Fatal("acceptResultWithEffect() = nil, want invalid run projection refusal")
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending != nil {
+		t.Fatalf("pending result acceptance = %#v, want no journal reservation", pending)
+	}
+	if harnessRuntime.finishCalls != 0 || workerRuntime.stopCalls != 0 || githubRuntime.replaceLabelCalls != 0 || githubRuntime.createCommentCalls != 0 || githubRuntime.editCommentCalls != 0 {
+		t.Fatalf("effects before invalid projection refusal = finish=%d stop=%d labels=%d creates=%d edits=%d, want all zero", harnessRuntime.finishCalls, workerRuntime.stopCalls, githubRuntime.replaceLabelCalls, githubRuntime.createCommentCalls, githubRuntime.editCommentCalls)
+	}
+}
+
+// TestStateTransitionRejectsAnUnpersistableRunBeforeTheEffect verifies the
+// shared state-transition seam applies the same pre-journal store validation.
+func TestStateTransitionRejectsAnUnpersistableRunBeforeTheEffect(t *testing.T) {
+	ctx := context.Background()
+	opened, _, run := openEffectMatrixStore(t, ctx)
+	defer func() { _ = opened.Close() }()
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(run)},
+	}
+	service := newEffectMatrixService(githubRuntime, nil, nil, nil)
+	next := run
+	next.Revision++
+	next.RoleHandoff = &store.RoleHandoff{
+		ChangeSummary:     "completed implementation",
+		AcceptanceMapping: []store.HandoffAcceptance{{Criterion: "criterion", Evidence: "focused test"}},
+		FocusedCommands:   []string{"go test ./internal/factory"},
+	}
+	if _, err := service.applyStateTransition(ctx, opened, stateTransition{
+		Repository: github.Repository{Owner: "example", Name: "project"},
+		Issue:      githubRuntime.issue,
+		Previous:   run,
+		Next:       next,
+	}); err == nil {
+		t.Fatal("applyStateTransition() = nil, want invalid run projection refusal")
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending != nil {
+		t.Fatalf("pending state transition = %#v, want no journal reservation", pending)
+	}
+	if githubRuntime.replaceLabelCalls != 0 || githubRuntime.createCommentCalls != 0 || githubRuntime.editCommentCalls != 0 {
+		t.Fatalf("GitHub mutations before invalid projection refusal = labels=%d creates=%d edits=%d, want all zero", githubRuntime.replaceLabelCalls, githubRuntime.createCommentCalls, githubRuntime.editCommentCalls)
+	}
+}
+
 // TestRepeatedTestAcceptanceResumesAnUnfinishedStageProjection verifies a
 // terminal invocation is not mistaken for a fully projected test-stage result
 // when the durable run still points at that stage.

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -1393,12 +1393,25 @@ func (s *Service) pauseRunLocally(ctx context.Context, runStore RunStore, run st
 	if err := s.stopActiveRunWorkers(ctx, runStore, run); err != nil {
 		return run, err
 	}
+	reason := recoveryDiscrepancyReason(diagnosis)
 	if isRestartReconciliationPause(run) {
-		return run, nil
+		if run.LifecycleReason == reason {
+			return run, nil
+		}
+		// Repeated reconciliation must refresh a stale local diagnosis without
+		// advancing the pending effect's revision or crossing an external
+		// boundary a second time.
+		next := run
+		next.LifecycleReason = reason
+		next.UpdatedAt = s.deps.Now().UTC()
+		if err := saveRunWithRetry(ctx, runStore, next); err != nil {
+			return next, fmt.Errorf("refresh local restart reconciliation pause: %w", err)
+		}
+		return next, nil
 	}
 	next := run
 	next.Status = store.StatusWaitingForHuman
-	next.LifecycleReason = recoveryDiscrepancyReason(diagnosis)
+	next.LifecycleReason = reason
 	next.Revision = run.Revision + 1
 	next.UpdatedAt = s.deps.Now().UTC()
 	if err := saveRunWithRetry(ctx, runStore, next); err != nil {
@@ -1537,16 +1550,36 @@ func (s *Service) resumeRecoveredCheck(ctx context.Context, registration config.
 }
 
 // recoveryDiscrepancyReason renders a bounded single-line workflow reason so
-// the human can identify exactly which projection prevented continuation.
+// the human can identify exactly which projection prevented continuation. A
+// deterministic workflow refusal takes precedence over infrastructure
+// observations, because those observations may be consequences of the same
+// failed transition rather than its cause.
 func recoveryDiscrepancyReason(diagnosis RecoveryDiagnosis) string {
-	parts := make([]string, 0, len(diagnosis.Discrepancies))
-	for _, discrepancy := range diagnosis.Discrepancies {
-		parts = append(parts, fmt.Sprintf("%s.%s expected=%q observed=%q", discrepancy.Source, discrepancy.Field, safeStatusCommentValue(discrepancy.Expected), safeStatusCommentValue(discrepancy.Observed)))
+	discrepancies := diagnosis.Discrepancies
+	if hasWorkflowDiscrepancy(diagnosis) {
+		discrepancies = make([]RecoveryDiscrepancy, 0, len(diagnosis.Discrepancies))
+		for _, discrepancy := range diagnosis.Discrepancies {
+			if discrepancy.Kind == RecoveryDiscrepancyWorkflow {
+				discrepancies = append(discrepancies, discrepancy)
+			}
+		}
+	}
+	parts := make([]string, 0, len(discrepancies))
+	for _, discrepancy := range discrepancies {
+		parts = append(parts, fmt.Sprintf("%s.%s expected=%q observed=%q", discrepancy.Source, discrepancy.Field, recoveryReasonValue(discrepancy.Expected), recoveryReasonValue(discrepancy.Observed)))
 	}
 	if len(parts) == 0 {
 		return "restart reconciliation paused: unresolved discrepancy"
 	}
 	return "restart reconciliation paused: " + strings.Join(parts, "; ")
+}
+
+// recoveryReasonValue keeps a prior reconciliation pause from becoming part
+// of the next pause's nested lifecycle reason while retaining the observation
+// that it was a previous coordinator diagnosis.
+func recoveryReasonValue(value string) string {
+	value = safeStatusCommentValue(value)
+	return strings.ReplaceAll(value, restartReconciliationPausePrefix, "prior reconciliation pause:")
 }
 
 // newRecoveryDiagnosis creates the read-only comparison envelope and operator

--- a/internal/factory/recovery_journal_test.go
+++ b/internal/factory/recovery_journal_test.go
@@ -25,6 +25,138 @@ import (
 // journaled restart fixture.
 const journalRecoveryImageDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
+// TestRecoveryPauseReasonPrioritizesTheBlockingWorkflowRefusal verifies a
+// deterministic projection refusal is visible even when recovery also saw a
+// worker discrepancy from the prior external cleanup.
+func TestRecoveryPauseReasonPrioritizesTheBlockingWorkflowRefusal(t *testing.T) {
+	reason := recoveryDiscrepancyReason(RecoveryDiagnosis{Discrepancies: []RecoveryDiscrepancy{
+		{
+			Kind:     RecoveryDiscrepancyInfrastructure,
+			Source:   "worker",
+			Field:    "lifecycle",
+			Expected: "running",
+			Observed: "stopped",
+		},
+		{
+			Kind:     RecoveryDiscrepancyWorkflow,
+			Source:   "pending effect",
+			Field:    "result_acceptance",
+			Expected: "persistable run projection",
+			Observed: "role handoff is incomplete; restart reconciliation paused: previous refusal",
+		},
+	}})
+	if !strings.Contains(reason, "role handoff is incomplete") {
+		t.Fatalf("recovery pause reason = %q, want the blocking workflow refusal", reason)
+	}
+	if strings.Contains(reason, "worker.lifecycle") {
+		t.Fatalf("recovery pause reason = %q, want no self-inflicted worker diagnosis", reason)
+	}
+	if strings.Count(reason, restartReconciliationPausePrefix) != 1 {
+		t.Fatalf("recovery pause reason = %q, want one reconciliation pause prefix", reason)
+	}
+}
+
+// TestReconcilePausesOnAnInvalidPendingRunProjection verifies an old pending
+// result-acceptance payload is refused before replay can repeat worker or
+// GitHub effects, while the operator-visible pause identifies the store rule.
+func TestReconcilePausesOnAnInvalidPendingRunProjection(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	worktreePath := filepath.Join(root, "worktree")
+	if err := os.MkdirAll(worktreePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	checkpoint := strings.Repeat("a", 40)
+	packetData, err := json.Marshal(SpecificationPacket{
+		Version: specificationPacketVersion,
+		Issue:   github.Issue{Number: 42, Title: "Invalid handoff", Body: "reconcile the persisted effect"},
+		RepositoryConfig: config.RepositoryConfig{
+			TargetBranch: "main",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := store.Run{
+		ID: "run-invalid-pending", RepositoryPath: root, IssueNumber: 42,
+		Stage: store.StageImplementation, Status: store.StatusWaitingForHuman,
+		Branch: "factory/run-invalid-pending", Worktree: worktreePath,
+		CheckpointSHA: checkpoint, StatusCommentID: "status-invalid-pending",
+		LifecycleReason:     "restart reconciliation paused: worker.lifecycle expected=\"running\" observed=\"stopped\"",
+		SpecificationPacket: string(packetData), CreatedAt: now, UpdatedAt: now,
+	}
+	databasePath := filepath.Join(root, "state", "factory.db")
+	opened, err := store.Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.Close() }()
+	if err := opened.SaveRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	githubRuntime := &effectMatrixGitHub{
+		issue:         github.Issue{Number: run.IssueNumber, State: "open", Labels: []string{github.LabelAgentRunning}},
+		statusComment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(run)},
+	}
+	workspace := &journalRecoveryWorkspace{state: gitadapter.WorktreeState{
+		RepositoryPath: root, Branch: run.Branch, HeadSHA: run.CheckpointSHA,
+	}}
+	service := newEffectMatrixService(githubRuntime, nil, workspace, nil)
+	next := run
+	next.Revision++
+	next.RoleHandoff = &store.RoleHandoff{
+		ChangeSummary:     "completed implementation",
+		AcceptanceMapping: []store.HandoffAcceptance{{Criterion: "criterion", Evidence: "focused test"}},
+		FocusedCommands:   []string{"go test ./internal/factory"},
+	}
+	effect, err := service.newPendingEffect(run.ID, store.PendingEffectKindResultAcceptance, "invalid-handoff", resultAcceptanceEffectPayload{
+		Repository: github.Repository{Owner: "example", Name: "project"},
+		Issue:      github.Issue{Number: run.IssueNumber},
+		Previous:   run,
+		Next:       next,
+		StopWorker: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := opened.SavePendingEffect(ctx, effect); err != nil {
+		t.Fatal(err)
+	}
+	updated, diagnosis, outcome, reconcileErr := service.reconcileInterruptedRun(ctx, config.RepositoryRegistration{
+		Path: root, GitHub: config.GitHubConfig{Owner: "example", Repository: "project"},
+	}, opened, run)
+	if reconcileErr == nil {
+		t.Fatal("reconcileInterruptedRun() = nil, want workflow refusal")
+	}
+	var workflowErr *WorkflowFailureError
+	if !errors.As(reconcileErr, &workflowErr) {
+		t.Fatalf("reconcileInterruptedRun() error = %v, want WorkflowFailureError", reconcileErr)
+	}
+	if outcome != RecoveryOutcomeWaitingForHuman || updated.Status != store.StatusWaitingForHuman {
+		t.Fatalf("reconciliation result = status %q outcome %q, want waiting_for_human", updated.Status, outcome)
+	}
+	if !strings.Contains(updated.LifecycleReason, "role handoff is incomplete") || !strings.Contains(updated.LifecycleReason, "pending effect.result_acceptance") {
+		t.Fatalf("lifecycle reason = %q, want the blocking store refusal", updated.LifecycleReason)
+	}
+	if strings.Contains(updated.LifecycleReason, "worker.lifecycle") {
+		t.Fatalf("lifecycle reason = %q, want no worker discrepancy", updated.LifecycleReason)
+	}
+	if diagnosis.SourcesAgree || !hasWorkflowDiscrepancy(diagnosis) {
+		t.Fatalf("recovery diagnosis = %#v, want a workflow disagreement", diagnosis)
+	}
+	pending, err := opened.PendingEffect(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending == nil {
+		t.Fatal("pending effect was cleared, want fail-closed reservation")
+	}
+	if githubRuntime.replaceLabelCalls != 0 || githubRuntime.createCommentCalls != 0 || githubRuntime.editCommentCalls != 0 {
+		t.Fatalf("GitHub mutations during invalid replay = labels=%d creates=%d edits=%d, want all zero", githubRuntime.replaceLabelCalls, githubRuntime.createCommentCalls, githubRuntime.editCommentCalls)
+	}
+}
+
 // TestRecoveryTargetsOnlyTheReviewerWithARecoverableProjection verifies that
 // one failed reviewer cannot make the coordinator resume a healthy concurrent
 // reviewer after restart.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -394,13 +394,17 @@ type ValidationContext struct {
 	// deferTestPathPolicy defers repository-specific ownership checks until the
 	// coordinator supplies the frozen configuration during report acceptance.
 	deferTestPathPolicy bool
+	// allowEmptyProductionFiles allows the worker-side envelope writer and
+	// reader to defer the completed-handoff file check until the coordinator has
+	// inspected the worktree.
+	allowEmptyProductionFiles bool
 }
 
 // WriteAtomic validates and publishes a report as report.json below the
 // invocation-specific result directory. A temporary file is synced and
 // renamed so readers never observe a partial JSON document.
 func WriteAtomic(resultDirectory string, value Report) (string, error) {
-	if err := Validate(value, identityFrom(value, value.InvocationID)); err != nil {
+	if err := validate(value, identityFrom(value, value.InvocationID), true); err != nil {
 		return "", err
 	}
 	if err := validateInvocationDirectory(resultDirectory, value.InvocationID); err != nil {
@@ -414,7 +418,7 @@ func WriteAtomic(resultDirectory string, value Report) (string, error) {
 // identity parameter keeps the protocol safe even though the in-worker mount
 // itself is named /results rather than after the host invocation id.
 func WriteAtomicForInvocation(resultDirectory, invocationID string, value Report) (string, error) {
-	if err := Validate(value, identityFrom(value, invocationID)); err != nil {
+	if err := validate(value, identityFrom(value, invocationID), true); err != nil {
 		return "", err
 	}
 	if !filepath.IsAbs(resultDirectory) {
@@ -492,7 +496,7 @@ func Read(path string) (Report, error) {
 	if err != nil {
 		return Report{}, err
 	}
-	if err := Validate(value, identityFrom(value, value.InvocationID)); err != nil {
+	if err := validate(value, identityFrom(value, value.InvocationID), true); err != nil {
 		return Report{}, err
 	}
 	return value, nil
@@ -556,6 +560,14 @@ func ReadEnvelope(path string) (Report, error) {
 // Validate checks identity, outcome shape, path safety, and observed worktree
 // containment before a coordinator accepts a report.
 func Validate(value Report, context ValidationContext) error {
+	return validate(value, context, false)
+}
+
+// validate applies report rules with an explicit worker-envelope mode. The
+// worker can only publish the report shape; the coordinator owns the exact
+// worktree observation needed to decide whether an empty file list is honest.
+func validate(value Report, context ValidationContext, allowEmptyProductionFiles bool) error {
+	context.allowEmptyProductionFiles = allowEmptyProductionFiles
 	if value.SchemaVersion != SchemaVersion {
 		return fmt.Errorf("unsupported report schema_version %d", value.SchemaVersion)
 	}
@@ -761,6 +773,13 @@ func validateHandoff(value Handoff, context ValidationContext) error {
 		if err := validateText(fmt.Sprintf("acceptance_mapping[%d].evidence", index), mapping.Evidence, maxTextRunes, true); err != nil {
 			return err
 		}
+	}
+	// A clean, coordinator-inspected worktree is the one honest exception for
+	// a rerun against an already-committed checkpoint: there are no new paths
+	// for the role to name. Any observed change still requires the handoff to
+	// name at least one production file.
+	if len(value.ProductionFilesChanged) == 0 && !context.allowEmptyProductionFiles && (!context.WorktreeObserved || len(context.ObservedChanges) != 0) {
+		return errors.New("completed handoff production_files_changed is required")
 	}
 	observed := make(map[string]struct{}, len(context.ObservedChanges))
 	for _, path := range context.ObservedChanges {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/report"
+	"github.com/Stevie1704/sw-factory/internal/store"
 )
 
 // TestWriteAtomicWritesOneInvocationReport verifies that a valid report is
@@ -85,11 +86,13 @@ func TestValidateRejectsAReportThatDoesNotMatchTheInvocation(t *testing.T) {
 	value := completedReport()
 	value.InvocationID = "stale-invocation"
 	err := report.Validate(value, report.ValidationContext{
-		InvocationID: "inv-1",
-		RunID:        "run-1",
-		Harness:      "codex",
-		Role:         "implementation",
-		Stage:        "implementation",
+		InvocationID:     "inv-1",
+		RunID:            "run-1",
+		Harness:          "codex",
+		Role:             "implementation",
+		Stage:            "implementation",
+		WorktreeObserved: true,
+		ObservedChanges:  []string{"internal/factory/agent.go"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "invocation_id") {
 		t.Fatalf("Validate() error = %v, want invocation identity error", err)
@@ -506,6 +509,58 @@ func TestValidateRejectsAProductionFileFromAnInspectedCleanWorktree(t *testing.T
 	})
 	if err == nil || !strings.Contains(err.Error(), "was not observed") {
 		t.Fatalf("Validate() error = %v, want clean-worktree mismatch", err)
+	}
+}
+
+// TestValidateRejectsACompletedHandoffWithoutProductionFiles verifies that a
+// completed handoff names at least one repository file changed by the role.
+func TestValidateRejectsACompletedHandoffWithoutProductionFiles(t *testing.T) {
+	value := completedReport()
+	value.Handoff.ProductionFilesChanged = nil
+	err := report.Validate(value, report.ValidationContext{
+		InvocationID:     "inv-1",
+		RunID:            "run-1",
+		Harness:          "codex",
+		Role:             "implementation",
+		Stage:            "implementation",
+		WorktreeObserved: true,
+		ObservedChanges:  []string{"internal/factory/agent.go"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "production_files_changed") {
+		t.Fatalf("Validate() error = %v, want missing-production-files rejection", err)
+	}
+}
+
+// TestReportAndStoreValidatorsAgreeOnCompletedHandoffFiles verifies both
+// validation seams reject the same incomplete completed handoff.
+func TestReportAndStoreValidatorsAgreeOnCompletedHandoffFiles(t *testing.T) {
+	value := completedReport()
+	value.Handoff.ProductionFilesChanged = nil
+	reportErr := report.Validate(value, report.ValidationContext{
+		InvocationID:     "inv-1",
+		RunID:            "run-1",
+		Harness:          "codex",
+		Role:             "implementation",
+		Stage:            "implementation",
+		WorktreeObserved: true,
+		ObservedChanges:  []string{"internal/factory/agent.go"},
+	})
+	storeErr := store.ValidateRun(store.Run{
+		ID:             "run-1",
+		RepositoryPath: "/work/repository",
+		Status:         store.StatusActive,
+		RoleHandoff: &store.RoleHandoff{
+			ChangeSummary:          value.Handoff.ChangeSummary,
+			AcceptanceMapping:      []store.HandoffAcceptance{{Criterion: "criterion", Evidence: "test"}},
+			ProductionFilesChanged: nil,
+			FocusedCommands:        []string{"go test ./internal/factory"},
+		},
+	})
+	if (reportErr == nil) != (storeErr == nil) {
+		t.Fatalf("validator agreement = report error %v, store error %v", reportErr, storeErr)
+	}
+	if reportErr == nil {
+		t.Fatal("report and store validators accepted an empty production-file list")
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1077,6 +1077,14 @@ func (s *Store) SaveRun(ctx context.Context, run Run) error {
 	return nil
 }
 
+// ValidateRun applies the operational-store run rules without persisting the
+// projection. Coordinator effect paths use it before reserving an external
+// mutation so an unpersistable run cannot cross that effect boundary.
+func ValidateRun(run Run) error {
+	_, err := normalizeRun(run)
+	return err
+}
+
 // PendingEffect returns the one durable external-effect reservation for a run,
 // or nil when the run has no mutation awaiting reconciliation.
 func (s *Store) PendingEffect(ctx context.Context, runID string) (*PendingEffect, error) {


### PR DESCRIPTION
<!-- factory-generated:start -->
## Factory run

- run: `run-bd38f28a-afd0-4907-955f-72ab5780a0cb`
- issue: #130 — An accepted structured report can build a run state the operational store refuses, and reconciliation cannot leave it
- specification packet: version 1, target branch `main`
- checkpoint: `093f38a88fa4016bdb2091a512cec1d8aeb709ec`
- stage: `draft_pr`
- intervention: `none`
- test policy: `advisory (implementation-owned TDD)`
- route: `default (repository test policy)`

Closes #130

<!-- factory-generated:review:start -->

### Specification review

- reviewed checkpoint: `093f38a88fa4016bdb2091a512cec1d8aeb709ec`
- outcome: 0 blocking findings, 0 advisory findings
- findings: none

### Standards review

- reviewed checkpoint: `093f38a88fa4016bdb2091a512cec1d8aeb709ec`
- outcome: 0 blocking findings, 0 advisory findings
- findings: none
<!-- factory-generated:review:end -->

### Issue summary

## What happened

Run `run-5be45279-0e9a-41e2-81ca-23d2c61b9f6a` (issue #116) is parked at `implementation` / `waiting_for_human`. No coordinator path can accept its report, and the only operator exit costs a repeated implementation stage.

Its implementation invocation `inv-run-3cd67839-…` completed and wrote a structured report whose handoff names no production file:

```json
"handoff": {
  "change_summary": "Added internal/effect protocol kernel and registered factory replay handlers.",
  "acceptance_mapping": [ { "criterion": "kernel", "evidence": "…" } ],
  "production_files_changed": null,
  "focused_commands": ["scripts/worker-go.sh test ./internal/effect -count=1"]
}
```

The report is not honest — the run worktree holds five changed paths (`internal/factory/effects.go`, `effects_test.go`, `recovery.go`, and the untracked `internal/effect/` and `internal/factory/effect_replay.go`) — but the report contract accepted it, and the coordinator built the run's next state from it.

## The contract split

Two validators disagree about an empty `production_files_changed`:

| Validator | `acceptance_mapping` | `focused_commands` | `production_files_changed` |
| --- | --- | --- | --- |
| `internal/report/report.go:747` `validateHandoff` | required non-empty (`:751`) | required non-empty (`:803`) | **upper bound only** (`:776`) |
| `internal/store/store.go:1452` `validateRun` | required non-empty | required non-empty | **required non-empty** |

```go
// internal/store/store.go:1452
if len(roleHandoff.AcceptanceMapping) == 0 || len(roleHandoff.ProductionFilesChanged) == 0 || len(roleHandoff.FocusedCommands) == 0 {
    return errors.New("role handoff is incomplete")
}
```

`agent.go:781` → `roleHandoffFromReport` (`review.go:40`) copies the empty slice straight through, so every `SaveRun` carrying that handoff fails with `role handoff is incomplete`.

## Why the run cannot leave the state

`acceptResultWithEffect` (`effects.go:1075`) reserves the durable effect from `next` **before** anything validates `next` against the operational store's rules. Inside `apply` the order is:

1. reserve the terminal invocation row,
2. `harnessRuntime.Finish` — external,
3. `stopRunWorker` — external,
4. `applyStateTransitionEffects` — external GitHub label and status comment,
5. `saveRunWithRetry` — **the first and only store validation** (`effects.go:1151`).

Steps 1–4 succeed. Step 5 fails. The pending effect therefore stays in the journal by design, and every later reconciliation repeats the same sequence: it re-crosses the external boundary — idempotent, so the comment write is now a no-op — and fails at the same local save. `replayAcceptedResult` (`effects.go:1249`) and `replayPendingStateTransition` (`effects.go:1663`) both end at a `saveRun` carrying the same handoff.

The run is pinned at revision 4. Observable proof that the failure is after the external boundary: the GitHub status comment already renders the revision-5 projection while `operational_runs.revision` is still 4.

Each pause also nests the previous lifecycle reason into the new one, so the reason string grows on every pass and the operator reads a progressively less useful message.

## Why the reported message names the wrong thing

`factory status` reports:

```
lifecycle reason: restart reconciliation paused:
  worker.lifecycle expected="running" observed="stopped";
  native session.identity expected="01a062a8-…"
    observed="worker "run-5be45279-…" is not running"
```

Both discrepancies are self-inflicted. Reconciliation stopped the worker at 15:29:07 UTC (`docker stop`, exit 137, `OOMKilled=false`). The recovery diagnosis then inspected that same worker at 15:29:41 (`recovery.go:561`, `recovery.go:683`), found it stopped, and could not read the Codex session because the worker was gone. Neither line names the store refusal that actually blocks the run.

`recovery.go:1562` offers `factory reconcile --abandon-effect state_transition:4f88c43a… --reason …` as a safe action. It clears the journal row but does not make the report acceptable. The invocation is terminal and `report.json` is unchanged; `agent.go:326` re-reads that same report through `report.Read`, which validates with an empty `ValidationContext`, so the worktree cross-check never runs and the same handoff is rebuilt.

The one exit is `--abandon-effect` and then `/factory refresh`. `handleRefreshCommand` (`command.go:303`) admits a non-terminal run with no pending check-repair attempt, and `resetTestProjectionForPacketChange` (`command.go:344`, `:654`) clears `RoleHandoff`, so the run becomes persistable again. The cost is a new specification packet version and a repeated implementation stage for work the role already did — the same shape as #128.

## The condition

The failure needs all three:

1. a role reports a completed handoff with an empty `production_files_changed`;
2. the report contract admits it, so acceptance proceeds;
3. store-level validation runs only at the final `saveRun`, after the journal row and the external GitHub writes.

Condition 3 is the one that turns a bad report into a stuck run. Any future divergence between the two validators reproduces the same dead end even after 1 and 2 are closed.

## What to decide

Two decisions, and they are independent.

### A. Which contract is right about an empty production-file list

`report.go:79` defines `ProductionFilesChanged` as the repository-relative files changed by the role — every file, not only non-test files. A `completed` handoff naming none is therefore self-contradictory. The store rule is the correct one and the report contract is missing the check.

| Shape | Change | Trade-off |
| --- | --- | --- |
| **Report contract tightens** (recommended). A completed handoff requires minimum one production file | `validateHandoff` in `report.go` | Both validators then state the same rule. The refusal lands at acceptance, where the run is still active and the role can be asked again |
| **Store relaxes.** Allow an empty `ProductionFilesChanged` when the other two lists are populated | `validateRun` in `store.go` | Removes the split, but lets the store keep a handoff that describes no work at all |

One open question interlocks with #129: a role re-run against an already-committed checkpoint has no honest non-empty list either, because #129 shows the same field refused from the other side when the worktree is clean. Whatever tightens this rule has to leave that case an honest answer.

### B. Where store-level validation belongs (the part that makes it stick)

| Shape | Change | Trade-off |
| --- | --- | --- |
| **Validate before reserving.** Run the store's run validation against `next` before `withPendingEffect` reserves the journal row | `acceptResultWithEffect`, and the same guard on every effect that journals a run projection | Turns an unpersistable projection into an ordinary acceptance refusal on a still-active run. Needs the validation exposed as a pure function the factory package can call |
| **Operator exit only.** Admit an operator command that discards an unpersistable projection | a command guard | Leaves the coordinator able to perform external writes for a state it can never store — #128's dead end again, with GitHub already mutated |

The first is the one worth having.

## Related gap, not fixed here

`validateHandoff` checks that every listed path appears in the observed worktree changes, but never that every observed change appears in the list. A role can therefore change files and report none of them, which is exactly what happened. Worth its own issue; the two decisions above do not close it.

## Non-goals

- Changing what `factory reconcile --abandon-effect` does.
- Removing the fail-closed rule that keeps a pending effect until it completes or is abandoned.
- Making a role fabricate a handoff entry to satisfy either contract.

## Acceptance criteria

- [ ] A completed handoff that one validator admits and the other refuses cannot reach the durable effect journal.
- [ ] A test drives a completed implementation report with an empty `production_files_changed` and asserts the run stays in a state a role or an operator can leave — no pending effect, no external GitHub write.
- [ ] The two validators state the same rule for `production_files_changed`, and one test asserts they agree.
- [ ] A reconciliation pause reports the refusal that blocks the run, not a worker it stopped itself.
- [ ] A lifecycle reason does not nest a previous reconciliation reason into itself.
- [ ] `go test ./...` passes.

## Evidence

- Run row: `operational_runs` id `run-5be45279-…`, revision 4, `implementation` / `waiting_for_human`, `implementation_handoff` empty, `updated_at` 2026-09-02T15:29:07Z.
- Pending effect: one row, `state_transition:4f88c43ac5326475656291670c551e1eddfdca4e67379136953eaf686799f32a`, created 15:29:41Z. Its `Next.Revision` is 5 and its `Next.RoleHandoff.production_files_changed` is `null`.
- Report: `.factory-agents/run-5be45279-…/inv-run-3cd67839-…/results/report.json`, outcome `completed`, written 15:23:39Z.
- Invocation `inv-run-3cd67839-…`, role `implementation`, status `completed`, `recovery_resume_count` 0, native session `01a062a8-…`.
- Worker container `factory-worker-…`: exit 137, `OOMKilled=false`, finished 15:29:07Z — 34 seconds before the diagnosis that reports it stopped.
- `git status --porcelain` in the run worktree lists five changed paths; the accepted handoff names none.

### Gates

- `format`: passed
- `vet`: passed
- `test`: passed
- `build`: passed

### Control commands

- `factory status`
- `factory draft-pr --run-id run-bd38f28a-afd0-4907-955f-72ab5780a0cb`

<!-- factory-generated:end -->