### PR TITLE
factory start is silent for its entire lifetime: no coordinator progress output and no logging seam

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -161,6 +161,7 @@ func runStart(ctx context.Context, args []string, defaultConfigPath string, outp
 	flags := flag.NewFlagSet("start", flag.ContinueOnError)
 	flags.SetOutput(errorsOutput)
 	configPath := flags.String("config", defaultConfigPath, "host configuration path")
+	verbose := flags.Bool("verbose", false, "report coordinator progress")
 	if err := flags.Parse(args); err != nil {
 		return 2
 	}
@@ -171,7 +172,11 @@ func runStart(ctx context.Context, args []string, defaultConfigPath string, outp
 	if !writeOutput(output, errorsOutput, "factory polling starting\n") {
 		return 1
 	}
-	if err := factory.New(*configPath).Start(ctx); err != nil {
+	events := factory.EventSink(factory.DiscardEventSink{})
+	if *verbose {
+		events = factory.NewTextEventSink(errorsOutput)
+	}
+	if err := factory.New(*configPath).Start(ctx, events); err != nil {
 		writeError(errorsOutput, err)
 		return 1
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -91,6 +91,33 @@ base_synchronization:
 	}
 }
 
+// TestRunStartVerboseFlagKeepsCommandOutputSeparate verifies the start flag
+// is accepted and the legacy lifecycle line remains on stdout when startup
+// diagnosis stops the coordinator before any live event exists.
+func TestRunStartVerboseFlagKeepsCommandOutputSeparate(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	var defaultOutput, defaultErrors bytes.Buffer
+	if code := cli.Run(context.Background(), []string{"start", "--config", configPath}, &defaultOutput, &defaultErrors); code != 1 {
+		t.Fatalf("default start exit code = %d, want startup failure, stdout=%q stderr=%q", code, defaultOutput.String(), defaultErrors.String())
+	}
+	if defaultOutput.String() != "factory polling starting\n" {
+		t.Fatalf("default start stdout = %q, want the unchanged lifecycle line", defaultOutput.String())
+	}
+	var output, errorsOutput bytes.Buffer
+	code := cli.Run(context.Background(), []string{"start", "--config", configPath, "--verbose"}, &output, &errorsOutput)
+	if code != 1 {
+		t.Fatalf("start exit code = %d, want startup failure, stdout=%q stderr=%q", code, output.String(), errorsOutput.String())
+	}
+	if output.String() != "factory polling starting\n" {
+		t.Fatalf("start stdout = %q, want the unchanged lifecycle line", output.String())
+	}
+	if !strings.Contains(errorsOutput.String(), "error:") {
+		t.Fatalf("start stderr = %q, want the startup error on stderr", errorsOutput.String())
+	}
+}
+
 func TestRunRejectsAnUnknownCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/factory/claim_test.go
+++ b/internal/factory/claim_test.go
@@ -708,10 +708,14 @@ type fakeRunStore struct {
 	saved           []store.Run
 	saveErrors      []error
 	lifecycleClaims map[string]map[store.Status]bool
+	currentRun      func(context.Context) (*store.Run, error)
 }
 
 // CurrentRun returns the newest non-terminal record.
-func (f *fakeRunStore) CurrentRun(context.Context) (*store.Run, error) {
+func (f *fakeRunStore) CurrentRun(ctx context.Context) (*store.Run, error) {
+	if f.currentRun != nil {
+		return f.currentRun(ctx)
+	}
 	for index := len(f.saved) - 1; index >= 0; index-- {
 		run := f.saved[index]
 		if run.Status == store.StatusComplete || run.Status == store.StatusCancelled || run.Status == store.StatusFailed {

--- a/internal/factory/events.go
+++ b/internal/factory/events.go
@@ -1,0 +1,257 @@
+package factory
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// EventKind identifies the coordinator observation represented by an event.
+type EventKind string
+
+const (
+	// EventPollPass reports one completed queue observation.
+	EventPollPass EventKind = "poll_pass"
+	// EventClaim reports a newly claimed issue.
+	EventClaim EventKind = "claim"
+	// EventProgressionPass reports why one unattended progression pass stopped.
+	EventProgressionPass EventKind = "progression_pass"
+	// EventProgressionStep reports one selected unattended transition.
+	EventProgressionStep EventKind = "progression_step"
+	// EventRetry reports a retryable coordinator failure and its attempt.
+	EventRetry EventKind = "retry"
+	// EventCommandFailure reports a swallowed command-polling failure.
+	EventCommandFailure EventKind = "command_failure"
+	// EventStageTransition reports a persisted change of run stage.
+	EventStageTransition EventKind = "stage_transition"
+)
+
+// CoordinatorEvent is a content-free, structured observation from the
+// persistent coordinator. Only identifiers, outcomes, reasons, counts, and
+// stage or retry metadata belong in an event; issue and comment content,
+// credentials, and credential paths do not.
+type CoordinatorEvent struct {
+	// Timestamp is the coordinator clock observation at emission time.
+	Timestamp time.Time `json:"timestamp"`
+	// Kind identifies which event fields are populated.
+	Kind EventKind `json:"kind"`
+	// RunID identifies the run associated with the observation, when known.
+	RunID string `json:"run_id,omitempty"`
+	// Outcome is the poll or progression outcome, when applicable.
+	Outcome string `json:"outcome,omitempty"`
+	// IssueNumber identifies a claimed issue, when applicable.
+	IssueNumber int `json:"issue_number,omitempty"`
+	// Step is the human-readable coordinator transition name, when applicable.
+	Step string `json:"step,omitempty"`
+	// Steps is the number of transitions completed in a progression pass.
+	Steps int `json:"steps,omitempty"`
+	// Reason is a bounded coordinator reason when it is safe to publish.
+	Reason string `json:"reason,omitempty"`
+	// Operation identifies the retrying coordinator operation.
+	Operation string `json:"operation,omitempty"`
+	// Attempt is the one-based retry attempt number.
+	Attempt int `json:"attempt,omitempty"`
+	// MaxAttempts is the configured retry ceiling, when one exists.
+	MaxAttempts int `json:"max_attempts,omitempty"`
+	// Code identifies a stable command failure code, when applicable.
+	Code string `json:"code,omitempty"`
+	// FromStage is the stage before a stage transition.
+	FromStage store.Stage `json:"from_stage,omitempty"`
+	// ToStage is the stage after a stage transition.
+	ToStage store.Stage `json:"to_stage,omitempty"`
+}
+
+// Event is an alias for the public coordinator event value.
+type Event = CoordinatorEvent
+
+// EventSink receives structured coordinator events at the poll-loop seam.
+type EventSink interface {
+	Emit(CoordinatorEvent)
+}
+
+// EventSinkFunc adapts a function to the coordinator event sink interface.
+type EventSinkFunc func(CoordinatorEvent)
+
+// Emit sends one event to the adapted function.
+func (f EventSinkFunc) Emit(event CoordinatorEvent) {
+	if f != nil {
+		f(event)
+	}
+}
+
+// DiscardEventSink is the default sink for non-verbose coordinator runs.
+type DiscardEventSink struct{}
+
+// Emit discards one coordinator event.
+func (DiscardEventSink) Emit(CoordinatorEvent) {}
+
+// NewTextEventSink creates a sink that renders safe coordinator events to a
+// writer. The renderer is intentionally kept at the edge so other consumers
+// can observe the same structured values without parsing text.
+func NewTextEventSink(output io.Writer) EventSink {
+	return textEventSink{output: output}
+}
+
+// textEventSink is the CLI's line-oriented event adapter.
+type textEventSink struct {
+	output io.Writer
+}
+
+// Emit renders one coordinator event as a single timestamped, content-free
+// line. Writer failures are intentionally ignored so observability cannot
+// change coordinator ownership or progression behavior.
+func (s textEventSink) Emit(event CoordinatorEvent) {
+	if s.output == nil {
+		return
+	}
+	fields := []string{event.Timestamp.UTC().Format(time.RFC3339Nano), string(event.Kind)}
+	runID := event.RunID
+	if runID == "" {
+		runID = "-"
+	}
+	fields = append(fields, "run="+singleLineEventValue(runID))
+	if event.Outcome != "" {
+		fields = append(fields, "outcome="+singleLineEventValue(event.Outcome))
+	}
+	if event.IssueNumber != 0 {
+		fields = append(fields, fmt.Sprintf("issue=#%d", event.IssueNumber))
+	}
+	if event.Step != "" {
+		fields = append(fields, "step="+strconv.Quote(singleLineEventValue(event.Step)))
+	}
+	if event.Kind == EventProgressionPass {
+		fields = append(fields, fmt.Sprintf("steps=%d", event.Steps))
+	}
+	if event.Reason != "" {
+		fields = append(fields, "reason="+strconv.Quote(singleLineEventValue(event.Reason)))
+	}
+	if event.Operation != "" {
+		fields = append(fields, "operation="+singleLineEventValue(event.Operation))
+	}
+	if event.Attempt != 0 {
+		if event.MaxAttempts != 0 {
+			fields = append(fields, fmt.Sprintf("attempt=%d/%d", event.Attempt, event.MaxAttempts))
+		} else {
+			fields = append(fields, fmt.Sprintf("attempt=%d", event.Attempt))
+		}
+	}
+	if event.Code != "" {
+		fields = append(fields, "code="+singleLineEventValue(event.Code))
+	}
+	if event.FromStage != "" || event.ToStage != "" {
+		from := string(event.FromStage)
+		if from == "" {
+			from = "-"
+		}
+		to := string(event.ToStage)
+		if to == "" {
+			to = "-"
+		}
+		fields = append(fields, "from_stage="+singleLineEventValue(from), "to_stage="+singleLineEventValue(to))
+	}
+	_, _ = io.WriteString(s.output, strings.Join(fields, " ")+"\n")
+}
+
+// singleLineEventValue prevents an event value from changing the CLI's line
+// structure if a future coordinator field is sourced from external input.
+func singleLineEventValue(value string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\x00', '\r', '\n', '\t':
+			return ' '
+		default:
+			return r
+		}
+	}, value)
+}
+
+// coordinatorEventSink selects the first supplied sink or the discard sink.
+func coordinatorEventSink(sinks []EventSink) EventSink {
+	if len(sinks) > 0 && sinks[0] != nil {
+		return sinks[0]
+	}
+	return DiscardEventSink{}
+}
+
+// emitCoordinatorEvent attaches the coordinator clock to one event before it
+// crosses the event sink seam.
+func (s *Service) emitCoordinatorEvent(sink EventSink, event CoordinatorEvent) {
+	event.Timestamp = s.deps.Now().UTC()
+	sink.Emit(event)
+}
+
+// emitStageTransition publishes a changed workflow stage observed around one
+// progression action.
+func (s *Service) emitStageTransition(sink EventSink, runID string, from, to store.Stage) {
+	if from == to {
+		return
+	}
+	s.emitCoordinatorEvent(sink, CoordinatorEvent{
+		Kind:      EventStageTransition,
+		RunID:     runID,
+		FromStage: from,
+		ToStage:   to,
+	})
+}
+
+// progressionOutcomeForEvent converts an errored progression pass into a
+// stable observation without copying arbitrary adapter error text into events.
+func progressionOutcomeForEvent(result progressionResult, err error) string {
+	if err != nil {
+		return "error"
+	}
+	return string(result.Outcome)
+}
+
+// progressionReasonForEvent keeps only reasons produced by the progression
+// planner. Failure causes and arbitrary lifecycle reasons can contain adapter
+// paths or external content, so they are intentionally not copied into the
+// event.
+func progressionReasonForEvent(result progressionResult) string {
+	switch result.Outcome {
+	case progressionIdle:
+		if result.Reason == "no run to drive" || strings.HasPrefix(result.Reason, "run disappeared after ") {
+			return result.Reason
+		}
+	case progressionInvocationActive:
+		if strings.HasPrefix(result.Reason, "invocations ") {
+			return result.Reason
+		}
+	case progressionUnsupported:
+		return "operational store has no durable invocation history"
+	case progressionDraftPullRequest:
+		if strings.HasPrefix(result.Reason, "draft pull request #") {
+			return result.Reason
+		}
+	case progressionTerminal:
+		if strings.HasPrefix(result.Reason, "run is ") {
+			return result.Reason
+		}
+	case progressionWaiting:
+		// Waiting reasons may come from a persisted lifecycle projection. The
+		// named planner step is enough to identify this safe observation.
+		if result.Step == "agent deadline" || result.Step == "pull-request readiness" {
+			return result.Reason
+		}
+	}
+	return ""
+}
+
+// commandFailureCode converts a swallowed command-polling error into stable
+// content-free event metadata without copying its potentially unsafe message.
+func commandFailureCode(err error) string {
+	var rejection *PolicyRejection
+	if errors.As(err, &rejection) {
+		return string(rejection.Code)
+	}
+	var transportErr *pollingTransportError
+	if errors.As(err, &transportErr) {
+		return "transport"
+	}
+	return "polling_failed"
+}

--- a/internal/factory/events.go
+++ b/internal/factory/events.go
@@ -90,6 +90,88 @@ type DiscardEventSink struct{}
 // Emit discards one coordinator event.
 func (DiscardEventSink) Emit(CoordinatorEvent) {}
 
+// coordinatorStageTracker keeps the last persisted stage at the coordinator
+// seam while forwarding every typed event to the caller's sink. Seeding is
+// deliberately silent; only a subsequent observed change is a live
+// transition.
+type coordinatorStageTracker struct {
+	service     *Service
+	sink        EventSink
+	initialized bool
+	runID       string
+	stage       store.Stage
+}
+
+// newCoordinatorStageTracker wraps a sink with persisted-stage tracking.
+func newCoordinatorStageTracker(service *Service, sink EventSink) *coordinatorStageTracker {
+	return &coordinatorStageTracker{service: service, sink: sink}
+}
+
+// Emit forwards an event and keeps tracker state aligned with stage events
+// emitted by progression itself.
+func (t *coordinatorStageTracker) Emit(event CoordinatorEvent) {
+	if event.Kind == EventStageTransition {
+		t.initialized = true
+		t.runID = event.RunID
+		t.stage = event.ToStage
+	}
+	if t.sink != nil {
+		t.sink.Emit(event)
+	}
+}
+
+// seed installs a persisted snapshot without manufacturing a transition for
+// state that predates this coordinator process.
+func (t *coordinatorStageTracker) seed(run *store.Run) {
+	t.initialized = true
+	if run == nil {
+		t.runID = ""
+		t.stage = ""
+		return
+	}
+	t.runID = run.ID
+	t.stage = run.Stage
+}
+
+// reset clears the snapshot after queue release so the next claimed run is
+// represented as a new run's initial stage.
+func (t *coordinatorStageTracker) reset() {
+	t.initialized = false
+	t.runID = ""
+	t.stage = ""
+}
+
+// observe compares a post-operation persisted snapshot with the last known
+// snapshot and emits a transition only for the same run's changed stage.
+func (t *coordinatorStageTracker) observe(run *store.Run) {
+	if run == nil {
+		t.seed(nil)
+		return
+	}
+	if !t.initialized {
+		t.seed(run)
+		return
+	}
+	if t.runID == run.ID {
+		if t.stage != run.Stage {
+			t.service.emitStageTransition(t, run.ID, t.stage, run.Stage)
+		}
+	} else if run.Stage != "" {
+		// A different run is a queue release followed by a new claim, not a
+		// stage transition between two run identities.
+		t.service.emitStageTransition(t, run.ID, "", run.Stage)
+	}
+	t.initialized = true
+	t.runID = run.ID
+	t.stage = run.Stage
+}
+
+// observeStage lets the poll loop inspect a persisted run around operations
+// that do not return their final run projection directly.
+func (t *coordinatorStageTracker) observeStage(run *store.Run) {
+	t.observe(run)
+}
+
 // NewTextEventSink creates a sink that renders safe coordinator events to a
 // writer. The renderer is intentionally kept at the edge so other consumers
 // can observe the same structured values without parsing text.

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -31,8 +31,9 @@ type Factory interface {
 	// can be claimed safely.
 	Doctor(context.Context) (DoctorResult, error)
 	// Start runs the supervised polling coordinator until its context is
-	// cancelled or a separate Stop command signals it.
-	Start(context.Context) error
+	// cancelled or a separate Stop command signals it. An optional event sink
+	// receives typed coordinator observations.
+	Start(context.Context, ...EventSink) error
 	// Stop asks a running coordinator to stop polling without changing the
 	// state of its active run.
 	Stop(context.Context) (StopResult, error)

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -82,8 +82,11 @@ func (e *StartupBlockedError) Error() string {
 // budgets. After every observation that found or claimed a run it drives that
 // run toward its draft pull request, so the routine path needs no
 // stage-driving CLI command. Claim failures are returned because the claim
-// state machine may already have performed compensating effects.
-func (s *Service) Start(ctx context.Context) error {
+// state machine may already have performed compensating effects. An optional
+// event sink receives typed coordinator observations; omitting it discards
+// those observations for compatibility with non-verbose embedders.
+func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
+	events := coordinatorEventSink(eventSinks)
 	diagnosis, err := s.startupDiagnosis(ctx)
 	if err != nil {
 		return fmt.Errorf("run startup diagnosis: %w", err)
@@ -124,8 +127,11 @@ func (s *Service) Start(ctx context.Context) error {
 
 	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
 	leaseRunID := ""
+	leaseRunStage := store.Stage("")
 	delay := time.Duration(0)
 	consecutiveLeaseFailures := 0
+	consecutiveQueueFailures := 0
+	consecutiveCommandFailures := 0
 	consecutiveProgressionFailures := 0
 	for {
 		if err := waitPolling(pollContext, delay); err != nil {
@@ -152,6 +158,13 @@ func (s *Service) Start(ctx context.Context) error {
 				return nil
 			}
 			consecutiveLeaseFailures++
+			s.emitCoordinatorEvent(events, CoordinatorEvent{
+				Kind:        EventRetry,
+				RunID:       leaseRunID,
+				Operation:   "lease renewal",
+				Attempt:     consecutiveLeaseFailures,
+				MaxAttempts: maxConsecutiveLeaseFailures,
+			})
 			if consecutiveLeaseFailures > maxConsecutiveLeaseFailures {
 				return fmt.Errorf("lease renewal failed after %d consecutive attempts: %w", maxConsecutiveLeaseFailures, err)
 			}
@@ -166,20 +179,59 @@ func (s *Service) Start(ctx context.Context) error {
 			}
 			return err
 		}
-		if err := s.pollLoopCommands(pollContext); err != nil {
+		commandResults, commandErr := s.pollLoopCommandResults(pollContext)
+		for _, commandResult := range commandResults {
+			if commandResult.Run.ID != "" {
+				if commandResult.Run.ID == leaseRunID {
+					s.emitStageTransition(events, commandResult.Run.ID, leaseRunStage, commandResult.Run.Stage)
+				}
+				leaseRunID = commandResult.Run.ID
+				leaseRunStage = commandResult.Run.Stage
+			}
+			if commandResult.Outcome == CommandRejected && commandResult.Rejection != nil {
+				runID := commandResult.Run.ID
+				if runID == "" {
+					runID = leaseRunID
+				}
+				s.emitCoordinatorEvent(events, CoordinatorEvent{
+					Kind:  EventCommandFailure,
+					RunID: runID,
+					Code:  string(commandResult.Rejection.Code),
+				})
+			}
+		}
+		if commandErr != nil {
+			err := commandErr
 			if pollingContextDone(err) {
 				return nil
 			}
+			s.emitCoordinatorEvent(events, CoordinatorEvent{
+				Kind:  EventCommandFailure,
+				RunID: leaseRunID,
+				Code:  commandFailureCode(err),
+			})
 			var transportErr *pollingTransportError
 			if errors.As(err, &transportErr) {
+				consecutiveCommandFailures++
+				s.emitCoordinatorEvent(events, CoordinatorEvent{
+					Kind:        EventRetry,
+					RunID:       leaseRunID,
+					Operation:   "command polling",
+					Attempt:     consecutiveCommandFailures,
+					MaxAttempts: 0,
+				})
 				delay = backoff
 				continue
 			}
+			consecutiveCommandFailures = 0
 			// Every remaining command failure, from a rejected comment to an
 			// unreadable command store, leaves the run untouched and is
 			// retried by the next pass over the same comments. None of them
 			// may stop an unattended coordinator, so the queue observation
 			// below still runs.
+		}
+		if commandErr == nil {
+			consecutiveCommandFailures = 0
 		}
 		result, err := s.pollOnce(pollContext, registration)
 		if err != nil {
@@ -188,20 +240,73 @@ func (s *Service) Start(ctx context.Context) error {
 			}
 			var transportErr *pollingTransportError
 			if errors.As(err, &transportErr) {
+				consecutiveQueueFailures++
+				s.emitCoordinatorEvent(events, CoordinatorEvent{
+					Kind:      EventRetry,
+					RunID:     leaseRunID,
+					Operation: "queue polling",
+					Attempt:   consecutiveQueueFailures,
+				})
 				delay = backoff
 				continue
 			}
 			return err
 		}
-		leaseRunID = result.Run.ID
+		consecutiveQueueFailures = 0
+		if result.Run.ID == "" {
+			leaseRunID = ""
+			leaseRunStage = ""
+		} else {
+			if result.Run.ID == leaseRunID {
+				s.emitStageTransition(events, result.Run.ID, leaseRunStage, result.Run.Stage)
+			}
+			leaseRunID = result.Run.ID
+			leaseRunStage = result.Run.Stage
+		}
 		delay = interval
+		s.emitCoordinatorEvent(events, CoordinatorEvent{
+			Kind:        EventPollPass,
+			Outcome:     string(result.Outcome),
+			RunID:       result.Run.ID,
+			IssueNumber: result.IssueNumber,
+		})
+		if result.Outcome == PollClaimed {
+			s.emitCoordinatorEvent(events, CoordinatorEvent{
+				Kind:        EventClaim,
+				RunID:       result.Run.ID,
+				IssueNumber: result.IssueNumber,
+			})
+			s.emitStageTransition(events, result.Run.ID, "", result.Run.Stage)
+		}
 		if result.Outcome == PollClaimed || result.Outcome == PollActiveRun {
-			progression, err := s.driveRun(pollContext, registration)
+			progression, err := s.driveRun(pollContext, registration, events)
+			progressionRunID := progression.Run.ID
+			if progressionRunID == "" {
+				progressionRunID = result.Run.ID
+			}
+			if progression.Run.ID == result.Run.ID && progression.Run.Stage != "" {
+				leaseRunStage = progression.Run.Stage
+			}
+			s.emitCoordinatorEvent(events, CoordinatorEvent{
+				Kind:    EventProgressionPass,
+				Outcome: progressionOutcomeForEvent(progression, err),
+				RunID:   progressionRunID,
+				Step:    progression.Step,
+				Steps:   progression.Steps,
+				Reason:  progressionReasonForEvent(progression),
+			})
 			if err != nil {
 				if pollingContextDone(err) {
 					return nil
 				}
 				consecutiveProgressionFailures++
+				s.emitCoordinatorEvent(events, CoordinatorEvent{
+					Kind:        EventRetry,
+					RunID:       progressionRunID,
+					Operation:   "progression",
+					Attempt:     consecutiveProgressionFailures,
+					MaxAttempts: maxConsecutiveProgressionFailures,
+				})
 				if consecutiveProgressionFailures > maxConsecutiveProgressionFailures {
 					return fmt.Errorf("drive run %s after %d consecutive attempts: %w", result.Run.ID, maxConsecutiveProgressionFailures, err)
 				}
@@ -216,6 +321,7 @@ func (s *Service) Start(ctx context.Context) error {
 			// release, so it keeps the ordinary interval.
 			if progression.Outcome == progressionTerminal || (progression.Outcome == progressionIdle && progression.Steps > 0) {
 				leaseRunID = ""
+				leaseRunStage = ""
 				delay = 0
 			}
 		}
@@ -227,17 +333,26 @@ func (s *Service) Start(ctx context.Context) error {
 // ordinary idle case of an unattended coordinator, not a failure, so it
 // reports no error.
 func (s *Service) pollLoopCommands(ctx context.Context) error {
+	_, err := s.pollLoopCommandResults(ctx)
+	return err
+}
+
+// pollLoopCommandResults preserves command decisions that PollCommands
+// intentionally returns as typed rejections, allowing the live event stream
+// to report them without changing the unattended failure policy.
+func (s *Service) pollLoopCommandResults(ctx context.Context) ([]CommandResult, error) {
 	if s.deps.Comments == nil {
-		return nil
+		return nil, nil
 	}
-	if _, err := s.PollCommands(ctx, CommandPollRequest{}); err != nil {
+	results, err := s.PollCommands(ctx, CommandPollRequest{})
+	if err != nil {
 		var rejection *PolicyRejection
 		if errors.As(err, &rejection) && rejection.Code == PolicyRejectionNoRun {
-			return nil
+			return nil, nil
 		}
-		return err
+		return results, err
 	}
-	return nil
+	return results, nil
 }
 
 // reconcileRegisteredRun opens the operational store once after the polling

--- a/internal/factory/polling.go
+++ b/internal/factory/polling.go
@@ -87,6 +87,8 @@ func (e *StartupBlockedError) Error() string {
 // those observations for compatibility with non-verbose embedders.
 func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
 	events := coordinatorEventSink(eventSinks)
+	stageTracker := newCoordinatorStageTracker(s, events)
+	events = stageTracker
 	diagnosis, err := s.startupDiagnosis(ctx)
 	if err != nil {
 		return fmt.Errorf("run startup diagnosis: %w", err)
@@ -113,9 +115,12 @@ func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
 		return err
 	}
 	defer func() { _ = lock.release() }()
+	s.seedCoordinatorStageFromStore(ctx, registration, stageTracker)
 	if err := s.reconcileRegisteredRun(ctx, registration); err != nil {
+		s.observeCoordinatorStageFromStore(ctx, registration, events)
 		return fmt.Errorf("reconcile persisted run at startup: %w", err)
 	}
+	s.observeCoordinatorStageFromStore(ctx, registration, events)
 
 	pollContext, cancel := context.WithCancel(ctx)
 	if !s.setPollCancel(cancel) {
@@ -127,7 +132,6 @@ func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
 
 	repository := github.Repository{Owner: registration.GitHub.Owner, Name: registration.GitHub.Repository}
 	leaseRunID := ""
-	leaseRunStage := store.Stage("")
 	delay := time.Duration(0)
 	consecutiveLeaseFailures := 0
 	consecutiveQueueFailures := 0
@@ -174,19 +178,19 @@ func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
 		consecutiveLeaseFailures = 0
 
 		if err := s.retryWaitingForHarness(pollContext, registration); err != nil {
+			s.observeCoordinatorStageFromStore(pollContext, registration, events)
 			if pollingContextDone(err) {
 				return nil
 			}
 			return err
 		}
+		s.observeCoordinatorStageFromStore(pollContext, registration, events)
+		s.seedCoordinatorStageFromStore(pollContext, registration, stageTracker)
 		commandResults, commandErr := s.pollLoopCommandResults(pollContext)
 		for _, commandResult := range commandResults {
 			if commandResult.Run.ID != "" {
-				if commandResult.Run.ID == leaseRunID {
-					s.emitStageTransition(events, commandResult.Run.ID, leaseRunStage, commandResult.Run.Stage)
-				}
+				stageTracker.observe(&commandResult.Run)
 				leaseRunID = commandResult.Run.ID
-				leaseRunStage = commandResult.Run.Stage
 			}
 			if commandResult.Outcome == CommandRejected && commandResult.Rejection != nil {
 				runID := commandResult.Run.ID
@@ -230,6 +234,7 @@ func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
 			// may stop an unattended coordinator, so the queue observation
 			// below still runs.
 		}
+		s.observeCoordinatorStageFromStore(pollContext, registration, events)
 		if commandErr == nil {
 			consecutiveCommandFailures = 0
 		}
@@ -255,13 +260,8 @@ func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
 		consecutiveQueueFailures = 0
 		if result.Run.ID == "" {
 			leaseRunID = ""
-			leaseRunStage = ""
 		} else {
-			if result.Run.ID == leaseRunID {
-				s.emitStageTransition(events, result.Run.ID, leaseRunStage, result.Run.Stage)
-			}
 			leaseRunID = result.Run.ID
-			leaseRunStage = result.Run.Stage
 		}
 		delay = interval
 		s.emitCoordinatorEvent(events, CoordinatorEvent{
@@ -276,16 +276,21 @@ func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
 				RunID:       result.Run.ID,
 				IssueNumber: result.IssueNumber,
 			})
-			s.emitStageTransition(events, result.Run.ID, "", result.Run.Stage)
+		}
+		if result.Run.ID == "" {
+			stageTracker.observe(nil)
+		} else {
+			stageTracker.observe(&result.Run)
 		}
 		if result.Outcome == PollClaimed || result.Outcome == PollActiveRun {
 			progression, err := s.driveRun(pollContext, registration, events)
+			s.observeCoordinatorStageFromStore(pollContext, registration, events)
 			progressionRunID := progression.Run.ID
 			if progressionRunID == "" {
 				progressionRunID = result.Run.ID
 			}
 			if progression.Run.ID == result.Run.ID && progression.Run.Stage != "" {
-				leaseRunStage = progression.Run.Stage
+				stageTracker.observe(&progression.Run)
 			}
 			s.emitCoordinatorEvent(events, CoordinatorEvent{
 				Kind:    EventProgressionPass,
@@ -321,10 +326,52 @@ func (s *Service) Start(ctx context.Context, eventSinks ...EventSink) error {
 			// release, so it keeps the ordinary interval.
 			if progression.Outcome == progressionTerminal || (progression.Outcome == progressionIdle && progression.Steps > 0) {
 				leaseRunID = ""
-				leaseRunStage = ""
+				stageTracker.reset()
 				delay = 0
 			}
 		}
+	}
+}
+
+// readCoordinatorRunForEvents reads the active run or latest terminal run
+// solely for live stage tracking. Its best-effort nature keeps observability
+// from changing coordinator ownership when the operational store is unavailable.
+func (s *Service) readCoordinatorRunForEvents(ctx context.Context, registration config.RepositoryRegistration) (*store.Run, error) {
+	opened, err := s.deps.OpenStore(ctx, registration.OperationalDataPath)
+	if err != nil {
+		return nil, err
+	}
+	run, readErr := readReconciliationRun(ctx, opened)
+	closeErr := opened.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return run, nil
+}
+
+// seedCoordinatorStageFromStore snapshots the persisted stage before an
+// operation such as command polling can mutate it.
+func (s *Service) seedCoordinatorStageFromStore(ctx context.Context, registration config.RepositoryRegistration, tracker *coordinatorStageTracker) {
+	run, err := s.readCoordinatorRunForEvents(ctx, registration)
+	if err == nil {
+		tracker.seed(run)
+	}
+}
+
+// observeCoordinatorStageFromStore compares the persisted stage after an
+// operation that may have mutated it. Store-read failures are intentionally
+// ignored because event delivery is not workflow authority.
+func (s *Service) observeCoordinatorStageFromStore(ctx context.Context, registration config.RepositoryRegistration, sink EventSink) {
+	observer, ok := sink.(interface{ observeStage(*store.Run) })
+	if !ok {
+		return
+	}
+	run, err := s.readCoordinatorRunForEvents(ctx, registration)
+	if err == nil {
+		observer.observeStage(run)
 	}
 }
 

--- a/internal/factory/polling_test.go
+++ b/internal/factory/polling_test.go
@@ -156,8 +156,9 @@ func TestStartUsesTransportBackoffWithoutChangingRunState(t *testing.T) {
 	ctx, stop := context.WithCancel(context.Background())
 	cancel = stop
 	started := time.Now()
+	var events pollingEventSink
 
-	if err := service.Start(ctx); err != nil {
+	if err := service.Start(ctx, &events); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
 	if reader.calls != 2 {
@@ -168,6 +169,16 @@ func TestStartUsesTransportBackoffWithoutChangingRunState(t *testing.T) {
 	}
 	if len(runStore.saved) != 0 {
 		t.Fatalf("runs saved after queue transport failures = %#v, want none", runStore.saved)
+	}
+	var retry *factory.CoordinatorEvent
+	for index := range events.events {
+		if events.events[index].Kind == factory.EventRetry && events.events[index].Operation == "queue polling" {
+			retry = &events.events[index]
+			break
+		}
+	}
+	if retry == nil || retry.Attempt != 1 {
+		t.Fatalf("queue retry event = %#v, want attempt 1", retry)
 	}
 }
 
@@ -255,6 +266,166 @@ func TestStartBacksOffCommandTransportFailures(t *testing.T) {
 	if savedCommandWatermark(runStore.saved, "15", "status") {
 		t.Fatal("a queued command was applied although every comment listing failed")
 	}
+}
+
+// TestStartEmitsTypedPollAndClaimEvents verifies that the persistent
+// coordinator exposes a successful queue observation through its event seam.
+func TestStartEmitsTypedPollAndClaimEvents(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	issues := []github.Issue{{Number: 7, Title: "claim me", State: "open", Labels: []string{github.LabelAgentReady}}}
+	githubAdapter := &pollingGitHub{fakeGitHub: &fakeGitHub{}, issues: issues}
+	runStore := &fakeRunStore{}
+	var cancel context.CancelFunc
+	lease := &pollingLease{onRenew: func(value github.Lease) {
+		if value.RunID == "run-fixed" && cancel != nil {
+			cancel()
+		}
+	}}
+	var events pollingEventSink
+	service := newPollingService(root, githubAdapter, githubAdapter, lease, runStore, &fakeWorktree{workspace: gitadapter.Workspace{
+		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
+	}}, nil)
+	ctx, stop := context.WithCancel(context.Background())
+	cancel = stop
+
+	if err := service.Start(ctx, &events); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	var poll, claim, stage *factory.CoordinatorEvent
+	for index := range events.events {
+		event := &events.events[index]
+		switch event.Kind {
+		case factory.EventPollPass:
+			poll = event
+		case factory.EventClaim:
+			claim = event
+		case factory.EventStageTransition:
+			if event.FromStage == "" && event.ToStage == store.StageClaim {
+				stage = event
+			}
+		}
+	}
+	if poll == nil || poll.Outcome != string(factory.PollClaimed) || poll.RunID != "run-fixed" || poll.IssueNumber != 7 {
+		t.Fatalf("poll event = %#v, want claimed issue 7/run-fixed", poll)
+	}
+	if claim == nil || claim.RunID != "run-fixed" || claim.IssueNumber != 7 {
+		t.Fatalf("claim event = %#v, want issue 7/run-fixed", claim)
+	}
+	if stage == nil || stage.RunID != "run-fixed" || stage.ToStage != store.StageClaim {
+		t.Fatalf("claim stage transition = %#v, want empty -> claim for run-fixed", stage)
+	}
+	if poll.Timestamp.IsZero() || claim.Timestamp.IsZero() {
+		t.Fatalf("events = %#v, want timestamps", events.events)
+	}
+}
+
+// TestStartEmitsLeaseRetryAttempts verifies that each retryable lease failure
+// is observable before the coordinator backs off.
+func TestStartEmitsLeaseRetryAttempts(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	reader := &pollingIssueReader{}
+	runStore := &fakeRunStore{}
+	var cancel context.CancelFunc
+	lease := &pollingLease{renewErrors: []error{errors.New("lease unavailable")}}
+	lease.onRenew = func(github.Lease) {
+		if len(lease.calls) >= 2 && cancel != nil {
+			cancel()
+		}
+	}
+	var events pollingEventSink
+	service := newPollingService(root, &fakeGitHub{}, reader, lease, runStore, &fakeWorktree{}, nil)
+	ctx, stop := context.WithCancel(context.Background())
+	cancel = stop
+
+	if err := service.Start(ctx, &events); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	var retry *factory.CoordinatorEvent
+	for index := range events.events {
+		if events.events[index].Kind == factory.EventRetry && events.events[index].Operation == "lease renewal" {
+			retry = &events.events[index]
+			break
+		}
+	}
+	if retry == nil {
+		t.Fatalf("events = %#v, want a lease retry event", events.events)
+	}
+	if retry.Attempt != 1 || retry.MaxAttempts != 5 || !retry.Timestamp.Equal(time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("lease retry event = %#v, want attempt 1/5 with coordinator timestamp", retry)
+	}
+}
+
+// TestStartEmitsSwallowedCommandFailure verifies that a rejected structured
+// command is reported while the polling loop continues to own the run.
+func TestStartEmitsSwallowedCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	issues := []github.Issue{{Number: 7, Title: "claim me", State: "open", Labels: []string{github.LabelAgentReady}}}
+	githubAdapter := &pollingGitHub{fakeGitHub: &fakeGitHub{statusComment: github.Comment{ID: "status-1"}}, issues: issues}
+	runStore := &fakeRunStore{}
+	var commandSeen bool
+	comments := &pollingCommentReader{
+		commentBatches: [][]github.Comment{
+			{{ID: "14", Author: "alice", Body: "/factory status"}},
+			{
+				{ID: "14", Author: "alice", Body: "/factory status"},
+				{ID: "15", Author: "mallory", Body: "/factory status"},
+			},
+		},
+		onList: func(call int) {
+			if call >= 2 {
+				commandSeen = true
+			}
+		},
+	}
+	var cancel context.CancelFunc
+	lease := &pollingLease{}
+	lease.onRenew = func(github.Lease) {
+		if len(lease.calls) >= 2 && commandSeen && cancel != nil {
+			cancel()
+		}
+	}
+	var events pollingEventSink
+	service := newPollingService(root, githubAdapter, githubAdapter, lease, runStore, &fakeWorktree{workspace: gitadapter.Workspace{
+		BaseSHA: "base", Branch: "factory/run-fixed", Worktree: "/worktree/run-fixed",
+	}}, comments)
+	ctx, stop := context.WithCancel(context.Background())
+	cancel = stop
+
+	if err := service.Start(ctx, &events); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	var failure *factory.CoordinatorEvent
+	for index := range events.events {
+		if events.events[index].Kind == factory.EventCommandFailure {
+			failure = &events.events[index]
+			break
+		}
+	}
+	if failure == nil {
+		t.Fatalf("events = %#v, comments calls=%d commandSeen=%t, want a swallowed command failure event", events.events, comments.calls, commandSeen)
+	}
+	if failure.RunID != "run-fixed" || failure.Code != string(factory.PolicyRejectionUnauthorized) {
+		t.Fatalf("command failure event = %#v, want unauthorized failure for run-fixed", failure)
+	}
+}
+
+// pollingEventSink records coordinator events without rendering them.
+type pollingEventSink struct {
+	events []factory.CoordinatorEvent
+}
+
+// Emit records one coordinator event for typed seam assertions.
+func (s *pollingEventSink) Emit(event factory.CoordinatorEvent) {
+	s.events = append(s.events, event)
 }
 
 // savedCommandWatermark reports whether any persisted run recorded the named
@@ -357,8 +528,9 @@ func (f *pollingIssueReader) ListEligibleIssues(_ context.Context, _ github.Repo
 
 // pollingLease records visible lease renewals for start-loop assertions.
 type pollingLease struct {
-	calls   []github.Lease
-	onRenew func(github.Lease)
+	calls       []github.Lease
+	renewErrors []error
+	onRenew     func(github.Lease)
 }
 
 // RenewLease records the lease and invokes its optional test hook.
@@ -366,6 +538,11 @@ func (f *pollingLease) RenewLease(_ context.Context, _ github.Repository, lease 
 	f.calls = append(f.calls, lease)
 	if f.onRenew != nil {
 		f.onRenew(lease)
+	}
+	if len(f.renewErrors) > 0 {
+		err := f.renewErrors[0]
+		f.renewErrors = f.renewErrors[1:]
+		return err
 	}
 	return nil
 }

--- a/internal/factory/polling_test.go
+++ b/internal/factory/polling_test.go
@@ -418,6 +418,56 @@ func TestStartEmitsSwallowedCommandFailure(t *testing.T) {
 	}
 }
 
+// TestStartEmitsACommandStageTransitionAfterRestart verifies that the live
+// stage tracker is seeded from persisted state before the first command poll.
+func TestStartEmitsACommandStageTransitionAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	var persisted store.Run
+	available := false
+	runStore := &fakeRunStore{currentRun: func(context.Context) (*store.Run, error) {
+		if !available {
+			return nil, nil
+		}
+		copy := persisted
+		return &copy, nil
+	}}
+	githubAdapter := &pollingGitHub{
+		fakeGitHub: &fakeGitHub{issueValue: github.Issue{Number: 42, State: "open"}},
+		issues:     []github.Issue{{Number: 42, State: "open"}},
+	}
+	comments := &pollingCommentReader{onList: func(int) {
+		persisted.Stage = store.StageClaim
+	}}
+	var cancel context.CancelFunc
+	lease := &pollingLease{}
+	lease.onRenew = func(github.Lease) {
+		if len(lease.calls) == 1 {
+			available = true
+		}
+		if len(lease.calls) >= 2 && cancel != nil {
+			cancel()
+		}
+	}
+	var events pollingEventSink
+	service := newPollingService(root, githubAdapter, githubAdapter, lease, runStore, &fakeWorktree{}, comments)
+	persisted = store.Run{ID: "run-restarted", IssueNumber: 42, Stage: store.StageDraftPR, Status: store.StatusActive}
+	ctx, stop := context.WithCancel(context.Background())
+	cancel = stop
+
+	if err := service.Start(ctx, &events); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	for _, event := range events.events {
+		if event.Kind == factory.EventStageTransition && event.RunID == persisted.ID && event.FromStage == store.StageDraftPR && event.ToStage == store.StageClaim {
+			return
+		}
+	}
+	t.Fatalf("events = %#v, want restart command transition %s -> %s for %s", events.events, store.StageDraftPR, store.StageClaim, persisted.ID)
+}
+
 // pollingEventSink records coordinator events without rendering them.
 type pollingEventSink struct {
 	events []factory.CoordinatorEvent

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -202,7 +202,8 @@ func (a progressionAction) validate() error {
 // same coordinator seam the matching one-shot command uses, so a repeated pass
 // or a coordinator restart reuses their exactly-once effect journal instead of
 // creating a second invocation, checkpoint, push, comment, or pull request.
-func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRegistration) (progressionResult, error) {
+func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRegistration, eventSinks ...EventSink) (progressionResult, error) {
+	events := coordinatorEventSink(eventSinks)
 	result := progressionResult{Outcome: progressionIdle}
 	lifecycle, err := s.observePullRequestEvents(ctx, registration)
 	if err != nil {
@@ -242,6 +243,11 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 		if err := step.validate(); err != nil {
 			return result, err
 		}
+		s.emitCoordinatorEvent(events, CoordinatorEvent{
+			Kind:  EventProgressionStep,
+			RunID: step.runID,
+			Step:  step.name,
+		})
 		var stepErr error
 		switch step.kind {
 		case progressionActionStartAgent:
@@ -260,6 +266,9 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 			stepErr = &progressionActionError{Action: step, Reason: "kind is not declared for dispatch"}
 		}
 		if stepErr != nil {
+			if after, readErr := s.readProgressionState(ctx, registration); readErr == nil && after.Run != nil {
+				s.emitStageTransition(events, state.Run.ID, state.Run.Stage, after.Run.Stage)
+			}
 			return s.stopProgressionAfterFailure(ctx, registration, *state.Run, step.name, stepErr, result.Steps)
 		}
 		result.Steps++
@@ -271,6 +280,7 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 			return progressionResult{Outcome: progressionIdle, Steps: result.Steps, Reason: "run disappeared after " + step.name}, nil
 		}
 		result.Run = *advanced.Run
+		s.emitStageTransition(events, state.Run.ID, state.Run.Stage, advanced.Run.Stage)
 		if !progressionAdvancedMany(*state.Run, state.ActiveInvocations, *advanced.Run, advanced.ActiveInvocations) {
 			return s.publishProgressionStop(ctx, registration, *advanced.Run, progressionResult{
 				Outcome: progressionWaiting,

--- a/internal/factory/progression.go
+++ b/internal/factory/progression.go
@@ -206,6 +206,7 @@ func (s *Service) driveRun(ctx context.Context, registration config.RepositoryRe
 	events := coordinatorEventSink(eventSinks)
 	result := progressionResult{Outcome: progressionIdle}
 	lifecycle, err := s.observePullRequestEvents(ctx, registration)
+	s.observeCoordinatorStageFromStore(ctx, registration, events)
 	if err != nil {
 		if pollingContextDone(err) || ctx.Err() != nil {
 			return result, err

--- a/internal/factory/unattended_test.go
+++ b/internal/factory/unattended_test.go
@@ -72,6 +72,104 @@ func TestStartDrivesAnAdvisoryIssueFromQueueToDraftPullRequest(t *testing.T) {
 	}
 }
 
+// TestStartEmitsProgressionStepsAndStageTransitions verifies that the
+// unattended progression seam reports its named transitions and resulting
+// workflow stages as typed values.
+func TestStartEmitsProgressionStepsAndStageTransitions(t *testing.T) {
+	t.Parallel()
+
+	fixture := newUnattendedFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopWhenPullRequestExists(cancel)
+	var events pollingEventSink
+
+	if err := fixture.service.Start(ctx, &events); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	wantSteps := map[string]bool{
+		"run baseline":              false,
+		"start agent":               false,
+		"accept agent report":       false,
+		"create draft pull request": false,
+	}
+	transitions := make(map[[2]store.Stage]bool)
+	progressionPasses := 0
+	for _, event := range events.events {
+		switch event.Kind {
+		case factory.EventProgressionStep:
+			if _, ok := wantSteps[event.Step]; ok {
+				wantSteps[event.Step] = true
+			}
+		case factory.EventProgressionPass:
+			progressionPasses++
+		case factory.EventStageTransition:
+			transitions[[2]store.Stage{event.FromStage, event.ToStage}] = true
+		}
+	}
+	for step, seen := range wantSteps {
+		if !seen {
+			t.Errorf("progression step %q was not emitted; events = %#v", step, events.events)
+		}
+	}
+	if progressionPasses == 0 {
+		t.Fatalf("progression events = %#v, want at least one progression pass", events.events)
+	}
+	for _, transition := range [][2]store.Stage{
+		{store.StageClaim, store.StageImplementation},
+		{store.StageImplementation, store.StageDraftPR},
+	} {
+		if !transitions[transition] {
+			t.Errorf("stage transition %q -> %q was not emitted; events = %#v", transition[0], transition[1], events.events)
+		}
+	}
+}
+
+// TestStartEmitsProgressionRetryAttempts verifies that an unreadable run
+// progression pass reports its retry number before the next polling delay.
+func TestStartEmitsProgressionRetryAttempts(t *testing.T) {
+	t.Parallel()
+
+	fixture := newUnattendedFixture(t)
+	dependencies := fixture.dependencies()
+	remainingFailures := 2
+	dependencies.OpenStore = func(ctx context.Context, path string) (factory.OperationalStore, error) {
+		opened, err := store.Open(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+		return &progressionFailureStore{
+			Store:             opened,
+			RemainingFailures: &remainingFailures,
+			Claimed:           func() bool { return fixture.commands.claimed != 0 },
+		}, nil
+	}
+	fixture.service = factory.NewWithDependencies(fixture.configPath, dependencies)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixture.stopAfterLeaseRenewals(cancel, 2)
+	var events pollingEventSink
+
+	if err := fixture.service.Start(ctx, &events); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	var retry *factory.CoordinatorEvent
+	for index := range events.events {
+		if events.events[index].Kind == factory.EventRetry && events.events[index].Operation == "progression" {
+			retry = &events.events[index]
+			break
+		}
+	}
+	if retry == nil {
+		t.Fatalf("events = %#v, want a progression retry event", events.events)
+	}
+	if retry.RunID != "run-unattended" || retry.Attempt != 1 || retry.MaxAttempts != 5 {
+		t.Fatalf("progression retry event = %#v, want run-unattended attempt 1/5", retry)
+	}
+}
+
 // TestUnattendedProgressionStopsAtAWaitingStateAndPublishesIt verifies that a
 // run parked in a human waiting state stops unattended progression instead of
 // relaunching a role, and that the published status distinguishes it from a
@@ -615,6 +713,23 @@ func (w *unattendedWorkspace) RemoteBranchHead(context.Context, gitadapter.PushR
 type unattendedWorker struct {
 	agentWorker
 	resultPath string
+}
+
+// progressionFailureStore injects bounded run-read failures after the issue
+// has been claimed, leaving the polling observation itself recoverable.
+type progressionFailureStore struct {
+	*store.Store
+	RemainingFailures *int
+	Claimed           func() bool
+}
+
+// CurrentRun fails the configured number of post-claim progression reads.
+func (s *progressionFailureStore) CurrentRun(ctx context.Context) (*store.Run, error) {
+	if s.Claimed != nil && s.Claimed() && s.RemainingFailures != nil && *s.RemainingFailures > 0 {
+		*s.RemainingFailures--
+		return nil, errors.New("progression state unavailable")
+	}
+	return s.Store.CurrentRun(ctx)
 }
 
 // Start records the mounted result directory before delegating.

--- a/internal/factory/unattended_test.go
+++ b/internal/factory/unattended_test.go
@@ -133,7 +133,7 @@ func TestStartEmitsProgressionRetryAttempts(t *testing.T) {
 
 	fixture := newUnattendedFixture(t)
 	dependencies := fixture.dependencies()
-	remainingFailures := 2
+	remainingFailures := 3
 	dependencies.OpenStore = func(ctx context.Context, path string) (factory.OperationalStore, error) {
 		opened, err := store.Open(ctx, path)
 		if err != nil {


### PR DESCRIPTION
<!-- factory-generated:start -->
## Factory run

- run: `run-e2453c42-1a25-4962-8d1e-6a8c0c4db1dc`
- issue: #138 — factory start is silent for its entire lifetime: no coordinator progress output and no logging seam
- specification packet: version 1, target branch `main`
- checkpoint: `6e6e5c98b219bf0edabb1350777ecfc977eac79f`
- stage: `draft_pr`
- intervention: `none`
- test policy: `advisory (implementation-owned TDD)`
- route: `default (repository test policy)`

Closes #138

<!-- factory-generated:review:start -->

### Specification review

- reviewed checkpoint: `6e6e5c98b219bf0edabb1350777ecfc977eac79f`
- outcome: 0 blocking findings, 0 advisory findings
- findings: none

### Standards review

- reviewed checkpoint: `6e6e5c98b219bf0edabb1350777ecfc977eac79f`
- outcome: 0 blocking findings, 1 advisory findings

#### Finding 1 — advisory/taste
- location: `internal/factory/events.go:256`
- claim: The variadic sink API implies that all supplied sinks are supported, but coordinatorEventSink silently selects only the first and discards the rest.
- evidence: source=heuristic:Speculative Generality;hunk=internal/factory/events.go:256;coordinatorEventSink receives []EventSink and returns only sinks[0], so additional supplied sinks have no effect.
- suggested resolution: Make the seam singular (while preserving the explicit no-sink default through a separate wrapper if needed), or implement and document fan-out; remove the misleading plural contract.
- suggested owner: `implementation`
<!-- factory-generated:review:end -->

### Issue summary

## What happens today

`factory start` writes exactly two lines for the entire life of the coordinator:

```go
// internal/cli/cli.go:171
writeOutput(output, errorsOutput, "factory polling starting\n")
// internal/cli/cli.go:174
factory.New(*configPath).Start(ctx)
// internal/cli/cli.go:178
writeOutput(output, errorsOutput, "factory polling stopped\n")
```

Between them the coordinator claims issues, launches invocations, runs gates, routes review findings, opens pull requests, and pauses runs — and prints none of it. An operator watching the terminal cannot distinguish a coordinator that is driving a run from one that has been idling for four hours.

There is no logging seam to turn on. `log` and `slog` appear nowhere in the tree except `internal/git/worktree.go`. Every other CLI command takes `output, errorsOutput io.Writer` and reports what it did; `Start` is the exception, because `func (s *Service) Start(ctx context.Context) error` (`polling.go:86`) has no writer to report through.

## The data already exists

This is not new instrumentation. Every value a log line would carry is already computed on the hot path, typed, and then dropped on the floor:

| Value | Computed at | Carries | Where it goes |
| --- | --- | --- | --- |
| `PollResult` | `polling.go:321` | `Outcome` (`claimed`/`active_run`/`no_work`), `Run`, `IssueNumber` | Only `result.Run.ID` is read, into `leaseRunID` |
| `progressionResult` | `progression.go:199` | `Outcome`, `Reason`, `Steps`, `Run` | Only `Outcome` and `Steps` are read, to decide the next delay |
| `progressionAction.name` | `progression.go:415` etc. | `"accept agent report"` and friends — human-readable by construction | Read only on failure (`:256`, `:264`, `:271`); never on success |
| `consecutiveLeaseFailures` | `polling.go:154` | GitHub lease trouble, retry 1..5 | Silent until it exceeds 5 and kills the coordinator (`:156`) |
| `consecutiveProgressionFailures` | `polling.go:204` | Run cannot be driven, retry 1..5 | Silent until it exceeds 5 and kills the coordinator (`:206`) |

`progressionAction` even carries a `name` field written for a human to read, and the only time a human ever sees it is inside an error string.

## What is invisible today

| Symptom | Why nothing is printed |
| --- | --- |
| A run stalls with a dead harness turn | Progression returns `progressionInvocationActive` every pass forever (#136); the outcome is never printed |
| A `/factory` comment is rejected | `pollLoopCommands` errors are deliberately swallowed at `polling.go:178-182` so a bad comment cannot stop an unattended coordinator. Correct behaviour, but the operator is never told the command was refused |
| GitHub is failing | Lease renewal backs off silently four times before the fifth kills the coordinator |
| A gate fails and a check-repair starts | Recorded in `gate_results` and the status comment; nothing on the terminal |
| The coordinator claimed a new issue | Nothing on the terminal |

The first row is the one that cost an afternoon: run `run-bd38f28a-…` sat active for 3h 47m with a live but idle Codex process, and the terminal that started the coordinator showed `factory polling starting` and nothing else.

## Shape of the fix

| Shape | Change | Trade-off |
| --- | --- | --- |
| **A writer on the poll loop** (recommended). `Start` takes an event sink; `runStart` passes one that renders to `errorsOutput` when `--verbose` is set and discards otherwise | `polling.go:86`, `cli.go:160-182`, one sink type | Matches how every other command already reports. The sink is a seam, so tests assert on emitted events rather than scraped text, and a future UI consumes the same stream |
| **`slog` into the existing `Dependencies`** | a `Logger` field on `Dependencies` (`factory.go:136`), called from the loop | Standard library, no new type, free `--log-format json`. But it invites log calls to spread through the whole package rather than staying at the coordinator boundary |
| **File-only log** | write to a fixed path, tail it | Answers nothing the operational store does not already answer better, and adds a file to rotate |

The first is the one worth having. Keep the emit points at the poll-loop boundary — one per pass outcome, plus each progression step and each retry — not scattered through `progression.go`.

## Direction, not scope

A UI over the coordinator is wanted later. It does not change what this issue builds, but it sets one constraint: the events must be **structured values rendered at the edge**, not `fmt.Fprintf` strings. A sink that emits typed events can gain a JSON renderer and a UI consumer without touching the poll loop again. A sink that emits pre-formatted lines cannot.

## Non-goals

- Building the UI. Out of scope here; the sink seam is what makes it cheap later.
- Enforcing `timeouts.agent`, or any other detection of a stalled invocation. That is #136. This issue makes the stall *visible*; #136 makes it *end*.
- Logging harness or agent output. Roles own their terminals, and the coordinator must not treat that output as evidence.
- Logging secrets, tokens, credential paths, or issue and comment bodies. Ids, outcomes, reasons, counts, durations only.
- Replacing the GitHub status comment or `factory status`. Those stay the durable projections; this is the live feed.

## Acceptance criteria

- [ ] `factory start --verbose` reports every poll pass outcome, every progression step by name, every claim, and every stage transition, with a timestamp and the run id.
- [ ] Lease-renewal and progression retries are reported as they happen, with the attempt number, not only when the coordinator dies at attempt 5.
- [ ] A swallowed `pollLoopCommands` failure is reported without changing the rule that it cannot stop the coordinator.
- [ ] `factory start` without `--verbose` keeps its current two-line output byte for byte.
- [ ] Verbose output goes to stderr, so redirecting stdout does not mix it with command results.
- [ ] Events are emitted as typed values through a seam a test can assert on; no test scrapes formatted text.
- [ ] No token, credential path, issue body, or comment body appears in any event.
- [ ] `go test ./...` passes.

## Evidence

- `internal/cli/cli.go:160-182` — the whole of `runStart`; two `writeOutput` calls, both outside `Start`.
- `internal/factory/polling.go:86` — `func (s *Service) Start(ctx context.Context) error`, no writer parameter.
- `internal/factory/polling.go:130-222` — the poll loop; no writer, no logger, no print.
- `internal/factory/polling.go:178-182` — the comment that documents deliberately swallowing command failures.
- `rg -l "log/slog|\"log\"" internal cmd` returns `internal/git/worktree.go` only.
- Motivating run: `run-bd38f28a-…` active 14:58:27Z → 18:45:31Z with no terminal output; diagnosed only by reading the operational store and the cmux surface by hand.

### Gates

- `format`: passed
- `vet`: passed
- `test`: passed
- `build`: passed

### Control commands

- `factory status`
- `factory draft-pr --run-id run-e2453c42-1a25-4962-8d1e-6a8c0c4db1dc`

<!-- factory-generated:end -->