### PR TITLE
make role-mandated craft skills visible to every shipped harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .serena
+.worker-build.*
 /bin/
 target/
 .DS_Store

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,7 +80,7 @@ A typed discrepancy result that reports the agreement state and discovered discr
 _Avoid_: Recovered run, implicit operator approval
 
 **Startup diagnosis**:
-A complete pre-claim report of host configuration, external access, repository, terminal, worker, harness, authentication, and operational-store readiness. Every subsystem contributes its own bounded check, including one independent target-branch resolution check for every configured `role_craft` entry, and the doctor reports all failures before a run can start.
+A complete pre-claim report of host configuration, external access, repository, terminal, worker, harness, authentication, and operational-store readiness. Every subsystem contributes its own bounded check, including one independent target-branch resolution check for every configured `role_craft` entry and one skill-contract check for every harness the worker image ships, and the doctor reports all failures before a run can start.
 _Avoid_: First failure, mid-run diagnosis
 
 **Gate**:
@@ -92,8 +92,12 @@ The per-run isolated execution environment that exposes only the run worktree, r
 _Avoid_: Container in workflow decisions
 
 **Worker skill set**:
-The curated craft skills the worker image installs into both role homes, pinned by the worker image digest and scoped per role by the embedded role prompts.
+The curated craft skills the worker image installs into both role homes, pinned by the worker image digest and scoped per role by the embedded role prompts. A skill a role prompt mandates by name must also stay out of each harness's hidden-skill metadata, because a harness that withholds a skill from its model-visible catalog leaves that role unable to follow its own instructions.
 _Avoid_: Personal skill, installed skill
+
+**Worker skill smoke evidence**:
+The recorded result of a real worker invocation in which one harness loaded and used the role-mandated skills, keyed by the immutable worker image digest and the harness version observed in that image. Startup reads the record instead of repeating the paid, nondeterministic model call, and a rebuilt image invalidates every record keyed by the previous digest.
+_Avoid_: Skill test, live startup check
 
 **WorkerRuntime**:
 The portable seam that starts, resumes, commands, stops, and inspects a worker while hiding runtime identifiers, container paths, role homes, invocation packets, result files, and process tracking.

--- a/README.md
+++ b/README.md
@@ -245,9 +245,10 @@ You need:
 
 The <code>factory doctor</code> command checks these prerequisites together. It
 also checks the repository remote and hooks, worker image, harness executables
-and capabilities, cmux, authentication sources, and SQLite readiness. Run it
-before claiming an issue rather than discovering a host problem after the
-issue has been relabeled.
+and capabilities, the role-mandated worker skill set each harness advertises,
+cmux, authentication sources, and SQLite readiness. Run it before claiming an
+issue rather than discovering a host problem after the issue has been
+relabeled.
 
 ## Build and install
 
@@ -1604,6 +1605,13 @@ causes are an unreachable Docker daemon, a missing pinned image digest, an
 unavailable cmux socket, missing <code>gh</code> permissions, an unsupported
 harness executable, or a repository/operational path that is not absolute and
 safely scoped.
+
+A blocked <code>worker skill contract</code> check means the pinned image does
+not advertise a role-mandated skill to that harness, or that no smoke result
+is recorded for the pinned digest and harness version. Every shipped harness
+must carry that evidence, not only the one the repository currently selects.
+Rebuilding the image invalidates the recorded evidence. See
+<code>worker/SKILLS.md</code> for the rebuild, record, and verify sequence.
 
 ### The issue was not claimed
 

--- a/docs/agent-runtime.md
+++ b/docs/agent-runtime.md
@@ -42,7 +42,9 @@ MCP server, or setting. The only skills a session sees are the curated set the
 worker image installs into both role homes, which the worker image digest pins
 for the run; `worker/SKILLS.md` records the set and ADR 0006 records the
 boundary. Each role prompt names the skills that role may use, because both
-harnesses advertise every installed skill to every role. `DISABLE_AUTOUPDATER=1` keeps Claude Code on the
+harnesses advertise every installed skill to every role. A skill a role prompt
+mandates must therefore stay out of each harness's hidden-skill metadata;
+`worker/SKILLS.md` records that activation contract and how it is verified. `DISABLE_AUTOUPDATER=1` keeps Claude Code on the
 version pinned by the run's worker image digest, so a tool upgrade cannot
 change behavior halfway through a run.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,6 +356,11 @@ pins the skills a role agent sees, exactly as it pins the harness versions. See
 `worker/SKILLS.md` for the set and its curation rule, and ADR 0006 for the
 boundary. Changing a skill needs a rebuild and a new digest.
 
+The recorded worker skill smoke evidence in `worker/skill-smoke.json` is keyed
+by this digest and by each harness's version, so a new digest invalidates it.
+Re-run `./scripts/smoke-skills.sh` after recording a new digest, or the startup
+diagnosis blocks every shipped harness.
+
 The checked-in `worker_build.image` is intentionally an image name without a
 mutable tag. The reported SHA-256 digest is appended by the worker adapter as
 `image@digest`, so a run never starts from a mutable tag and never pulls an

--- a/factory.yaml
+++ b/factory.yaml
@@ -61,7 +61,7 @@ caches:
     read_only: false
 worker_build:
   image: ghcr.io/stevie1704/sw-factory-worker
-  digest: sha256:57b860a2c81dc250f5889ec32aa0d3ae8c0aed5ba1c38e16d94620caa14e1929
+  digest: sha256:238d1ef93894612ab4caaa195b52ed88a67f4651c937e2ba9492fbf3d2f1ff58
   definition: worker/Dockerfile
 base_synchronization:
   mode: never

--- a/internal/factory/doctor.go
+++ b/internal/factory/doctor.go
@@ -2,6 +2,8 @@ package factory
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
 	"github.com/Stevie1704/sw-factory/internal/config"
 	"github.com/Stevie1704/sw-factory/internal/doctor"
@@ -70,6 +72,8 @@ func (s *Service) Doctor(ctx context.Context) (DoctorResult, error) {
 		Checker:               s.doctorHarnessChecker(),
 		AuthenticationChecker: s.doctorHarnessAuthenticationChecker(),
 		Resolve:               s.deps.HarnessCapabilities,
+		SkillChecker:          s.doctorSkillContractChecker(),
+		SkillEvidencePath:     skillEvidencePath(registration.Path),
 	})...)
 	checks = append(checks, store.StartupCheck(registration.OperationalDataPath))
 
