### PR TITLE
fix: read the review diff from the claimed worktree

### DIFF
--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -319,14 +319,16 @@ func reviewDiffCommandError(err error) error {
 	if !errors.As(err, &exit) {
 		return err
 	}
-	detail := strings.TrimSpace(string(exit.Stderr))
+	detail := strings.ReplaceAll(strings.TrimSpace(string(exit.Stderr)), "\n", "; ")
 	if detail == "" {
 		return err
 	}
 	if len(detail) > maxReviewDiffErrorBytes {
-		detail = detail[:maxReviewDiffErrorBytes]
+		// The bound is a byte count, so the cut can split a multi-byte rune.
+		// Dropping the incomplete sequence keeps the text printable.
+		detail = strings.ToValidUTF8(detail[:maxReviewDiffErrorBytes], "")
 	}
-	return fmt.Errorf("%w: %s", err, strings.ReplaceAll(detail, "\n", "; "))
+	return fmt.Errorf("%w: %s", err, detail)
 }
 
 // publishSpecificationReviewStatus publishes one exact-SHA reviewer status.

--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -36,6 +36,9 @@ const (
 	// Wide context multiplies the packet size without adding anything the
 	// reviewer could not already read.
 	reviewDiffContextLines = 10
+	// maxReviewDiffErrorBytes bounds the Git standard-error text carried into a
+	// lifecycle reason, which is published as a GitHub comment.
+	maxReviewDiffErrorBytes = 512
 )
 
 // reviewAxisRoles lists the reviewer roles that own a per-axis durable result
@@ -258,10 +261,11 @@ func (s *Service) captureReviewDiff(ctx context.Context, run store.Run, _ store.
 		}
 		return reviewDiffCaptureFromOutput(output, base, run.CheckpointSHA), nil
 	}
-	if result, err := captureReviewDiffFromWorktree(ctx, run.Worktree, base, run.CheckpointSHA); err == nil {
-		return reviewDiffCaptureFromOutput(result, base, run.CheckpointSHA), nil
+	output, err := captureReviewDiffFromWorktree(ctx, run.Worktree, base, run.CheckpointSHA)
+	if err != nil {
+		return reviewDiffCapture{}, fmt.Errorf("capture exact review diff from the pinned worktree: %w", err)
 	}
-	return reviewDiffCapture{}, errors.New("capture exact review diff from the pinned worktree")
+	return reviewDiffCaptureFromOutput(output, base, run.CheckpointSHA), nil
 }
 
 // reviewDiffCaptureFromOutput keeps a small diff in the packet and describes
@@ -284,12 +288,45 @@ func captureReviewDiffFromWorktree(ctx context.Context, worktree, base, checkpoi
 	command := exec.CommandContext(ctx, "git", "-C", worktree, "diff", "--no-ext-diff", "--binary", fmt.Sprintf("--unified=%d", reviewDiffContextLines), base, checkpoint, "--", ".")
 	// The factory worker environment may provide a coordinator-level Git
 	// projection. Review gather must inspect the claimed worktree itself.
-	command.Env = append(os.Environ(), "GIT_DIR=", "GIT_WORK_TREE=")
+	command.Env = environmentWithoutGitProjection()
 	output, err := command.Output()
 	if err != nil {
-		return "", err
+		return "", reviewDiffCommandError(err)
 	}
 	return string(output), nil
+}
+
+// environmentWithoutGitProjection removes inherited repository overrides
+// instead of blanking them. Git reads an empty GIT_DIR as a repository path of
+// "" and refuses every command, so an empty value is not an unset value.
+func environmentWithoutGitProjection() []string {
+	environment := os.Environ()
+	filtered := make([]string, 0, len(environment))
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, "GIT_DIR=") || strings.HasPrefix(entry, "GIT_WORK_TREE=") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+// reviewDiffCommandError names why Git refused the capture. The bare exit
+// status reaches a person as an unactionable lifecycle reason, so the bounded
+// standard-error text travels with it.
+func reviewDiffCommandError(err error) error {
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		return err
+	}
+	detail := strings.TrimSpace(string(exit.Stderr))
+	if detail == "" {
+		return err
+	}
+	if len(detail) > maxReviewDiffErrorBytes {
+		detail = detail[:maxReviewDiffErrorBytes]
+	}
+	return fmt.Errorf("%w: %s", err, strings.ReplaceAll(detail, "\n", "; "))
 }
 
 // publishSpecificationReviewStatus publishes one exact-SHA reviewer status.

