### PR TITLE
fix: stop a pause reason from quoting the pause before it

### DIFF
--- a/internal/factory/claim.go
+++ b/internal/factory/claim.go
@@ -1251,6 +1251,17 @@ func safeStatusCommentValue(value string) string {
 	return strings.TrimSpace(value)
 }
 
+// boundedText truncates value to at most limit bytes and marks the cut. The
+// limit counts bytes, so the cut can split a multi-byte rune; the incomplete
+// sequence is dropped to keep the result printable.
+func boundedText(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	const cut = "\u2026"
+	return strings.ToValidUTF8(value[:limit-len(cut)], "") + cut
+}
+
 // statusCommentMarker identifies the one editable status comment for a run.
 func statusCommentMarker(runID string) string {
 	return fmt.Sprintf("<!-- factory-status: %s -->", runID)

--- a/internal/factory/recovery.go
+++ b/internal/factory/recovery.go
@@ -2,6 +2,8 @@ package factory
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -28,6 +30,19 @@ const RecoveryRequiredCode = "recovery-required"
 // itself, which is the only waiting-for-human state eligible for check-stage
 // re-entry without a new agent invocation.
 const restartReconciliationPausePrefix = "restart reconciliation paused:"
+
+const (
+	// maxRecoveryReasonValueBytes bounds one observation inside a pause reason.
+	maxRecoveryReasonValueBytes = 512
+	// maxRecoveryReasonBytes bounds the assembled pause reason. The reason is
+	// published as a GitHub comment and stored in a bounded pending-effect
+	// payload, so an unbounded reason stops the coordinator from reporting why
+	// it paused.
+	maxRecoveryReasonBytes = 4096
+	// lifecycleReasonLinePrefix is the status-comment line that states why a
+	// run is waiting.
+	lifecycleReasonLinePrefix = "- lifecycle reason: "
+)
 
 // RecoveryDiscrepancyKind identifies whether a restart disagreement is an
 // infrastructure observation or a workflow-owned failure.
@@ -1607,7 +1622,7 @@ func recoveryDiscrepancyReason(diagnosis RecoveryDiagnosis) string {
 	if len(parts) == 0 {
 		return "restart reconciliation paused: unresolved discrepancy"
 	}
-	return "restart reconciliation paused: " + strings.Join(parts, "; ")
+	return boundedText("restart reconciliation paused: "+strings.Join(parts, "; "), maxRecoveryReasonBytes)
 }
 
 // recoveryReasonValue keeps a prior reconciliation pause from becoming part
@@ -1615,7 +1630,31 @@ func recoveryDiscrepancyReason(diagnosis RecoveryDiagnosis) string {
 // that it was a previous coordinator diagnosis.
 func recoveryReasonValue(value string) string {
 	value = safeStatusCommentValue(value)
-	return strings.ReplaceAll(value, restartReconciliationPausePrefix, "prior reconciliation pause:")
+	value = strings.ReplaceAll(value, restartReconciliationPausePrefix, "prior reconciliation pause:")
+	return boundedText(value, maxRecoveryReasonValueBytes)
+}
+
+// statusCommentIdentity describes a status comment by size and content
+// identity. A body is unbounded and carries the run's own lifecycle reason, so
+// recording one verbatim would make each pause quote the pause before it.
+func statusCommentIdentity(body string) string {
+	digest := sha256.Sum256([]byte(body))
+	return fmt.Sprintf("%d bytes, sha256 %s", len(body), hex.EncodeToString(digest[:]))
+}
+
+// statusCommentComparable drops the lifecycle-reason line before comparing two
+// status comments. That line states the result of this comparison, so
+// comparing it makes every pause an input to the next one.
+func statusCommentComparable(body string) string {
+	lines := strings.Split(body, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		if strings.HasPrefix(line, lifecycleReasonLinePrefix) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
 }
 
 // newRecoveryDiagnosis creates the read-only comparison envelope and operator
@@ -1749,8 +1788,8 @@ func inspectGitHubProjection(ctx context.Context, diagnosis *RecoveryDiagnosis, 
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: run.StatusCommentID, Observed: "missing"})
 	} else if !strings.Contains(comment.Body, marker) {
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment marker", Expected: marker, Observed: "marker missing"})
-	} else if comment.Body != statusCommentBody(run) {
-		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: statusCommentBody(run), Observed: comment.Body})
+	} else if statusCommentComparable(comment.Body) != statusCommentComparable(statusCommentBody(run)) {
+		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: statusCommentIdentity(statusCommentBody(run)), Observed: statusCommentIdentity(comment.Body)})
 	} else if strings.TrimSpace(run.StatusCommentID) == "" {
 		addRecoveryDiscrepancy(diagnosis, RecoveryDiscrepancy{Source: "github", Field: "status comment", Expected: "persisted comment " + comment.ID, Observed: "persisted identity missing"})
 	} else if comment.ID != run.StatusCommentID {

--- a/internal/factory/recovery_reason_internal_test.go
+++ b/internal/factory/recovery_reason_internal_test.go
@@ -1,0 +1,156 @@
+package factory
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Stevie1704/sw-factory/internal/github"
+	"github.com/Stevie1704/sw-factory/internal/store"
+)
+
+// TestRecoveryPauseReasonConvergesAcrossGenerations verifies a pause reason
+// stops growing when it observes the comment that carries the previous pause
+// reason. Recording both comment bodies verbatim made every generation quote
+// the one before it, and one run reached a 872 MB lifecycle reason that no
+// longer fit the bounded pending-effect payload.
+func TestRecoveryPauseReasonConvergesAcrossGenerations(t *testing.T) {
+	t.Parallel()
+
+	run := reasonLoopRun()
+	sizes := make([]int, 0, 12)
+	for generation := 0; generation < 12; generation++ {
+		diagnosis := newRecoveryDiagnosis(run.ID)
+		addRecoveryDiscrepancy(&diagnosis, RecoveryDiscrepancy{
+			Source:   "github",
+			Field:    "status comment",
+			Expected: statusCommentBody(run),
+			Observed: statusCommentBody(run) + "drift",
+		})
+		run.LifecycleReason = recoveryDiscrepancyReason(diagnosis)
+		sizes = append(sizes, len(run.LifecycleReason))
+	}
+
+	final := sizes[len(sizes)-1]
+	if final > maxRecoveryReasonBytes {
+		t.Fatalf("pause reason = %d bytes after %d generations, want at most %d", final, len(sizes), maxRecoveryReasonBytes)
+	}
+	if final != sizes[1] {
+		t.Fatalf("pause reason sizes = %v, want a stable size after the first generation", sizes)
+	}
+}
+
+// TestStatusCommentDiscrepancyRecordsIdentityNotBody verifies the projection
+// comparison records what the bodies are rather than what they contain, so a
+// pause reason cannot carry the comment that carries it.
+func TestStatusCommentDiscrepancyRecordsIdentityNotBody(t *testing.T) {
+	t.Parallel()
+
+	run := reasonLoopRun()
+	client := &reasonLoopGitHub{
+		issue:   github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentNeedsInput}},
+		comment: github.Comment{ID: run.StatusCommentID, Body: statusCommentMarker(run.ID) + "\ndrifted body\n"},
+	}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+
+	inspectGitHubProjection(context.Background(), &diagnosis, client, nil, github.Repository{Owner: "owner", Name: "repository"}, run)
+
+	discrepancy, found := reasonLoopDiscrepancy(diagnosis, "status comment")
+	if !found {
+		t.Fatalf("discrepancies = %#v, want a status comment discrepancy", diagnosis.Discrepancies)
+	}
+	for _, value := range []string{discrepancy.Expected, discrepancy.Observed} {
+		if !strings.Contains(value, "sha256 ") {
+			t.Fatalf("status comment discrepancy value = %q, want a content identity", value)
+		}
+		if strings.Contains(value, statusCommentMarker(run.ID)) {
+			t.Fatalf("status comment discrepancy value = %q, want no comment body", value)
+		}
+	}
+}
+
+// TestStatusCommentComparisonIgnoresTheLifecycleReason verifies two comments
+// that differ only in the reason line agree. That line states the result of
+// this comparison, so comparing it feeds each pause into the next one.
+func TestStatusCommentComparisonIgnoresTheLifecycleReason(t *testing.T) {
+	t.Parallel()
+
+	run := reasonLoopRun()
+	run.LifecycleReason = "restart reconciliation paused: an earlier observation"
+	published := run
+	published.LifecycleReason = "restart reconciliation paused: a different earlier observation"
+	if statusCommentBody(run) == statusCommentBody(published) {
+		t.Fatal("status comment bodies are identical, want the reason line to differ")
+	}
+
+	if statusCommentComparable(statusCommentBody(run)) != statusCommentComparable(statusCommentBody(published)) {
+		t.Fatalf("comparable bodies differ:\n%q\n%q", statusCommentComparable(statusCommentBody(run)), statusCommentComparable(statusCommentBody(published)))
+	}
+
+	client := &reasonLoopGitHub{
+		issue:   github.Issue{Number: run.IssueNumber, Labels: []string{github.LabelAgentNeedsInput}},
+		comment: github.Comment{ID: run.StatusCommentID, Body: statusCommentBody(published)},
+	}
+	diagnosis := newRecoveryDiagnosis(run.ID)
+	inspectGitHubProjection(context.Background(), &diagnosis, client, nil, github.Repository{Owner: "owner", Name: "repository"}, run)
+	if _, found := reasonLoopDiscrepancy(diagnosis, "status comment"); found {
+		t.Fatalf("discrepancies = %#v, want no status comment drift from the reason line alone", diagnosis.Discrepancies)
+	}
+}
+
+// reasonLoopRun returns the waiting run the reason-loop tests project.
+func reasonLoopRun() store.Run {
+	return store.Run{
+		ID:              "run-reason-loop",
+		IssueNumber:     141,
+		Status:          store.StatusWaitingForHuman,
+		Stage:           store.StageReview,
+		StatusCommentID: "comment-1",
+	}
+}
+
+// reasonLoopDiscrepancy returns the first discrepancy recorded for a field.
+func reasonLoopDiscrepancy(diagnosis RecoveryDiagnosis, field string) (RecoveryDiscrepancy, bool) {
+	for _, discrepancy := range diagnosis.Discrepancies {
+		if discrepancy.Field == field {
+			return discrepancy, true
+		}
+	}
+	return RecoveryDiscrepancy{}, false
+}
+
+// reasonLoopGitHub is the read-only projection the inspection reads.
+type reasonLoopGitHub struct {
+	issue   github.Issue
+	comment github.Comment
+}
+
+// Issue returns the fixture issue.
+func (c *reasonLoopGitHub) Issue(context.Context, github.Repository, int) (github.Issue, error) {
+	return c.issue, nil
+}
+
+// FindStatusComment returns the fixture status comment.
+func (c *reasonLoopGitHub) FindStatusComment(context.Context, github.Repository, int, string) (github.Comment, error) {
+	return c.comment, nil
+}
+
+// CreateLabel is never called by a read-only inspection.
+func (*reasonLoopGitHub) CreateLabel(context.Context, github.Repository, github.Label) error {
+	return nil
+}
+
+// ReplaceIssueLabels is never called by a read-only inspection.
+func (*reasonLoopGitHub) ReplaceIssueLabels(context.Context, github.Repository, int, []string) error {
+	return nil
+}
+
+// CreateIssueComment is never called by a read-only inspection.
+func (*reasonLoopGitHub) CreateIssueComment(context.Context, github.Repository, int, string) (github.Comment, error) {
+	return github.Comment{}, nil
+}
+
+// EditIssueComment is never called by a read-only inspection.
+func (*reasonLoopGitHub) EditIssueComment(context.Context, github.Repository, string, string) error {
+	return nil
+}

