### PR TITLE
fix: keep the worktree access mode in the worker mount contract

### DIFF
--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -1503,7 +1503,10 @@ func validateMountContract(existingMounts []ContainerMount, request StartRequest
 	requiredMounts[WorktreePath] = ContainerMount{
 		Source:      request.WorktreePath,
 		Destination: WorktreePath,
-		ReadOnly:    false,
+		// A review worker mounts the checkpoint worktree read-only, so the
+		// access mode belongs to the request. Requiring read-write here made
+		// every stopped review worker unrecoverable.
+		ReadOnly: request.WorktreeReadOnly,
 	}
 	requiredMounts[GitMetadataPath] = ContainerMount{
 		Source:      request.GitMetadataPath,

--- a/internal/worker/runtime_contract_test.go
+++ b/internal/worker/runtime_contract_test.go
@@ -2,6 +2,7 @@ package worker_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -830,6 +831,59 @@ func TestDockerRuntimeRefusesMountContractMismatch(t *testing.T) {
 	}
 	if countLogLines(lines, " start ") != 0 {
 		t.Fatalf("Docker start calls = %d, want 0 (mount mismatches should not restart container); calls = %#v", countLogLines(lines, " start "), lines)
+	}
+}
+
+// TestDockerRuntimeRestartsAStoppedReviewWorker verifies a stopped worker
+// whose checkpoint is mounted read-only is started in place. The mount
+// contract required a read-write worktree whatever the request asked for, so
+// recovering any review invocation failed with a mount contract mismatch.
+func TestDockerRuntimeRestartsAStoppedReviewWorker(t *testing.T) {
+	stub, logPath, _ := writeDockerStub(t)
+	worktree := makeDirectory(t, "worktree")
+	gitMetadata := makeDirectory(t, "git-metadata")
+	request := worker.StartRequest{
+		RunID:            "run-contract-review-worker",
+		WorktreePath:     worktree,
+		WorktreeReadOnly: true,
+		GitMetadataPath:  gitMetadata,
+		Role:             "spec_review",
+		Image:            "ghcr.io/example/factory-worker",
+		ImageDigest:      testWorkerDigest,
+	}
+	runtime := &worker.DockerRuntime{DockerBinary: stub}
+
+	if err := runtime.Start(context.Background(), request); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	inspection, err := json.Marshal(map[string]any{
+		"State":  map[string]bool{"Running": false},
+		"Config": map[string]string{"Image": request.Image + "@" + request.ImageDigest},
+		"Mounts": []map[string]any{
+			{"Type": "bind", "Source": worktree, "Destination": worker.WorktreePath, "RW": false},
+			{"Type": "bind", "Source": gitMetadata, "Destination": worker.GitMetadataPath, "RW": false},
+			{"Type": "volume", "Name": testRoleVolumeName(request.RunID, request.Role), "Destination": "/home/factory", "RW": true},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspectionPath := filepath.Join(t.TempDir(), "inspection.json")
+	if err := os.WriteFile(inspectionPath, inspection, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WORKER_DOCKER_INSPECT_JSON_FILE", inspectionPath)
+
+	if err := runtime.Start(context.Background(), request); err != nil {
+		t.Fatalf("Start() restart error = %v, want the stopped review worker started in place", err)
+	}
+
+	lines := readStubLog(t, logPath)
+	if countLogLines(lines, " start ") != 1 {
+		t.Fatalf("Docker start calls = %d, want 1; calls = %#v", countLogLines(lines, " start "), lines)
+	}
+	if countLogLines(lines, " rm ") != 0 {
+		t.Fatalf("Docker rm calls = %d, want 0 (a matching review worker is not recreated); calls = %#v", countLogLines(lines, " rm "), lines)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `validateMountContract` hardcoded `ReadOnly: false` for the `/work` mount, ignoring `StartRequest.WorktreeReadOnly`. A review worker mounts the checkpoint worktree read-only by design, so restarting a stopped one always failed with `mount contract mismatch: mount at "/work" is read-only, want read-write`.
- That made every review invocation unrecoverable once its worker stopped: invocation recovery builds a correct read-only request, and the contract check refused it.
- `expectedWorkerMountReadOnly` already derives the worktree mode from the request. This makes the contract check agree with it.
- Surfaced by the run for #141 after PR #154 let reviewers launch at all. It was unreachable before, because no review worker had ever been created.

## Changes

`internal/worker/runtime.go`

- `validateMountContract` takes the `/work` access mode from `request.WorktreeReadOnly` instead of requiring read-write.

`internal/worker/runtime_contract_test.go`

- `TestDockerRuntimeRestartsAStoppedReviewWorker` starts a stopped worker with a read-only checkpoint in place, using a structured Docker inspection so the production comparison path is exercised.

The safety property is unchanged: a request that genuinely widens the access mode still fails `workerMountsPresent`, so the worker is recreated with the requested contract rather than reused.

## Contract Impact

None. No worker image, mount set, packet field, or store schema changes. Only the accepted access mode for an existing container's `/work` mount.

## Test Plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` passes
- [x] The new test fails with the hardcoded `ReadOnly: false` restored, reproducing the exact production error
- [x] Existing mount-mismatch and stopped-worker-reuse tests still pass

## Checklist

- [x] Tests pass
- [x] No breaking changes
- [x] CLAUDE.md updated if architecture changed (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jh2xx6pcfsewSQa1mPaow