### PR TITLE
record claude skill smoke for the pinned worker digest

### DIFF
--- a/worker/SKILLS.md
+++ b/worker/SKILLS.md
@@ -108,18 +108,26 @@ the startup diagnosis.
 
 ### Currently recorded
 
-`worker/skill-smoke.json` holds a `codex` record for the pinned digest only.
-The `claude` smoke has not been run, because it needs a Claude credential file
-at the configured `claude_auth_path` and none exists on the machine that
-recorded the codex result. Until someone runs
+`worker/skill-smoke.json` holds a `codex` record and a `claude` record for the
+pinned digest, so the startup diagnosis passes both `worker skill contract`
+checks.
+
+macOS keeps the Claude Code credential in the login Keychain rather than in a
+file, so the smoke finds no source at the default `CLAUDE_AUTH_PATH` and skips
+the `claude` harness. Export the credential to a temporary file, point the
+smoke at it, and delete it again:
 
 ```sh
-HARNESSES=claude ./scripts/smoke-skills.sh
+umask 077
+security find-generic-password -s "Claude Code-credentials" -w \
+  > "$TMPDIR/claude-credentials.json"
+HARNESSES=claude CLAUDE_AUTH_PATH="$TMPDIR/claude-credentials.json" \
+  ./scripts/smoke-skills.sh
+rm -f "$TMPDIR/claude-credentials.json"
 ```
 
-and commits the updated file, the startup diagnosis blocks on `claude worker
-skill contract`. That is the contract this document states, not an oversight in
-it.
+The export is a live credential. Keep it outside the repository, and delete it
+when the smoke is recorded.
 
 ## Curation rule
 

--- a/worker/skill-smoke.json
+++ b/worker/skill-smoke.json
@@ -3,6 +3,17 @@
   "records": [
     {
       "image_digest": "sha256:238d1ef93894612ab4caaa195b52ed88a67f4651c937e2ba9492fbf3d2f1ff58",
+      "harness": "claude",
+      "harness_version": "2.1.232 (Claude Code)",
+      "skills": [
+        "implement",
+        "specification-review",
+        "standards-review"
+      ],
+      "verified_at": "2026-09-04T19:18:13Z"
+    },
+    {
+      "image_digest": "sha256:238d1ef93894612ab4caaa195b52ed88a67f4651c937e2ba9492fbf3d2f1ff58",
       "harness": "codex",
       "harness_version": "codex-cli 0.148.0",
       "skills": [


### PR DESCRIPTION
The startup diagnosis requires smoke evidence for every shipped harness, not only the one role_harness_defaults selects. Only codex carried it, so `factory doctor` blocked on `claude worker skill contract`.

macOS keeps the Claude Code credential in the login Keychain rather than in a file, which is why the smoke skipped claude and left the evidence incomplete. Record the export-and-smoke sequence next to the contract so the next digest rebuild does not rediscover it.


Claude-Session: https://claude.ai/code/session_011jh2xx6pcfsewSQa1mPaow