--- a/internal/factory/review_diff_internal_test.go
+++ b/internal/factory/review_diff_internal_test.go
@@ -1,0 +1,83 @@
+package factory
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCaptureReviewDiffFromWorktreeIgnoresAnInheritedGitProjection verifies the
+// capture reads the claimed worktree even when the coordinator process carries
+// a repository override. Blanking the override instead of removing it made Git
+// read "" as the repository and stopped every review round.
+func TestCaptureReviewDiffFromWorktreeIgnoresAnInheritedGitProjection(t *testing.T) {
+	worktree, base, checkpoint := reviewDiffRepository(t)
+	t.Setenv("GIT_DIR", filepath.Join(t.TempDir(), "projected.git"))
+	t.Setenv("GIT_WORK_TREE", t.TempDir())
+
+	diff, err := captureReviewDiffFromWorktree(t.Context(), worktree, base, checkpoint)
+	if err != nil {
+		t.Fatalf("captureReviewDiffFromWorktree() error = %v", err)
+	}
+	if !strings.Contains(diff, "+checkpoint") {
+		t.Fatalf("captureReviewDiffFromWorktree() diff = %q, want the checkpoint change", diff)
+	}
+}
+
+// TestCaptureReviewDiffFromWorktreeNamesWhyGitRefused verifies a refused
+// capture reports Git's own reason instead of a bare exit status, so the
+// published lifecycle reason is actionable.
+func TestCaptureReviewDiffFromWorktreeNamesWhyGitRefused(t *testing.T) {
+	worktree, base, _ := reviewDiffRepository(t)
+	missing := "0000000000000000000000000000000000000000"
+
+	_, err := captureReviewDiffFromWorktree(t.Context(), worktree, base, missing)
+	if err == nil {
+		t.Fatal("captureReviewDiffFromWorktree() error = nil, want the unknown-checkpoint refusal")
+	}
+	if !strings.Contains(err.Error(), "fatal:") {
+		t.Fatalf("captureReviewDiffFromWorktree() error = %q, want Git's own reason", err)
+	}
+}
+
+// reviewDiffRepository creates a two-commit repository and returns its path,
+// base commit, and checkpoint commit.
+func reviewDiffRepository(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	worktree := t.TempDir()
+	runReviewDiffGit(t, worktree, "init", "-b", "main")
+	runReviewDiffGit(t, worktree, "config", "user.email", "factory@example.test")
+	runReviewDiffGit(t, worktree, "config", "user.name", "Factory Test")
+	if err := os.WriteFile(filepath.Join(worktree, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewDiffGit(t, worktree, "add", "README.md")
+	runReviewDiffGit(t, worktree, "commit", "-m", "base")
+	base := strings.TrimSpace(runReviewDiffGit(t, worktree, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(worktree, "README.md"), []byte("base\ncheckpoint\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewDiffGit(t, worktree, "commit", "-am", "checkpoint")
+	return worktree, base, strings.TrimSpace(runReviewDiffGit(t, worktree, "rev-parse", "HEAD"))
+}
+
+// runReviewDiffGit runs one fixture Git command in a repository the test owns.
+func runReviewDiffGit(t *testing.T, directory string, args ...string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, "git", args...)
+	command.Dir = directory
+	command.Env = environmentWithoutGitProjection()
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}

--- a/internal/factory/review_diff_internal_test.go
+++ b/internal/factory/review_diff_internal_test.go
@@ -2,12 +2,14 @@ package factory
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 // TestCaptureReviewDiffFromWorktreeIgnoresAnInheritedGitProjection verifies the
@@ -43,6 +45,67 @@ func TestCaptureReviewDiffFromWorktreeNamesWhyGitRefused(t *testing.T) {
 		t.Fatalf("captureReviewDiffFromWorktree() error = %q, want Git's own reason", err)
 	}
 }
+
+// TestReviewDiffCommandErrorHoldsTheBoundAcrossNewlineNormalisation verifies
+// the published detail never exceeds maxReviewDiffErrorBytes. Git's usage text
+// is thousands of bytes over dozens of lines, and each newline becomes the
+// two-byte "; " separator, so truncating before normalising doubled the bound.
+func TestReviewDiffCommandErrorHoldsTheBoundAcrossNewlineNormalisation(t *testing.T) {
+	t.Parallel()
+
+	command := exec.CommandContext(t.Context(), "git", "diff", "--no-such-option")
+	command.Dir = t.TempDir()
+	command.Env = environmentWithoutGitProjection()
+	_, raw := command.Output()
+	if raw == nil {
+		t.Fatal("git diff --no-such-option succeeded, want the usage refusal")
+	}
+	var exit *exec.ExitError
+	if !errors.As(raw, &exit) {
+		t.Fatalf("git diff --no-such-option error = %v, want an exit error carrying stderr", raw)
+	}
+	if len(exit.Stderr) <= maxReviewDiffErrorBytes {
+		t.Fatalf("git stderr is %d bytes, too short to exercise the bound", len(exit.Stderr))
+	}
+
+	detail := strings.TrimPrefix(reviewDiffCommandError(raw).Error(), raw.Error()+": ")
+	if len(detail) > maxReviewDiffErrorBytes {
+		t.Fatalf("detail = %d bytes, want at most %d", len(detail), maxReviewDiffErrorBytes)
+	}
+	if strings.Contains(detail, "\n") {
+		t.Fatalf("detail = %q, want newlines normalised", detail)
+	}
+	if !utf8.ValidString(detail) {
+		t.Fatalf("detail = %q, want valid UTF-8 after truncation", detail)
+	}
+}
+
+// TestReviewDiffCommandErrorDropsARuneSplitByTheBound verifies truncation ends
+// on a rune boundary when the stderr text is not ASCII.
+func TestReviewDiffCommandErrorDropsARuneSplitByTheBound(t *testing.T) {
+	t.Parallel()
+
+	stderr := strings.Repeat("…", maxReviewDiffErrorBytes)
+	detail := strings.TrimPrefix(reviewDiffCommandError(&reviewDiffExitError{stderr: []byte(stderr)}).Error(), "exit status 1: ")
+	if len(detail) > maxReviewDiffErrorBytes {
+		t.Fatalf("detail = %d bytes, want at most %d", len(detail), maxReviewDiffErrorBytes)
+	}
+	if !utf8.ValidString(detail) {
+		t.Fatalf("detail = %q, want valid UTF-8 after truncation", detail)
+	}
+}
+
+// reviewDiffExitError supplies exact stderr bytes without depending on a real
+// process, which cannot be made to emit a chosen encoding reliably.
+type reviewDiffExitError struct {
+	stderr []byte
+}
+
+// Error reports the fixed exit status the bound test strips.
+func (*reviewDiffExitError) Error() string { return "exit status 1" }
+
+// Unwrap exposes the exec error shape reviewDiffCommandError inspects.
+func (e *reviewDiffExitError) Unwrap() error { return &exec.ExitError{Stderr: e.stderr} }
 
 // reviewDiffRepository creates a two-commit repository and returns its path,
 // base commit, and checkpoint commit.


### PR DESCRIPTION
## Summary

- Every review round has been stopping at `start concurrent reviews` because the host-side diff capture blanked `GIT_DIR` and `GIT_WORK_TREE` instead of removing them. Git reads an empty `GIT_DIR` as a repository path of `\"\"` and refuses the command with `fatal: not a git repository: ''`.
- The bug dates to 06b9f1b but was masked by `captureReviewDiffFromWorker`, which ran the diff inside the worker where `GIT_DIR` is set properly. d33867e removed that fallback, leaving the broken path as the only one. The production `WorktreeManager` does not implement `reviewDiffReader`, so no run could start a reviewer.
- Gather also discarded the exec error and published a bare `capture exact review diff from the pinned worktree` lifecycle reason, so the refusal reached a person with none of Git's own diagnosis.
- Adds the regression coverage that was missing: every existing review test routed through the `ReadDiff` seam, so nothing exercised the exec path.

## Changes

`internal/factory/review.go`

- `environmentWithoutGitProjection` removes inherited `GIT_DIR`/`GIT_WORK_TREE` entries rather than setting them empty.
- `captureReviewDiff` wraps and returns the capture error instead of replacing it with a generic message.
- `reviewDiffCommandError` attaches `exec.ExitError.Stderr`, bounded by `maxReviewDiffErrorBytes` (512) because the text is published in the run's GitHub status comment.

`internal/factory/review_diff_internal_test.go`

- Capture succeeds against a real repository while the process carries a `GIT_DIR`/`GIT_WORK_TREE` projection.
- A refused capture reports Git's own reason.

## Contract Impact

None. No packet field, report schema, prompt version, or store column changes. The published lifecycle reason for a failed capture is now longer and names the Git error.

## Test Plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` passes
- [x] New tests fail with the old `append(os.Environ(), \"GIT_DIR=\", \"GIT_WORK_TREE=\")` line restored, confirming they are not vacuous
- [x] Rebuilt coordinator launches a specification reviewer on the stuck run for #141, which previously stopped at capture

## Checklist

- [x] Tests pass
- [x] No breaking changes
- [x] CLAUDE.md updated if architecture changed (not applicable)

Note: #141 replaces this capture path with a streamed `/invocation/review.diff` artifact and carries the same env fix. This lands the fix on `main` first so the coordinator can review that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jh2xx6pcfsewSQa1mPaow