@@ -117,6 +121,23 @@ func (s *Service) doctorHarnessChecker() worker.HarnessChecker {
 func (s *Service) doctorHarnessAuthenticationChecker() worker.HarnessAuthenticationChecker {
 	checker, _ := s.deps.Worker.(worker.HarnessAuthenticationChecker)
 	return checker
+}
+
+// doctorSkillContractChecker resolves the worker-owned skill contract probe
+// seam.
+func (s *Service) doctorSkillContractChecker() worker.SkillContractChecker {
+	checker, _ := s.deps.Worker.(worker.SkillContractChecker)
+	return checker
+}
+
+// skillEvidencePath resolves the recorded worker skill smoke evidence inside
+// the registered repository, leaving the path empty when no repository is
+// registered so the diagnosis stays independent of configuration failures.
+func skillEvidencePath(repositoryPath string) string {
+	if strings.TrimSpace(repositoryPath) == "" {
+		return ""
+	}
+	return filepath.Join(repositoryPath, filepath.FromSlash(harness.SkillEvidenceFile))
 }
 
 // targetBranch extracts the checked-in branch while leaving dependent checks

--- a/internal/factory/doctor_test.go
+++ b/internal/factory/doctor_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/Stevie1704/sw-factory/internal/factory"
 	gitadapter "github.com/Stevie1704/sw-factory/internal/git"
 	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/harness"
 	"github.com/Stevie1704/sw-factory/internal/store"
 	"github.com/Stevie1704/sw-factory/internal/terminal"
 	"github.com/Stevie1704/sw-factory/internal/worker"
@@ -24,6 +26,7 @@ func TestDoctorComposesEverySubsystemAndKeepsOptionalAuthNonBlocking(t *testing.
 		t.Fatal(err)
 	}
 	writeRepositoryConfig(t, repositoryPath)
+	writeSkillSmokeEvidence(t, repositoryPath)
 	configPathOnDisk := filepath.Join(repositoryPath, config.RepositoryConfigFileName)
 	configData, err := os.ReadFile(configPathOnDisk)
 	if err != nil {
@@ -81,7 +84,9 @@ func TestDoctorComposesEverySubsystemAndKeepsOptionalAuthNonBlocking(t *testing.
 		"git role craft implementation", "git role craft standards_review",
 		"cmux executable", "cmux socket",
 		"docker daemon", "worker image",
-		"harness capability", "claude worker executable", "codex worker executable",
+		"harness capability",
+		"claude worker executable", "claude worker skill contract",
+		"codex worker executable", "codex worker skill contract",
 		"codex authentication", "claude authentication", "SQLite",
 	}
 	if len(result.Report.Results) != len(wantNames) {
@@ -199,6 +204,42 @@ func (w *factoryDoctorWorker) CheckHarness(context.Context, worker.HarnessCheckR
 // seam.
 func (*factoryDoctorWorker) CheckHarnessAuthentication(context.Context, worker.HarnessAuthenticationCheckRequest) error {
 	return nil
+}
+
+// CheckSkillContract implements the worker-owned skill contract probe seam.
+func (*factoryDoctorWorker) CheckSkillContract(_ context.Context, request worker.SkillContractRequest) (worker.SkillContract, error) {
+	return worker.SkillContract{Harness: request.Harness, Version: doctorHarnessVersion}, nil
+}
+
+// doctorHarnessVersion is the harness version the composition test's worker
+// probe reports and its recorded smoke evidence is keyed by.
+const doctorHarnessVersion = "1.2.3"
+
+// writeSkillSmokeEvidence records a smoke result for both shipped harnesses at
+// the repository's pinned worker digest.
+func writeSkillSmokeEvidence(t *testing.T, repositoryPath string) {
+	t.Helper()
+	path := filepath.Join(repositoryPath, filepath.FromSlash(harness.SkillEvidenceFile))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	evidence := harness.SkillSmokeEvidence{SchemaVersion: 1}
+	for _, name := range []string{harness.NameClaude, harness.NameCodex} {
+		evidence.Records = append(evidence.Records, harness.SkillSmokeRecord{
+			ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			Harness:        name,
+			HarnessVersion: doctorHarnessVersion,
+			Skills:         harness.MandatorySkills(),
+			VerifiedAt:     "2026-09-04T00:00:00Z",
+		})
+	}
+	body, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // factoryDoctorTerminal implements terminal lifecycle and diagnosis seams for

--- a/internal/harness/doctor.go
+++ b/internal/harness/doctor.go
@@ -95,6 +95,11 @@ type StartupRequest struct {
 	AuthenticationChecker worker.HarnessAuthenticationChecker
 	// Resolve supplies adapter capabilities; nil selects built-ins.
 	Resolve CapabilityResolver
+	// SkillChecker verifies the installed skill set inside the worker image.
+	SkillChecker worker.SkillContractChecker
+	// SkillEvidencePath is the host path of the recorded worker skill smoke
+	// evidence.
+	SkillEvidencePath string
 }
 
 // StartupChecks returns independent capability, executable, and authentication
@@ -105,6 +110,7 @@ func StartupChecks(request StartupRequest) []doctor.Check {
 	for _, name := range selected {
 		harnessName := name
 		checks = append(checks, executableCheck(request.Checker, request.Image, harnessName))
+		checks = append(checks, skillContractCheck(request, harnessName))
 	}
 	checks = append(checks,
 		credentialCheck(NameCodex, request.Authentication.CodexAuthPath, request.Image, request.AuthenticationChecker),
@@ -181,5 +187,31 @@ func credentialCheck(name, path string, image worker.ImageReference, checker wor
 			return doctor.Failure(name+" authentication", "the configured credential is not usable by the worker harness", "authenticate the "+name+" harness and provide a valid private credential source")
 		}
 		return doctor.Success(name + " authentication")
+	}
+}
+
+// skillContractCheck verifies one harness advertises every role-mandated skill
+// in the pinned worker image, and that a recorded smoke result proves a real
+// invocation of that exact image and harness build could use them. Startup
+// reads the recorded result rather than paying for a model call.
+func skillContractCheck(request StartupRequest, name string) doctor.Check {
+	return func(ctx context.Context) doctor.Result {
+		diagnosis := name + " worker skill contract"
+		if request.SkillChecker == nil {
+			return doctor.Failure(diagnosis, "the worker skill diagnosis adapter is unavailable", "configure the Docker worker runtime")
+		}
+		required := MandatorySkills()
+		contract, err := request.SkillChecker.CheckSkillContract(ctx, worker.SkillContractRequest{Image: request.Image, Harness: name, Skills: required})
+		if err != nil {
+			return doctor.Failure(diagnosis, "the pinned worker image does not advertise every role-mandated skill to "+name, "rebuild the worker image so each role-mandated skill is installed once per discovery root and left model-visible")
+		}
+		evidence, err := LoadSkillSmokeEvidence(request.SkillEvidencePath)
+		if err != nil {
+			return doctor.Failure(diagnosis, "the recorded worker skill smoke evidence is unavailable", "record a smoke result for the pinned worker digest with scripts/smoke-skills.sh")
+		}
+		if !evidence.Covers(request.Image.Digest, name, contract.Version, required) {
+			return doctor.Failure(diagnosis, "no recorded smoke result proves "+name+" can use the role-mandated skills in the pinned worker image", "record a smoke result for the pinned worker digest and harness version with scripts/smoke-skills.sh")
+		}
+		return doctor.Success(diagnosis)
 	}
 }

--- a/internal/harness/doctor.go
+++ b/internal/harness/doctor.go
@@ -95,7 +95,7 @@ type StartupRequest struct {
 	AuthenticationChecker worker.HarnessAuthenticationChecker
 	// Resolve supplies adapter capabilities; nil selects built-ins.
 	Resolve CapabilityResolver
-	// SkillChecker verifies the installed skill set inside the worker image.
+	// SkillChecker verifies the worker skill set inside the worker image.
 	SkillChecker worker.SkillContractChecker
 	// SkillEvidencePath is the host path of the recorded worker skill smoke
 	// evidence.
@@ -205,7 +205,7 @@ func skillContractCheck(request StartupRequest, name string) doctor.Check {
 		required := MandatorySkills()
 		contract, err := request.SkillChecker.CheckSkillContract(ctx, worker.SkillContractRequest{Image: request.Image, Harness: name, Skills: required})
 		if err != nil {
-			return doctor.Failure(diagnosis, "the pinned worker image does not advertise every role-mandated skill to "+name, "rebuild the worker image so each role-mandated skill is installed once per discovery root and left model-visible")
+			return doctor.Failure(diagnosis, "the pinned worker image does not satisfy the role-mandated skill contract for "+name, "rebuild the worker image so each role-mandated skill appears once per discovery root and stays model-visible, and verify the configured image digest")
 		}
 		evidence, err := LoadSkillSmokeEvidence(request.SkillEvidencePath)
 		if err != nil {

--- a/internal/harness/doctor.go
+++ b/internal/harness/doctor.go
@@ -193,7 +193,9 @@ func credentialCheck(name, path string, image worker.ImageReference, checker wor
 // skillContractCheck verifies one harness advertises every role-mandated skill
 // in the pinned worker image, and that a recorded smoke result proves a real
 // invocation of that exact image and harness build could use them. Startup
-// reads the recorded result rather than paying for a model call.
+// reads the recorded result rather than paying for a model call. Every shipped
+// harness must carry that evidence: a repository may assign any role to any
+// supported harness, so an unverified harness is not a safe run.
 func skillContractCheck(request StartupRequest, name string) doctor.Check {
 	return func(ctx context.Context) doctor.Result {
 		diagnosis := name + " worker skill contract"

--- a/internal/harness/doctor_test.go
+++ b/internal/harness/doctor_test.go
@@ -202,6 +202,7 @@ func TestStartupChecksRefuseAWorkerImageThatHidesAMandatorySkill(t *testing.T) {
 	secret := "probe-output-secret"
 	checker := &harnessDoctorChecker{skillError: errors.New(secret)}
 	report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
+		Policy:            &config.RepositoryConfig{RoleHarnessDefaults: map[string]config.Harness{"implementation": config.HarnessCodex}},
 		Image:             probedImage,
 		Checker:           &harnessDoctorChecker{},
 		SkillChecker:      checker,
@@ -219,7 +220,8 @@ func TestStartupChecksRefuseAWorkerImageThatHidesAMandatorySkill(t *testing.T) {
 
 // TestStartupChecksRequireSmokeEvidenceForThePinnedDigestAndVersion verifies
 // startup refuses evidence recorded against a different worker image or a
-// different harness build, without making a model call of its own.
+// different harness build, without making a model call of its own. Every
+// shipped harness blocks, because a role may be assigned to any of them.
 func TestStartupChecksRequireSmokeEvidenceForThePinnedDigestAndVersion(t *testing.T) {
 	otherDigest := "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
 	for name, path := range map[string]string{
@@ -230,6 +232,7 @@ func TestStartupChecksRequireSmokeEvidenceForThePinnedDigestAndVersion(t *testin
 	} {
 		t.Run(name, func(t *testing.T) {
 			report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
+				Policy:            &config.RepositoryConfig{RoleHarnessDefaults: map[string]config.Harness{"implementation": config.HarnessCodex}},
 				Image:             probedImage,
 				Checker:           &harnessDoctorChecker{},
 				SkillChecker:      &harnessDoctorChecker{},

--- a/internal/harness/doctor_test.go
+++ b/internal/harness/doctor_test.go
@@ -2,6 +2,7 @@ package harness_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -43,16 +44,18 @@ func TestStartupChecksProbeBothHarnessesAndConfiguredCredentials(t *testing.T) {
 		Policy: &config.RepositoryConfig{RoleHarnessDefaults: map[string]config.Harness{
 			"test": config.HarnessCodex, "implementation": config.HarnessClaude,
 		}},
-		Authentication: config.AuthenticationConfig{CodexAuthPath: codexPath, ClaudeAuthPath: claudePath},
-		Image: worker.ImageReference{
-			Name:   "ghcr.io/example/factory-worker",
-			Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-		},
+		Authentication:        config.AuthenticationConfig{CodexAuthPath: codexPath, ClaudeAuthPath: claudePath},
+		Image:                 probedImage,
 		Checker:               checker,
 		AuthenticationChecker: checker,
+		SkillChecker:          checker,
+		SkillEvidencePath:     writeSkillEvidence(t, probedImage.Digest, probedHarnessVersion, harness.MandatorySkills()),
 	})...)
 	if !report.Ready() {
 		t.Fatalf("harness report = %#v, want ready", report)
+	}
+	if checker.skillCalls != 2 {
+		t.Fatalf("harness skill contract checks = %d, want Codex and Claude", checker.skillCalls)
 	}
 	if checker.calls != 2 {
 		t.Fatalf("harness executable checks = %d, want Codex and Claude", checker.calls)
@@ -66,12 +69,11 @@ func TestStartupChecksProbeBothHarnessesAndConfiguredCredentials(t *testing.T) {
 // may defer authentication to an interactive worker session.
 func TestStartupChecksKeepMissingOptionalCredentialsNonBlocking(t *testing.T) {
 	report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
-		Policy: &config.RepositoryConfig{RoleHarnessDefaults: map[string]config.Harness{"test": config.HarnessCodex}},
-		Image: worker.ImageReference{
-			Name:   "ghcr.io/example/factory-worker",
-			Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-		},
-		Checker: &harnessDoctorChecker{},
+		Policy:            &config.RepositoryConfig{RoleHarnessDefaults: map[string]config.Harness{"test": config.HarnessCodex}},
+		Image:             probedImage,
+		Checker:           &harnessDoctorChecker{},
+		SkillChecker:      &harnessDoctorChecker{},
+		SkillEvidencePath: writeSkillEvidence(t, probedImage.Digest, probedHarnessVersion, harness.MandatorySkills()),
 	})...)
 	if !report.Ready() || len(report.Warnings()) != 2 {
 		t.Fatalf("harness report = %#v, want two non-blocking auth warnings", report)
@@ -121,10 +123,13 @@ func TestStartupChecksDoNotRenderWorkerAuthenticationErrors(t *testing.T) {
 
 // harnessDoctorChecker records worker-image harness probes.
 type harnessDoctorChecker struct {
-	err       error
-	calls     int
-	authCalls int
-	authError error
+	err        error
+	calls      int
+	authCalls  int
+	authError  error
+	skillCalls int
+	skillError error
+	version    string
 }
 
 // CheckHarness implements the worker harness diagnosis seam.
@@ -139,5 +144,112 @@ func (c *harnessDoctorChecker) CheckHarnessAuthentication(context.Context, worke
 	return c.authError
 }
 
+// CheckSkillContract implements the worker skill contract diagnosis seam.
+func (c *harnessDoctorChecker) CheckSkillContract(_ context.Context, request worker.SkillContractRequest) (worker.SkillContract, error) {
+	c.skillCalls++
+	if c.skillError != nil {
+		return worker.SkillContract{}, c.skillError
+	}
+	version := c.version
+	if version == "" {
+		version = probedHarnessVersion
+	}
+	return worker.SkillContract{Harness: request.Harness, Version: version}, nil
+}
+
 var _ worker.HarnessChecker = (*harnessDoctorChecker)(nil)
 var _ worker.HarnessAuthenticationChecker = (*harnessDoctorChecker)(nil)
+var _ worker.SkillContractChecker = (*harnessDoctorChecker)(nil)
+
+// probedHarnessVersion is the harness version a fake worker probe reports.
+const probedHarnessVersion = "1.2.3"
+
+// probedImage is the pinned worker image used by the harness diagnosis tests.
+var probedImage = worker.ImageReference{
+	Name:   "ghcr.io/example/factory-worker",
+	Digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+}
+
+// writeSkillEvidence records a smoke result for every supported harness at the
+// pinned digest and returns the evidence file path.
+func writeSkillEvidence(t *testing.T, digest, version string, skills []string) string {
+	t.Helper()
+	evidence := harness.SkillSmokeEvidence{SchemaVersion: 1}
+	for _, name := range []string{harness.NameClaude, harness.NameCodex} {
+		evidence.Records = append(evidence.Records, harness.SkillSmokeRecord{
+			ImageDigest:    digest,
+			Harness:        name,
+			HarnessVersion: version,
+			Skills:         skills,
+			VerifiedAt:     "2026-09-04T00:00:00Z",
+		})
+	}
+	body, err := json.Marshal(evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "skill-smoke.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestStartupChecksRefuseAWorkerImageThatHidesAMandatorySkill verifies a role
+// cannot start against an image whose harness omits a role-mandated skill from
+// its model-visible catalog.
+func TestStartupChecksRefuseAWorkerImageThatHidesAMandatorySkill(t *testing.T) {
+	secret := "probe-output-secret"
+	checker := &harnessDoctorChecker{skillError: errors.New(secret)}
+	report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
+		Image:             probedImage,
+		Checker:           &harnessDoctorChecker{},
+		SkillChecker:      checker,
+		SkillEvidencePath: writeSkillEvidence(t, probedImage.Digest, probedHarnessVersion, harness.MandatorySkills()),
+	})...)
+	if got := skillContractFailures(report); got != 2 {
+		t.Fatalf("harness skill contract failures = %d, want one per shipped harness", got)
+	}
+	for _, result := range report.Results {
+		if strings.Contains(result.Problem+result.Action, secret) {
+			t.Fatalf("harness result exposed worker probe output: %#v", result)
+		}
+	}
+}
+
+// TestStartupChecksRequireSmokeEvidenceForThePinnedDigestAndVersion verifies
+// startup refuses evidence recorded against a different worker image or a
+// different harness build, without making a model call of its own.
+func TestStartupChecksRequireSmokeEvidenceForThePinnedDigestAndVersion(t *testing.T) {
+	otherDigest := "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+	for name, path := range map[string]string{
+		"missing file":         filepath.Join(t.TempDir(), "absent.json"),
+		"other worker image":   writeSkillEvidence(t, otherDigest, probedHarnessVersion, harness.MandatorySkills()),
+		"other harness build":  writeSkillEvidence(t, probedImage.Digest, "9.9.9", harness.MandatorySkills()),
+		"incomplete skill set": writeSkillEvidence(t, probedImage.Digest, probedHarnessVersion, []string{"implement"}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			report := doctor.Run(context.Background(), harness.StartupChecks(harness.StartupRequest{
+				Image:             probedImage,
+				Checker:           &harnessDoctorChecker{},
+				SkillChecker:      &harnessDoctorChecker{},
+				SkillEvidencePath: path,
+			})...)
+			if got := skillContractFailures(report); got != 2 {
+				t.Fatalf("harness skill contract failures = %d, want one per shipped harness", got)
+			}
+		})
+	}
+}
+
+// skillContractFailures counts the blocking skill-contract diagnoses in a
+// report, leaving unrelated harness checks out of the assertion.
+func skillContractFailures(report doctor.Report) int {
+	failures := 0
+	for _, result := range report.Failures() {
+		if strings.HasSuffix(result.Name, "worker skill contract") {
+			failures++
+		}
+	}
+	return failures
+}

--- a/internal/harness/skills.go
+++ b/internal/harness/skills.go
@@ -1,0 +1,87 @@
+package harness
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+)
+
+// SkillEvidenceFile is the repository-relative path of the recorded worker
+// skill smoke evidence. Startup reads the recorded result instead of making a
+// model call, which would be paid and nondeterministic.
+const SkillEvidenceFile = "worker/skill-smoke.json"
+
+// MandatorySkills returns the worker skills the embedded role prompts require
+// by name, in deterministic order. Every shipped harness must advertise all of
+// them, because a repository may assign any role to any supported harness.
+func MandatorySkills() []string {
+	return []string{"implement", "specification-review", "standards-review"}
+}
+
+// SkillSmokeRecord is one recorded proof that a real worker invocation of one
+// harness loaded and used the role-mandated skills. It is keyed by the
+// immutable worker image digest and the harness version observed in it.
+type SkillSmokeRecord struct {
+	// ImageDigest is the worker image digest the smoke ran against.
+	ImageDigest string `json:"image_digest"`
+	// Harness is the harness that was invoked.
+	Harness string `json:"harness"`
+	// HarnessVersion is the version line that harness reported in the image.
+	HarnessVersion string `json:"harness_version"`
+	// Skills are the role-mandated skills the invocation proved usable.
+	Skills []string `json:"skills"`
+	// VerifiedAt is the RFC 3339 instant the smoke was recorded.
+	VerifiedAt string `json:"verified_at"`
+}
+
+// SkillSmokeEvidence is the checked-in set of recorded smoke results.
+type SkillSmokeEvidence struct {
+	// SchemaVersion identifies the evidence file format.
+	SchemaVersion int `json:"schema_version"`
+	// Records contains one result per worker digest and harness.
+	Records []SkillSmokeRecord `json:"records"`
+}
+
+// LoadSkillSmokeEvidence reads the recorded smoke evidence from one file.
+func LoadSkillSmokeEvidence(path string) (SkillSmokeEvidence, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return SkillSmokeEvidence{}, errors.New("the worker skill smoke evidence file is unavailable")
+	}
+	var evidence SkillSmokeEvidence
+	if err := json.Unmarshal(body, &evidence); err != nil {
+		return SkillSmokeEvidence{}, errors.New("the worker skill smoke evidence file is not readable")
+	}
+	return evidence, nil
+}
+
+// Covers reports whether the evidence contains a record proving one harness
+// build in one worker image loaded every required skill.
+func (e SkillSmokeEvidence) Covers(digest, harness, version string, required []string) bool {
+	for _, record := range e.Records {
+		if !strings.EqualFold(record.ImageDigest, digest) || record.Harness != harness {
+			continue
+		}
+		if record.HarnessVersion != version || !coversSkills(record.Skills, required) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// coversSkills reports whether a recorded skill set contains every required
+// skill.
+func coversSkills(recorded, required []string) bool {
+	present := make(map[string]struct{}, len(recorded))
+	for _, skill := range recorded {
+		present[skill] = struct{}{}
+	}
+	for _, skill := range required {
+		if _, ok := present[skill]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/worker/doctor.go
+++ b/internal/worker/doctor.go
@@ -243,7 +243,7 @@ type SkillContract struct {
 }
 
 // SkillContractChecker is the worker execution seam used by the harness module
-// to verify the installed skill set inside the worker image.
+// to verify the worker skill set inside the worker image.
 type SkillContractChecker interface {
 	CheckSkillContract(context.Context, SkillContractRequest) (SkillContract, error)
 }
@@ -257,8 +257,8 @@ const duplicateSkillRoot = "/home/factory/.agents/skills"
 // worker output cannot grow a diagnosis result without limit.
 const maxHarnessVersionLength = 120
 
-// CheckSkillContract verifies each role-mandated skill is installed exactly
-// once in one harness's discovery root and is not hidden from that harness's
+// CheckSkillContract verifies each role-mandated skill appears exactly once in
+// one harness's discovery root and is not hidden from that harness's
 // model-visible catalog, using a disposable network-isolated container. It
 // returns the harness version and never the probe's diagnostic output.
 func (r *DockerRuntime) CheckSkillContract(ctx context.Context, request SkillContractRequest) (SkillContract, error) {
@@ -306,7 +306,7 @@ func harnessSkillRoot(name string) (string, error) {
 }
 
 // skillContractProbe builds the in-worker shell probe asserting each skill is
-// installed, self-named, unduplicated, and model-visible under both harness
+// present, self-named, unduplicated, and model-visible under both harness
 // activation policies. Skill names are validated before they reach the shell.
 func skillContractProbe(harness, root string, skills []string) (string, error) {
 	probe := "set -eu\ntest ! -e " + duplicateSkillRoot + "\n"

--- a/internal/worker/doctor.go
+++ b/internal/worker/doctor.go
@@ -218,3 +218,121 @@ func validateImageReference(image ImageReference) error {
 var _ DoctorChecker = (*DockerRuntime)(nil)
 var _ HarnessChecker = (*DockerRuntime)(nil)
 var _ HarnessAuthenticationChecker = (*DockerRuntime)(nil)
+var _ SkillContractChecker = (*DockerRuntime)(nil)
+
+// SkillContractRequest identifies the role-mandated skills one harness must
+// advertise to the model inside the immutable worker image.
+type SkillContractRequest struct {
+	// Image is the worker image to inspect.
+	Image ImageReference
+	// Harness is the built-in harness whose discovery root is inspected.
+	Harness string
+	// Skills are the role-mandated skill names that must be installed once and
+	// left visible to the model.
+	Skills []string
+}
+
+// SkillContract is the observed skill contract of one harness inside the
+// pinned worker image. Version keys recorded smoke evidence to the exact
+// harness build that produced it.
+type SkillContract struct {
+	// Harness is the inspected harness name.
+	Harness string
+	// Version is the harness's reported version line.
+	Version string
+}
+
+// SkillContractChecker is the worker execution seam used by the harness module
+// to verify the installed skill set inside the worker image.
+type SkillContractChecker interface {
+	CheckSkillContract(context.Context, SkillContractRequest) (SkillContract, error)
+}
+
+// duplicateSkillRoot is the additional discovery root a harness would also
+// read. The worker installs one skill set per harness root, so a skill set
+// here would let one name resolve to two installations.
+const duplicateSkillRoot = "/home/factory/.agents/skills"
+
+// maxHarnessVersionLength bounds the harness version line kept from a probe so
+// worker output cannot grow a diagnosis result without limit.
+const maxHarnessVersionLength = 120
+
+// CheckSkillContract verifies each role-mandated skill is installed exactly
+// once in one harness's discovery root and is not hidden from that harness's
+// model-visible catalog, using a disposable network-isolated container. It
+// returns the harness version and never the probe's diagnostic output.
+func (r *DockerRuntime) CheckSkillContract(ctx context.Context, request SkillContractRequest) (SkillContract, error) {
+	if err := validateImageReference(request.Image); err != nil {
+		return SkillContract{}, err
+	}
+	root, err := harnessSkillRoot(request.Harness)
+	if err != nil {
+		return SkillContract{}, err
+	}
+	if len(request.Skills) == 0 {
+		return SkillContract{}, errors.New("at least one role-mandated skill is required")
+	}
+	probe, err := skillContractProbe(request.Harness, root, request.Skills)
+	if err != nil {
+		return SkillContract{}, err
+	}
+	result, err := r.runDocker(ctx, []string{
+		"run", "--rm", "--pull=never", "--user", WorkerUser,
+		"--cap-drop", "ALL", "--security-opt", "no-new-privileges", "--network", "none",
+		"--entrypoint", "/bin/sh",
+		imageReference(request.Image.Name, request.Image.Digest), "-c", probe,
+	})
+	if err != nil {
+		return SkillContract{}, errors.New("the worker image does not satisfy the harness skill contract")
+	}
+	version := harnessVersionLine(result.Stdout)
+	if version == "" {
+		return SkillContract{}, errors.New("the worker harness did not report a version")
+	}
+	return SkillContract{Harness: request.Harness, Version: version}, nil
+}
+
+// harnessSkillRoot returns the fixed in-worker discovery root one harness
+// reads its skill set from. It never incorporates user text into a path.
+func harnessSkillRoot(name string) (string, error) {
+	switch name {
+	case "codex":
+		return "/home/factory/.codex/skills", nil
+	case "claude":
+		return "/home/factory/.claude/skills", nil
+	default:
+		return "", fmt.Errorf("unsupported harness skill probe %q", name)
+	}
+}
+
+// skillContractProbe builds the in-worker shell probe asserting each skill is
+// installed, self-named, unduplicated, and model-visible under both harness
+// activation policies. Skill names are validated before they reach the shell.
+func skillContractProbe(harness, root string, skills []string) (string, error) {
+	probe := "set -eu\ntest ! -e " + duplicateSkillRoot + "\n"
+	for _, skill := range skills {
+		if !validName(skill) {
+			return "", errors.New("role-mandated skill name is unsafe")
+		}
+		directory := root + "/" + skill
+		probe += "test -f " + directory + "/SKILL.md\n"
+		probe += "grep -q '^name: " + skill + "$' " + directory + "/SKILL.md\n"
+		probe += "! grep -q 'disable-model-invocation' " + directory + "/SKILL.md\n"
+		probe += "! grep -rq 'allow_implicit_invocation' " + directory + "/agents\n"
+	}
+	return probe + harness + " --version\n", nil
+}
+
+// harnessVersionLine reduces a harness version command's output to one bounded
+// printable line usable as a smoke-evidence key.
+func harnessVersionLine(output string) string {
+	line := strings.TrimSpace(strings.SplitN(strings.TrimSpace(output), "\n", 2)[0])
+	var kept strings.Builder
+	for _, character := range line {
+		if character < ' ' || character > '~' || kept.Len() >= maxHarnessVersionLength {
+			continue
+		}
+		kept.WriteRune(character)
+	}
+	return kept.String()
+}

--- a/scripts/smoke-skills.sh
+++ b/scripts/smoke-skills.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+
+# Prove each shipped harness can load and use the role-mandated worker skills
+# inside the pinned worker image, and record the result keyed by the image
+# digest and the harness version. Startup diagnostics read that record instead
+# of repeating this paid, nondeterministic model call.
+set -eu
+
+DOCKER="${DOCKER:-docker}"
+REPOSITORY_ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd -P)"
+EVIDENCE_FILE="${EVIDENCE_FILE:-$REPOSITORY_ROOT/worker/skill-smoke.json}"
+WORKER_IMAGE="${WORKER_IMAGE:-$(sed -n 's/^  image: \(.*\)$/\1/p' "$REPOSITORY_ROOT/factory.yaml")}"
+WORKER_DIGEST="${WORKER_DIGEST:-$(sed -n 's/^  digest: \(.*\)$/\1/p' "$REPOSITORY_ROOT/factory.yaml")}"
+CODEX_AUTH_PATH="${CODEX_AUTH_PATH:-$HOME/.codex/auth.json}"
+CLAUDE_AUTH_PATH="${CLAUDE_AUTH_PATH:-$HOME/.claude/.credentials.json}"
+HARNESSES="${HARNESSES:-codex claude}"
+MANDATORY_SKILLS="${MANDATORY_SKILLS:-implement specification-review standards-review}"
+WORKER_REFERENCE="$WORKER_IMAGE@$WORKER_DIGEST"
+
+# credential_path returns the host credential file one harness authenticates
+# with, and the in-worker file it is streamed to.
+credential_path() {
+  case "$1" in
+    codex) echo "$CODEX_AUTH_PATH /home/factory/.codex/auth.json" ;;
+    claude) echo "$CLAUDE_AUTH_PATH /home/factory/.claude/.credentials.json" ;;
+    *) echo "unsupported harness $1" >&2; exit 1 ;;
+  esac
+}
+
+# harness_invocation returns the non-interactive command one harness answers a
+# single prompt with. The worker is the security boundary, so both harnesses
+# run without their redundant inner approval gates, exactly as a run does.
+harness_invocation() {
+  case "$1" in
+    codex) echo "codex exec --skip-git-repo-check -s danger-full-access -c project_doc_max_bytes=0" ;;
+    claude) echo "claude -p --dangerously-skip-permissions" ;;
+    *) echo "unsupported harness $1" >&2; exit 1 ;;
+  esac
+}
+
+# skill_sentinel returns the first instruction line of one skill body. The line
+# exists only inside the installed SKILL.md, so a reply that quotes it could
+# not have been produced without loading the skill.
+skill_sentinel() {
+  awk 'BEGIN { markers = 0 }
+    /^---$/ { markers++; next }
+    markers >= 2 && NF { print; exit }' "$REPOSITORY_ROOT/worker/skills/$1/SKILL.md"
+}
+
+# ask_harness streams one host credential into a disposable worker and asks
+# that harness one prompt there. The credential never reaches a Docker
+# argument, and the prompt reaches the harness through the environment rather
+# than through in-container shell quoting.
+ask_harness() {
+  harness_name="$1"
+  smoke_prompt="$2"
+  invocation="$(harness_invocation "$harness_name")"
+  set -- $(credential_path "$harness_name")
+  host_credential="$1"
+  worker_credential="$2"
+  "$DOCKER" run --rm -i --pull=never --user 10001:10001 \
+    --cap-drop ALL --security-opt no-new-privileges \
+    --env "SMOKE_PROMPT=$smoke_prompt" \
+    --entrypoint /bin/sh "$WORKER_REFERENCE" -c "
+      umask 077
+      mkdir -p \"\$(dirname $worker_credential)\"
+      cat > $worker_credential
+      chmod 0400 $worker_credential
+      $invocation \"\$SMOKE_PROMPT\"
+    " < "$host_credential"
+}
+
+# record_evidence merges one verified smoke result into the evidence file.
+record_evidence() {
+  jq --arg digest "$WORKER_DIGEST" \
+     --arg harness "$1" \
+     --arg version "$2" \
+     --arg verified "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     --argjson skills "$3" \
+     '.schema_version = 1
+      | .records = ((.records // [])
+        | map(select(.image_digest != $digest or .harness != $harness))
+        + [{image_digest: $digest, harness: $harness, harness_version: $version, skills: $skills, verified_at: $verified}]
+        | sort_by(.image_digest, .harness))' \
+     "$EVIDENCE_FILE" > "$EVIDENCE_FILE.next"
+  mv "$EVIDENCE_FILE.next" "$EVIDENCE_FILE"
+}
+
+test -f "$EVIDENCE_FILE" || printf '{\n  "schema_version": 1,\n  "records": []\n}\n' > "$EVIDENCE_FILE"
+
+for harness_name in $HARNESSES; do
+  set -- $(credential_path "$harness_name")
+  if [ ! -f "$1" ]; then
+    echo "No $harness_name credential at $1; skipping its smoke." >&2
+    echo "Startup stays blocked for $harness_name until its result is recorded." >&2
+    continue
+  fi
+
+  version="$("$DOCKER" run --rm --pull=never --user 10001:10001 \
+    --cap-drop ALL --security-opt no-new-privileges --network none \
+    --entrypoint /bin/sh "$WORKER_REFERENCE" -c "$harness_name --version" | head -n 1 | tr -d '\r')"
+  echo "Smoking $harness_name $version in $WORKER_REFERENCE"
+
+  verified='[]'
+  for skill in $MANDATORY_SKILLS; do
+    sentinel="$(skill_sentinel "$skill")"
+    prompt="Use the \`$skill\` skill. Reply with the first instruction line of that skill, verbatim, and nothing else."
+    reply="$(ask_harness "$harness_name" "$prompt" 2>/dev/null || true)"
+    case "$reply" in
+      *"$sentinel"*) ;;
+      *)
+        echo "$harness_name could not load the \`$skill\` skill in $WORKER_REFERENCE" >&2
+        exit 1
+        ;;
+    esac
+    verified="$(printf '%s' "$verified" | jq --arg skill "$skill" '. + [$skill]')"
+    echo "  $skill loaded"
+  done
+
+  record_evidence "$harness_name" "$version" "$verified"
+  echo "Recorded $harness_name evidence for $WORKER_DIGEST in $EVIDENCE_FILE"
+done

--- a/scripts/smoke-skills.sh
+++ b/scripts/smoke-skills.sh
@@ -38,9 +38,12 @@ harness_invocation() {
   esac
 }
 
-# skill_sentinel returns the first instruction line of one skill body. The line
-# exists only inside the installed SKILL.md, so a reply that quotes it could
-# not have been produced without loading the skill.
+# skill_sentinel returns the first instruction line of one skill body. A reply
+# that quotes it shows the harness surfaced that skill's body to the model in
+# this invocation. It is not proof the model could not have read the file
+# another way: the deterministic activation checks in worker/skills_contract_test.go
+# own the hidden-skill question, and this layer answers whether a real
+# invocation reaches the skill at all.
 skill_sentinel() {
   awk 'BEGIN { markers = 0 }
     /^---$/ { markers++; next }
@@ -88,17 +91,20 @@ record_evidence() {
 
 test -f "$EVIDENCE_FILE" || printf '{\n  "schema_version": 1,\n  "records": []\n}\n' > "$EVIDENCE_FILE"
 
+unrecorded=""
+
 for harness_name in $HARNESSES; do
   set -- $(credential_path "$harness_name")
   if [ ! -f "$1" ]; then
     echo "No $harness_name credential at $1; skipping its smoke." >&2
-    echo "Startup stays blocked for $harness_name until its result is recorded." >&2
+    unrecorded="$unrecorded $harness_name"
     continue
   fi
 
   version="$("$DOCKER" run --rm --pull=never --user 10001:10001 \
     --cap-drop ALL --security-opt no-new-privileges --network none \
-    --entrypoint /bin/sh "$WORKER_REFERENCE" -c "$harness_name --version" | head -n 1 | tr -d '\r')"
+    --entrypoint /bin/sh "$WORKER_REFERENCE" -c "$harness_name --version" \
+    | head -n 1 | tr -cd '\040-\176' | cut -c1-120)"
   echo "Smoking $harness_name $version in $WORKER_REFERENCE"
 
   verified='[]'
@@ -120,3 +126,9 @@ for harness_name in $HARNESSES; do
   record_evidence "$harness_name" "$version" "$verified"
   echo "Recorded $harness_name evidence for $WORKER_DIGEST in $EVIDENCE_FILE"
 done
+
+if [ -n "$unrecorded" ]; then
+  echo "No smoke result recorded for:$unrecorded" >&2
+  echo "Startup stays blocked for those harnesses until their result is recorded." >&2
+  exit 1
+fi

--- a/worker/SKILLS.md
+++ b/worker/SKILLS.md
@@ -9,6 +9,100 @@ The set is factory-owned and pinned by the worker image digest recorded in
 an agent's visible instructions stay reproducible for the run's digest. See
 `docs/adr/0006-factory-owned-worker-skills.md` for the boundary this preserves.
 
+## Supported harnesses and discovery roots
+
+The worker image installs the harnesses pinned by `worker/base.Dockerfile`.
+Each one reads the skill set from its own role home, so the two installations
+are separate roots holding the same names rather than one shared root.
+
+| Harness | Installed root | Other roots it also reads |
+| --- | --- | --- |
+| `codex` | `$HOME/.codex/skills` | `$HOME/.agents/skills`, the project `.codex/skills`, the system cache root |
+| `claude` | `$HOME/.claude/skills` | the project `.claude/skills`, installed plugins |
+
+Pinned Codex still discovers the deprecated `$CODEX_HOME/skills` root, so the
+`.codex/skills` installation remains the supported location for that version.
+
+`$HOME/.agents/skills` is deliberately left empty and the checks assert it
+stays that way. A second root holding the same names would let one skill name
+resolve to two installations, and the worker must not ship that ambiguity.
+Migrating to `$HOME/.agents/skills` is a separate decision, not a repair for
+skill visibility.
+
+The mounted worktree is repository content and can hold its own project skill
+directory. That is untrusted input like the rest of the checkout; the factory
+never relies on it for a role-mandated skill.
+
+## Activation semantics
+
+Installing a skill is not the same as advertising it. Each harness has its own
+switch that removes an installed skill from the model-visible catalog:
+
+| Harness | Hidden by | Default |
+| --- | --- | --- |
+| `codex` | `policy.allow_implicit_invocation: false` in `agents/openai.yaml` | absent, so the skill is advertised |
+| `claude` | `disable-model-invocation: true` in the `SKILL.md` front matter | absent, so the skill is advertised |
+
+A hidden skill under pinned Codex is reachable only through an explicit
+`$skill-name` mention in the prompt text. The factory role prompts name a skill
+in backticks as prose, which is not an explicit mention, so a hidden skill
+would leave a role mandated to use guidance it cannot reach. Neither switch
+appears in this set: role prompts, not activation metadata, decide which role
+uses which skill.
+
+The role-mandated skills are `implement` for the implementation role,
+`specification-review` for the specification reviewer, and `standards-review`
+for the standards reviewer. Every shipped harness must advertise all three,
+because a repository may assign any role to any supported harness.
+
+## Verification
+
+Three layers verify the contract, and they stay separate because only the
+middle one costs a model call.
+
+1. Artifact contract, deterministic and offline:
+
+   ```sh
+   go test ./worker/...
+   ```
+
+   It fails when a role prompt names a skill the image does not install, when a
+   mandatory skill is hidden from either harness, or when the image definition
+   seeds a skill set into more than one discovery root per harness.
+
+2. Real invocation smoke, once per worker digest and harness version:
+
+   ```sh
+   make worker-build                 # prints the new digest
+   # record the digest in factory.yaml, then:
+   ./scripts/smoke-skills.sh
+   ```
+
+   The smoke asks each harness, inside the pinned image and with the exact
+   phrasing the role prompts use, to load each mandatory skill and quote a line
+   that exists only in that skill's body. It records the result in
+   `worker/skill-smoke.json`, keyed by image digest and harness version. It
+   needs a host credential for each harness it smokes and skips any harness
+   without one. Set `HARNESSES` to smoke a subset.
+
+3. Startup diagnosis, deterministic and offline:
+
+   ```sh
+   factory doctor
+   ```
+
+   For every shipped harness it probes the pinned image for the installed,
+   unduplicated, model-visible skill set, and then reads the recorded smoke
+   result for that exact digest and harness version. It never makes a model
+   call of its own. Both parts block for every shipped harness, not only for
+   the harness `role_harness_defaults` currently selects: a repository may
+   assign any role to any supported harness, so an unverified harness is not a
+   safe run.
+
+Rebuilding the image invalidates the recorded evidence, because the digest is
+part of the key. Rebuild, record the new digest, re-run the smoke, then run
+the startup diagnosis.
+
 ## Curation rule
 
 A skill belongs here only when it is craft guidance that applies inside the

--- a/worker/SKILLS.md
+++ b/worker/SKILLS.md
@@ -35,8 +35,8 @@ never relies on it for a role-mandated skill.
 
 ## Activation semantics
 
-Installing a skill is not the same as advertising it. Each harness has its own
-switch that removes an installed skill from the model-visible catalog:
+Shipping a skill is not the same as advertising it. Each harness has its own
+switch that removes a shipped skill from the model-visible catalog:
 
 | Harness | Hidden by | Default |
 | --- | --- | --- |
@@ -99,9 +99,27 @@ middle one costs a model call.
    assign any role to any supported harness, so an unverified harness is not a
    safe run.
 
+The smoke exits non-zero when any harness it was asked to prove produced no
+record, so a skipped harness never reads as a pass.
+
 Rebuilding the image invalidates the recorded evidence, because the digest is
 part of the key. Rebuild, record the new digest, re-run the smoke, then run
 the startup diagnosis.
+
+### Currently recorded
+
+`worker/skill-smoke.json` holds a `codex` record for the pinned digest only.
+The `claude` smoke has not been run, because it needs a Claude credential file
+at the configured `claude_auth_path` and none exists on the machine that
+recorded the codex result. Until someone runs
+
+```sh
+HARNESSES=claude ./scripts/smoke-skills.sh
+```
+
+and commits the updated file, the startup diagnosis blocks on `claude worker
+skill contract`. That is the contract this document states, not an oversight in
+it.
 
 ## Curation rule
 

--- a/worker/skill-smoke.json
+++ b/worker/skill-smoke.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "records": [
+    {
+      "image_digest": "sha256:238d1ef93894612ab4caaa195b52ed88a67f4651c937e2ba9492fbf3d2f1ff58",
+      "harness": "codex",
+      "harness_version": "codex-cli 0.148.0",
+      "skills": [
+        "implement",
+        "specification-review",
+        "standards-review"
+      ],
+      "verified_at": "2026-09-04T17:59:25Z"
+    }
+  ]
+}

--- a/worker/skill-smoke.json
+++ b/worker/skill-smoke.json
@@ -10,7 +10,7 @@
         "specification-review",
         "standards-review"
       ],
-      "verified_at": "2026-09-04T17:59:25Z"
+      "verified_at": "2026-09-04T18:12:32Z"
     }
   ]
 }

--- a/worker/skills/implement/agents/openai.yaml
+++ b/worker/skills/implement/agents/openai.yaml
@@ -1,5 +1,3 @@
 interface:
   display_name: "Implement"
   short_description: "Build the frozen factory specification"
-policy:
-  allow_implicit_invocation: false

--- a/worker/skills/specification-review/agents/openai.yaml
+++ b/worker/skills/specification-review/agents/openai.yaml
@@ -1,5 +1,3 @@
 interface:
   display_name: "Specification Review"
   short_description: "Review one checkpoint against its frozen spec"
-policy:
-  allow_implicit_invocation: false

--- a/worker/skills/standards-review/agents/openai.yaml
+++ b/worker/skills/standards-review/agents/openai.yaml
@@ -1,5 +1,3 @@
 interface:
   display_name: "Standards Review"
   short_description: "Review one checkpoint against repository standards"
-policy:
-  allow_implicit_invocation: false

--- a/worker/skills_contract_test.go
+++ b/worker/skills_contract_test.go
@@ -2,6 +2,8 @@ package worker_test
 
 import (
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -74,4 +76,130 @@ func readSkill(t *testing.T, path string) string {
 		t.Fatalf("ReadFile(%q) error = %v", path, err)
 	}
 	return string(body)
+}
+
+// mandatorySkills are the worker skills a factory role prompt requires by
+// name. A role prompt that mandates a skill the harness hides leaves the role
+// unable to follow its own instructions.
+var mandatorySkills = []string{"implement", "specification-review", "standards-review"}
+
+// harnessSkillRoots maps each harness shipped in the worker image to the role
+// home directory that harness reads its skill set from.
+var harnessSkillRoots = map[string]string{
+	"claude": "/home/factory/.claude/skills",
+	"codex":  "/home/factory/.codex/skills",
+}
+
+// TestMandatorySkillsAreModelVisibleUnderEveryHarness verifies no shipped
+// harness hides a role-mandated skill from the model-visible catalog. Codex
+// hides a skill whose openai.yaml denies implicit invocation; Claude hides one
+// whose SKILL.md front matter disables model invocation.
+func TestMandatorySkillsAreModelVisibleUnderEveryHarness(t *testing.T) {
+	for _, skill := range mandatorySkills {
+		t.Run(skill, func(t *testing.T) {
+			body := readSkill(t, "skills/"+skill+"/SKILL.md")
+			if !strings.Contains(body, "name: "+skill+"\n") {
+				t.Fatalf("skill %q does not declare its own name:\n%s", skill, body)
+			}
+			if strings.Contains(body, "disable-model-invocation") {
+				t.Fatalf("skill %q is hidden from the Claude model-visible catalog:\n%s", skill, body)
+			}
+			metadata := readSkill(t, "skills/"+skill+"/agents/openai.yaml")
+			if strings.Contains(metadata, "allow_implicit_invocation") {
+				t.Fatalf("skill %q is hidden from the Codex model-visible catalog:\n%s", skill, metadata)
+			}
+		})
+	}
+}
+
+// TestWorkerImageInstallsOneSkillSetPerHarnessRoot verifies the image
+// definition seeds exactly one skill set per harness discovery root. A second
+// root holding the same skill names would let a harness resolve one name to
+// two installations.
+func TestWorkerImageInstallsOneSkillSetPerHarnessRoot(t *testing.T) {
+	definition := readSkill(t, "Dockerfile")
+	for harnessName, root := range harnessSkillRoots {
+		if got := strings.Count(definition, " "+root+"\n"); got != 1 {
+			t.Fatalf("%s skill root %q installed %d times, want once:\n%s", harnessName, root, got, definition)
+		}
+	}
+	if strings.Contains(definition, ".agents/skills") {
+		t.Fatalf("worker image installs a duplicate skill set under an additional discovery root:\n%s", definition)
+	}
+}
+
+// TestRolePromptsOnlyMandateInstalledVisibleSkills verifies every skill an
+// embedded role prompt names is installed in the worker image and advertised
+// by both harnesses. It is the artifact-level statement of the role contract:
+// a prompt never instructs an agent to use a skill the harness withheld.
+func TestRolePromptsOnlyMandateInstalledVisibleSkills(t *testing.T) {
+	installed := installedSkills(t)
+	prompts, err := filepath.Glob(filepath.Join("..", "internal", "prompt", "prompts", "*.md"))
+	if err != nil {
+		t.Fatalf("Glob(prompts) error = %v", err)
+	}
+	if len(prompts) == 0 {
+		t.Fatal("no embedded role prompts were found")
+	}
+	for _, path := range prompts {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", path, err)
+		}
+		for _, named := range promptSkillNames(string(body)) {
+			if _, ok := installed[named]; !ok {
+				t.Fatalf("role prompt %q names skill %q, which the worker image does not install", path, named)
+			}
+			if hiddenFromAHarness(t, named) {
+				t.Fatalf("role prompt %q names skill %q, which a shipped harness hides from the model", path, named)
+			}
+		}
+	}
+}
+
+// promptSkillNames returns the bare backticked names a prompt uses on a line
+// that speaks about skills. Prompt bodies name a skill only in that context,
+// so the surrounding line keeps unrelated backticked paths out of the result.
+func promptSkillNames(body string) []string {
+	pattern := regexp.MustCompile("`([a-z][a-z0-9-]{2,})`")
+	var names []string
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.Contains(line, "skill") {
+			continue
+		}
+		for _, match := range pattern.FindAllStringSubmatch(line, -1) {
+			names = append(names, match[1])
+		}
+	}
+	return names
+}
+
+// installedSkills returns the skill names the worker image ships.
+func installedSkills(t *testing.T) map[string]struct{} {
+	t.Helper()
+	entries, err := os.ReadDir("skills")
+	if err != nil {
+		t.Fatalf("ReadDir(skills) error = %v", err)
+	}
+	installed := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			installed[entry.Name()] = struct{}{}
+		}
+	}
+	return installed
+}
+
+// hiddenFromAHarness reports whether either shipped harness would omit one
+// installed skill from its model-visible catalog.
+func hiddenFromAHarness(t *testing.T, skill string) bool {
+	t.Helper()
+	if strings.Contains(readSkill(t, "skills/"+skill+"/SKILL.md"), "disable-model-invocation") {
+		return true
+	}
+	metadata, err := os.ReadFile(filepath.Join("skills", skill, "agents", "openai.yaml"))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(metadata), "allow_implicit_invocation")
 }

--- a/worker/skills_contract_test.go
+++ b/worker/skills_contract_test.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/harness"
 )
 
 // TestImplementationSkillKeepsTDDAndReviewOwnershipSeparated verifies the
@@ -78,34 +80,38 @@ func readSkill(t *testing.T, path string) string {
 	return string(body)
 }
 
-// mandatorySkills are the worker skills a factory role prompt requires by
-// name. A role prompt that mandates a skill the harness hides leaves the role
-// unable to follow its own instructions.
-var mandatorySkills = []string{"implement", "specification-review", "standards-review"}
-
 // harnessSkillRoots maps each harness shipped in the worker image to the role
-// home directory that harness reads its skill set from.
+// home directory that harness reads the worker skill set from.
 var harnessSkillRoots = map[string]string{
 	"claude": "/home/factory/.claude/skills",
 	"codex":  "/home/factory/.codex/skills",
 }
+
+// Each harness has its own switch that withholds a shipped skill from the
+// model-visible catalog. A role-mandated skill must carry neither.
+const (
+	// claudeHiddenSwitch hides a skill through its SKILL.md front matter.
+	claudeHiddenSwitch = "disable-model-invocation"
+	// codexHiddenSwitch hides a skill through its Codex activation policy.
+	codexHiddenSwitch = "allow_implicit_invocation"
+)
 
 // TestMandatorySkillsAreModelVisibleUnderEveryHarness verifies no shipped
 // harness hides a role-mandated skill from the model-visible catalog. Codex
 // hides a skill whose openai.yaml denies implicit invocation; Claude hides one
 // whose SKILL.md front matter disables model invocation.
 func TestMandatorySkillsAreModelVisibleUnderEveryHarness(t *testing.T) {
-	for _, skill := range mandatorySkills {
+	for _, skill := range harness.MandatorySkills() {
 		t.Run(skill, func(t *testing.T) {
 			body := readSkill(t, "skills/"+skill+"/SKILL.md")
 			if !strings.Contains(body, "name: "+skill+"\n") {
 				t.Fatalf("skill %q does not declare its own name:\n%s", skill, body)
 			}
-			if strings.Contains(body, "disable-model-invocation") {
+			if strings.Contains(body, claudeHiddenSwitch) {
 				t.Fatalf("skill %q is hidden from the Claude model-visible catalog:\n%s", skill, body)
 			}
 			metadata := readSkill(t, "skills/"+skill+"/agents/openai.yaml")
-			if strings.Contains(metadata, "allow_implicit_invocation") {
+			if strings.Contains(metadata, codexHiddenSwitch) {
 				t.Fatalf("skill %q is hidden from the Codex model-visible catalog:\n%s", skill, metadata)
 			}
 		})
@@ -128,12 +134,12 @@ func TestWorkerImageInstallsOneSkillSetPerHarnessRoot(t *testing.T) {
 	}
 }
 
-// TestRolePromptsOnlyMandateInstalledVisibleSkills verifies every skill an
-// embedded role prompt names is installed in the worker image and advertised
+// TestRolePromptsOnlyMandateVisibleWorkerSkills verifies every skill an
+// embedded role prompt names belongs to the worker skill set and is advertised
 // by both harnesses. It is the artifact-level statement of the role contract:
 // a prompt never instructs an agent to use a skill the harness withheld.
-func TestRolePromptsOnlyMandateInstalledVisibleSkills(t *testing.T) {
-	installed := installedSkills(t)
+func TestRolePromptsOnlyMandateVisibleWorkerSkills(t *testing.T) {
+	set := workerSkillSet(t)
 	prompts, err := filepath.Glob(filepath.Join("..", "internal", "prompt", "prompts", "*.md"))
 	if err != nil {
 		t.Fatalf("Glob(prompts) error = %v", err)
@@ -147,8 +153,8 @@ func TestRolePromptsOnlyMandateInstalledVisibleSkills(t *testing.T) {
 			t.Fatalf("ReadFile(%q) error = %v", path, err)
 		}
 		for _, named := range promptSkillNames(string(body)) {
-			if _, ok := installed[named]; !ok {
-				t.Fatalf("role prompt %q names skill %q, which the worker image does not install", path, named)
+			if _, ok := set[named]; !ok {
+				t.Fatalf("role prompt %q names skill %q, which the worker skill set does not contain", path, named)
 			}
 			if hiddenFromAHarness(t, named) {
 				t.Fatalf("role prompt %q names skill %q, which a shipped harness hides from the model", path, named)
@@ -174,32 +180,32 @@ func promptSkillNames(body string) []string {
 	return names
 }
 
-// installedSkills returns the skill names the worker image ships.
-func installedSkills(t *testing.T) map[string]struct{} {
+// workerSkillSet returns the skill names the worker image ships.
+func workerSkillSet(t *testing.T) map[string]struct{} {
 	t.Helper()
 	entries, err := os.ReadDir("skills")
 	if err != nil {
 		t.Fatalf("ReadDir(skills) error = %v", err)
 	}
-	installed := make(map[string]struct{}, len(entries))
+	set := make(map[string]struct{}, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() {
-			installed[entry.Name()] = struct{}{}
+			set[entry.Name()] = struct{}{}
 		}
 	}
-	return installed
+	return set
 }
 
 // hiddenFromAHarness reports whether either shipped harness would omit one
-// installed skill from its model-visible catalog.
+// worker skill from its model-visible catalog.
 func hiddenFromAHarness(t *testing.T, skill string) bool {
 	t.Helper()
-	if strings.Contains(readSkill(t, "skills/"+skill+"/SKILL.md"), "disable-model-invocation") {
+	if strings.Contains(readSkill(t, "skills/"+skill+"/SKILL.md"), claudeHiddenSwitch) {
 		return true
 	}
 	metadata, err := os.ReadFile(filepath.Join("skills", skill, "agents", "openai.yaml"))
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(metadata), "allow_implicit_invocation")
+	return strings.Contains(string(metadata), codexHiddenSwitch)
 }


### PR DESCRIPTION
Closes #146.

## What changed

`policy.allow_implicit_invocation: false` is gone from `implement`,
`specification-review`, and `standards-review`. Pinned Codex renders a skill
with that policy as `hidden_from_prompt()`, so the three role prompts mandated
craft their own harness had withheld. The prompts are unchanged: they name the
skill in backticks, and the smoke below proves that phrasing now reaches it.
No prompt version or content identity moves.

Three verification layers, deliberately separate:

1. **Artifact contract** (`go test ./worker/...`, offline). Every skill a role
   prompt names must belong to the worker skill set and carry neither hidden-skill
   switch — Codex `allow_implicit_invocation`, Claude `disable-model-invocation`.
   The image definition must seed exactly one skill set per harness root and
   leave `$HOME/.agents/skills` empty.
2. **Real invocation smoke** (`scripts/smoke-skills.sh`). Asks each harness,
   inside the pinned image and with the exact phrasing the role prompts use,
   to quote a line that exists only in that skill's body. Records the result in
   `worker/skill-smoke.json`, keyed by image digest and harness version.
3. **Startup diagnosis** (`factory doctor`). Per shipped harness: probes the
   pinned image for the present, unduplicated, model-visible skill set, then
   reads the recorded smoke result for that exact digest and harness version.
   It never makes a model call.

The worker image was rebuilt and `factory.yaml` now pins
`sha256:238d1ef9…`. Three consecutive `./scripts/build-worker.sh` runs
reproduced that digest against the committed tree.

## Evidence

- Codex smoke passed against the pinned digest for all three skills.
- Negative control: a one-layer image that re-adds
  `allow_implicit_invocation: false` fails the same smoke on `implement`. The
  smoke discriminates; it is not a no-op.
- `factory doctor` reports `codex worker skill contract: passed`.
- `go vet ./...` clean, 1121 tests pass, and the in-image gate suite passes.

## Left out — needs a human

**Claude smoke evidence is not recorded.** No Claude credential file exists on
this host, and I did not read the macOS keychain. Until it is recorded,
`factory doctor` blocks on `claude worker skill contract` — which is the
contract this PR states, not an oversight in it. To close the gap:

```sh
# place a credentials file where claude_auth_path points, then:
HARNESSES=claude ./scripts/smoke-skills.sh
git add worker/skill-smoke.json && git commit
```

`worker/SKILLS.md` records this gap under "Currently recorded" so a reader
meets it where the contract is stated.

## Review

Ran `/code-review` on both axes and applied every finding: glossary drift off
CONTEXT.md's avoided "installed skill", one source for the mandatory skill list
and for each hidden-skill switch, an image-probe diagnosis that no longer claims
more than its error paths support, a smoke run that exits non-zero when a
requested harness is skipped, a version key normalized the same way by producer
and consumer, and a sentinel docstring that states what the reply actually
proves rather than claiming impossibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzoLLLrNvUPH7wKRgrPCvi
