### PR TITLE
An active invocation whose harness turn dies never ends, and the declared timeouts.agent is never enforced

### DIFF
--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/report"
@@ -76,6 +77,12 @@ type progressionState struct {
 	// ReadyInvocationIDs records the report-readiness observation made while
 	// reading each active invocation. The planner must not repeat that I/O.
 	ReadyInvocationIDs map[string]bool
+	// AgentTimeout is the parsed agent deadline from the frozen specification
+	// packet. A zero value preserves the no-deadline behavior of legacy packets
+	// that predate the required timeout field.
+	AgentTimeout time.Duration
+	// Now is the coordinator clock observation paired with AgentTimeout.
+	Now time.Time
 }
 
 // progressionActionKind identifies one coordinator seam that can advance a
@@ -418,6 +425,15 @@ func progressionStep(state progressionState, registry workflow.Registry) (progre
 				invocationID: active.ID,
 			}, nil
 		}
+		for _, active := range activeInvocations {
+			if elapsed, expired := agentInvocationExpired(*active, state.Now, state.AgentTimeout); expired {
+				return progressionAction{}, &progressionResult{
+					Outcome: progressionWaiting,
+					Step:    "agent deadline",
+					Reason:  fmt.Sprintf("invocation %q exceeded agent timeout of %s (elapsed %s)", active.ID, state.AgentTimeout, elapsed),
+				}
+			}
+		}
 		ids := make([]string, 0, len(activeInvocations))
 		for _, active := range activeInvocations {
 			ids = append(ids, active.ID)
@@ -570,6 +586,15 @@ func (s *Service) readProgressionState(ctx context.Context, registration config.
 		state.ActiveInvocations = []*store.Invocation{state.Active}
 	}
 	state.ReadyInvocationIDs = make(map[string]bool, len(state.ActiveInvocations))
+	if len(state.ActiveInvocations) > 0 {
+		state.AgentTimeout, err = agentTimeoutForProgression(*run)
+		if err != nil {
+			return progressionState{}, err
+		}
+		if state.AgentTimeout > 0 {
+			state.Now = s.deps.Now().UTC()
+		}
+	}
 	for _, invocation := range state.ActiveInvocations {
 		if invocation == nil {
 			continue
@@ -580,6 +605,42 @@ func (s *Service) readProgressionState(ctx context.Context, registration config.
 		return progressionState{}, fmt.Errorf("read latest invocation for progression: %w", err)
 	}
 	return state, nil
+}
+
+// agentTimeoutForProgression reads the agent deadline from the frozen
+// specification packet. A missing value is retained as an unconfigured
+// deadline for packets created before the timeout was consumed by progression.
+func agentTimeoutForProgression(run store.Run) (time.Duration, error) {
+	packet, err := decodeSpecificationPacket(run.SpecificationPacket)
+	if err != nil {
+		return 0, fmt.Errorf("decode specification packet for agent deadline: %w", err)
+	}
+	serialized := strings.TrimSpace(packet.RepositoryConfig.Timeouts.Agent)
+	if serialized == "" {
+		return 0, nil
+	}
+	timeout, err := time.ParseDuration(serialized)
+	if err != nil || timeout <= 0 {
+		if err == nil {
+			err = errors.New("duration must be positive")
+		}
+		return 0, fmt.Errorf("parse frozen agent timeout %q: %w", serialized, err)
+	}
+	return timeout, nil
+}
+
+// agentInvocationExpired reports whether an active invocation has reached its
+// frozen agent deadline and returns the observed age for operator-facing
+// evidence. Missing timestamps, clocks, or deadlines cannot prove expiry.
+func agentInvocationExpired(invocation store.Invocation, now time.Time, timeout time.Duration) (time.Duration, bool) {
+	if timeout <= 0 || invocation.CreatedAt.IsZero() || now.IsZero() {
+		return 0, false
+	}
+	elapsed := now.Sub(invocation.CreatedAt)
+	if elapsed < timeout {
+		return elapsed, false
+	}
+	return elapsed, true
 }
 
 // progressionAdvanced reports whether a transition changed durable run state.

--- a/internal/factory/progression_internal_test.go
+++ b/internal/factory/progression_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +40,130 @@ func TestProgressionStepPlansReportAcceptanceFromObservedReadiness(t *testing.T)
 	}
 	if action.runID != run.ID || action.invocationID != invocation.ID {
 		t.Fatalf("planned action operands = %#v, want run %q and invocation %q", action, run.ID, invocation.ID)
+	}
+}
+
+// TestDriveRunPausesAnExpiredActiveInvocation verifies unattended progression
+// pauses a report-less invocation after the frozen agent deadline instead of
+// continuing to publish that the invocation is executing.
+func TestDriveRunPausesAnExpiredActiveInvocation(t *testing.T) {
+	now := time.Date(2026, 9, 3, 13, 30, 0, 0, time.UTC)
+	createdAt := now.Add(-2 * time.Hour)
+	packetData, err := json.Marshal(SpecificationPacket{
+		Version: specificationPacketVersion,
+		RepositoryConfig: config.RepositoryConfig{
+			Timeouts: config.TimeoutConfig{Agent: "1h"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal deadline packet: %v", err)
+	}
+	invocation := store.Invocation{
+		ID:              "inv-expired",
+		RunID:           "run-expired",
+		Role:            workflow.RoleImplementation,
+		Stage:           store.StageImplementation,
+		Status:          store.InvocationStatusActive,
+		ResultDirectory: t.TempDir(),
+		CreatedAt:       createdAt,
+		UpdatedAt:       createdAt,
+	}
+	run := store.Run{
+		ID:                  invocation.RunID,
+		Stage:               store.StageImplementation,
+		Status:              store.StatusActive,
+		ActiveInvocationIDs: []string{invocation.ID},
+		SpecificationPacket: string(packetData),
+		CreatedAt:           createdAt,
+		UpdatedAt:           createdAt,
+	}
+	runStore := &progressionDispatchStore{run: run, active: []store.Invocation{invocation}}
+	registration := config.RepositoryRegistration{OperationalDataPath: "/state/factory.db"}
+	service := &Service{
+		deps: Dependencies{
+			OpenStore: func(context.Context, string) (OperationalStore, error) {
+				return runStore, nil
+			},
+			GitHub: progressionDispatchGitHub{},
+			Now: func() time.Time {
+				return now
+			},
+		},
+	}
+
+	result, err := service.driveRun(context.Background(), registration)
+	if err != nil {
+		t.Fatalf("driveRun() error = %v", err)
+	}
+	if result.Outcome != progressionWaiting {
+		t.Fatalf("driveRun() outcome = %q, want waiting after the deadline", result.Outcome)
+	}
+	if result.Run.Status != store.StatusWaitingForHuman {
+		t.Fatalf("driveRun() status = %q, want waiting_for_human", result.Run.Status)
+	}
+	for _, reason := range []string{result.Reason, result.Run.LifecycleReason} {
+		if !strings.Contains(reason, invocation.ID) || !strings.Contains(reason, "2h0m0s") {
+			t.Fatalf("pause reason = %q, want invocation %q and elapsed time", reason, invocation.ID)
+		}
+	}
+}
+
+// TestDriveRunKeepsAnActiveInvocationInsideItsDeadline verifies a report-less
+// invocation remains active while its frozen agent deadline has not elapsed.
+func TestDriveRunKeepsAnActiveInvocationInsideItsDeadline(t *testing.T) {
+	now := time.Date(2026, 9, 3, 13, 30, 0, 0, time.UTC)
+	createdAt := now.Add(-30 * time.Minute)
+	packetData, err := json.Marshal(SpecificationPacket{
+		Version: specificationPacketVersion,
+		RepositoryConfig: config.RepositoryConfig{
+			Timeouts: config.TimeoutConfig{Agent: "1h"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal deadline packet: %v", err)
+	}
+	invocation := store.Invocation{
+		ID:              "inv-within-deadline",
+		RunID:           "run-within-deadline",
+		Role:            workflow.RoleImplementation,
+		Stage:           store.StageImplementation,
+		Status:          store.InvocationStatusActive,
+		ResultDirectory: t.TempDir(),
+		CreatedAt:       createdAt,
+		UpdatedAt:       createdAt,
+	}
+	run := store.Run{
+		ID:                  invocation.RunID,
+		Stage:               store.StageImplementation,
+		Status:              store.StatusActive,
+		ActiveInvocationIDs: []string{invocation.ID},
+		SpecificationPacket: string(packetData),
+		CreatedAt:           createdAt,
+		UpdatedAt:           createdAt,
+	}
+	runStore := &progressionDispatchStore{run: run, active: []store.Invocation{invocation}}
+	registration := config.RepositoryRegistration{OperationalDataPath: "/state/factory.db"}
+	service := &Service{
+		deps: Dependencies{
+			OpenStore: func(context.Context, string) (OperationalStore, error) {
+				return runStore, nil
+			},
+			GitHub: progressionDispatchGitHub{},
+			Now: func() time.Time {
+				return now
+			},
+		},
+	}
+
+	result, err := service.driveRun(context.Background(), registration)
+	if err != nil {
+		t.Fatalf("driveRun() error = %v", err)
+	}
+	if result.Outcome != progressionInvocationActive {
+		t.Fatalf("driveRun() outcome = %q, want invocation_active before the deadline", result.Outcome)
+	}
+	if result.Run.Status != store.StatusActive {
+		t.Fatalf("driveRun() status = %q, want active before the deadline", result.Run.Status)
 	}
 }
 


### PR DESCRIPTION
<!-- factory-generated:start -->
## Factory run

- run: `run-89b0bf87-81aa-4b9c-b648-94d6146fb0b9`
- issue: #136 — An active invocation whose harness turn dies never ends, and the declared timeouts.agent is never enforced
- specification packet: version 1, target branch `main`
- checkpoint: `4a0ba10f41523a009cd07b9abd6e3659bcb56fb9`
- stage: `draft_pr`
- intervention: `none`
- test policy: `advisory (implementation-owned TDD)`
- route: `default (repository test policy)`

Closes #136

<!-- factory-generated:review:start -->

### Specification review

- reviewed checkpoint: `4a0ba10f41523a009cd07b9abd6e3659bcb56fb9`
- outcome: 0 blocking findings, 0 advisory findings
- findings: none

### Standards review

- reviewed checkpoint: `4a0ba10f41523a009cd07b9abd6e3659bcb56fb9`
- outcome: 0 blocking findings, 1 advisory findings

#### Finding 1 — advisory/taste
- location: `internal/factory/progression_internal_test.go:49-156`
- claim: The two new deadline tests duplicate the same packet, invocation, run, store, service, and driveRun fixture setup.
- evidence: source=heuristic:Duplicated Code;hunk=internal/factory/progression_internal_test.go:49-156;the two tests differ only in invocation age and identifiers while repeating the surrounding setup.
- suggested resolution: Factor the shared deadline fixture into a helper or table-driven test while retaining separate expired and within-deadline assertions.
- suggested owner: `implementation`
<!-- factory-generated:review:end -->

### Issue summary

## What happened

Run `run-bd38f28a-afd0-4907-955f-72ab5780a0cb` (issue #130) sat at `implementation` / `active` for **3h 47m** with a live but idle harness and no way for the coordinator to notice.

The review-repair invocation `inv-run-24afb317-…` was created at 14:58:27Z, its packet was written, and the prompt reached the Codex TUI. Codex then failed the turn against its own backend and stopped:

```
⚠ Falling back from WebSockets to HTTPS transport. unexpected status 404 Not Found: Unknown error,
  url: wss://chatgpt.com/backend-api/codex/responses
■ unexpected status 404 Not Found: Unknown error,
  url: https://chatgpt.com/backend-api/codex/responses
```

The harness process stayed alive at its composer. It never wrote `results/report.json`. The coordinator kept polling GitHub and reporting `activity=invocation-active` until an operator ran `factory resume` at 18:45Z.

Nothing in the run was corrupt. `factory status` reported `sources=agree` with zero discrepancies for the whole window, which is correct — this is not a reconciliation problem. The coordinator simply has no observation that distinguishes "the role is working" from "the role's turn died".

## Why the coordinator cannot notice

`progression.go:425` is the only decision made about an active invocation:

```go
return progressionAction{}, &progressionResult{
    Outcome: progressionInvocationActive,
    Reason:  fmt.Sprintf("invocations %s are executing", strings.Join(ids, ", ")),
}
```

It is reached whenever `state.ReadyInvocationIDs[active.ID]` is false (`:411`), and readiness is one file-presence check:

```go
// progression.go:673
func agentResultReady(invocation store.Invocation) bool {
	presence, err := structuredReportPresenceForInvocation(invocation)
	return err == nil && presence == structuredReportPresent
}
```

There is no deadline, no attempt counter, and no second observation. The polling loop reinforces it: `pollOnce` (`polling.go:338`) returns `PollActiveRun` the moment a run exists and never looks at the invocation, the worker, or the harness at all.

So the only exit from an active invocation is the agent itself calling `factory-report`. If the harness turn fails without the agent being able to report, the run has no exit.

## `timeouts.agent` is declared and never enforced

`factory.yaml` declares `timeouts.agent: 90m`. Had it been enforced, this run would have been surfaced at ~16:28Z instead of 18:45Z.

`Timeouts.Agent` is validated at `config.go:516` and read nowhere else. The same holds for `gate` and `review`:

| Field | Validated | Consumed |
| --- | --- | --- |
| `timeouts.setup` | `config.go:515` | `gate.go:401` (`SetupTimeout`) |
| `timeouts.agent` | `config.go:516` | **nowhere** |
| `timeouts.gate` | `config.go:517` | **nowhere** |
| `timeouts.review` | `config.go:518` | **nowhere** |

A repository can therefore state an agent deadline the coordinator accepts, records in the frozen packet, and then ignores.

## Two observations are missing, not one

They fail differently and should not be conflated.

| Observation | What it catches | This run |
| --- | --- | --- |
| **Deadline.** An active invocation exceeds `timeouts.agent` measured from `invocations.created_at` | Any silent stall, whatever the cause | Would have fired at 16:28Z |
| **Liveness.** The worker container or harness process backing an active invocation is gone | A crashed or killed harness, immediately | Would not have fired — the process stayed alive |

Liveness alone misses this run entirely. The deadline is the one that has to exist.

## Shape of the fix

| Shape | Change | Trade-off |
| --- | --- | --- |
| **Enforce the declared deadline** (recommended). Compare `now - invocations.created_at` against the packet's `timeouts.agent` in `progressionInvocationActive`, and pause the run `waiting_for_human` with the invocation id and elapsed time | `progression.go:404-425`, reading the frozen packet's timeouts | Uses a field the config already validates and the packet already freezes. Needs a decision on what a resumed invocation's clock is: `created_at` keeps one honest bound per invocation, but a legitimate long role that was resumed once inherits the elapsed time |
| **Add a liveness observation.** Read worker/harness state for each active invocation during progression | `progression.go`, plus a worker-state read | Catches a dead worker in seconds rather than at the deadline, but is a per-poll external read on the hot path, and would not have caught this failure |
| **Neither; keep the operator path.** Document `factory resume` as the response | docs only | The operator has to be watching. This run burned 3h 47m before anyone looked |

The first is the one worth having. The second is a reasonable follow-up once the first exists.

## Non-goals

- Cancelling or failing the run automatically. A deadline should pause it `waiting_for_human` with the evidence, not decide the work is dead.
- Reading harness terminal output as completion or liveness evidence. The role prompt already forbids the screen as evidence and the coordinator must hold the same rule.
- Changing what `factory resume` does. It was the correct exit here and it worked.
- Enforcing `timeouts.gate` and `timeouts.review`. Named above as fact; each deserves its own decision.

## Acceptance criteria

- [ ] An active invocation whose age exceeds the packet's `timeouts.agent` stops progression instead of reporting `invocations … are executing` forever.
- [ ] The resulting pause is `waiting_for_human` and its lifecycle reason names the invocation id and the elapsed time, so `factory status` states the actual cause.
- [ ] `factory resume` remains the exit from that pause and does not consume a repair attempt.
- [ ] A test drives an active invocation past the configured deadline with no report file and asserts the run pauses rather than returning `progressionInvocationActive`.
- [ ] A test asserts an invocation inside its deadline with no report file still returns `progressionInvocationActive`.
- [ ] `timeouts.agent` has at least one consumer, so the config field and coordinator behaviour agree.
- [ ] `go test ./...` passes.

## Evidence

- Run row: `operational_runs` id `run-bd38f28a-…`, `implementation` / `active`, `updated_at` 2026-09-03T14:58:45Z, unchanged until 18:45Z.
- Invocation `inv-run-24afb317-…`, role `implementation`, status `active`, `created_at` = `updated_at` = 2026-09-03T14:58:27Z, `attach_required` 0, `launch_voided` 0, `recovery_resume_count` 0.
- `…/inv-run-24afb317-…/packet/specification.json` written; `…/results/` empty for the whole window. The three sibling invocations each hold a `results/report.json`.
- Worker alive throughout: `docker exec … -m gpt-5.6-luna … resume 01a0679b-… ` (pid 86867) started 14:58Z and still running at 18:45Z.
- Harness state read from cmux surface `7271ED85-…`: full `implementation-v8 (continuation)` prompt delivered, then the two 404 lines above, then an idle composer.
- Coordinator alive and polling throughout: `factory start` pid 86917, started 11:20Z, `gh api repos/Stevie1704/sw-factory/issues…` observed at 18:13Z.
- `factory status` for the whole window: `recovery: recovery-required (run=run-bd38f28a-… sources=agree)` with zero `recovery discrepancy:` lines.
- Recovery after `factory resume` → `factory attach`: invocation completed 18:45:31Z, run advanced to `review` at checkpoint `093f38a8`, `review_repair_attempts` still 1 of 4.

### Gates

- `format`: passed
- `vet`: passed
- `test`: passed
- `build`: passed

### Control commands

- `factory status`
- `factory draft-pr --run-id run-89b0bf87-81aa-4b9c-b648-94d6146fb0b9`

<!-- factory-generated:end -->