--- a/internal/factory/review.go
+++ b/internal/factory/review.go
@@ -323,12 +323,7 @@ func reviewDiffCommandError(err error) error {
 	if detail == "" {
 		return err
 	}
-	if len(detail) > maxReviewDiffErrorBytes {
-		// The bound is a byte count, so the cut can split a multi-byte rune.
-		// Dropping the incomplete sequence keeps the text printable.
-		detail = strings.ToValidUTF8(detail[:maxReviewDiffErrorBytes], "")
-	}
-	return fmt.Errorf("%w: %s", err, detail)
+	return fmt.Errorf("%w: %s", err, boundedText(detail, maxReviewDiffErrorBytes))
 }
 
 // publishSpecificationReviewStatus publishes one exact-SHA reviewer status.


### PR DESCRIPTION
## Summary

- Recovery recorded both status comment bodies verbatim in the discrepancy that becomes `run.LifecycleReason`, and the next status comment embeds that reason. Every reconciliation therefore quoted the previous one.
- `%q` escapes each nested copy again, so a backslash run grew 1 to 3 to 7 to 15, and the text roughly doubled per generation. The run for #141 reached a **872,491,679-byte** lifecycle reason after about 19 generations. Healthy runs hold 25 to 71 bytes.
- The failure is terminal, not cosmetic: a pending effect payload is bounded at 1 MiB, so the coordinator could no longer publish the pause that explains why it paused. Every `factory start` ended in `pending effect payload must be valid bounded JSON`.
- The existing guard only rewrote the literal `restart reconciliation paused:` prefix and applied no bound, so it never touched the embedded bodies where the growth actually was.

## Changes

`internal/factory/recovery.go`

- The status comment discrepancy records each body's size and SHA-256 (`statusCommentIdentity`) instead of the body.
- `statusCommentComparable` drops the `- lifecycle reason: ` line before comparing two comments. That line states the result of this comparison, so comparing it is the feedback edge itself.
- `recoveryReasonValue` bounds one observation at 512 bytes; `recoveryDiscrepancyReason` bounds the assembled reason at 4096, well under the payload limit.

`internal/factory/claim.go`

- `boundedText` truncates on a byte limit and drops the incomplete rune the cut leaves behind. `reviewDiffCommandError` now uses it too, replacing the third copy of the same logic.

## Contract Impact

None. No packet field, report schema, or store column changes. A pause reason for a drifted status comment now names size and content identity rather than quoting both bodies, and a comment that differs only in its reason line is no longer reported as drift.

## Test Plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` passes
- [x] `TestRecoveryPauseReasonConvergesAcrossGenerations` reaches **27,005,142 bytes after 12 generations** without the bound, and a stable size with it
- [x] `TestStatusCommentDiscrepancyRecordsIdentityNotBody` and `TestStatusCommentComparisonIgnoresTheLifecycleReason` both fail against the previous call site
- [x] The affected run's 872 MB row was truncated so the coordinator can publish again

## Checklist

- [x] Tests pass
- [x] No breaking changes
- [x] CLAUDE.md updated if architecture changed (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jh2xx6pcfsewSQa1mPaow